### PR TITLE
Add manage_resolv_conf to cloud-init

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -30,3 +30,17 @@ write_files:
    owner: root:root
    path: /var/lib/cloud/scripts/per-boot/00-lima.boot.sh
    permissions: '0755'
+
+{{- if .DNSAddresses }}
+# This has no effect on systems using systemd-resolved, but is used
+# on e.g. Alpine to set up /etc/resolv.conf on first boot.
+
+manage_resolv_conf: true
+
+resolv_conf:
+  nameservers:
+  {{- range $ns := $.DNSAddresses }}
+  - {{$ns}}
+  {{- end }}
+  - {{.SlirpDNS}}
+{{- end }}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -53,6 +53,7 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML) error {
 		Containerd:   Containerd{System: *y.Containerd.System, User: *y.Containerd.User},
 		SlirpNICName: qemuconst.SlirpNICName,
 		SlirpGateway: qemuconst.SlirpGateway,
+		SlirpDNS:     qemuconst.SlirpDNS,
 		Env:          y.Env,
 	}
 

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -37,6 +37,7 @@ type TemplateArgs struct {
 	Networks     []Network
 	SlirpNICName string
 	SlirpGateway string
+	SlirpDNS     string
 	Env          map[string]*string
 	DNSAddresses []string
 }

--- a/pkg/qemu/qemuconst/qemuconst.go
+++ b/pkg/qemu/qemuconst/qemuconst.go
@@ -5,5 +5,6 @@ const (
 	// CIDR is intentionally hardcoded to 192.168.5.0/24, as each of QEMU has its own independent slirp network.
 	SlirpNetwork   = "192.168.5.0/24"
 	SlirpGateway   = "192.168.5.2"
+	SlirpDNS       = "192.168.5.3"
 	SlirpIPAddress = "192.168.5.15"
 )


### PR DESCRIPTION
This has no effect on instances managed by systemd, but is necessary on e.g. Alpine.
