### PR TITLE
copy: use SSHArgs if copying to a single remote host.

### DIFF
--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -64,6 +64,9 @@ func copyAction(clicontext *cli.Context) error {
 
 	sshArgs := []string{}
 	if len(instDirs) == 1 {
+		// Only one (instance) host is involved; we can use the instance-specific
+		// arguments such as ControlPath.  This is preferred as we can multiplex
+		// sessions without re-authenticating (MaxSessions permitting).
 		for _, instDir := range instDirs {
 			sshArgs, err = sshutil.SSHArgs(instDir, false)
 			if err != nil {

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -172,7 +172,7 @@ func SSHArgs(instDir string, useDotSSH bool) ([]string, error) {
 		return nil, err
 	}
 	args = append(args,
-		"-l", u.Username, // guest and host have the same username, but we should specify the username explicitly (#85)
+		"-o", fmt.Sprintf("User=%s", u.Username), // guest and host have the same username, but we should specify the username explicitly (#85)
 		"-o", "ControlMaster=auto",
 		"-o", fmt.Sprintf("ControlPath=\"%s\"", controlSock),
 		"-o", "ControlPersist=5m",


### PR DESCRIPTION
This lets us use `ControlPath` with the connection, so that if a small number of copies run in parallel we can reuse the connection, rather than failing when too many connections are in flight.  Note that this only works if there's a single remote host; if the copy involves multiple hosts (`limactl copy one:/some/path two:/some/path`), the syntax does not allow for separate configuration, so we have to fall back to the old way without a `ControlPath`.

Having too many copies in parallel will still hit any limits imposed by `MaxSessions` (default 10), at which point `scp` falls back to not using the control connection (and may hit `MaxStartups` instead).