### PR TITLE
examples: add {docker,podman,singularity}.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Lima is expected to be used on macOS hosts, but can be used on Linux hosts as we
 
 ✅ Automatic port forwarding
 
-✅ Built-in support for [containerd](https://containerd.io)
+✅ Built-in support for [containerd](https://containerd.io) ([Other container engines can be used too](./examples))
 
 ✅ Intel on Intel
 
@@ -191,7 +191,7 @@ The current default spec:
   - ["What's my login password?"](#whats-my-login-password)
   - ["Does Lima work on ARM Mac?"](#does-lima-work-on-arm-mac)
   - ["Can I run non-Ubuntu guests?"](#can-i-run-non-ubuntu-guests)
-  - ["Can I run other container engines such as Podman?"](#can-i-run-other-container-engines-such-as-podman)
+  - ["Can I run other container engines such as Docker and Podman?"](#can-i-run-other-container-engines-such-as-docker-and-podman)
   - ["Can I run Lima with a remote Linux machine?"](#can-i-run-lima-with-a-remote-linux-machine)
   - ["Advantages compared to Docker for Mac?"](#advantages-compared-to-docker-for-mac)
 - [QEMU](#qemu)
@@ -231,10 +231,15 @@ An image has to satisfy the following requirements:
   - `newuidmap` and `newgidmap`
 - `apt-get`, `dnf`, `apk`, `pacman`, or `zypper` (if you want to contribute support for another package manager, run `git grep apt-get` to find out where to modify)
 
-#### "Can I run other container engines such as Podman?"
-Yes, if you install it.
+#### "Can I run other container engines such as Docker and Podman?"
+Yes, any container engine should work with Lima.
 
-containerd can be stopped with `systemctl --user disable --now containerd`.
+See examples:
+- [`./examples/docker.yaml`](./examples/docker.yaml)
+- [`./examples/podman.yaml`](./examples/podman.yaml)
+- [`./examples/singularity.yaml`](./examples/singularity.yaml)
+
+The default Ubuntu image also contains LXD. Run`lima sudo lxc init` to set up LXD.
 
 #### "Can I run Lima with a remote Linux machine?"
 Lima itself does not support connecting to a remote Linux machine, but [sshocker](https://github.com/lima-vm/sshocker),

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,26 @@
 # Lima examples
 
+Default: [`default.yaml`](../pkg/limayaml/default.yaml) (Ubuntu, with containerd/nerdctl)
+
+Distro:
+- [`alpine.yaml`](./alpine.yaml): Alpine Linux
+- [`archlinux.yaml`](./archlinux.yaml): Arch Linux
+- [`debian.yaml`](./debian.yaml): Debian GNU/Linux
+- [`fedora.yaml`](./fedora.yaml): Fedora
+- [`opensuse.yaml`](./opensuse.yaml): openSUSE Leap
+- [`ubuntu.yaml`](./ubuntu.yaml): Ubuntu (same as `default.yaml` but without bogus YAML lines)
+
+Container engines:
+- [`docker.yaml`](./docker.yaml): Docker
+- [`podman.yaml`](./podman.yaml): Podman
+- [`k3s.yaml`](./k3s.yaml): k3s
+- [`singularity.yaml`](./singularity.yaml): Singularity
+- LXD is installed in the default Ubuntu template, so there is no `lxd.yaml`
+
+Others:
+- [`vmnet.yaml`](./vmnet.yaml): enable [`vmnet.framework`](../docs/network.md)
+
+## Usage
 Run `limactl start fedora.yaml` to create a Lima instance named "fedora".
 
 To open a shell, run `limactl shell fedora bash` or `LIMA_INSTANCE=fedora lima bash`.

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -1,0 +1,65 @@
+# Example to use Docker instead of containerd & nerdctl
+# $ limactl start ./docker.yaml
+# $ limactl shell docker docker run -it -v $HOME:$HOME --rm alpine
+
+# Hint: To allow `docker` CLI on the host to connect to the Docker daemon running inside the guest,
+# add `NoHostAuthenticationForLocalhost yes` in ~/.ssh/config , and then run the following commands:
+# $ export DOCKER_HOST=ssh://localhost:60006
+# $ docker ...
+
+# If ssh:// ... does not work, try the following commands:
+# $ ssh -f -N -p 60006 -i ~/.lima/_config/user -o NoHostAuthenticationForLocalhost=yes -L $HOME/docker.sock:/run/user/$(id -u)/docker.sock 127.0.0.1
+# $ export DOCKER_HOST=unix://$HOME/docker.sock
+# $ docker ...
+
+images:
+  # Hint: run `limactl prune` to invalidate the "current" cache
+  - location: "https://cloud-images.ubuntu.com/hirsute/current/hirsute-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/hirsute/current/hirsute-server-cloudimg-arm64.img"
+    arch: "aarch64"
+mounts:
+  - location: "~"
+    writable: false
+  - location: "/tmp/lima"
+    writable: true
+ssh:
+  localPort: 60006
+  # Load ~/.ssh/*.pub in addition to $LIMA_HOME/_config/user.pub , for allowing DOCKER_HOST=ssh:// .
+  # This option is enabled by default.
+  # If you have an insecure key under ~/.ssh, do not use this option.
+  loadDotSSHPubKeys: true
+# containerd is managed by Docker, not by Lima, so the values are set to false here.
+containerd:
+  system: false
+  user: false
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      command -v docker >/dev/null 2>&1 && exit 0
+      export DEBIAN_FRONTEND=noninteractive
+      curl -fsSL https://get.docker.com | sh
+      # NOTE: you may remove the lines below, if you prefer to use rootful docker, not rootless
+      systemctl disable --now docker
+      apt-get install -y uidmap
+  - mode: user
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      dockerd-rootless-setuptool.sh install
+      docker context use rootless
+probes:
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until command -v docker >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "docker is not installed yet"
+        exit 1
+      fi
+      if ! timeout 30s bash -c "until pgrep rootlesskit; do sleep 3; done"; then
+        echo >&2 "rootlesskit (used by rootless docker) is not running"
+        exit 1
+      fi
+    hint: See "/var/log/cloud-init-output.log". in the guest

--- a/examples/podman.yaml
+++ b/examples/podman.yaml
@@ -1,0 +1,55 @@
+# Example to use Podman instead of containerd & nerdctl
+# $ limactl start ./podman.yaml
+# $ limactl shell podman podman run -it --rm -v $HOME:$HOME:ro docker.io/library/alpine
+
+# Hint: To allow `podman` CLI on the host to connect to the Podman daemon running inside the guest,
+# add `NoHostAuthenticationForLocalhost yes` in ~/.ssh/config , and then run the following commands:
+# $ export CONTAINER_HOST=ssh://$(id -un)@localhost:60906/run/user/$(id -u)/podman/podman.sock
+# $ export CONTAINER_SSHKEY=$HOME/.lima/_config/user
+# $ podman ...
+
+# Hint: To allow `docker` CLI on the host to connect to the Podman daemon running inside the guest, run the following commands:
+# $ ssh -f -N -p 60906 -i ~/.lima/_config/user -o NoHostAuthenticationForLocalhost=yes -L $HOME/podman.sock:/run/user/$(id -u)/podman/podman.sock 127.0.0.1
+# $ export DOCKER_HOST=unix://$HOME/podman.sock
+# $ docker ...
+
+images:
+  # Image is set to impish (21.10) ahead of its GA, to pick up the newer version of podman dpkg
+  # Hint: run `limactl prune` to invalidate the "current" cache
+  - location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-arm64.img"
+    arch: "aarch64"
+mounts:
+  - location: "~"
+    writable: false
+  - location: "/tmp/lima"
+    writable: true
+ssh:
+  localPort: 60906
+containerd:
+  system: false
+  user: false
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      command -v podman >/dev/null 2>&1 && exit 0
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      apt-get install -y podman
+  - mode: user
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      systemctl --user enable --now podman.socket
+probes:
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until command -v podman >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "podman is not installed yet"
+        exit 1
+      fi
+    hint: See "/var/log/cloud-init-output.log". in the guest

--- a/examples/singularity.yaml
+++ b/examples/singularity.yaml
@@ -1,0 +1,38 @@
+# Example to use Singularity instead of containerd & nerdctl
+# $ limactl start ./singularity.yaml
+# $ limactl shell singularity singularity run -u -B $HOME:$HOME docker://alpine
+
+# Fedora 34 provides Singularity 3.8.1 in the default dnf.
+# Ubuntu 21.04 does not seem to provide Singularity in the default apt.
+images:
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/Fedora-Cloud-Base-34-1.2.x86_64.qcow2"
+    arch: "x86_64"
+    digest: "sha256:b9b621b26725ba95442d9a56cbaa054784e0779a9522ec6eafff07c6e6f717ea"
+firmware:
+  legacyBIOS: true
+mounts:
+  - location: "~"
+    writable: false
+  - location: "/tmp/lima"
+    writable: true
+ssh:
+  localPort: 62045
+containerd:
+  system: false
+  user: false
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      command -v singularity >/dev/null 2>&1 && exit 0
+      dnf install -y singularity
+probes:
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until command -v singularity >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "singularity is not installed yet"
+        exit 1
+      fi
+    hint: See "/var/log/cloud-init-output.log". in the guest


### PR DESCRIPTION
Docker, Podman, Singularity, or whatever can be used instead of the default containerd/nerdctl .

LXD can be used too, of course, but there is no `lxd.yaml`, because LXD is included in the default Ubuntu image.

Example usage:
```
$ limactl start ./docker.yaml
$ limactl shell docker docker run -it --rm -v $HOME:$HOME alpine
```

```
$ limactl start ./podman.yaml
$ limactl shell podman podman run -it --rm -v $HOME:$HOME:ro docker.io/library/alpine
```

```
$ limactl start ./singularity.yaml
$ limactl shell singularity singularity run -u -B $HOME:$HOME docker://alpine
```

- - -

`docker` CLI on macOS can connect to `dockerd` inside the guest VM as well: `DOCKER_HOST=ssh://127.0.0.1:60006 docker run -it --rm -v $HOME:$HOME alpine` .

This requires `NoHostAuthenticationForLocalhost yes` in `~/.ssh/config`. (Alternatively you can just login to `ssh -p 60006 127.0.0.1` to initialize `~/.ssh/known_hosts`)

