### PR TITLE
Implement vde_vmnet management

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,6 +134,9 @@ jobs:
             make PREFIX=/opt/vde
             sudo make PREFIX=/opt/vde install
           )
+          (
+            limactl sudoers | sudo tee /etc/sudoers.d/lima
+          )
       - name: Prepare ssh
         run: |
           if [ -e ~/.ssh/id_rsa ]; then

--- a/cmd/limactl/delete.go
+++ b/cmd/limactl/delete.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/lima-vm/lima/pkg/networks"
+	"github.com/lima-vm/lima/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cmd/limactl/delete.go
+++ b/cmd/limactl/delete.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -42,7 +43,7 @@ func deleteAction(cmd *cobra.Command, args []string) error {
 		}
 		logrus.Infof("Deleted %q (%q)", instName, inst.Dir)
 	}
-	return nil
+	return networks.Reconcile(cmd.Context(), "")
 }
 
 func deleteInstance(inst *store.Instance, force bool) error {

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/version"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -38,6 +39,11 @@ func newApp() *cobra.Command {
 		if os.Geteuid() == 0 {
 			return errors.New("must not run as the root")
 		}
+		// Make sure either $HOME or $LIMA_HOME is defined, so we don't need
+		// to check for errors later
+		if _, err := store.LimaDir(); err != nil {
+			return err
+		}
 		return nil
 	}
 	rootCmd.AddCommand(
@@ -48,6 +54,7 @@ func newApp() *cobra.Command {
 		newListCommand(),
 		newDeleteCommand(),
 		newValidateCommand(),
+		newSudoersCommand(),
 		newPruneCommand(),
 		newHostagentCommand(),
 	)

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/lima-vm/lima/pkg/store"
+	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/version"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -41,7 +41,7 @@ func newApp() *cobra.Command {
 		}
 		// Make sure either $HOME or $LIMA_HOME is defined, so we don't need
 		// to check for errors later
