### PR TITLE
Use "lima" username if the local user is not a valid Linux name

### DIFF
--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"os/user"
 	"strings"
 
+	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/sshutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/sirupsen/logrus"
@@ -31,7 +31,7 @@ func copyAction(clicontext *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	u, err := user.Current()
+	u, err := osutil.LimaUser(false)
 	if err != nil {
 		return err
 	}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -39,7 +38,7 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML) error {
 	if err := limayaml.Validate(*y); err != nil {
 		return err
 	}
-	u, err := user.Current()
+	u, err := osutil.LimaUser(true)
 	if err != nil {
 		return err
 	}

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/lima-vm/lima/pkg/localpathutil"
+	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/qemu/qemuconst"
 	"github.com/sirupsen/logrus"
 )
@@ -61,7 +61,7 @@ func Validate(y LimaYAML) error {
 		return fmt.Errorf("field `memory` has an invalid value: %w", err)
 	}
 
-	u, err := user.Current()
+	u, err := osutil.LimaUser(false)
 	if err != nil {
 		return fmt.Errorf("internal error (not an error of YAML): %w", err)
 	}

--- a/pkg/osutil/user.go
+++ b/pkg/osutil/user.go
@@ -1,0 +1,38 @@
+package osutil
+
+import (
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"os/user"
+	"sync"
+
+	"github.com/containerd/containerd/identifiers"
+)
+
+const (
+	fallbackUser = "lima"
+)
+
+var cache struct {
+	sync.Once
+	u       *user.User
+	err     error
+	warning string
+}
+
+func LimaUser(warn bool) (*user.User, error) {
+	cache.Do(func() {
+		cache.u, cache.err = user.Current()
+		if cache.err == nil {
+			if err := identifiers.Validate(cache.u.Username); err != nil {
+				cache.warning = fmt.Sprintf("local user %q is not a valid Linux username: %v; using %q username instead",
+					cache.u.Username, err, fallbackUser)
+			}
+			cache.u.Username = fallbackUser
+		}
+	})
+	if warn && cache.warning != "" {
+		logrus.Warn(cache.warning)
+	}
+	return cache.u, cache.err
+}

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -163,7 +162,7 @@ func SSHArgs(instDir string, useDotSSH bool) ([]string, error) {
 	if len(controlSock) >= osutil.UnixPathMax {
 		return nil, fmt.Errorf("socket path %q is too long: >= UNIX_PATH_MAX=%d", controlSock, osutil.UnixPathMax)
 	}
-	u, err := user.Current()
+	u, err := osutil.LimaUser(false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
At least some companies set local users via directory services and choose the email address as the user name. The '@' character is not valid in Linux usernames.

Fixes #191