### PR TITLE
Update LongestSock to "ssh.sock.1234567890123456"

### DIFF
--- a/pkg/store/filenames/filenames.go
+++ b/pkg/store/filenames/filenames.go
@@ -41,4 +41,7 @@ const (
 // See unix(4).
 //
 // On Linux, the full path must be less than 108 characters.
-const LongestSock = SerialSock
+//
+// ssh appends 16 bytes of random characters when it first creates the socket:
+// https://github.com/openssh/openssh-portable/blob/V_8_7_P1/mux.c#L1271-L1285
+const LongestSock = SSHSock + ".1234567890123456"


### PR DESCRIPTION
Because ssh creates a temporary name with random suffix first to avoid race conditions.

Ref https://github.com/rancher-sandbox/rancher-desktop/issues/298#issuecomment-905730711