### PR TITLE
sshutil: Quote control socket path.

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -164,7 +164,7 @@ func SSHArgs(instDir string, useDotSSH bool) ([]string, error) {
 	args = append(args,
 		"-l", u.Username, // guest and host have the same username, but we should specify the username explicitly (#85)
 		"-o", "ControlMaster=auto",
-		"-o", "ControlPath="+controlSock,
+		"-o", fmt.Sprintf("ControlPath=\"%s\"", controlSock),
 		"-o", "ControlPersist=5m",
 	)
 	return args, nil


### PR DESCRIPTION
The path may contain spaces (such as "Application Support"); ensure that it can be used correctly by ssh.

I'm actually a little uncomfortable with this, since I couldn't figure out where the arguments get squished into a string; as far as I can tell it all goes straight to `exec.Command` as an array…