### PR TITLE
Fix user provisioning scripts for Alpine

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.sh
@@ -42,7 +42,9 @@ fi
 
 USER_SCRIPT="/home/${LIMA_CIDATA_USER}.linux/.lime-user-script"
 if [ -d "${LIMA_CIDATA_MNT}"/provision.user ]; then
-	until [ -e "/run/user/${LIMA_CIDATA_UID}/systemd/private" ]; do sleep 3; done
+	if [ ! -f /etc/alpine-release ]; then
+		until [ -e "/run/user/${LIMA_CIDATA_UID}/systemd/private" ]; do sleep 3; done
+	fi
 	for f in "${LIMA_CIDATA_MNT}"/provision.user/*; do
 		INFO "Executing $f (as user ${LIMA_CIDATA_USER})"
 		cp "$f" "${USER_SCRIPT}"


### PR DESCRIPTION
I thought I had tested them before, but they don't work right now, and I can't see how they would have worked before with this check in place, so 🤷 .

Not really happy with the explicit check for Alpine, but it matches the condition we have in `25-guestagent-base.sh`.