### PR TITLE
pkg/qemu: detect basedisk format

### DIFF
--- a/pkg/qemu/imgutil/imgutil.go
+++ b/pkg/qemu/imgutil/imgutil.go
@@ -1,0 +1,48 @@
+package imgutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Info corresponds to the output of `qemu-img info --output=json FILE`
+type Info struct {
+	Format string `json:"format,omitempty"` // since QEMU 1.3
+}
+
+func GetInfo(f string) (*Info, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("qemu-img", "info", "--output=json", f)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to run %v: stdout=%q, stderr=%q: %w",
+			cmd.Args, stdout.String(), stderr.String(), err)
+	}
+	var imgInfo Info
+	if err := json.Unmarshal(stdout.Bytes(), &imgInfo); err != nil {
+		return nil, err
+	}
+	return &imgInfo, nil
+}
+
+func DetectFormat(f string) (string, error) {
+	switch ext := strings.ToLower(filepath.Ext(f)); ext {
+	case ".qcow2":
+		return "qcow2", nil
+	case ".raw":
+		return "raw", nil
+	}
+	imgInfo, err := GetInfo(f)
+	if err != nil {
+		return "", err
+	}
+	if imgInfo.Format == "" {
+		return "", fmt.Errorf("failed to detect format of %q", f)
+	}
+	return imgInfo.Format, nil
+}

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lima-vm/lima/pkg/downloader"
 	"github.com/lima-vm/lima/pkg/iso9660util"
 	"github.com/lima-vm/lima/pkg/limayaml"
+	"github.com/lima-vm/lima/pkg/qemu/imgutil"
 	"github.com/lima-vm/lima/pkg/qemu/qemuconst"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/mattn/go-shellwords"
@@ -78,7 +79,11 @@ func EnsureDisk(cfg Config) error {
 	}
 	args := []string{"create", "-f", "qcow2"}
 	if !isBaseDiskISO {
-		args = append(args, "-F", "qcow2", "-b", baseDisk)
+		baseDiskFormat, err := imgutil.DetectFormat(baseDisk)
+		if err != nil {
+			return err
+		}
+		args = append(args, "-F", baseDiskFormat, "-b", baseDisk)
 	}
 	args = append(args, diffDisk, strconv.Itoa(int(diskSize)))
 	cmd := exec.Command("qemu-img", args...)


### PR DESCRIPTION
Follow-up to #174 `qemu-img 6.1.0 no longer supports using -b without -F`
