### PR TITLE
yaml: mark "Env" experimental for now

### DIFF
--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -165,7 +165,10 @@ network:
 #     hostPortRange: [1024, 65535]
 #   # Any port still not matched by a rule will not be forwarded (ignored)
 
-# # extra environment variables that will be loaded into the VM at start up
+# Extra environment variables that will be loaded into the VM at start up.
+# These variables are currently only consumed by internal init scripts, not by the user shell.
+# This field is experimental and may change in a future release of Lima.
+# https://github.com/lima-vm/lima/pull/200
 # env:
 #   KEY: value
 

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -21,7 +21,7 @@ type LimaYAML struct {
 	Probes       []Probe            `yaml:"probes,omitempty"`
 	PortForwards []PortForward      `yaml:"portForwards,omitempty"`
 	Network      Network            `yaml:"network,omitempty"`
-	Env          map[string]*string `yaml:"env,omitempty"`
+	Env          map[string]*string `yaml:"env,omitempty"` // EXPERIMENAL, see default.yaml
 }
 
 type Arch = string


### PR DESCRIPTION
The syntax and the behavior of this field is still under discussion (PR #200), so this field is treated as experimental in the next upcoming release (v0.6.3).

Probably we can move this out of experimental in v0.6.4.
