### PR TITLE
Ignore public keys that are not in ssh format

### DIFF
--- a/examples/alpine.yaml
+++ b/examples/alpine.yaml
@@ -1,7 +1,7 @@
 images:
-- location: https://github.com/lima-vm/alpine-lima/releases/download/v0.1.1/alpine-lima-std-3.13.5-x86_64.iso
+- location: https://github.com/lima-vm/alpine-lima/releases/download/v0.1.3/alpine-lima-std-3.13.5-x86_64.iso
   arch: "x86_64"
-  digest: "sha512:97099e0a0b3814799e0646d5ed5f1af5a7be77d8b8a59a51f5f65e1d8b5ec6fdc06a6e27be1c8344cce3614c201359cddff522e7959353f137adf6a85af938af"
+  digest: "sha512:b2d2d2e4d9d15113b94e6f45ec46bb752fed639f062c52a87f065561e441fa2b271e53ce37e30add0a9ac287c0b65e66110c3fa79b2150b3da788559d139717a"
 
 mounts:
 - location: "~"

--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -14,7 +14,7 @@ users:
     lock_passwd: true
     ssh-authorized-keys:
     {{- range $val := .SSHPubKeys}}
-      - {{$val}}
+      - "{{$val}}"
     {{- end}}
 
 write_files:

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -90,7 +90,11 @@ func DefaultPubKeys(loadDotSSH bool) ([]PubKey, error) {
 		}
 		entry, err := readPublicKey(f)
 		if err == nil {
-			res = append(res, entry)
+			if strings.ContainsRune(entry.Content, '\n') || !strings.HasPrefix(entry.Content, "ssh-") {
+				logrus.Warnf("public key %q doesn't seem to be in ssh format", entry.Filename)
+			} else {
+				res = append(res, entry)
+			}
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return nil, err
 		}


### PR DESCRIPTION
It seems that some ~/.ssh/*.pub files are public SSL keys, so add some minimal validation before using them as authorized_keys.

Ref https://github.com/lima-vm/lima/issues/104#issuecomment-914030614