### PR TITLE
Allow users to define custom environment variables to be loaded on VM start

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/lima.env
+++ b/pkg/cidata/cidata.TEMPLATE.d/lima.env
@@ -15,3 +15,6 @@ LIMA_CIDATA_CONTAINERD_SYSTEM=1
 LIMA_CIDATA_CONTAINERD_SYSTEM=
 {{- end}}
 LIMA_CIDATA_SLIRP_GATEWAY={{ .SlirpGateway }}
+{{- range $key, $val := .Env}}
+{{$key}}={{$val}}
+{{- end}}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -52,6 +52,7 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML) error {
 		UID:          uid,
 		Containerd:   Containerd{System: *y.Containerd.System, User: *y.Containerd.User},
 		SlirpGateway: qemuconst.SlirpGateway,
+		Env:          y.Env,
 	}
 
 	pubKeys, err := sshutil.DefaultPubKeys(*y.SSH.LoadDotSSHPubKeys)

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -36,6 +36,7 @@ type TemplateArgs struct {
 	Containerd   Containerd
 	Networks     []Network
 	SlirpGateway string
+	Env          map[string]*string
 }
 
 func ValidateTemplateArgs(args TemplateArgs) error {

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -57,6 +57,8 @@ ssh:
   # Default: true
   loadDotSSHPubKeys: true
 
+
+
 # ===================================================================== #
 # ADVANCED CONFIGURATION
 # ===================================================================== #
@@ -162,6 +164,10 @@ network:
 #     hostIP: "127.0.0.1"
 #     hostPortRange: [1024, 65535]
 #   # Any port still not matched by a rule will not be forwarded (ignored)
+
+# # extra environment variables that will be loaded into the VM at start up
+# env:
+#   KEY: value
 
 # ===================================================================== #
 # END OF TEMPLATE

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -7,20 +7,21 @@ import (
 )
 
 type LimaYAML struct {
-	Arch         Arch          `yaml:"arch,omitempty"`
-	Images       []File        `yaml:"images"` // REQUIRED
-	CPUs         int           `yaml:"cpus,omitempty"`
-	Memory       string        `yaml:"memory,omitempty"` // go-units.RAMInBytes
-	Disk         string        `yaml:"disk,omitempty"`   // go-units.RAMInBytes
-	Mounts       []Mount       `yaml:"mounts,omitempty"`
-	SSH          SSH           `yaml:"ssh,omitempty"` // REQUIRED (FIXME)
-	Firmware     Firmware      `yaml:"firmware,omitempty"`
-	Video        Video         `yaml:"video,omitempty"`
-	Provision    []Provision   `yaml:"provision,omitempty"`
-	Containerd   Containerd    `yaml:"containerd,omitempty"`
-	Probes       []Probe       `yaml:"probes,omitempty"`
-	PortForwards []PortForward `yaml:"portForwards,omitempty"`
-	Network      Network       `yaml:"network,omitempty"`
+	Arch         Arch               `yaml:"arch,omitempty"`
+	Images       []File             `yaml:"images"` // REQUIRED
+	CPUs         int                `yaml:"cpus,omitempty"`
+	Memory       string             `yaml:"memory,omitempty"` // go-units.RAMInBytes
+	Disk         string             `yaml:"disk,omitempty"`   // go-units.RAMInBytes
+	Mounts       []Mount            `yaml:"mounts,omitempty"`
+	SSH          SSH                `yaml:"ssh,omitempty"` // REQUIRED (FIXME)
+	Firmware     Firmware           `yaml:"firmware,omitempty"`
+	Video        Video              `yaml:"video,omitempty"`
+	Provision    []Provision        `yaml:"provision,omitempty"`
+	Containerd   Containerd         `yaml:"containerd,omitempty"`
+	Probes       []Probe            `yaml:"probes,omitempty"`
+	PortForwards []PortForward      `yaml:"portForwards,omitempty"`
+	Network      Network            `yaml:"network,omitempty"`
+	Env          map[string]*string `yaml:"env,omitempty"`
 }
 
 type Arch = string


### PR DESCRIPTION
In many corporate environments proxy environment variables `HTTPS_PROXY,HTTP_PROXY,NO_PROXY` may need to be supplied to allow access to the internet. These changes would allow users too append any additional environment variables they may want at VM start. 