### PR TITLE
qemu-img 6.1.0 no longer supports using -b without -F

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -78,7 +78,7 @@ func EnsureDisk(cfg Config) error {
 	}
 	args := []string{"create", "-f", "qcow2"}
 	if !isBaseDiskISO {
-		args = append(args, "-b", baseDisk)
+		args = append(args, "-F", "qcow2", "-b", baseDisk)
 	}
 	args = append(args, diffDisk, strconv.Itoa(int(diskSize)))
 	cmd := exec.Command("qemu-img", args...)


### PR DESCRIPTION
> Backing file specified without backing format
> Detected format of qcow2.
