### PR TITLE
qemu: use `-cpu host` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,7 @@ See [`./pkg/limayaml/default.yaml`](./pkg/limayaml/default.yaml).
 
 The current default spec:
 - OS: Ubuntu 21.04 (Hirsute Hippo)
-- CPU (x86\_64): Haswell v4, 4 cores
-- CPU (aarch64): Cortex A72, 4 cores
+- CPU: 4 cores
 - Memory: 4 GiB
 - Disk: 100 GiB
 - Mounts: `~` (read-only), `/tmp/lima` (writable)


### PR DESCRIPTION
`-cpu host` seemed to cause kernel panic with QEMU 5.2 on Intel Mac, but seems to work well with QEMU 6.1 now

The behavior can be rolled back by specifying an env var like `QEMU_SYSTEM_X86_64=qemu-system-x86_64 -cpu Haswell-v4` or `QEMU_SYSTEM_AARCH64=qemu-system-aarch64 -cpu cortex-a72` .
