### PR TITLE
Provide explicit DNS override

### DIFF
--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -81,9 +81,15 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML) error {
 		args.Networks = append(args.Networks, Network{MACAddress: vde.MACAddress, Name: vde.Name})
 	}
 
-	args.DNSAddresses, err = osutil.DNSAddresses()
-	if err != nil {
-		return err
+	if len(y.DNS) > 0 {
+		for _, addr := range y.DNS {
+			args.DNSAddresses = append(args.DNSAddresses, addr.String())
+		}
+	} else {
+		args.DNSAddresses, err = osutil.DNSAddresses()
+		if err != nil {
+			return err
+		}
 	}
 
 	if err := ValidateTemplateArgs(args); err != nil {

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -172,6 +172,15 @@ network:
 # env:
 #   KEY: value
 
+# Explicitly set DNS addresses for qemu user-mode networking. By default qemu picks *one*
+# nameserver from the host config and forwards all queries to this server. On macOS
+# Lima adds the nameservers configured for the "en0" interface to the list. In case this
+# still doesn't work (e.g. VPN setups), the servers can be specified here explicitly.
+# If nameservers are specified here, then the "en0" configuration will be ignored.
+# dns:
+# - 1.1.1.1
+# - 1.0.0.1
+
 # ===================================================================== #
 # END OF TEMPLATE
 # ===================================================================== #

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -22,6 +22,7 @@ type LimaYAML struct {
 	PortForwards []PortForward      `yaml:"portForwards,omitempty"`
 	Network      Network            `yaml:"network,omitempty"`
 	Env          map[string]*string `yaml:"env,omitempty"` // EXPERIMENAL, see default.yaml
+	DNS          []net.IP           `yaml:"dns,omitempty"`
 }
 
 type Arch = string


### PR DESCRIPTION
In some situations (e.g. VPN) the user may need to explicitly set the DNS addresses; even the fallback to the "en0" settings
does not work.

This cannot be done in a provisioning script because they run after the boot scripts, but working DNS is required to install
additional dependencies.
