### PR TITLE
Enable sudo nerdctl run to expose ports to localhost

### DIFF
--- a/cmd/lima-guestagent/daemon_linux.go
+++ b/cmd/lima-guestagent/daemon_linux.go
@@ -33,6 +33,9 @@ func daemonAction(cmd *cobra.Command, args []string) error {
 	if tick == 0 {
 		return errors.New("tick must be specified")
 	}
+	if os.Geteuid() != 0 {
+		return errors.New("must run as the root")
+	}
 	logrus.Infof("event tick: %v", tick)
 
 	newTicker := func() (<-chan time.Time, func()) {

--- a/cmd/lima-guestagent/install_systemd_linux.go
+++ b/cmd/lima-guestagent/install_systemd_linux.go
@@ -27,10 +27,7 @@ func installSystemdAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	unitPath, err := systemdUnitPath()
-	if err != nil {
-		return err
-	}
+	unitPath := "/etc/systemd/system/lima-guestagent.service"
 	if _, err := os.Stat(unitPath); !errors.Is(err, os.ErrNotExist) {
 		logrus.Infof("File %q already exists, overwriting", unitPath)
 	} else {
@@ -48,7 +45,7 @@ func installSystemdAction(cmd *cobra.Command, args []string) error {
 		{"enable", "--now", "lima-guestagent.service"},
 	}
 	for _, args := range argss {
-		cmd := exec.Command("systemctl", append([]string{"--user"}, args...)...)
+		cmd := exec.Command("systemctl", append([]string{"--system"}, args...)...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		logrus.Infof("Executing: %s", strings.Join(cmd.Args, " "))
@@ -58,15 +55,6 @@ func installSystemdAction(cmd *cobra.Command, args []string) error {
 	}
 	logrus.Info("Done")
 	return nil
-}
-
-func systemdUnitPath() (string, error) {
-	configDir, err := os.UserConfigDir()
-	if err != nil {
-		return "", err
-	}
-	unitPath := filepath.Join(configDir, "systemd/user/lima-guestagent.service")
-	return unitPath, nil
 }
 
 //go:embed lima-guestagent.TEMPLATE.service

--- a/cmd/lima-guestagent/lima-guestagent.TEMPLATE.service
+++ b/cmd/lima-guestagent/lima-guestagent.TEMPLATE.service
@@ -7,4 +7,4 @@ Type=simple
 Restart=on-failure
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/cmd/lima-guestagent/main_linux.go
+++ b/cmd/lima-guestagent/main_linux.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"errors"
-	"os"
 	"strings"
 
 	"github.com/lima-vm/lima/pkg/version"
@@ -27,9 +25,6 @@ func newApp() *cobra.Command {
 		debug, _ := cmd.Flags().GetBool("debug")
 		if debug {
 			logrus.SetLevel(logrus.DebugLevel)
-		}
-		if os.Geteuid() == 0 {
-			return errors.New("must not run as the root")
 		}
 		return nil
 	}

--- a/docs/internal.md
+++ b/docs/internal.md
@@ -46,7 +46,7 @@ SSH:
 - `ssh.sock`: SSH control master socket
 
 Guest agent:
-- `ga.sock`: Forwarded to `/run/user/$UID/lima-guestagent.sock` in the guest, via SSH
+- `ga.sock`: Forwarded to `/run/lima-guestagent.sock` in the guest, via SSH
 
 Host agent:
 - `ha.pid`: hostagent PID

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
@@ -13,7 +13,6 @@ for f in $(seq 0 $((LIMA_CIDATA_MOUNTS - 1))); do
 done
 
 # Install or update the guestagent binary
-rm -f /usr/local/bin/lima-guestagent
 install -m 755 "${LIMA_CIDATA_MNT}"/lima-guestagent /usr/local/bin/lima-guestagent
 
 # Launch the guestagent service
@@ -36,5 +35,8 @@ EOF
 	rc-update add lima-guestagent default
 	rc-service lima-guestagent start
 else
+	# Remove legacy systemd service
+	rm -f "/home/${LIMA_CIDATA_USER}.linux/.config/systemd/user/lima-guestagent.service"
+
 	sudo lima-guestagent install-systemd
 fi

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
@@ -13,6 +13,7 @@ for f in $(seq 0 $((LIMA_CIDATA_MOUNTS - 1))); do
 done
 
 # Install or update the guestagent binary
+rm -f /usr/local/bin/lima-guestagent
 install -m 755 "${LIMA_CIDATA_MNT}"/lima-guestagent /usr/local/bin/lima-guestagent
 
 # Launch the guestagent service

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
@@ -17,11 +17,6 @@ install -m 755 "${LIMA_CIDATA_MNT}"/lima-guestagent /usr/local/bin/lima-guestage
 
 # Launch the guestagent service
 if [ -f /etc/alpine-release ]; then
-	# Create directory for the lima-guestagent socket (normally done by systemd)
-	mkdir -p /run/user/"${LIMA_CIDATA_UID}"
-	gid=$(id -g "${LIMA_CIDATA_USER}")
-	chown "${LIMA_CIDATA_UID}:${gid}" /run/user/"${LIMA_CIDATA_UID}"
-	chmod 700 /run/user/"${LIMA_CIDATA_UID}"
 	# Install the openrc lima-guestagent service script
 	cat >/etc/init.d/lima-guestagent <<'EOF'
 #!/sbin/openrc-run
@@ -30,18 +25,16 @@ supervisor=supervise-daemon
 name="lima-guestagent"
 description="Forward ports to the lima-hostagent"
 
-export XDG_RUNTIME_DIR="/run/user/${LIMA_CIDATA_UID}"
 command=/usr/local/bin/lima-guestagent
 command_args="daemon"
 command_background=true
-command_user="${LIMA_CIDATA_USER}:${LIMA_CIDATA_USER}"
-pidfile="${XDG_RUNTIME_DIR}/lima-guestagent.pid"
+pidfile="/run/lima-guestagent.pid"
 EOF
 	chmod 755 /etc/init.d/lima-guestagent
 
 	rc-update add lima-guestagent default
 	rc-service lima-guestagent start
 else
-	until [ -e "/run/user/${LIMA_CIDATA_UID}/systemd/private" ]; do sleep 3; done
-	sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" lima-guestagent install-systemd
+	until [ -e "/run" ]; do sleep 3; done
+	sudo lima-guestagent install-systemd
 fi

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
@@ -35,6 +35,5 @@ EOF
 	rc-update add lima-guestagent default
 	rc-service lima-guestagent start
 else
-	until [ -e "/run" ]; do sleep 3; done
 	sudo lima-guestagent install-systemd
 fi

--- a/pkg/guestagent/guestagent_linux.go
+++ b/pkg/guestagent/guestagent_linux.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/lima-vm/lima/pkg/guestagent/api"
+	"github.com/lima-vm/lima/pkg/guestagent/iptables"
 	"github.com/lima-vm/lima/pkg/guestagent/procnettcp"
 	"github.com/sirupsen/logrus"
 	"github.com/yalue/native_endian"
@@ -129,6 +130,28 @@ func (a *agent) LocalPorts(ctx context.Context) ([]api.IPPort, error) {
 				})
 		}
 	}
+
+	ipts, err := iptables.GetPorts()
+	if err != nil {
+		return res, err
+	}
+	for _, ipt := range ipts {
+		// Make sure the port isn't already listed from procnettcp
+		found := false
+		for _, re := range res {
+			if re.Port == ipt.Port {
+				found = true
+			}
+		}
+		if !found {
+			res = append(res,
+				api.IPPort{
+					IP:   ipt.IP,
+					Port: ipt.Port,
+				})
+		}
+	}
+
 	return res, nil
 }
 

