### PR TITLE
SSH: Set UserKnownHostsFile to /dev/null

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -174,10 +174,6 @@ func (a *HostAgent) Run(ctx context.Context) error {
 	}
 	stBooting := stBase
 	a.emitEvent(ctx, hostagentapi.Event{Status: stBooting})
-	if err := sshutil.RemoveKnownHostEntries(sshLocalPort); err != nil {
-		a.l.WithError(err).Error("couldn't remove existing localhost host keys")
-		return err
-	}
 
 	go func() {
 		stRunning := stBase

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -155,6 +155,7 @@ func CommonArgs(useDotSSH bool) ([]string, error) {
 
 	args = append(args,
 		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "NoHostAuthenticationForLocalhost=yes",
 		"-o", "GSSAPIAuthentication=no",
 		"-o", "PreferredAuthentications=publickey",

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -1,7 +1,6 @@
 package sshutil
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"os/user"
@@ -96,25 +95,6 @@ func DefaultPubKeys(loadDotSSH bool) ([]PubKey, error) {
 		}
 	}
 	return res, nil
-}
-
-func RemoveKnownHostEntries(sshLocalPort int) error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-	// `ssh-keygen -R` will return a non-0 status when ~/.ssh/known_hosts doesn't exist
-	if _, err := os.Stat(filepath.Join(homeDir, ".ssh/known_hosts")); errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	sshFixCmd := exec.Command("ssh-keygen",
-		"-R", fmt.Sprintf("[127.0.0.1]:%d", sshLocalPort),
-		"-R", fmt.Sprintf("[localhost]:%d", sshLocalPort),
-	)
-	if out, err := sshFixCmd.CombinedOutput(); err != nil {
-		return errors.Wrapf(err, "failed to run %v: %q", sshFixCmd.Args, string(out))
-	}
-	return nil
 }
 
 func CommonArgs(useDotSSH bool) ([]string, error) {


### PR DESCRIPTION
As we are dealing with temporary SSH host keys, we should not pollute the users's known hosts file with ephemeral data.  Additionally, this avoids issues where the user has an invalid known hosts file, as in https://github.com/rancher-sandbox/rancher-desktop/issues/504.