-		if _, err := store.LimaDir(); err != nil {
+		if _, err := dirnames.LimaDir(); err != nil {
 			return err
 		}
 		return nil

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -12,7 +12,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/containerd/containerd/identifiers"
 	"github.com/lima-vm/lima/pkg/limayaml"
-	"github.com/lima-vm/lima/pkg/networks"
+	"github.com/lima-vm/lima/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/start"
 	"github.com/lima-vm/lima/pkg/store"
@@ -216,6 +216,9 @@ func startAction(cmd *cobra.Command, args []string) error {
 	inst, err := loadOrCreateInstance(cmd, args)
 	if err != nil {
 		return err
+	}
+	if len(inst.Errors) > 0 {
+		return fmt.Errorf("errors inspecting instance: %+v", inst.Errors)
 	}
 	switch inst.Status {
 	case store.StatusRunning:

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -120,7 +120,7 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string) (*store.Instance, e
 	if err != nil {
 		return nil, err
 	}
-	if err := limayaml.Validate(*y); err != nil {
+	if err := limayaml.Validate(*y, true); err != nil {
 		if !tty {
 			return nil, err
 		}

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/containerd/containerd/identifiers"
 	"github.com/lima-vm/lima/pkg/limayaml"
+	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/start"
 	"github.com/lima-vm/lima/pkg/store"
@@ -228,6 +229,10 @@ func startAction(cmd *cobra.Command, args []string) error {
 		logrus.Warnf("expected status %q, got %q", store.StatusStopped, inst.Status)
 	}
 	ctx := cmd.Context()
+	err = networks.Reconcile(ctx, inst.Name)
+	if err != nil {
+		return err
+	}
 	return start.Start(ctx, inst)
 }
 

--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	hostagentapi "github.com/lima-vm/lima/pkg/hostagent/api"
+	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/sirupsen/logrus"
@@ -47,10 +48,14 @@ func stopAction(cmd *cobra.Command, args []string) error {
 	}
 	if force {
 		stopInstanceForcibly(inst)
-		return nil
+	} else {
+		err = stopInstanceGracefully(inst)
 	}
-
-	return stopInstanceGracefully(inst)
+	// TODO: should we also reconcile networks if graceful stop returned an error?
+	if err == nil {
+		err = networks.Reconcile(cmd.Context(), "")
+	}
+	return err
 }
 
 func stopInstanceGracefully(inst *store.Instance) error {

--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	hostagentapi "github.com/lima-vm/lima/pkg/hostagent/api"
-	"github.com/lima-vm/lima/pkg/networks"
+	"github.com/lima-vm/lima/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/sirupsen/logrus"

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -16,8 +16,9 @@ func newSudoersCommand() *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE:  sudoersAction,
 	}
+	configFile, _ := networks.ConfigFile()
 	sudoersCommand.Flags().Bool("check", false,
-		"check that the sudoers file is up-to-date with $LIMA_HOME/_config/networks.yaml")
+		fmt.Sprintf("check that the sudoers file is up-to-date with %q", configFile))
 	return sudoersCommand
 }
 
@@ -30,39 +31,44 @@ func sudoersAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if check {
-		var file string
-		switch len(args) {
-		case 0:
-			config, err := networks.Config()
-			if err != nil {
-				return err
-			}
-			file = config.Paths.Sudoers
-			if file == "" {
-				return errors.New("no sudoers file defined in ~/.lima/_config/networks.yaml")
-			}
-		case 1:
-			file = args[0]
-		default:
-			return errors.New("can check only a single sudoers file")
-		}
-		config, err := networks.Config()
-		if err != nil {
-			return err
-		}
-		if err := config.Validate(); err != nil {
-			return err
-		}
-		if err := config.VerifySudoAccess(file); err != nil {
-			return err
-		}
-		fmt.Printf("%q is up-to-date (or sudo doesn't require a password)\n", file)
-		return nil
+		return verifySudoAccess(args)
 	}
 	sudoers, err := networks.Sudoers()
 	if err != nil {
 		return err
 	}
 	fmt.Print(sudoers)
+	return nil
+}
+
+func verifySudoAccess(args []string) error {
+	var file string
+	switch len(args) {
+	case 0:
+		config, err := networks.Config()
+		if err != nil {
+			return err
+		}
+		file = config.Paths.Sudoers
+		if file == "" {
+			configFile, _ := networks.ConfigFile()
+			return fmt.Errorf("no sudoers file defined in %q", configFile)
+		}
+	case 1:
+		file = args[0]
+	default:
+		return errors.New("can check only a single sudoers file")
+	}
+	config, err := networks.Config()
+	if err != nil {
+		return err
+	}
+	if err := config.Validate(); err != nil {
+		return err
+	}
+	if err := config.VerifySudoAccess(file); err != nil {
+		return err
+	}
+	fmt.Printf("%q is up-to-date (or sudo doesn't require a password)\n", file)
 	return nil
 }

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -3,16 +3,18 @@ package main
 import (
 	"errors"
 	"fmt"
+	"runtime"
+
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/spf13/cobra"
 )
 
 func newSudoersCommand() *cobra.Command {
 	sudoersCommand := &cobra.Command{
-		Use:               "sudoers [SUDOERSFILE]",
-		Short:             "Generate /etc/sudoers.d/lima file.",
-		Args:              cobra.MaximumNArgs(1),
-		RunE:              sudoersAction,
+		Use:   "sudoers [SUDOERSFILE]",
+		Short: "Generate /etc/sudoers.d/lima file.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  sudoersAction,
 	}
 	sudoersCommand.Flags().Bool("check", false,
 		"check that the sudoers file is up-to-date with $LIMA_HOME/_config/networks.yaml")
@@ -20,11 +22,14 @@ func newSudoersCommand() *cobra.Command {
 }
 
 func sudoersAction(cmd *cobra.Command, args []string) error {
+	if runtime.GOOS != "darwin" {
+		return errors.New("sudoers command is only supported on macOS right now")
+	}
 	check, err := cmd.Flags().GetBool("check")
 	if err != nil {
 		return err
 	}
-	if check	{
+	if check {
 		var file string
 		switch len(args) {
 		case 0:

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/lima-vm/lima/pkg/networks"
+	"github.com/spf13/cobra"
+)
+
+func newSudoersCommand() *cobra.Command {
+	sudoersCommand := &cobra.Command{
+		Use:               "sudoers [SUDOERSFILE]",
+		Short:             "Generate /etc/sudoers.d/lima file.",
+		Args:              cobra.MaximumNArgs(1),
+		RunE:              sudoersAction,
+	}
+	sudoersCommand.Flags().Bool("check", false,
+		"check that the sudoers file is up-to-date with $LIMA_HOME/_config/networks.yaml")
+	return sudoersCommand
+}
+
+func sudoersAction(cmd *cobra.Command, args []string) error {
+	check, err := cmd.Flags().GetBool("check")
+	if err != nil {
+		return err
+	}
+	if check	{
+		var file string
+		switch len(args) {
+		case 0:
+			config, err := networks.Config()
+			if err != nil {
+				return err
+			}
+			file = config.Paths.Sudoers
+			if file == "" {
+				return errors.New("no sudoers file defined in ~/.lima/_config/networks.yaml")
+			}
+		case 1:
+			file = args[0]
+		default:
+			return errors.New("can check only a single sudoers file")
+		}
+		if err := networks.CheckSudoers(file); err != nil {
+			return err
+		}
+		fmt.Printf("%q is up-to-date\n", file)
+		return nil
+	}
+	sudoers, err := networks.Sudoers()
+	if err != nil {
+		return err
+	}
+	fmt.Print(sudoers)
+	return nil
+}

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -46,10 +46,17 @@ func sudoersAction(cmd *cobra.Command, args []string) error {
 		default:
 			return errors.New("can check only a single sudoers file")
 		}
-		if err := networks.CheckSudoers(file); err != nil {
+		config, err := networks.Config()
+		if err != nil {
 			return err
 		}
-		fmt.Printf("%q is up-to-date\n", file)
+		if err := config.Validate(); err != nil {
+			return err
+		}
+		if err := config.VerifySudoAccess(file); err != nil {
+			return err
+		}
+		fmt.Printf("%q is up-to-date (or sudo doesn't require a password)\n", file)
 		return nil
 	}
 	sudoers, err := networks.Sudoers()

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -42,13 +42,16 @@ func sudoersAction(cmd *cobra.Command, args []string) error {
 }
 
 func verifySudoAccess(args []string) error {
+	config, err := networks.Config()
+	if err != nil {
+		return err
+	}
+	if err := config.Validate(); err != nil {
+		return err
+	}
 	var file string
 	switch len(args) {
 	case 0:
-		config, err := networks.Config()
-		if err != nil {
-			return err
-		}
 		file = config.Paths.Sudoers
 		if file == "" {
 			configFile, _ := networks.ConfigFile()
@@ -58,13 +61,6 @@ func verifySudoAccess(args []string) error {
 		file = args[0]
 	default:
 		return errors.New("can check only a single sudoers file")
-	}
-	config, err := networks.Config()
-	if err != nil {
-		return err
-	}
-	if err := config.Validate(); err != nil {
-		return err
 	}
 	if err := config.VerifySudoAccess(file); err != nil {
 		return err

--- a/docs/network.md
+++ b/docs/network.md
@@ -28,21 +28,89 @@ the host and other guests.
 To enable `vde_vmnet` (in addition the user-mode network), add the following lines to the YAML after installing `vde_vmnet`.
 
 ```yaml
-network:
-  # The instance can get routable IP addresses from the vmnet framework using
-  # https://github.com/lima-vm/vde_vmnet. Both vde_switch and vde_vmnet
-  # daemons must be running before the instance is started. The interface type
-  # (host, shared, or bridged) is configured in vde_vmnet and not lima.
-  vde:
-    # vnl (virtual network locator) points to the vde_switch socket directory,
-    # optionally with vde:// prefix
-    - vnl: "vde:///var/run/vde.ctl"
-      # MAC address of the instance; lima will pick one based on the instance name,
-      # so DHCP assigned ip addresses should remain constant over instance restarts.
-      macAddress: ""
-      # Interface name, defaults to "vde0", "vde1", etc.
-      name: ""
+networks:
+  # vnl (virtual network locator) points to the vde_switch socket directory,
+  # optionally with vde:// prefix
+  # - vnl: "vde:///var/run/vde.ctl"
+  #   # VDE Switch port number (not TCP/UDP port number). Set to 65535 for PTP mode.
+  #   # Default: 0
+  #   switchPort: 0
+  #   # MAC address of the instance; lima will pick one based on the instance name,
+  #   # so DHCP assigned ip addresses should remain constant over instance restarts.
+  #   macAddress: ""
+  #   # Interface name, defaults to "lima0", "lima1", etc.
+  #   interface: ""
 ```
 
 The IP address range is typically `192.168.105.0/24`, but depends on the configuration of `vde_vmnet`.
 See [the documentation of `vde_vmnet`](https://github.com/lima-vm/vde_vmnet) for further information.
+
+## Managed VMNet networks (via vde_vmnet)
+
+Starting with version v0.7.0 lima can manage the networking daemons automatically. Networks are defined in
+`$LIMA_HOME/_config/networks.yaml`. If this file doesn't already exist, it will be created with these default
+settings:
+
+```yaml
+# Paths to vde executables. Because vde_vmnet is invoked via sudo it should be
+# installed where only root can modify/replace it. This means also none of the
+# parent directories should be writable by the user.
+#
+# The varRun directory also must not be writable by the user because it will
+# include the vde_vmnet pid files. Those will be terminated via sudo, so replacing
+# the pid files would allow killing of arbitrary privileged processes. varRun
+# however MUST be writable by the daemon user.
+#
+# None of the paths segments may be symlinks, why it has to be /private/var
+# instead of /var etc.
+paths:
+  vdeSwitch: /opt/vde/bin/vde_switch
+  vdeVMNet: /opt/vde/bin/vde_vmnet
+  varRun: /private/var/run/lima
+  sudoers: /private/etc/sudoers.d/lima
+
+group: staff
+
+networks:
+  shared:
+    mode: shared
+    gateway: 192.168.105.1
+    dhcpEnd: 192.168.105.254
+    netmask: 255.255.255.0
+  bridged:
+    mode: bridged
+    interface: en0
+    # bridged mode doesn't have a gateway; dhcp is managed by outside network
+  host:
+    mode: host
+    gateway: 192.168.106.1
+    dhcpEnd: 192.168.106.254
+    netmask: 255.255.255.0
+```
+
+Instances can then reference these networks from their `lima.yaml` file:
+
+```yaml
+networks:
+  # Lima can manage daemons for networks defined in $LIMA_HOME/_config/networks.yaml
+  # automatically. Both vde_switch and vde_vmnet binaries must be installed into
+  # secure locations only alterable by the "root" user.
+  # - lima: shared
+  #   # MAC address of the instance; lima will pick one based on the instance name,
+  #   # so DHCP assigned ip addresses should remain constant over instance restarts.
+  #   macAddress: ""
+  #   # Interface name, defaults to "lima0", "lima1", etc.
+  #   interface: ""
+```
+
+The network daemons are started automatically when the first instance referencing them is started,
+and will stop automatically once the last instance has stopped. Daemon logs will be stored in the
+`$LIMA_HOME/_networks` directory.
+
+Since the commands to start and stop the `vde_vmnet` daemon requires root, the user either must
+have password-less `sudo` enabled, or add the required commands to a `sudoers` file. This can
+be done via:
+
+```shell
+limactl sudoers | sudo tee /etc/sudoers.d/lima
+```

--- a/examples/vmnet.yaml
+++ b/examples/vmnet.yaml
@@ -14,10 +14,9 @@ ssh:
   # (TODO: assign localPort automatically)
   localPort: 60105
 
-network:
+networks:
   # The instance can get routable IP addresses from the vmnet framework using
-  # https://github.com/lima-vm/vde_vmnet. Both vde_switch and vde_vmnet
-  # daemons must be running before the instance is started. The interface type
-  # (host, shared, or bridged) is configured in vde_vmnet and not lima.
-  vde:
-    - vnl: "vde:///var/run/vde.ctl"
+  # https://github.com/lima-vm/vde_vmnet. Available networks are defined in
+  # $LIMA_HOME/_config/networks.yaml. Supported network types are "host",
+  # "shared", or "bridged".
+- lima: shared

--- a/pkg/cidata/cidata.TEMPLATE.d/network-config
+++ b/pkg/cidata/cidata.TEMPLATE.d/network-config
@@ -1,12 +1,12 @@
 version: 2
 ethernets:
   {{- range $nw := .Networks}}
-  {{$nw.Name}}:
+  {{$nw.Interface}}:
     match:
       macaddress: '{{$nw.MACAddress}}'
     dhcp4: true
-    set-name: {{$nw.Name}}
-    {{- if and (eq $nw.Name $.SlirpNICName) (gt (len $.DNSAddresses) 0) }}
+    set-name: {{$nw.Interface}}
+    {{- if and (eq $nw.Interface $.SlirpNICName) (gt (len $.DNSAddresses) 0) }}
     nameservers:
       addresses:
       {{- range $ns := $.DNSAddresses }}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -35,7 +35,7 @@ var (
 )
 
 func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML) error {
-	if err := limayaml.Validate(*y); err != nil {
+	if err := limayaml.Validate(*y, false); err != nil {
 		return err
 	}
 	u, err := osutil.LimaUser(true)

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -77,9 +77,9 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML) error {
 	}
 
 	slirpMACAddress := limayaml.MACAddress(instDir)
-	args.Networks = append(args.Networks, Network{MACAddress: slirpMACAddress, Name: qemuconst.SlirpNICName})
-	for _, vde := range y.Network.VDE {
-		args.Networks = append(args.Networks, Network{MACAddress: vde.MACAddress, Name: vde.Name})
+	args.Networks = append(args.Networks, Network{MACAddress: slirpMACAddress, Interface: qemuconst.SlirpNICName})
+	for _, nw := range y.Networks {
+		args.Networks = append(args.Networks, Network{MACAddress: nw.MACAddress, Interface: nw.Interface})
 	}
 
 	if len(y.DNS) > 0 {

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -16,7 +16,7 @@ import (
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/localpathutil"
 	"github.com/lima-vm/lima/pkg/osutil"
-	"github.com/lima-vm/lima/pkg/qemu/qemuconst"
+	"github.com/lima-vm/lima/pkg/qemu/const"
 	"github.com/lima-vm/lima/pkg/sshutil"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/opencontainers/go-digest"
@@ -51,9 +51,9 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML) error {
 		User:         u.Username,
 		UID:          uid,
 		Containerd:   Containerd{System: *y.Containerd.System, User: *y.Containerd.User},
-		SlirpNICName: qemuconst.SlirpNICName,
-		SlirpGateway: qemuconst.SlirpGateway,
-		SlirpDNS:     qemuconst.SlirpDNS,
+		SlirpNICName: qemu.SlirpNICName,
+		SlirpGateway: qemu.SlirpGateway,
+		SlirpDNS:     qemu.SlirpDNS,
 		Env:          y.Env,
 	}
 
@@ -77,7 +77,7 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML) error {
 	}
 
 	slirpMACAddress := limayaml.MACAddress(instDir)
-	args.Networks = append(args.Networks, Network{MACAddress: slirpMACAddress, Interface: qemuconst.SlirpNICName})
+	args.Networks = append(args.Networks, Network{MACAddress: slirpMACAddress, Interface: qemu.SlirpNICName})
 	for _, nw := range y.Networks {
 		args.Networks = append(args.Networks, Network{MACAddress: nw.MACAddress, Interface: nw.Interface})
 	}

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -25,7 +25,7 @@ type Containerd struct {
 }
 type Network struct {
 	MACAddress string
-	Name       string
+	Interface  string
 }
 type TemplateArgs struct {
 	Name         string // instance name

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -121,23 +121,34 @@ video:
   # Default: "none"
   display: "none"
 
-network:
-  # The instance can get routable IP addresses from the vmnet framework using
-  # https://github.com/lima-vm/vde_vmnet. Both vde_switch and vde_vmnet
-  # daemons must be running before the instance is started. The interface type
-  # (host, shared, or bridged) is configured in vde_vmnet and not lima.
-  vde:
-    # vnl (virtual network locator) points to the vde_switch socket directory,
-    # optionally with vde:// prefix
-    # - vnl: "vde:///var/run/vde.ctl"
-    #   # VDE Switch port number (not TCP/UDP port number). Set to 65535 for PTP mode.
-    #   # Default: 0
-    #   switchPort: 0
-    #   # MAC address of the instance; lima will pick one based on the instance name,
-    #   # so DHCP assigned ip addresses should remain constant over instance restarts.
-    #   macAddress: ""
-    #   # Interface name, defaults to "vde0", "vde1", etc.
-    #   name: ""
+# The instance can get routable IP addresses from the vmnet framework using
+# https://github.com/lima-vm/vde_vmnet.
+networks:
+  # Lima can manage daemons for networks defined in $LIMA_HOME/_config/networks.yaml
+  # automatically. Both vde_switch and vde_vmnet binaries must be installed into
+  # secure locations only alterable by the "root" user.
+  # - lima: shared
+  #   # MAC address of the instance; lima will pick one based on the instance name,
+  #   # so DHCP assigned ip addresses should remain constant over instance restarts.
+  #   macAddress: ""
+  #   # Interface name, defaults to "lima0", "lima1", etc.
+  #   interface: ""
+  #
+  # Lima can also connect to "unmanaged" vde networks addressed by "vnl". This
+  # means that the daemons will not be controlled by Lima, but must be started
+  # before the instance.  The interface type (host, shared, or bridged) is
+  # configured in vde_vmnet and not in lima.
+  # vnl (virtual network locator) points to the vde_switch socket directory,
+  # optionally with vde:// prefix
+  # - vnl: "vde:///var/run/vde.ctl"
+  #   # VDE Switch port number (not TCP/UDP port number). Set to 65535 for PTP mode.
+  #   # Default: 0
+  #   switchPort: 0
+  #   # MAC address of the instance; lima will pick one based on the instance name,
+  #   # so DHCP assigned ip addresses should remain constant over instance restarts.
+  #   macAddress: ""
+  #   # Interface name, defaults to "lima0", "lima1", etc.
+  #   interface: ""
 
 # Port forwarding rules. Forwarding between ports 22 and ssh.localPort cannot be overridden.
 # Rules are checked sequentially until the first one matches.

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -72,14 +72,27 @@ func FillDefault(y *LimaYAML, filePath string) {
 		FillPortForwardDefaults(&y.PortForwards[i])
 		// After defaults processing the singular HostPort and GuestPort values should not be used again.
 	}
-	for i := range y.Network.VDE {
-		vde := &y.Network.VDE[i]
-		if vde.MACAddress == "" {
-			// every interface in every limayaml file must get its own unique MAC address
-			vde.MACAddress = MACAddress(fmt.Sprintf("%s#%d", filePath, i))
+
+	if len(y.Network.VDEDeprecated) > 0 && len(y.Networks) == 0 {
+		for _, vde := range y.Network.VDEDeprecated {
+			network := Network{
+				Interface: vde.Name,
+				MACAddress: vde.MACAddress,
+				SwitchPort: vde.SwitchPort,
+				VNL: vde.VNL,
+			}
+			y.Networks = append(y.Networks, network)
 		}
-		if vde.Name == "" {
-			vde.Name = "vde" + strconv.Itoa(i)
+		y.Network.migrated = true
+	}
+	for i := range y.Networks {
+		nw := &y.Networks[i]
+		if nw.MACAddress == "" {
+			// every interface in every limayaml file must get its own unique MAC address
+			nw.MACAddress = MACAddress(fmt.Sprintf("%s#%d", filePath, i))
+		}
+		if nw.Interface == "" {
+			nw.Interface = "lima" + strconv.Itoa(i)
 		}
 	}
 }

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -20,8 +20,9 @@ type LimaYAML struct {
 	Containerd   Containerd         `yaml:"containerd,omitempty"`
 	Probes       []Probe            `yaml:"probes,omitempty"`
 	PortForwards []PortForward      `yaml:"portForwards,omitempty"`
-	Network      Network            `yaml:"network,omitempty"`
-	Env          map[string]*string `yaml:"env,omitempty"` // EXPERIMENAL, see default.yaml
+	Networks     []Network          `yaml:"networks,omitempty"`
+	Network      NetworkDeprecated  `yaml:"network,omitempty"` // DEPRECATED, use `networks` instead
+	Env          map[string]*string `yaml:"env,omitempty"`     // EXPERIMENAL, see default.yaml
 	DNS          []net.IP           `yaml:"dns,omitempty"`
 }
 
@@ -110,11 +111,28 @@ type PortForward struct {
 }
 
 type Network struct {
-	VDE []VDE `yaml:"vde,omitempty"`
-}
-type VDE struct {
+	// `Lima` and `VNL` are mutually exclusive; exactly one is required
+	Lima string `yaml:"lima,omitempty"`
 	// VNL is a Virtual Network Locator (https://github.com/rd235/vdeplug4/commit/089984200f447abb0e825eb45548b781ba1ebccd).
 	// On macOS, only VDE2-compatible form (optionally with vde:// prefix) is supported.
+	VNL        string `yaml:"vnl,omitempty"`
+	SwitchPort uint16 `yaml:"switchPort,omitempty"` // VDE Switch port, not TCP/UDP port (only used by VDE networking)
+	MACAddress string `yaml:"macAddress,omitempty"`
+	Interface  string `yaml:"interface,omitempty"`
+}
+
+// DEPRECATED types below
+
+// Types have been renamed to turn all references to the old names into compiler errors,
+// and to avoid accidental usage in new code.
+
+type NetworkDeprecated struct {
+	VDEDeprecated []VDEDeprecated `yaml:"vde,omitempty"`
+	// migrate will be true when `network.VDE` has been copied to `networks` by FillDefaults()
+	migrated bool
+}
+
+type VDEDeprecated struct {
 	VNL        string `yaml:"vnl,omitempty"`
 	SwitchPort uint16 `yaml:"switchPort,omitempty"` // VDE Switch port, not TCP/UDP port
 	MACAddress string `yaml:"macAddress,omitempty"`

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -2,6 +2,7 @@ package limayaml
 
 import (
 	"fmt"
+	"github.com/lima-vm/lima/pkg/networks"
 	"net"
 	"os"
 	"path/filepath"
@@ -188,7 +189,13 @@ func validateNetwork(y LimaYAML) error {
 			if nw.SwitchPort != 0 {
 				return fmt.Errorf("field `%s.switchPort` cannot be used with field `%s.lima`", field, field)
 			}
-			// TODO: validate network name (we can't use networks and store packages right now)
+			config, err := networks.Config()
+			if err != nil {
+				return err
+			}
+			if config.Check(nw.Lima) != nil {
+				return fmt.Errorf("field `%s.lima` references network %q which is not defined in networks.yaml", field, nw.Lima)
+			}
 		} else {
 			if nw.VNL == "" {
 				return fmt.Errorf("field `%s.lima` or field `%s.vnl` must be set", field, field)

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -177,7 +177,14 @@ func validateNetwork(yNetwork Network) error {
 		// The field is called VDE.VNL in anticipation of QEMU upgrading VDE2 to VDEplug4,
 		// but right now the only valid value on macOS is a path to the vde_switch socket directory,
 		// optionally with vde:// prefix.
-		if !strings.Contains(vde.VNL, "://") || strings.HasPrefix(vde.VNL, "vde://") {
+		// TODO: use networks.LimaSchema after solving circular dependency
+		if strings.HasPrefix(vde.VNL, "lima://") {
+			// TODO: validate network names? Problem is we can't use "networks" or "store" packages here...
+			//name := strings.TrimPrefix(vde.VNL, networks.LimaScheme)
+			//if _, ok := networkConfig.Networks[name]; !ok {
+			//	return fmt.Errorf("field `%s.vnl` references undefined network %q", field, name)
+			//}
+		} else if !strings.Contains(vde.VNL, "://") || strings.HasPrefix(vde.VNL, "vde://") {
 			vdeSwitch := strings.TrimPrefix(vde.VNL, "vde://")
 			if fi, err := os.Stat(vdeSwitch); err != nil {
 				// negligible when the instance is stopped

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -13,7 +13,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/lima-vm/lima/pkg/localpathutil"
 	"github.com/lima-vm/lima/pkg/osutil"
-	"github.com/lima-vm/lima/pkg/qemu/qemuconst"
+	"github.com/lima-vm/lima/pkg/qemu/const"
 	"github.com/sirupsen/logrus"
 )
 
@@ -246,8 +246,8 @@ func validateNetwork(y LimaYAML) error {
 		if strings.ContainsAny(nw.Interface, " \t\n/") {
 			return fmt.Errorf("field `%s.interface` must not contain whitespace or slashes", field)
 		}
-		if nw.Interface == qemuconst.SlirpNICName {
-			return fmt.Errorf("field `%s.interface` must not be set to %q because it is reserved for slirp", field, qemuconst.SlirpNICName)
+		if nw.Interface == qemu.SlirpNICName {
+			return fmt.Errorf("field `%s.interface` must not be set to %q because it is reserved for slirp", field, qemu.SlirpNICName)
 		}
 		if prev, ok := interfaceName[nw.Interface]; ok {
 			return fmt.Errorf("field `%s.interface` value %q has already been used by field `network.vde[%d].name`", field, nw.Interface, prev)

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -2,7 +2,6 @@ package limayaml
 
 import (
 	"fmt"
-	"github.com/lima-vm/lima/pkg/networks"
 	"net"
 	"os"
 	"path/filepath"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/lima-vm/lima/pkg/localpathutil"
+	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/qemu/const"
 	"github.com/sirupsen/logrus"

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -179,6 +179,9 @@ func validateNetwork(y LimaYAML) error {
 	for i, nw := range y.Networks {
 		field := fmt.Sprintf("networks[%d]", i)
 		if nw.Lima != "" {
+			if runtime.GOOS != "darwin" {
+				return fmt.Errorf("field `%s.lima` is only supported on macOS right now", field)
+			}
 			if nw.VNL != "" {
 				return fmt.Errorf("field `%s.lima` and field `%s.vnl` are mutually exclusive", field, field)
 			}

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -160,86 +160,96 @@ func Validate(y LimaYAML) error {
 		// processed sequentially and the first matching rule for a guest port determines forwarding behavior.
 	}
 
-	if err := validateNetwork(y.Network); err != nil {
+	if err := validateNetwork(y); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func validateNetwork(yNetwork Network) error {
-	networkName := make(map[string]int)
-	for i, vde := range yNetwork.VDE {
-		field := fmt.Sprintf("network.vde[%d]", i)
-		if vde.VNL == "" {
-			return fmt.Errorf("field `%s.vnl` must not be empty", field)
+func validateNetwork(y LimaYAML) error {
+	if len(y.Network.VDEDeprecated) > 0 {
+		if y.Network.migrated {
+			logrus.Warnf("field `network.VDE` is deprecated; please use `networks` instead")
+		} else {
+			return fmt.Errorf("you cannot use deprecated field `network.VDE` together with replacement field `networks`")
 		}
-		// The field is called VDE.VNL in anticipation of QEMU upgrading VDE2 to VDEplug4,
-		// but right now the only valid value on macOS is a path to the vde_switch socket directory,
-		// optionally with vde:// prefix.
-		// TODO: use networks.LimaSchema after solving circular dependency
-		if strings.HasPrefix(vde.VNL, "lima://") {
-			// TODO: validate network names? Problem is we can't use "networks" or "store" packages here...
-			//name := strings.TrimPrefix(vde.VNL, networks.LimaScheme)
-			//if _, ok := networkConfig.Networks[name]; !ok {
-			//	return fmt.Errorf("field `%s.vnl` references undefined network %q", field, name)
-			//}
-		} else if !strings.Contains(vde.VNL, "://") || strings.HasPrefix(vde.VNL, "vde://") {
-			vdeSwitch := strings.TrimPrefix(vde.VNL, "vde://")
-			if fi, err := os.Stat(vdeSwitch); err != nil {
-				// negligible when the instance is stopped
-				logrus.WithError(err).Debugf("field `%s.vnl` %q failed stat", field, vdeSwitch)
-			} else {
-				if fi.IsDir() {
-					/* Switch mode (vdeSwitch is dir, port != 65535) */
-					ctlSocket := filepath.Join(vdeSwitch, "ctl")
-					// ErrNotExist during os.Stat(ctlSocket) can be ignored. ctlSocket does not need to exist until actually starting the VM
-					if fi, err = os.Stat(ctlSocket); err == nil {
+	}
+	interfaceName := make(map[string]int)
+	for i, nw := range y.Networks {
+		field := fmt.Sprintf("networks[%d]", i)
+		if nw.Lima != "" {
+			if nw.VNL != "" {
+				return fmt.Errorf("field `%s.lima` and field `%s.vnl` are mutually exclusive", field, field)
+			}
+			if nw.SwitchPort != 0 {
+				return fmt.Errorf("field `%s.switchPort` cannot be used with field `%s.lima`", field, field)
+			}
+			// TODO: validate network name (we can't use networks and store packages right now)
+		} else {
+			if nw.VNL == "" {
+				return fmt.Errorf("field `%s.lima` or field `%s.vnl` must be set", field, field)
+			}
+			// The field is called VDE.VNL in anticipation of QEMU upgrading VDE2 to VDEplug4,
+			// but right now the only valid value on macOS is a path to the vde_switch socket directory,
+			// optionally with vde:// prefix.
+			if !strings.Contains(nw.VNL, "://") || strings.HasPrefix(nw.VNL, "vde://") {
+				vdeSwitch := strings.TrimPrefix(nw.VNL, "vde://")
+				if fi, err := os.Stat(vdeSwitch); err != nil {
+					// negligible when the instance is stopped
+					logrus.WithError(err).Debugf("field `%s.vnl` %q failed stat", field, vdeSwitch)
+				} else {
+					if fi.IsDir() {
+						/* Switch mode (vdeSwitch is dir, port != 65535) */
+						ctlSocket := filepath.Join(vdeSwitch, "ctl")
+						// ErrNotExist during os.Stat(ctlSocket) can be ignored. ctlSocket does not need to exist until actually starting the VM
+						if fi, err = os.Stat(ctlSocket); err == nil {
+							if fi.Mode()&os.ModeSocket == 0 {
+								return fmt.Errorf("field `%s.vnl` file %q is not a UNIX socket", field, ctlSocket)
+							}
+						}
+						if nw.SwitchPort == 65535 {
+							return fmt.Errorf("field `%s.vnl` points to a non-PTP switch, so the port number must not be 65535", field)
+						}
+					} else {
+						/* PTP mode (vdeSwitch is socket, port == 65535) */
 						if fi.Mode()&os.ModeSocket == 0 {
-							return fmt.Errorf("field `%s.vnl` file %q is not a UNIX socket", field, ctlSocket)
+							return fmt.Errorf("field `%s.vnl` %q is not a directory nor a UNIX socket", field, vdeSwitch)
+						}
+						if nw.SwitchPort != 65535 {
+							return fmt.Errorf("field `%s.vnl` points to a PTP (switchless) socket %q, so the port number has to be 65535 (got %d)",
+								field, vdeSwitch, nw.SwitchPort)
 						}
 					}
-					if vde.SwitchPort == 65535 {
-						return fmt.Errorf("field `%s.vnl` points to a non-PTP switch, so the port number must not be 65535", field)
-					}
-				} else {
-					/* PTP mode (vdeSwitch is socket, port == 65535) */
-					if fi.Mode()&os.ModeSocket == 0 {
-						return fmt.Errorf("field `%s.vnl` %q is not a directory nor a UNIX socket", field, vdeSwitch)
-					}
-					if vde.SwitchPort != 65535 {
-						return fmt.Errorf("field `%s.vnl` points to a PTP (switchless) socket %q, so the port number has to be 65535 (got %d)",
-							field, vdeSwitch, vde.SwitchPort)
-					}
 				}
+			} else if runtime.GOOS != "linux" {
+				logrus.Warnf("field `%s.vnl` is unlikely to work for %s (unless libvdeplug4 has been ported to %s and is installed)",
+					field, runtime.GOOS, runtime.GOOS)
 			}
-		} else if runtime.GOOS != "linux" {
-			logrus.Warnf("field `%s.vnl` is unlikely to work for %s (unless libvdeplug4 has been ported to %s and is installed)",
-				field, runtime.GOOS, runtime.GOOS)
 		}
-		if vde.MACAddress != "" {
-			hw, err := net.ParseMAC(vde.MACAddress)
+		if nw.MACAddress != "" {
+			hw, err := net.ParseMAC(nw.MACAddress)
 			if err != nil {
 				return fmt.Errorf("field `vmnet.mac` invalid: %w", err)
 			}
 			if len(hw) != 6 {
-				return fmt.Errorf("field `%s.macAddress` must be a 48 bit (6 bytes) MAC address; actual length of %q is %d bytes", field, vde.MACAddress, len(hw))
+				return fmt.Errorf("field `%s.macAddress` must be a 48 bit (6 bytes) MAC address; actual length of %q is %d bytes", field, nw.MACAddress, len(hw))
 			}
 		}
-		// FillDefault() will make sure that vde.Name is not the empty string
-		if len(vde.Name) >= 16 {
-			return fmt.Errorf("field `%s.name` must be less than 16 bytes, but is %d bytes: %q", field, len(vde.Name), vde.Name)
+		// FillDefault() will make sure that nw.Interface is not the empty string
+		if len(nw.Interface) >= 16 {
+			return fmt.Errorf("field `%s.interface` must be less than 16 bytes, but is %d bytes: %q", field, len(nw.Interface), nw.Interface)
 		}
-		if strings.ContainsAny(vde.Name, " \t\n/") {
-			return fmt.Errorf("field `%s.name` must not contain whitespace or slashes", field)
+		if strings.ContainsAny(nw.Interface, " \t\n/") {
+			return fmt.Errorf("field `%s.interface` must not contain whitespace or slashes", field)
 		}
-		if vde.Name == qemuconst.SlirpNICName {
-			return fmt.Errorf("field `%s.name` must not be set to %q because it is reserved for slirp", field, qemuconst.SlirpNICName)
+		if nw.Interface == qemuconst.SlirpNICName {
+			return fmt.Errorf("field `%s.interface` must not be set to %q because it is reserved for slirp", field, qemuconst.SlirpNICName)
 		}
-		if prev, ok := networkName[vde.Name]; ok {
-			return fmt.Errorf("field `%s.name` value %q has already been used by field `network.vde[%d].name`", field, vde.Name, prev)
+		if prev, ok := interfaceName[nw.Interface]; ok {
+			return fmt.Errorf("field `%s.interface` value %q has already been used by field `network.vde[%d].name`", field, nw.Interface, prev)
 		}
-		networkName[vde.Name] = i
+		interfaceName[nw.Interface] = i
 	}
 	return nil
 }

--- a/pkg/networks/commands.go
+++ b/pkg/networks/commands.go
@@ -1,0 +1,84 @@
+package networks
+
+import (
+	"fmt"
+	"github.com/lima-vm/lima/pkg/store"
+)
+
+const (
+	Switch = "switch"
+	VMNet  = "vmnet"
+)
+
+// Commands in `sudoers` cannot use quotes, so all arguments are printed via "%s"
+// and not "%q". config.Paths.* entries must not include any whitespace!
+
+func (config *NetworksConfig) Check(name string) error {
+	if _, ok := config.Networks[name]; ok {
+		return nil
+	}
+	return fmt.Errorf("network %q is not defined", name)
+}
+
+func (config *NetworksConfig) VDESock(name string) string {
+	return fmt.Sprintf("%s/%s.ctl", config.Paths.VarRun, name)
+}
+
+func (config *NetworksConfig) PIDFile(name, daemon string) string {
+	return fmt.Sprintf("%s/%s_%s.pid", config.Paths.VarRun, name, daemon)
+}
+
+func (config *NetworksConfig) LogFile(name, daemon, stream string) string {
+	networksDir, _ := store.LimaNetworksDir()
+	return fmt.Sprintf("%s/%s_%s.%s.log", networksDir, name, daemon, stream)
+}
+
+func (config *NetworksConfig) DaemonUser(daemon string) string {
+	switch daemon {
+	case Switch:
+		return "daemon"
+	case VMNet:
+		return "root"
+	}
+	panic("daemonuser")
+}
+
+func (config *NetworksConfig) DaemonGroup(daemon string) string {
+	switch daemon {
+	case Switch:
+		return config.Group
+	case VMNet:
+		return "wheel"
+	}
+	panic("daemongroup")
+}
+
+func (config *NetworksConfig) MkdirCmd() string {
+	return fmt.Sprintf("/bin/mkdir -m 775 -p %s", config.Paths.VarRun)
+}
+
+func (config *NetworksConfig) StartCmd(name, daemon string) string {
+	var cmd string
+	switch daemon {
+	case Switch:
+		cmd = fmt.Sprintf("%s --pidfile=%s --sock=%s --group=%s --dirmode=0770 --nostdin",
+			config.Paths.VDESwitch, config.PIDFile(name, Switch), config.VDESock(name), config.Group)
+	case VMNet:
+		nw := config.Networks[name]
+		cmd = fmt.Sprintf("%s --pidfile=%s --vde-group=%s --vmnet-mode=%s",
+			config.Paths.VDEVMNet, config.PIDFile(name, VMNet), config.Group, nw.Mode)
+		switch nw.Mode {
+		case ModeBridged:
+			cmd += fmt.Sprintf(" --vmnet-interface=%s", nw.Interface)
+		case ModeHost, ModeShared:
+			cmd += fmt.Sprintf(" --vmnet-gateway=%s --vmnet-dhcp-end=%s --vmnet-mask=%s",
+				nw.Gateway, nw.DHCPEnd, nw.NetMask)
+		}
+		cmd += " " + config.VDESock(name)
+	}
+	return cmd
+}
+
+func (config *NetworksConfig) StopCmd(name, daemon string) string {
+	return fmt.Sprintf("/usr/bin/pkill -F %s", config.PIDFile(name, daemon))
+}

--- a/pkg/networks/commands.go
+++ b/pkg/networks/commands.go
@@ -2,7 +2,7 @@ package networks
 
 import (
 	"fmt"
-	"github.com/lima-vm/lima/pkg/store"
+	"github.com/lima-vm/lima/pkg/store/dirnames"
 )
 
 const (
@@ -29,7 +29,7 @@ func (config *NetworksConfig) PIDFile(name, daemon string) string {
 }
 
 func (config *NetworksConfig) LogFile(name, daemon, stream string) string {
-	networksDir, _ := store.LimaNetworksDir()
+	networksDir, _ := dirnames.LimaNetworksDir()
 	return fmt.Sprintf("%s/%s_%s.%s.log", networksDir, name, daemon, stream)
 }
 

--- a/pkg/networks/commands_test.go
+++ b/pkg/networks/commands_test.go
@@ -1,0 +1,105 @@
+package networks
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/lima-vm/lima/pkg/store/dirnames"
+	"gotest.tools/v3/assert"
+)
+
+func TestCheck(t *testing.T) {
+	config, err := DefaultConfig()
+	assert.NilError(t, err)
+
+	for _, name := range []string{"bridged", "shared", "host"} {
+		err = config.Check(name)
+		assert.NilError(t, err)
+	}
+	err = config.Check("unknown")
+	assert.ErrorContains(t, err, "not defined")
+}
+
+func TestVDESock(t *testing.T) {
+	config, err := DefaultConfig()
+	assert.NilError(t, err)
+
+	vdeSock := config.VDESock("foo")
+	assert.Equal(t, vdeSock, "/private/var/run/lima/foo.ctl")
+}
+
+func TestPIDFile(t *testing.T) {
+	config, err := DefaultConfig()
+	assert.NilError(t, err)
+
+	pidFile := config.PIDFile("name", "daemon")
+	assert.Equal(t, pidFile, "/private/var/run/lima/name_daemon.pid")
+}
+
+func TestLogFile(t *testing.T) {
+	config, err := DefaultConfig()
+	assert.NilError(t, err)
+
+	logFile := config.LogFile("name", "daemon", "stream")
+	networksDir, err := dirnames.LimaNetworksDir()
+	assert.NilError(t, err)
+	assert.Equal(t, logFile, filepath.Join(networksDir, "name_daemon.stream.log"))
+}
+
+func TestUser(t *testing.T) {
+	config, err := DefaultConfig()
+	assert.NilError(t, err)
+
+	user, err := config.User(Switch)
+	assert.NilError(t, err)
+	assert.Equal(t, user.User, "daemon")
+	assert.Equal(t, user.Group, config.Group)
+	if runtime.GOOS == "darwin" {
+		assert.Equal(t, user.Uid, uint32(1))
+	}
+
+	user, err = config.User(VMNet)
+	assert.NilError(t, err)
+	assert.Equal(t, user.User, "root")
+	if runtime.GOOS == "darwin" {
+		assert.Equal(t, user.Group, "wheel")
+	} else {
+		assert.Equal(t, user.Group, "root")
+	}
+	assert.Equal(t, user.Uid, uint32(0))
+	assert.Equal(t, user.Gid, uint32(0))
+}
+
+func TestMkdirCmd(t *testing.T) {
+	config, err := DefaultConfig()
+	assert.NilError(t, err)
+
+	cmd := config.MkdirCmd()
+	assert.Equal(t, cmd, "/bin/mkdir -m 775 -p /private/var/run/lima")
+}
+
+func TestStartCmd(t *testing.T) {
+	config, err := DefaultConfig()
+	assert.NilError(t, err)
+
+	cmd := config.StartCmd("shared", Switch)
+	assert.Equal(t, cmd, "/opt/vde/bin/vde_switch --pidfile=/private/var/run/lima/shared_switch.pid "+
+		"--sock=/private/var/run/lima/shared.ctl --group=staff --dirmode=0770 --nostdin")
+
+	cmd = config.StartCmd("shared", VMNet)
+	assert.Equal(t, cmd, "/opt/vde/bin/vde_vmnet --pidfile=/private/var/run/lima/shared_vmnet.pid --vde-group=staff --vmnet-mode=shared "+
+		"--vmnet-gateway=192.168.105.1 --vmnet-dhcp-end=192.168.105.254 --vmnet-mask=255.255.255.0 /private/var/run/lima/shared.ctl")
+
+	cmd = config.StartCmd("bridged", VMNet)
+	assert.Equal(t, cmd, "/opt/vde/bin/vde_vmnet --pidfile=/private/var/run/lima/bridged_vmnet.pid --vde-group=staff --vmnet-mode=bridged "+
+		"--vmnet-interface=en0 /private/var/run/lima/bridged.ctl")
+}
+
+func TestStopCmd(t *testing.T) {
+	config, err := DefaultConfig()
+	assert.NilError(t, err)
+
+	cmd := config.StopCmd("name", "daemon")
+	assert.Equal(t, cmd, "/usr/bin/pkill -F /private/var/run/lima/name_daemon.pid")
+}

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -45,7 +45,7 @@ func loadCache() {
 				return
 			}
 			configDir := filepath.Dir(configFile)
-			cache.err = os.MkdirAll(configDir, 0700)
+			cache.err = os.MkdirAll(configDir, 0755)
 			if cache.err != nil {
 				cache.err = fmt.Errorf("could not create %q directory: %w", configDir, cache.err)
 				return

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -56,6 +56,7 @@ func load() {
 		if cache.err != nil {
 			cache.err = fmt.Errorf("cannot parse %q: %w", configFile, cache.err)
 		}
+		cache.err = cache.config.validate()
 	})
 }
 

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/lima-vm/lima/pkg/store"
+	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 )
 
@@ -27,7 +27,7 @@ var cache struct {
 func load() {
 	cache.Do(func() {
 		var configDir string
-		configDir, cache.err = store.LimaConfigDir()
+		configDir, cache.err = dirnames.LimaConfigDir()
 		if cache.err != nil {
 			return
 		}

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -7,7 +7,6 @@ import (
 	"gopkg.in/yaml.v2"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/lima-vm/lima/pkg/store"
@@ -66,16 +65,12 @@ func Config() (NetworksConfig, error) {
 }
 
 func VDESock(name string) (string, error) {
-	if strings.HasPrefix(name, LimaScheme) {
-		load()
-		if cache.err != nil {
-			return "", cache.err
-		}
-		name = strings.TrimPrefix(name, LimaScheme)
-		if err := cache.config.Check(name); err != nil {
-			return "", err
-		}
-		return cache.config.VDESock(name), nil
+	load()
+	if cache.err != nil {
+		return "", cache.err
 	}
-	return name, nil
+	if err := cache.config.Check(name); err != nil {
+		return "", err
+	}
+	return cache.config.VDESock(name), nil
 }

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
+	"gopkg.in/yaml.v2"
 )
 
 //go:embed networks.yaml
@@ -56,7 +56,6 @@ func load() {
 		if cache.err != nil {
 			cache.err = fmt.Errorf("cannot parse %q: %w", configFile, cache.err)
 		}
-		cache.err = cache.config.validate()
 	})
 }
 

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 
 	"github.com/lima-vm/lima/pkg/store"
@@ -60,8 +61,11 @@ func load() {
 
 // Config returns the network config from the _config/networks.yaml file.
 func Config() (NetworksConfig, error) {
-	load()
-	return cache.config, cache.err
+	if runtime.GOOS == "darwin" {
+		load()
+		return cache.config, cache.err
+	}
+	return NetworksConfig{}, errors.New("networks.yaml configuration is only supported on macOS right now")
 }
 
 func VDESock(name string) (string, error) {

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -17,6 +17,12 @@ import (
 //go:embed networks.yaml
 var defaultConfig []byte
 
+func DefaultConfig() (NetworksConfig, error) {
+	var config NetworksConfig
+	err := yaml.Unmarshal(defaultConfig, &config)
+	return config, err
+}
+
 var cache struct {
 	sync.Once
 	config NetworksConfig

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -1,0 +1,81 @@
+package networks
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/lima-vm/lima/pkg/store"
+	"github.com/lima-vm/lima/pkg/store/filenames"
+)
+
+//go:embed networks.yaml
+var defaultConfig []byte
+
+var cache struct {
+	sync.Once
+	config NetworksConfig
+	err    error
+}
+
+// load() loads the _config/networks.yaml file.
+func load() {
+	cache.Do(func() {
+		var configDir string
+		configDir, cache.err = store.LimaConfigDir()
+		if cache.err != nil {
+			return
+		}
+		configFile := filepath.Join(configDir, filenames.NetworksConfig)
+		_, cache.err = os.Stat(configFile)
+		if cache.err != nil {
+			if !errors.Is(cache.err, os.ErrNotExist) {
+				return
+			}
+			cache.err = os.MkdirAll(configDir, 0700)
+			if cache.err != nil {
+				cache.err = fmt.Errorf("could not create %q directory: %w", configDir, cache.err)
+				return
+			}
+			cache.err = os.WriteFile(configFile, defaultConfig, 0644)
+			if cache.err != nil {
+				return
+			}
+		}
+		var b []byte
+		b, cache.err = os.ReadFile(configFile)
+		if cache.err != nil {
+			return
+		}
+		cache.err = yaml.Unmarshal(b, &cache.config)
+		if cache.err != nil {
+			cache.err = fmt.Errorf("cannot parse %q: %w", configFile, cache.err)
+		}
+	})
+}
+
+// Config returns the network config from the _config/networks.yaml file.
+func Config() (NetworksConfig, error) {
+	load()
+	return cache.config, cache.err
+}
+
+func VDESock(name string) (string, error) {
+	if strings.HasPrefix(name, LimaScheme) {
+		load()
+		if cache.err != nil {
+			return "", cache.err
+		}
+		name = strings.TrimPrefix(name, LimaScheme)
+		if err := cache.config.Check(name); err != nil {
+			return "", err
+		}
+		return cache.config.VDESock(name), nil
+	}
+	return name, nil
+}

--- a/pkg/networks/networks.go
+++ b/pkg/networks/networks.go
@@ -16,7 +16,7 @@ type Paths struct {
 	VDESwitch string `yaml:"vdeSwitch"`
 	VDEVMNet  string `yaml:"vdeVMNet"`
 	VarRun    string `yaml:"varRun"`
-	Sudoers   string `yaml:"sudoers"`
+	Sudoers   string `yaml:"sudoers,omitempty"`
 }
 
 const (

--- a/pkg/networks/networks.go
+++ b/pkg/networks/networks.go
@@ -1,0 +1,34 @@
+package networks
+
+import "net"
+
+const (
+	LimaScheme = "lima://"
+)
+
+type NetworksConfig struct {
+	Paths    Paths              `yaml:"paths"`
+	Group    string             `yaml:"group,omitempty"` // default: "staff"
+	Networks map[string]Network `yaml:"networks"`
+}
+
+type Paths struct {
+	VDESwitch string `yaml:"vdeSwitch"`
+	VDEVMNet  string `yaml:"vdeVMNet"`
+	VarRun    string `yaml:"varRun"`
+	Sudoers   string `yaml:"sudoers"`
+}
+
+const (
+	ModeHost    = "host"
+	ModeShared  = "shared"
+	ModeBridged = "bridged"
+)
+
+type Network struct {
+	Mode      string `yaml:"mode"`                // "host", "shared", or "bridged"
+	Interface string `yaml:"interface,omitempty"` // only used by "bridged" networks
+	Gateway   net.IP `yaml:"gateway,omitempty"`   // only used by "host" and "shared" networks
+	DHCPEnd   net.IP `yaml:"dhcpEnd,omitempty"`   // default: same as Gateway, last byte is 254
+	NetMask   net.IP `yaml:"netmask,omitempty"`   // default: 255.255.255.0
+}

--- a/pkg/networks/networks.yaml
+++ b/pkg/networks/networks.yaml
@@ -2,9 +2,13 @@
 # installed where only root can modify/replace it. This means also none of the
 # parent directories should be writable by the user.
 #
-# The var_run directory also must not be writable by the user because it will
+# The varRun directory also must not be writable by the user because it will
 # include the vde_vmnet pid files. Those will be terminated via sudo, so replacing
-# the pid files would allow killing of arbitrary privileged processes.
+# the pid files would allow killing of arbitrary privileged processes. varRun
+# however MUST be writable by the daemon user.
+#
+# None of the paths segments may be symlinks, why it has to be /private/var
+# instead of /var etc.
 paths:
   vdeSwitch: /opt/vde/bin/vde_switch
   vdeVMNet: /opt/vde/bin/vde_vmnet

--- a/pkg/networks/networks.yaml
+++ b/pkg/networks/networks.yaml
@@ -9,7 +9,7 @@ paths:
   vdeSwitch: /opt/vde/bin/vde_switch
   vdeVMNet: /opt/vde/bin/vde_vmnet
   varRun: /private/var/run/lima
-  sudoers: /etc/sudoers.d/lima
+  sudoers: /private/etc/sudoers.d/lima
 
 group: staff
 

--- a/pkg/networks/networks.yaml
+++ b/pkg/networks/networks.yaml
@@ -1,0 +1,30 @@
+# Paths to vde executables. Because vde_vmnet is invoked via sudo it should be
+# installed where only root can modify/replace it. This means also none of the
+# parent directories should be writable by the user.
+#
+# The var_run directory also must not be writable by the user because it will
+# include the vde_vmnet pid files. Those will be terminated via sudo, so replacing
+# the pid files would allow killing of arbitrary privileged processes.
+paths:
+  vdeSwitch: /opt/vde/bin/vde_switch
+  vdeVMNet: /opt/vde/bin/vde_vmnet
+  varRun: /var/run/lima
+  sudoers: /etc/sudoers.d/lima
+
+group: staff
+
+networks:
+  shared:
+    mode: shared
+    gateway: 192.168.105.1
+    dhcpEnd: 192.168.105.254
+    netmask: 255.255.255.0
+  bridged:
+    mode: bridged
+    interface: en0
+    # bridged mode doesn't have a gateway; dhcp is managed by outside network
+  host:
+    mode: host
+    gateway: 192.168.106.1
+    dhcpEnd: 192.168.106.254
+    netmask: 255.255.255.0

--- a/pkg/networks/networks.yaml
+++ b/pkg/networks/networks.yaml
@@ -8,7 +8,7 @@
 paths:
   vdeSwitch: /opt/vde/bin/vde_switch
   vdeVMNet: /opt/vde/bin/vde_vmnet
-  varRun: /var/run/lima
+  varRun: /private/var/run/lima
   sudoers: /etc/sudoers.d/lima
 
 group: staff

--- a/pkg/networks/reconcile.go
+++ b/pkg/networks/reconcile.go
@@ -1,0 +1,167 @@
+package networks
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/lima-vm/lima/pkg/store"
+	"github.com/sirupsen/logrus"
+)
+
+func Reconcile(ctx context.Context, newInst string) error {
+	config, err := Config()
+	if err != nil {
+		return err
+	}
+
+	instances, err := store.Instances()
+	if err != nil {
+		return err
+	}
+
+	activeNetwork := make(map[string]bool, 3)
+	for _, instName := range instances {
+		instance, err := store.Inspect(instName)
+		if err != nil {
+			return err
+		}
+		// newInst is about to be started, so its networks should be running
+		if instance.Status != store.StatusRunning && instName != newInst {
+			continue
+		}
+		for _, vde := range instance.Network.VDE {
+			if strings.HasPrefix(vde.VNL, LimaScheme) {
+				name := strings.TrimPrefix(vde.VNL, LimaScheme)
+				if _, ok := config.Networks[name]; !ok {
+					logrus.Errorf("network %q (used by instance %q) is missing from networks.yaml", name, instName)
+					continue
+				}
+				activeNetwork[name] = true
+			}
+		}
+	}
+	for name := range config.Networks {
+		var err error
+		if activeNetwork[name] {
+			err = config.startNetwork(ctx, name)
+		} else {
+			err = config.stopNetwork(name)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func sudo(user, group, command string) error {
+	args := []string{"--user", user, "--group", group, "--non-interactive"}
+	args = append(args, strings.Split(command, " ")...)
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("sudo", args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	logrus.Debugf("Running: %v", cmd.Args)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run %v: stdout=%q, stderr=%q: %w",
+			cmd.Args, stdout.String(), stderr.String(), err)
+	}
+	return nil
+}
+
+func (config *NetworksConfig) startDaemon(ctx context.Context, name, daemon string) error {
+	err := sudo("root", "wheel", config.MkdirCmd())
+	if err != nil {
+		return err
+	}
+
+	networksDir, _ := store.LimaNetworksDir()
+	if err := os.MkdirAll(networksDir, 0755); err != nil {
+		return err
+	}
+
+	stdoutPath := config.LogFile(name, daemon, "stdout")
+	stderrPath := config.LogFile(name, daemon, "stderr")
+	if err := os.RemoveAll(stdoutPath); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(stderrPath); err != nil {
+		return err
+	}
+	stdoutW, err := os.Create(stdoutPath)
+	if err != nil {
+		return err
+	}
+	// no defer stdoutW.Close()
+	stderrW, err := os.Create(stderrPath)
+	if err != nil {
+		return err
+	}
+	// no defer stderrW.Close()
+
+	args := []string{"--user", config.DaemonUser(daemon), "--group", config.DaemonGroup(daemon), "--non-interactive"}
+	args = append(args, strings.Split(config.StartCmd(name, daemon), " ")...)
+	cmd := exec.CommandContext(ctx, "sudo", args...)
+	cmd.Stdout = stdoutW
+	cmd.Stderr = stderrW
+	logrus.Debugf("Starting %q daemon for %q network: %v", daemon, name, cmd.Args)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return nil
+}
+
+var sudoersCheck struct {
+	sync.Once
+	err error
+}
+
+func (config *NetworksConfig) checkSudoers() error {
+	sudoersCheck.Do(func() {
+		if config.Paths.Sudoers != "" {
+			sudoersCheck.err = CheckSudoers(config.Paths.Sudoers)
+		}
+	})
+	return sudoersCheck.err
+}
+
+func (config *NetworksConfig) startNetwork(ctx context.Context, name string) error {
+	logrus.Debugf("Make sure %q network is running", name)
+	for _, daemon := range []string{Switch, VMNet} {
+		pid, _ := store.ReadPIDFile(config.PIDFile(name, daemon))
+		if pid == 0 {
+			logrus.Infof("Starting %s daemon for %q network", daemon, name)
+			if err := config.checkSudoers(); err != nil {
+				return err
+			}
+			if err := config.startDaemon(ctx, name, daemon); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (config *NetworksConfig) stopNetwork(name string) error {
+	logrus.Debugf("Make sure %q network is stopped", name)
+	for _, daemon := range []string{VMNet, Switch} {
+		pid, _ := store.ReadPIDFile(config.PIDFile(name, daemon))
+		if pid != 0 {
+			logrus.Infof("Stopping %s daemon for %q network", daemon, name)
+			if err := config.checkSudoers(); err != nil {
+				return err
+			}
+			err := sudo(config.DaemonUser(daemon), config.DaemonGroup(daemon), config.StopCmd(name, daemon))
+			if err != nil {
+				return err
+			}
+		}
+		// TODO: wait for VMNet to terminate before stopping Switch, otherwise the socket may not get deleted
+	}
+	return nil
+}

--- a/pkg/networks/reconcile.go
+++ b/pkg/networks/reconcile.go
@@ -34,15 +34,15 @@ func Reconcile(ctx context.Context, newInst string) error {
 		if instance.Status != store.StatusRunning && instName != newInst {
 			continue
 		}
-		for _, vde := range instance.Network.VDE {
-			if strings.HasPrefix(vde.VNL, LimaScheme) {
-				name := strings.TrimPrefix(vde.VNL, LimaScheme)
-				if _, ok := config.Networks[name]; !ok {
-					logrus.Errorf("network %q (used by instance %q) is missing from networks.yaml", name, instName)
-					continue
-				}
-				activeNetwork[name] = true
+		for _, nw := range instance.Networks {
+			if nw.Lima == "" {
+				continue
 			}
+			if _, ok := config.Networks[nw.Lima]; !ok {
+				logrus.Errorf("network %q (used by instance %q) is missing from networks.yaml", nw.Lima, instName)
+				continue
+			}
+			activeNetwork[nw.Lima] = true
 		}
 	}
 	for name := range config.Networks {

--- a/pkg/networks/reconcile.go
+++ b/pkg/networks/reconcile.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/lima-vm/lima/pkg/store"
+	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/sirupsen/logrus"
 )
 
@@ -84,7 +85,7 @@ func (config *NetworksConfig) startDaemon(ctx context.Context, name, daemon stri
 		return err
 	}
 
-	networksDir, _ := store.LimaNetworksDir()
+	networksDir, _ := dirnames.LimaNetworksDir()
 	if err := os.MkdirAll(networksDir, 0755); err != nil {
 		return err
 	}

--- a/pkg/networks/reconcile.go
+++ b/pkg/networks/reconcile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -14,6 +15,9 @@ import (
 )
 
 func Reconcile(ctx context.Context, newInst string) error {
+	if runtime.GOOS != "darwin" {
+		return nil
+	}
 	config, err := Config()
 	if err != nil {
 		return err

--- a/pkg/networks/reconcile/reconcile.go
+++ b/pkg/networks/reconcile/reconcile.go
@@ -113,6 +113,9 @@ func startDaemon(config *networks.NetworksConfig, ctx context.Context, name, dae
 	args := []string{"--user", config.DaemonUser(daemon), "--group", config.DaemonGroup(daemon), "--non-interactive"}
 	args = append(args, strings.Split(config.StartCmd(name, daemon), " ")...)
 	cmd := exec.CommandContext(ctx, "sudo", args...)
+	// set directory to a path the daemon user has read access to because vde_switch calls getcwd() which
+	// can fail when called from directories like ~/Downloads, which has 700 permissions
+	cmd.Dir = config.Paths.VarRun
 	cmd.Stdout = stdoutW
 	cmd.Stderr = stderrW
 	logrus.Debugf("Starting %q daemon for %q network: %v", daemon, name, cmd.Args)

--- a/pkg/networks/sudoers.go
+++ b/pkg/networks/sudoers.go
@@ -1,0 +1,54 @@
+package networks
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+func Sudoers() (string, error) {
+	config, err := Config()
+	if err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%%%s ALL=(root:wheel) NOPASSWD:NOSETENV: %s\n", config.Group, config.MkdirCmd()))
+
+	// names must be in stable order to be able to check if sudoers file needs updating
+	names := make([]string, 0, len(config.Networks))
+	for name := range config.Networks {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		sb.WriteRune('\n')
+		sb.WriteString(fmt.Sprintf("# Manage %q network daemons\n", name))
+		for _, daemon := range []string{Switch, VMNet} {
+			prefix := strings.ToUpper(name + "_" + daemon)
+			sb.WriteRune('\n')
+			sb.WriteString(fmt.Sprintf("Cmnd_Alias %s_START = %s\n", prefix, config.StartCmd(name, daemon)))
+			sb.WriteString(fmt.Sprintf("Cmnd_Alias %s_STOP = %s\n", prefix, config.StopCmd(name, daemon)))
+			sb.WriteString(fmt.Sprintf("%%%s ALL=(%s:%s) NOPASSWD:NOSETENV: %s_START, %s_STOP\n",
+				config.Group, config.DaemonUser(daemon), config.DaemonGroup(daemon), prefix, prefix))
+		}
+	}
+	return sb.String(), nil
+}
+
+func CheckSudoers(sudoersFile string) error {
+	b, err := os.ReadFile(sudoersFile)
+	if err != nil {
+		return fmt.Errorf("can't read %q: %s", sudoersFile, err)
+	}
+	sudoers, err := Sudoers()
+	if err != nil {
+		return err
+	}
+	if string(b) != sudoers {
+		return fmt.Errorf("sudoers file %q is out of sync and must be regenerated", sudoersFile)
+	}
+	return nil
+}

--- a/pkg/networks/sudoers.go
+++ b/pkg/networks/sudoers.go
@@ -31,12 +31,11 @@ func Sudoers() (string, error) {
 		sb.WriteRune('\n')
 		sb.WriteString(fmt.Sprintf("# Manage %q network daemons\n", name))
 		for _, daemon := range []string{Switch, VMNet} {
-			prefix := strings.ToUpper(name + "_" + daemon)
 			sb.WriteRune('\n')
-			sb.WriteString(fmt.Sprintf("Cmnd_Alias %s_START = %s\n", prefix, config.StartCmd(name, daemon)))
-			sb.WriteString(fmt.Sprintf("Cmnd_Alias %s_STOP = %s\n", prefix, config.StopCmd(name, daemon)))
-			sb.WriteString(fmt.Sprintf("%%%s ALL=(%s:%s) NOPASSWD:NOSETENV: %s_START, %s_STOP\n",
-				config.Group, config.DaemonUser(daemon), config.DaemonGroup(daemon), prefix, prefix))
+			sb.WriteString(fmt.Sprintf("%%%s ALL=(%s:%s) NOPASSWD:NOSETENV: \\\n",
+				config.Group, config.DaemonUser(daemon), config.DaemonGroup(daemon)))
+			sb.WriteString(fmt.Sprintf("    %s, \\\n", config.StartCmd(name, daemon)))
+			sb.WriteString(fmt.Sprintf("    %s\n", config.StopCmd(name, daemon)))
 		}
 	}
 	return sb.String(), nil

--- a/pkg/networks/sudoers.go
+++ b/pkg/networks/sudoers.go
@@ -1,10 +1,14 @@
 package networks
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"sort"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 func Sudoers() (string, error) {
@@ -38,9 +42,45 @@ func Sudoers() (string, error) {
 	return sb.String(), nil
 }
 
-func CheckSudoers(sudoersFile string) error {
+func (config *NetworksConfig) passwordLessSudo() error {
+	// Flush cached sudo password
+	cmd := exec.Command("sudo", "-k")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run %v: %w", cmd.Args, err)
+	}
+	// Verify that user/groups for both daemons work without a password, e.g.
+	// %admin ALL = (ALL:ALL) NOPASSWD: ALL
+	for _, daemon := range []string{Switch, VMNet} {
+		cmd = exec.Command("sudo", "--user", config.DaemonUser(daemon),
+			"--group", config.DaemonGroup(daemon), "--non-interactive", "true")
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to run %v: %w", cmd.Args, err)
+		}
+	}
+	return nil
+}
+
+func (config *NetworksConfig) VerifySudoAccess(sudoersFile string) error {
+	if sudoersFile == "" {
+		if err := config.passwordLessSudo(); err == nil {
+			logrus.Debug("sudo doesn't seem to require a password")
+			return nil
+		} else {
+			return fmt.Errorf("passwordLessSudo error: %w", err)
+		}
+	}
 	b, err := os.ReadFile(sudoersFile)
 	if err != nil {
+		// Default networks.yaml specifies /etc/sudoers.d/lima file. Don't throw an error when the
+		// file doesn't exist, as long as password-less sudo still works.
+		if errors.Is(err, os.ErrNotExist) {
+			if err := config.passwordLessSudo(); err == nil {
+				logrus.Debugf("%q does not exist, but sudo doesn't seem to require a password", sudoersFile)
+				return nil
+			} else {
+				logrus.Debugf("%q does not exist; passwordLessSudo error: %s", sudoersFile, err)
+			}
+		}
 		return fmt.Errorf("can't read %q: %s", sudoersFile, err)
 	}
 	sudoers, err := Sudoers()

--- a/pkg/networks/validate.go
+++ b/pkg/networks/validate.go
@@ -1,0 +1,94 @@
+package networks
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
+)
+
+func (config *NetworksConfig) validate() error {
+	// validate all paths.* values
+	paths := reflect.ValueOf(&config.Paths).Elem()
+	for i := 0; i < paths.NumField(); i++ {
+		// extract YAML name from struct tag; strip options like "omitempty"
+		name := paths.Type().Field(i).Tag.Get("yaml")
+		if i := strings.IndexRune(name, ','); i > -1 {
+			name = name[:i]
+		}
+		path := paths.Field(i).Interface().(string)
+		// varPath will be created securely, but any existing parent directories must already be secure
+		if name == "varRun" {
+			path = findBaseDirectory(path)
+		}
+		err := validatePath(path)
+		if err != nil {
+			// sudoers file does not need to exist; otherwise `limactl sudoers` couldn't bootstrap
+			if name == "sudoers" && errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("network.yaml field `paths.%s` error: %w", name, err)
+		}
+	}
+	// TODO: validate network definitions
+	return nil
+}
+
+// findBaseDirectory removes non-existing directories from the end of the path.
+func findBaseDirectory(path string) string {
+	if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist)	{
+		if path != "/" {
+			return findBaseDirectory(filepath.Dir(path))
+		}
+	}
+	return path
+}
+
+func validatePath(path string) error {
+	if path == "" {
+		return nil
+	}
+	if path[0] != '/' {
+		return fmt.Errorf("path %q is not an absolute path", path)
+	}
+	if strings.ContainsRune(path, ' ') {
+		return fmt.Errorf("path %q contains whitespace", path)
+	}
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	file := "file"
+	if fi.Mode().IsDir() {
+		file = "dir"
+	}
+	// TODO: should we allow symlinks when both the link and the target are secure?
+	// E.g. on macOS /var is a symlink to /private/var
+	if (fi.Mode() & fs.ModeSymlink) != 0 {
+		return fmt.Errorf("%s %q is a symlink", file, path)
+	}
+	if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
+		if stat.Uid != 0 {
+			return fmt.Errorf("%s %q is not owned by 0 (root), but by %d", file, path, stat.Uid)
+		}
+		if (fi.Mode() & 020) != 0 {
+			if stat.Gid != 0 && stat.Gid != 1 {
+				return fmt.Errorf("%s %q is group-writable and group is neither 0 (wheel) nor 1 (daemon), but is %d", file, path, stat.Gid)
+			}
+		}
+		if (fi.Mode() & 002) != 0 {
+			return fmt.Errorf("%s %q is world-writable", file, path)
+		}
+	} else {
+		// should never happen
+		return fmt.Errorf("could not retrieve stat buffer for %q", path)
+	}
+	if path != "/" {
+		return validatePath(filepath.Dir(path))
+	}
+	return nil
+}

--- a/pkg/networks/validate.go
+++ b/pkg/networks/validate.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 )
 
-func (config *NetworksConfig) validate() error {
+func (config *NetworksConfig) Validate() error {
 	// validate all paths.* values
 	paths := reflect.ValueOf(&config.Paths).Elem()
 	for i := 0; i < paths.NumField(); i++ {
@@ -31,7 +31,7 @@ func (config *NetworksConfig) validate() error {
 			if name == "sudoers" && errors.Is(err, os.ErrNotExist) {
 				continue
 			}
-			return fmt.Errorf("network.yaml field `paths.%s` error: %w", name, err)
+			return fmt.Errorf("networks.yaml field `paths.%s` error: %w", name, err)
 		}
 	}
 	// TODO: validate network definitions

--- a/pkg/qemu/const/const.go
+++ b/pkg/qemu/const/const.go
@@ -1,4 +1,4 @@
-package qemuconst
+package qemu
 
 const (
 	SlirpNICName = "eth0"

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -260,36 +260,47 @@ func Cmdline(cfg Config) (string, []string, error) {
 	args = append(args, "-netdev", fmt.Sprintf("user,id=net0,net=%s,dhcpstart=%s,hostfwd=tcp:127.0.0.1:%d-:22",
 		qemuconst.SlirpNetwork, qemuconst.SlirpIPAddress, y.SSH.LocalPort))
 	args = append(args, "-device", "virtio-net-pci,netdev=net0,mac="+limayaml.MACAddress(cfg.InstanceDir))
-	if len(y.Network.VDE) > 0 && !strings.Contains(string(features.NetdevHelp), "vde") {
+	usingVDE := false
+	for _, nw := range y.Networks {
+		if nw.VNL != "" {
+			usingVDE = true
+		}
+	}
+	if usingVDE && !strings.Contains(string(features.NetdevHelp), "vde") {
 		return "", nil, fmt.Errorf("netdev \"vde\" is not supported by %s ( Hint: recompile QEMU with `configure --enable-vde` )", exe)
 	}
-	for i, vde := range y.Network.VDE {
-		// Replace internal lima:// network name with proper socket path
-		vdeSock, err := networks.VDESock(vde.VNL)
-		if err != nil {
-			return "", nil, err
-		}
-		// VDE4 accepts VNL like vde:///var/run/vde.ctl as well as file path like /var/run/vde.ctl .
-		// VDE2 only accepts the latter form.
-		// VDE2 supports macOS but VDE4 does not yet, so we trim vde:// prefix here for VDE2 compatibility.
-		vdeSock = strings.TrimPrefix(vdeSock, "vde://")
-		if !strings.Contains(vdeSock, "://") {
-			if _, err := os.Stat(vdeSock); err != nil {
-				return "", nil, fmt.Errorf("cannot use VNL %q: %w", vde.VNL, err)
+	for i, nw := range y.Networks {
+		var vdeSock string
+		if nw.Lima != "" {
+			vdeSock, err = networks.VDESock(nw.Lima)
+			if err != nil {
+				return "", nil, err
 			}
-			// vdeSock is a directory, unless vde.SwitchPort == 65535 (PTP)
-			actualSocket := filepath.Join(vdeSock, "ctl")
-			if vde.SwitchPort == 65535 { // PTP
-				actualSocket = vdeSock
-			}
-			if st, err := os.Stat(actualSocket); err != nil {
-				return "", nil, fmt.Errorf("cannot use VNL %q: failed to stat %q: %w", vde.VNL, actualSocket, err)
-			} else if st.Mode()&fs.ModeSocket == 0 {
-				return "", nil, fmt.Errorf("cannot use VNL %q: %q is not a socket: %w", vde.VNL, actualSocket, err)
+			// TODO: should we also validate that the socket exists, or do we rely on the
+			// networks reconciler to throw an error when the network cannot start?
+		} else {
+			// VDE4 accepts VNL like vde:///var/run/vde.ctl as well as file path like /var/run/vde.ctl .
+			// VDE2 only accepts the latter form.
+			// VDE2 supports macOS but VDE4 does not yet, so we trim vde:// prefix here for VDE2 compatibility.
+			vdeSock = strings.TrimPrefix(nw.VNL, "vde://")
+			if !strings.Contains(vdeSock, "://") {
+				if _, err := os.Stat(vdeSock); err != nil {
+					return "", nil, fmt.Errorf("cannot use VNL %q: %w", nw.VNL, err)
+				}
+				// vdeSock is a directory, unless vde.SwitchPort == 65535 (PTP)
+				actualSocket := filepath.Join(vdeSock, "ctl")
+				if nw.SwitchPort == 65535 { // PTP
+					actualSocket = vdeSock
+				}
+				if st, err := os.Stat(actualSocket); err != nil {
+					return "", nil, fmt.Errorf("cannot use VNL %q: failed to stat %q: %w", nw.VNL, actualSocket, err)
+				} else if st.Mode()&fs.ModeSocket == 0 {
+					return "", nil, fmt.Errorf("cannot use VNL %q: %q is not a socket: %w", nw.VNL, actualSocket, err)
+				}
 			}
 		}
 		args = append(args, "-netdev", fmt.Sprintf("vde,id=net%d,sock=%s", i+1, vdeSock))
-		args = append(args, "-device", fmt.Sprintf("virtio-net-pci,netdev=net%d,mac=%s", i+1, vde.MACAddress))
+		args = append(args, "-device", fmt.Sprintf("virtio-net-pci,netdev=net%d,mac=%s", i+1, nw.MACAddress))
 	}
 
 	// virtio-rng-pci accelerates starting up the OS, according to https://wiki.gentoo.org/wiki/QEMU/Options

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -260,13 +260,7 @@ func Cmdline(cfg Config) (string, []string, error) {
 	args = append(args, "-netdev", fmt.Sprintf("user,id=net0,net=%s,dhcpstart=%s,hostfwd=tcp:127.0.0.1:%d-:22",
 		qemu.SlirpNetwork, qemu.SlirpIPAddress, y.SSH.LocalPort))
 	args = append(args, "-device", "virtio-net-pci,netdev=net0,mac="+limayaml.MACAddress(cfg.InstanceDir))
-	usingVDE := false
-	for _, nw := range y.Networks {
-		if nw.VNL != "" {
-			usingVDE = true
-		}
-	}
-	if usingVDE && !strings.Contains(string(features.NetdevHelp), "vde") {
+	if len(y.Networks) > 0 && !strings.Contains(string(features.NetdevHelp), "vde") {
 		return "", nil, fmt.Errorf("netdev \"vde\" is not supported by %s ( Hint: recompile QEMU with `configure --enable-vde` )", exe)
 	}
 	for i, nw := range y.Networks {

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -17,8 +17,8 @@ import (
 	"github.com/lima-vm/lima/pkg/iso9660util"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/networks"
+	"github.com/lima-vm/lima/pkg/qemu/const"
 	"github.com/lima-vm/lima/pkg/qemu/imgutil"
-	"github.com/lima-vm/lima/pkg/qemu/qemuconst"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/mattn/go-shellwords"
 	"github.com/sirupsen/logrus"
@@ -258,7 +258,7 @@ func Cmdline(cfg Config) (string, []string, error) {
 
 	// Network
 	args = append(args, "-netdev", fmt.Sprintf("user,id=net0,net=%s,dhcpstart=%s,hostfwd=tcp:127.0.0.1:%d-:22",
-		qemuconst.SlirpNetwork, qemuconst.SlirpIPAddress, y.SSH.LocalPort))
+		qemu.SlirpNetwork, qemu.SlirpIPAddress, y.SSH.LocalPort))
 	args = append(args, "-device", "virtio-net-pci,netdev=net0,mac="+limayaml.MACAddress(cfg.InstanceDir))
 	usingVDE := false
 	for _, nw := range y.Networks {

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/lima-vm/lima/pkg/lockutil"
 	"github.com/lima-vm/lima/pkg/osutil"
-	"github.com/lima-vm/lima/pkg/store"
+	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/sirupsen/logrus"
 )
@@ -41,7 +41,7 @@ func readPublicKey(f string) (PubKey, error) {
 // an identity explicitly.
 func DefaultPubKeys(loadDotSSH bool) ([]PubKey, error) {
 	// Read $LIMA_HOME/_config/user.pub
-	configDir, err := store.LimaConfigDir()
+	configDir, err := dirnames.LimaConfigDir()
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func DefaultPubKeys(loadDotSSH bool) ([]PubKey, error) {
 }
 
 func CommonArgs(useDotSSH bool) ([]string, error) {
-	configDir, err := store.LimaConfigDir()
+	configDir, err := dirnames.LimaConfigDir()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/dirnames/dirnames.go
+++ b/pkg/store/dirnames/dirnames.go
@@ -1,0 +1,47 @@
+package dirnames
+
+import (
+	"path/filepath"
+	"os"
+
+	"github.com/lima-vm/lima/pkg/store/filenames"
+)
+
+// DotLima is a directory that appears under the home directory.
+const DotLima = ".lima"
+
+// LimaDir returns the abstract path of `~/.lima` (or $LIMA_HOME, if set).
+//
+// NOTE: We do not use `~/Library/Application Support/Lima` on macOS.
+// We use `~/.lima` so that we can have enough space for the length of the socket path,
+// which can be only 104 characters on macOS.
+func LimaDir() (string, error) {
+	dir := os.Getenv("LIMA_HOME")
+	if dir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		dir = filepath.Join(homeDir, DotLima)
+	}
+	return dir, nil
+}
+
+// LimaConfigDir returns the path of the config directory, $LIMA_HOME/_config.
+func LimaConfigDir() (string, error) {
+	limaDir, err := LimaDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(limaDir, filenames.ConfigDir), nil
+}
+
+// LimaNetworksDir returns the path of the networks log directory, $LIMA_HOME/_networks.
+func LimaNetworksDir() (string, error) {
+	limaDir, err := LimaDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(limaDir, filenames.NetworksDir), nil
+}
+

--- a/pkg/store/filenames/filenames.go
+++ b/pkg/store/filenames/filenames.go
@@ -7,8 +7,9 @@ package filenames
 // Instance names starting with an underscore are reserved for lima internal usage
 
 const (
-	ConfigDir = "_config"
-	CacheDir  = "_cache" // not yet implemented
+	ConfigDir   = "_config"
+	CacheDir    = "_cache" // not yet implemented
+	NetworksDir = "_networks" // network log files are stored here
 )
 
 // Filenames used inside the ConfigDir
@@ -16,6 +17,7 @@ const (
 const (
 	UserPrivateKey = "user"
 	UserPublicKey  = UserPrivateKey + ".pub"
+	NetworksConfig = "networks.yaml"
 )
 
 // Filenames that may appear under an instance directory

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -22,15 +22,15 @@ const (
 )
 
 type Instance struct {
-	Name         string           `json:"name"`
-	Status       Status           `json:"status"`
-	Dir          string           `json:"dir"`
-	Arch         limayaml.Arch    `json:"arch"`
-	Network      limayaml.Network `json:"network,omitempty"`
-	SSHLocalPort int              `json:"sshLocalPort,omitempty"`
-	HostAgentPID int              `json:"hostAgentPID,omitempty"`
-	QemuPID      int              `json:"qemuPID,omitempty"`
-	Errors       []error          `json:"errors,omitempty"`
+	Name         string             `json:"name"`
+	Status       Status             `json:"status"`
+	Dir          string             `json:"dir"`
+	Arch         limayaml.Arch      `json:"arch"`
+	Networks     []limayaml.Network `json:"network,omitempty"`
+	SSHLocalPort int                `json:"sshLocalPort,omitempty"`
+	HostAgentPID int                `json:"hostAgentPID,omitempty"`
+	QemuPID      int                `json:"qemuPID,omitempty"`
+	Errors       []error            `json:"errors,omitempty"`
 }
 
 func (inst *Instance) LoadYAML() (*limayaml.LimaYAML, error) {
@@ -64,7 +64,7 @@ func Inspect(instName string) (*Instance, error) {
 	}
 	inst.Dir = instDir
 	inst.Arch = y.Arch
-	inst.Network = y.Network
+	inst.Networks = y.Networks
 	inst.SSHLocalPort = y.SSH.LocalPort
 
 	inst.HostAgentPID, err = ReadPIDFile(filepath.Join(instDir, filenames.HostAgentPID))

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -54,7 +54,7 @@ func LoadYAMLByFilePath(filePath string) (*limayaml.LimaYAML, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := limayaml.Validate(*y); err != nil {
+	if err := limayaml.Validate(*y, false); err != nil {
 		return nil, err
 	}
 	return y, nil

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -7,50 +7,12 @@ import (
 
 	"github.com/containerd/containerd/identifiers"
 	"github.com/lima-vm/lima/pkg/limayaml"
-	"github.com/lima-vm/lima/pkg/store/filenames"
+	"github.com/lima-vm/lima/pkg/store/dirnames"
 )
-
-// DotLima is a directory that appears under the home directory.
-const DotLima = ".lima"
-
-// LimaDir returns the abstract path of `~/.lima` (or $LIMA_HOME, if set).
-//
-// NOTE: We do not use `~/Library/Application Support/Lima` on macOS.
-// We use `~/.lima` so that we can have enough space for the length of the socket path,
-// which can be only 104 characters on macOS.
-func LimaDir() (string, error) {
-	dir := os.Getenv("LIMA_HOME")
-	if dir == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		dir = filepath.Join(homeDir, DotLima)
-	}
-	return dir, nil
-}
-
-// LimaConfigDir returns the path of the config directory, $LIMA_HOME/_config.
-func LimaConfigDir() (string, error) {
-	limaDir, err := LimaDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(limaDir, filenames.ConfigDir), nil
-}
-
-// LimaNetworksDir returns the path of the networks log directory, $LIMA_HOME/_networks.
-func LimaNetworksDir() (string, error) {
-	limaDir, err := LimaDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(limaDir, filenames.NetworksDir), nil
-}
 
 // Instances returns the names of the instances under LimaDir.
 func Instances() ([]string, error) {
-	limaDir, err := LimaDir()
+	limaDir, err := dirnames.LimaDir()
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +36,7 @@ func InstanceDir(name string) (string, error) {
 	if err := identifiers.Validate(name); err != nil {
 		return "", err
 	}
-	limaDir, err := LimaDir()
+	limaDir, err := dirnames.LimaDir()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -39,6 +39,15 @@ func LimaConfigDir() (string, error) {
 	return filepath.Join(limaDir, filenames.ConfigDir), nil
 }
 
+// LimaNetworksDir returns the path of the networks log directory, $LIMA_HOME/_networks.
+func LimaNetworksDir() (string, error) {
+	limaDir, err := LimaDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(limaDir, filenames.NetworksDir), nil
+}
+
 // Instances returns the names of the instances under LimaDir.
 func Instances() ([]string, error) {
 	limaDir, err := LimaDir()


### PR DESCRIPTION
Lima uses ~/.lima/_config/networks.yaml to define managed networks for instances. By default "shared", "bridged", and "host" are defined. They can be referenced from `lima.yaml` via e.g. `lima://shared`.

The networks will be automatically started by lime as long as any instance referencing them are running, and once the last instance using a network is stopped, the network is brought down as well.

A new command `limactl sudoers` can be used to write a sudoers file to allow lima to start/stop the daemons via `sudo`. Lima does not support prompting for a sudo password; either the sudoers file must
be maintained, or the user must have password-less sudo configured.

Every time the `networks.yaml` configuration is changed, the sudoers file must be regenerated to match.

Resolves #175