### PR TITLE
Pass DNS addresses from en0 interface to guest instance

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/network-config
+++ b/pkg/cidata/cidata.TEMPLATE.d/network-config
@@ -6,4 +6,11 @@ ethernets:
       macaddress: '{{$nw.MACAddress}}'
     dhcp4: true
     set-name: {{$nw.Name}}
+    {{- if and (eq $nw.Name $.SlirpNICName) (gt (len $.DNSAddresses) 0) }}
+    nameservers:
+      addresses:
+      {{- range $ns := $.DNSAddresses }}
+      - {{$ns}}
+      {{- end }}
+    {{- end }}
   {{- end }}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lima-vm/lima/pkg/iso9660util"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/localpathutil"
+	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/qemu/qemuconst"
 	"github.com/lima-vm/lima/pkg/sshutil"
 	"github.com/lima-vm/lima/pkg/store/filenames"
@@ -51,6 +52,7 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML) error {
 		User:         u.Username,
 		UID:          uid,
 		Containerd:   Containerd{System: *y.Containerd.System, User: *y.Containerd.User},
+		SlirpNICName: qemuconst.SlirpNICName,
 		SlirpGateway: qemuconst.SlirpGateway,
 		Env:          y.Env,
 	}
@@ -78,6 +80,11 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML) error {
 	args.Networks = append(args.Networks, Network{MACAddress: slirpMACAddress, Name: qemuconst.SlirpNICName})
 	for _, vde := range y.Network.VDE {
 		args.Networks = append(args.Networks, Network{MACAddress: vde.MACAddress, Name: vde.Name})
+	}
+
+	args.DNSAddresses, err = osutil.DNSAddresses()
+	if err != nil {
+		return err
 	}
 
 	if err := ValidateTemplateArgs(args); err != nil {

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -35,8 +35,10 @@ type TemplateArgs struct {
 	Mounts       []string // abs path, accessible by the User
 	Containerd   Containerd
 	Networks     []Network
+	SlirpNICName string
 	SlirpGateway string
 	Env          map[string]*string
+	DNSAddresses []string
 }
 
 func ValidateTemplateArgs(args TemplateArgs) error {

--- a/pkg/osutil/dns_darwin.go
+++ b/pkg/osutil/dns_darwin.go
@@ -1,0 +1,25 @@
+package osutil
+
+import "github.com/lima-vm/lima/pkg/sysprof"
+
+func DNSAddresses() ([]string, error) {
+	nwData, err := sysprof.NetworkData()
+	if err != nil {
+		return nil, err
+	}
+	var addresses []string
+	if len(nwData) > 0 {
+		// Return DNS addresses from en0 interface
+		for _, nw := range nwData {
+			if nw.Interface == "en0" {
+				addresses = nw.DNS.ServerAddresses
+				break
+			}
+		}
+		// In case "en0" is not found, use the addresses of the first interface
+		if len(addresses) == 0 {
+			addresses = nwData[0].DNS.ServerAddresses
+		}
+	}
+	return addresses, nil
+}

--- a/pkg/osutil/dns_others.go
+++ b/pkg/osutil/dns_others.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+// +build !darwin
+
+package osutil
+
+func DNSAddresses() ([]string, error) {
+	// TODO: parse /etc/resolv.conf?
+	return []string{}, nil
+}

--- a/pkg/osutil/osutil_others.go
+++ b/pkg/osutil/osutil_others.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package osutil

--- a/pkg/sysprof/network_darwin.go
+++ b/pkg/sysprof/network_darwin.go
@@ -1,0 +1,14 @@
+package sysprof
+
+type SPNetworkDataType struct {
+	SPNetworkDataType []NetworkDataType `json:"SPNetworkDataType"`
+}
+
+type NetworkDataType struct {
+	DNS       DNS    `json:"DNS"`
+	Interface string `json:"interface"`
+}
+
+type DNS struct {
+	ServerAddresses []string `json:"ServerAddresses"`
+}

--- a/pkg/sysprof/sysprof_darwin.go
+++ b/pkg/sysprof/sysprof_darwin.go
@@ -1,0 +1,37 @@
+package sysprof
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"sync"
+)
+
+var (
+	networkDataOnce   sync.Once
+	networkDataCached SPNetworkDataType
+	networkDataError  error
+)
+
+func NetworkData() ([]NetworkDataType, error) {
+	networkDataOnce.Do(func() {
+		jsonBytes, networkDataError := SystemProfiler("SPNetworkDataType")
+		if networkDataError == nil {
+			networkDataError = json.Unmarshal(jsonBytes, &networkDataCached)
+		}
+	})
+	return networkDataCached.SPNetworkDataType, networkDataError
+}
+
+func SystemProfiler(dataType string) ([]byte, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("system_profiler", dataType, "-json")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to run %v: stdout=%q, stderr=%q: %w",
+			cmd.Args, stdout.String(), stderr.String(), err)
+	}
+	return stdout.Bytes(), nil
+}


### PR DESCRIPTION
qemu user-mode networking is forwarding DNS to just a single DNS entry from the host. So if that entry does not resolve
the query, there is no fallback.

Fixes #150 (I hope)

Please review the code updating the DNS entries in the guest. The direct updates to `/etc/resolv.conf` are probably useless because the file will still be regenerated after cloud-init is done. I've included code to configure `systemd-resolved`, and `udhcpc` (used by Alpine). Any other mechanisms needing support?

The `sysprof` code is expected to be used to provide default proxy information as well (see https://github.com/lima-vm/lima/issues/189#issuecomment-911972759)