--- a/pkg/guestagent/iptables/iptables.go
+++ b/pkg/guestagent/iptables/iptables.go
@@ -17,7 +17,7 @@ type Entry struct {
 
 // This regex can detect a line in the iptables added by portmap to do the
 // forwarding. The following two are examples of lines (notice that one has the
-// destinateion IP and the other does not):
+// destination IP and the other does not):
 //    -A CNI-DN-2e2f8d5b91929ef9fc152 -d 127.0.0.1/32 -p tcp -m tcp --dport 8081 -j DNAT --to-destination 10.4.0.7:80
 //    -A CNI-DN-04579c7bb67f4c3f6cca0 -p tcp -m tcp --dport 8082 -j DNAT --to-destination 10.4.0.10:80
 // The -A on the front is to amend the rule that was already created. portmap
@@ -27,7 +27,7 @@ type Entry struct {
 // ipv4 IP address. We need to detect this IP.
 // --dport is the destination port. We need to detect this port
 // -j DNAT this tells us it's the line doing the port forwarding.
-var findPortRegex = regexp.MustCompile(`.*-A\W+CNI-DN-\w*\W+(?:-d ((?:\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}))?(?:/\d+\W+)?-p.*--dport (\d+) -j DNAT`)
+var findPortRegex = regexp.MustCompile(`-A\s+CNI-DN-\w*\s+(?:-d ((?:\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}))?(?:/32\s+)?-p .*--dport (\d+) -j DNAT`)
 
 func GetPorts() ([]Entry, error) {
 	// TODO: add support for ipv6

--- a/pkg/guestagent/iptables/iptables.go
+++ b/pkg/guestagent/iptables/iptables.go
@@ -1,0 +1,111 @@
+package iptables
+
+import (
+	"bytes"
+	"errors"
+	"net"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type Entry struct {
+	IP   net.IP
+	Port int
+}
+
+// This regex can detect a line in the iptables added by portmap to do the
+// forwarding. The following two are examples of lines (notice that one has the
+// destinateion IP and the other does not):
+//    -A CNI-DN-2e2f8d5b91929ef9fc152 -d 127.0.0.1/32 -p tcp -m tcp --dport 8081 -j DNAT --to-destination 10.4.0.7:80
+//    -A CNI-DN-04579c7bb67f4c3f6cca0 -p tcp -m tcp --dport 8082 -j DNAT --to-destination 10.4.0.10:80
+// The -A on the front is to amend the rule that was already created. portmap
+// ensures the rule is created before creating this line so it is always -A.
+// CNI-DN- is the prefix used for rule for an individual container.
+// -d is followed by the IP address. The regular expression looks for a valid
+// ipv4 IP address. We need to detect this IP.
+// --dport is the destination port. We need to detect this port
+// -j DNAT this tells us it's the line doing the port forwarding.
+var findPortRegex = regexp.MustCompile(`.*-A\W+CNI-DN-\w*\W+(?:-d ((?:\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}))?(?:/\d+\W+)?-p.*--dport (\d+) -j DNAT`)
+
+func GetPorts() ([]Entry, error) {
+	// TODO: add support for ipv6
+
+	// Detect the location of iptables. If it is not installed skip the lookup
+	// and return no results. The lookup is performed on each run so that the
+	// agent does not need to be started to detect if iptables was installed
+	// after the agent is already running.
+	pth, err := exec.LookPath("iptables")
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	res, err := listNATRules(pth)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsePortsFromRules(res)
+}
+
+func parsePortsFromRules(rules []string) ([]Entry, error) {
+	var entries []Entry
+	for _, rule := range rules {
+		if found := findPortRegex.FindStringSubmatch(rule); found != nil {
+			if len(found) == 3 {
+				port, err := strconv.Atoi(found[2])
+				if err != nil {
+					return nil, err
+				}
+
+				// if the IP is blank the port forwarding the portforwarding,
+				// which gets information from this, will skip it. When no IP
+				// is present localhost will work.
+				ip := found[1]
+				if ip == "" {
+					ip = "127.0.0.1"
+				}
+				ent := Entry{
+					IP:   net.ParseIP(ip),
+					Port: port,
+				}
+				entries = append(entries, ent)
+			}
+		}
+	}
+
+	return entries, nil
+}
+
+// listNATRules performs the lookup with iptables and returns the raw rules
+// Note, this does not use github.com/coreos/go-iptables (a transitive dependency
+// of lima) because that package would require multiple calls to iptables. This
+// function does everything in a single call.
+func listNATRules(pth string) ([]string, error) {
+	args := []string{pth, "-t", "nat", "-S"}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := exec.Cmd{
+		Path:   pth,
+		Args:   args,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+
+	// turn the output into a rule per line.
+	rules := strings.Split(stdout.String(), "\n")
+	if len(rules) > 0 && rules[len(rules)-1] == "" {
+		rules = rules[:len(rules)-1]
+	}
+
+	return rules, nil
+}

--- a/pkg/guestagent/iptables/iptables_test.go
+++ b/pkg/guestagent/iptables/iptables_test.go
@@ -84,10 +84,10 @@ func TestParsePortsFromRules(t *testing.T) {
 		t.Fatalf("expected 2 ports parsed from iptables but parsed %d", l)
 	}
 
-	if res[0].IP.String() != "127.0.0.1" || res[0].Port != 8082 {
-		t.Errorf("expected port 8082 on IP 127.0.0.1 but go port %d on IP %s", res[0].Port, res[0].IP.String())
+	if res[0].IP.String() != "127.0.0.1" || res[0].Port != 8082 || res[0].TCP != true {
+		t.Errorf("expected port 8082 on IP 127.0.0.1 with TCP true but go port %d on IP %s with TCP %t", res[0].Port, res[0].IP.String(), res[0].TCP)
 	}
-	if res[1].IP.String() != "127.0.0.1" || res[1].Port != 8081 {
-		t.Errorf("expected port 8081 on IP 127.0.0.1 but go port %d on IP %s", res[1].Port, res[1].IP.String())
+	if res[1].IP.String() != "127.0.0.1" || res[1].Port != 8081 || res[1].TCP != true {
+		t.Errorf("expected port 8081 on IP 127.0.0.1 with TCP true but go port %d on IP %s with TCP %t", res[1].Port, res[1].IP.String(), res[1].TCP)
 	}
 }

--- a/pkg/guestagent/iptables/iptables_test.go
+++ b/pkg/guestagent/iptables/iptables_test.go
@@ -1,0 +1,93 @@
+package iptables
+
+import (
+	"strings"
+	"testing"
+)
+
+// data is from a run of `iptables -t nat -S` with two containers running (started
+// with sudo nerdctl) and have exposed ports 8081 and 8082.
+const data = `# Warning: iptables-legacy tables present, use iptables-legacy to see them
+-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N CNI-04579c7bb67f4c3f6cca0185
+-N CNI-28e04aad9bf52e38b43f8700
+-N CNI-2d72aeb202429907277c53c5
+-N CNI-2e2f8d5b91929ef9fc152e75
+-N CNI-3cbb832b23c724bdddedd7e4
+-N CNI-5033e3bad9f1265a2b04037f
+-N CNI-DN-04579c7bb67f4c3f6cca0
+-N CNI-DN-2d72aeb202429907277c5
+-N CNI-DN-2e2f8d5b91929ef9fc152
+-N CNI-HOSTPORT-DNAT
+-N CNI-HOSTPORT-MASQ
+-N CNI-HOSTPORT-SETMARK
+-N CNI-cb0db077a14ecd8d4a843636
+-N CNI-f1ca917e7b9939c7d8457d68
+-A PREROUTING -m addrtype --dst-type LOCAL -j CNI-HOSTPORT-DNAT
+-A OUTPUT -m addrtype --dst-type LOCAL -j CNI-HOSTPORT-DNAT
+-A POSTROUTING -m comment --comment "CNI portfwd requiring masquerade" -j CNI-HOSTPORT-MASQ
+-A POSTROUTING -s 10.4.0.3/32 -m comment --comment "name: \"bridge\" id: \"default-44540a2b2cc6c1154d2a21aec473d6987ec4d6bc339e89ee295a6db433ad623e\"" -j CNI-5033e3bad9f1265a2b04037f
+-A POSTROUTING -s 10.4.0.4/32 -m comment --comment "name: \"bridge\" id: \"default-cf12b94944785a4c8937e237a0a277d893cbadebd50409ed5d4b8ca3f90fedf3\"" -j CNI-28e04aad9bf52e38b43f8700
+-A POSTROUTING -s 10.4.0.5/32 -m comment --comment "name: \"bridge\" id: \"default-e9d499901490e6a66277688ba8d71cca35a6d1ca6261bc5a7e11e45e80aa3ea3\"" -j CNI-3cbb832b23c724bdddedd7e4
+-A POSTROUTING -s 10.4.0.6/32 -m comment --comment "name: \"bridge\" id: \"default-a65e32cc21f9da99b4aa826914873e343f8f09f910657450be551aa24d676e51\"" -j CNI-f1ca917e7b9939c7d8457d68
+-A POSTROUTING -s 10.4.0.7/32 -m comment --comment "name: \"bridge\" id: \"default-c93e2a3a2264f98647f0d33dc80d88de81c0710bf30ea822e2ed19213f9c53b5\"" -j CNI-2e2f8d5b91929ef9fc152e75
+-A POSTROUTING -s 10.4.0.8/32 -m comment --comment "name: \"bridge\" id: \"default-a8df9868a5f7ee2468118331dd6185e5655f7ff8e77f067408b7ff40e9457860\"" -j CNI-cb0db077a14ecd8d4a843636
+-A POSTROUTING -s 10.4.0.9/32 -m comment --comment "name: \"bridge\" id: \"default-393bd750d06186633a02b44487765ce038b7df434bfb16027ca1903bf5f3dc31\"" -j CNI-2d72aeb202429907277c53c5
+-A POSTROUTING -s 10.4.0.10/32 -m comment --comment "name: \"bridge\" id: \"default-3d263c6a1c710edc1362764464c073ca834ec9adc0766411772f2b7a3dd1de0f\"" -j CNI-04579c7bb67f4c3f6cca0185
+-A CNI-04579c7bb67f4c3f6cca0185 -d 10.4.0.0/24 -m comment --comment "name: \"bridge\" id: \"default-3d263c6a1c710edc1362764464c073ca834ec9adc0766411772f2b7a3dd1de0f\"" -j ACCEPT
+-A CNI-04579c7bb67f4c3f6cca0185 ! -d 224.0.0.0/4 -m comment --comment "name: \"bridge\" id: \"default-3d263c6a1c710edc1362764464c073ca834ec9adc0766411772f2b7a3dd1de0f\"" -j MASQUERADE
+-A CNI-28e04aad9bf52e38b43f8700 -d 10.4.0.0/24 -m comment --comment "name: \"bridge\" id: \"default-cf12b94944785a4c8937e237a0a277d893cbadebd50409ed5d4b8ca3f90fedf3\"" -j ACCEPT
+-A CNI-28e04aad9bf52e38b43f8700 ! -d 224.0.0.0/4 -m comment --comment "name: \"bridge\" id: \"default-cf12b94944785a4c8937e237a0a277d893cbadebd50409ed5d4b8ca3f90fedf3\"" -j MASQUERADE
+-A CNI-2d72aeb202429907277c53c5 -d 10.4.0.0/24 -m comment --comment "name: \"bridge\" id: \"default-393bd750d06186633a02b44487765ce038b7df434bfb16027ca1903bf5f3dc31\"" -j ACCEPT
+-A CNI-2d72aeb202429907277c53c5 ! -d 224.0.0.0/4 -m comment --comment "name: \"bridge\" id: \"default-393bd750d06186633a02b44487765ce038b7df434bfb16027ca1903bf5f3dc31\"" -j MASQUERADE
+-A CNI-2e2f8d5b91929ef9fc152e75 -d 10.4.0.0/24 -m comment --comment "name: \"bridge\" id: \"default-c93e2a3a2264f98647f0d33dc80d88de81c0710bf30ea822e2ed19213f9c53b5\"" -j ACCEPT
+-A CNI-2e2f8d5b91929ef9fc152e75 ! -d 224.0.0.0/4 -m comment --comment "name: \"bridge\" id: \"default-c93e2a3a2264f98647f0d33dc80d88de81c0710bf30ea822e2ed19213f9c53b5\"" -j MASQUERADE
+-A CNI-3cbb832b23c724bdddedd7e4 -d 10.4.0.0/24 -m comment --comment "name: \"bridge\" id: \"default-e9d499901490e6a66277688ba8d71cca35a6d1ca6261bc5a7e11e45e80aa3ea3\"" -j ACCEPT
+-A CNI-3cbb832b23c724bdddedd7e4 ! -d 224.0.0.0/4 -m comment --comment "name: \"bridge\" id: \"default-e9d499901490e6a66277688ba8d71cca35a6d1ca6261bc5a7e11e45e80aa3ea3\"" -j MASQUERADE
+-A CNI-5033e3bad9f1265a2b04037f -d 10.4.0.0/24 -m comment --comment "name: \"bridge\" id: \"default-44540a2b2cc6c1154d2a21aec473d6987ec4d6bc339e89ee295a6db433ad623e\"" -j ACCEPT
+-A CNI-5033e3bad9f1265a2b04037f ! -d 224.0.0.0/4 -m comment --comment "name: \"bridge\" id: \"default-44540a2b2cc6c1154d2a21aec473d6987ec4d6bc339e89ee295a6db433ad623e\"" -j MASQUERADE
+-A CNI-DN-04579c7bb67f4c3f6cca0 -s 10.4.0.0/24 -p tcp -m tcp --dport 8082 -j CNI-HOSTPORT-SETMARK
+-A CNI-DN-04579c7bb67f4c3f6cca0 -s 127.0.0.1/32 -p tcp -m tcp --dport 8082 -j CNI-HOSTPORT-SETMARK
+-A CNI-DN-04579c7bb67f4c3f6cca0 -p tcp -m tcp --dport 8082 -j DNAT --to-destination 10.4.0.10:80
+-A CNI-DN-2e2f8d5b91929ef9fc152 -s 10.4.0.0/24 -d 127.0.0.1/32 -p tcp -m tcp --dport 8081 -j CNI-HOSTPORT-SETMARK
+-A CNI-DN-2e2f8d5b91929ef9fc152 -s 127.0.0.1/32 -d 127.0.0.1/32 -p tcp -m tcp --dport 8081 -j CNI-HOSTPORT-SETMARK
+-A CNI-DN-2e2f8d5b91929ef9fc152 -d 127.0.0.1/32 -p tcp -m tcp --dport 8081 -j DNAT --to-destination 10.4.0.7:80
+-A CNI-HOSTPORT-DNAT -p tcp -m comment --comment "dnat name: \"bridge\" id: \"default-c93e2a3a2264f98647f0d33dc80d88de81c0710bf30ea822e2ed19213f9c53b5\"" -m multiport --dports 8081 -j CNI-DN-2e2f8d5b91929ef9fc152
+-A CNI-HOSTPORT-DNAT -p tcp -m comment --comment "dnat name: \"bridge\" id: \"default-393bd750d06186633a02b44487765ce038b7df434bfb16027ca1903bf5f3dc31\"" -m multiport --dports 8082 -j CNI-DN-2d72aeb202429907277c5
+-A CNI-HOSTPORT-DNAT -p tcp -m comment --comment "dnat name: \"bridge\" id: \"default-3d263c6a1c710edc1362764464c073ca834ec9adc0766411772f2b7a3dd1de0f\"" -m multiport --dports 8082 -j CNI-DN-04579c7bb67f4c3f6cca0
+-A CNI-HOSTPORT-MASQ -m mark --mark 0x2000/0x2000 -j MASQUERADE
+-A CNI-HOSTPORT-SETMARK -m comment --comment "CNI portfwd masquerade mark" -j MARK --set-xmark 0x2000/0x2000
+-A CNI-cb0db077a14ecd8d4a843636 -d 10.4.0.0/24 -m comment --comment "name: \"bridge\" id: \"default-a8df9868a5f7ee2468118331dd6185e5655f7ff8e77f067408b7ff40e9457860\"" -j ACCEPT
+-A CNI-cb0db077a14ecd8d4a843636 ! -d 224.0.0.0/4 -m comment --comment "name: \"bridge\" id: \"default-a8df9868a5f7ee2468118331dd6185e5655f7ff8e77f067408b7ff40e9457860\"" -j MASQUERADE
+-A CNI-f1ca917e7b9939c7d8457d68 -d 10.4.0.0/24 -m comment --comment "name: \"bridge\" id: \"default-a65e32cc21f9da99b4aa826914873e343f8f09f910657450be551aa24d676e51\"" -j ACCEPT
+-A CNI-f1ca917e7b9939c7d8457d68 ! -d 224.0.0.0/4 -m comment --comment "name: \"bridge\" id: \"default-a65e32cc21f9da99b4aa826914873e343f8f09f910657450be551aa24d676e51\"" -j MASQUERADE
+`
+
+func TestParsePortsFromRules(t *testing.T) {
+
+	// Turn the string into individual lines
+	rules := strings.Split(data, "\n")
+	if len(rules) > 0 && rules[len(rules)-1] == "" {
+		rules = rules[:len(rules)-1]
+	}
+
+	res, err := parsePortsFromRules(rules)
+	if err != nil {
+		t.Errorf("parsing iptables ports failed with error: %s", err)
+	}
+
+	l := len(res)
+	if l != 2 {
+		t.Fatalf("expected 2 ports parsed from iptables but parsed %d", l)
+	}
+
+	if res[0].IP.String() != "127.0.0.1" || res[0].Port != 8082 {
+		t.Errorf("expected port 8082 on IP 127.0.0.1 but go port %d on IP %s", res[0].Port, res[0].IP.String())
+	}
+	if res[1].IP.String() != "127.0.0.1" || res[1].Port != 8081 {
+		t.Errorf("expected port 8081 on IP 127.0.0.1 but go port %d on IP %s", res[1].Port, res[1].IP.String())
+	}
+}

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -290,7 +290,7 @@ func (a *HostAgent) watchGuestAgentEvents(ctx context.Context) {
 
 	localUnix := filepath.Join(a.instDir, filenames.GuestAgentSock)
 	// guest should have same UID as the host (specified in cidata)
-	remoteUnix := fmt.Sprintf("/run/user/%d/lima-guestagent.sock", os.Getuid())
+	remoteUnix := "/run/lima-guestagent.sock"
 
 	for {
 		if !isGuestAgentSocketAccessible(ctx, localUnix) {

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -102,13 +102,13 @@ fi
 		description: "the guest agent to be running",
 		script: `#!/bin/bash
 set -eux -o pipefail
-sock="/run/user/$(id -u)/lima-guestagent.sock"
+sock="/run/lima-guestagent.sock"
 if ! timeout 30s bash -c "until [ -S \"${sock}\" ]; do sleep 3; done"; then
 	echo >&2 "lima-guestagent is not installed yet"
 	exit 1
 fi
 `,
-		debugHint: `The guest agent (/run/user/$UID/lima-guestagent.sock) does not seem running.
+		debugHint: `The guest agent (/run/lima-guestagent.sock) does not seem running.
 Make sure that you are using an officially supported image.
 Also see "/var/log/cloud-init-output.log" in the guest.
 A possible workaround is to run "lima-guestagent install-systemd" in the guest.


### PR DESCRIPTION
A couple changes were made to make this possible including:
- Adding iptables package to read the ports exposed by portmap
  CNI plugin. This was done so that 1 call to iptables is all
  that is needed on each run.
- Move the lima-guestagent to run as root. This is needed for
  permission to use iptables.

Note, this implementation only includes ipv4 support. Does not work for ipv6.

Closes #140 

Note, this is my first pass. Happy to make changes as needed.