### PR TITLE
Fix `lima (start|stop|shell)` suggestion to remove instance name

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -41,10 +41,7 @@ func shellAction(clicontext *cli.Context) error {
 	switch clicontext.Args().Get(1) {
 	case "start", "delete", "shell":
 		// `lima start` (alias of `limactl $LIMA_INSTANCE start`) is probably a typo of `limactl start`
-		logrus.Warnf("Perhaps you meant `limactl %s %s %s`?",
-			clicontext.Args().Get(1),
-			clicontext.Args().First(),
-			strings.Join(clicontext.Args().Slice()[2:], " "))
+		logrus.Warnf("Perhaps you meant `limactl %s`?", strings.Join(clicontext.Args().Slice()[1:], " "))
 	}
 
 	inst, err := store.Inspect(instName)


### PR DESCRIPTION
Because the lima wrapper turns `lima start foo` into `limactl shell default start foo` and the instance name should not
be part of the suggestion "Perhaps you meant `limactl start foo`".

Fixes #185