### PR TITLE
Map usernames not allowed by useradd to the fallbackUser "lima"

### DIFF
--- a/pkg/osutil/user.go
+++ b/pkg/osutil/user.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"github.com/sirupsen/logrus"
 	"os/user"
+	"regexp"
 	"sync"
-
-	"github.com/containerd/containerd/identifiers"
 )
 
 const (
@@ -24,9 +23,12 @@ func LimaUser(warn bool) (*user.User, error) {
 	cache.Do(func() {
 		cache.u, cache.err = user.Current()
 		if cache.err == nil {
-			if err := identifiers.Validate(cache.u.Username); err != nil {
-				cache.warning = fmt.Sprintf("local user %q is not a valid Linux username: %v; using %q username instead",
-					cache.u.Username, err, fallbackUser)
+			// `useradd` only allows user and group names matching the following pattern:
+			// (it allows a trailing '$', but it feels prudent to map those to the fallback user as well)
+			validName := "^[a-z_][a-z0-9_-]*$"
+			if !regexp.MustCompile(validName).Match([]byte(cache.u.Username)) {
+				cache.warning = fmt.Sprintf("local user %q is not a valid Linux username (must match %q); using %q username instead",
+					cache.u.Username, validName, fallbackUser)
 				cache.u.Username = fallbackUser
 			}
 		}


### PR DESCRIPTION
This PR expands on #214.

The `useradd` utility uses a more restrictive pattern than the containerd `identifiers.Validate()` function: https://github.com/shadow-maint/shadow/blob/26bbee8/libmisc/chkname.c#L51-L78

Also a fully numeric username seems to break systemd/cloud-init, as `/run/user/$UID/systemd/private` is never created.

Note that this PR will also disallow the `firstname.lastname` usernames.

Fixes #235