### PR TITLE
Switch sshfs mount options `-o allow_root` to `-o allow_other`

### DIFF
--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -47,8 +47,8 @@ func (a *HostAgent) setupMount(ctx context.Context, m limayaml.Mount) (*mount, e
 		Port:       a.y.SSH.LocalPort,
 		RemotePath: expanded,
 		Readonly:   !m.Writable,
-		// NOTE: allow_root requires "user_allow_other" in /etc/fuse.conf
-		SSHFSAdditionalArgs: []string{"-o", "allow_root"},
+		// NOTE: allow_other requires "user_allow_other" in /etc/fuse.conf
+		SSHFSAdditionalArgs: []string{"-o", "allow_other"},
 	}
 	if err := rsf.Prepare(); err != nil {
 		return nil, fmt.Errorf("failed to prepare reverse sshfs for %q: %w", expanded, err)

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -35,7 +35,7 @@ memory: "4GiB"
 # Default: "100GiB"
 disk: "100GiB"
 
-# Expose host directories to the guest
+# Expose host directories to the guest, the mount point might be accessible from all UIDs in the guest
 # Default: none
 mounts:
   - location: "~"


### PR DESCRIPTION
limactl start by default uses `-o allow_root` to mount macbook host directories into lima host.
```
zhao@lima-default:~$ ps aux | grep sshfs
zhao        1505  0.2  0.0 597028  3752 ?        Ssl  03:18   0:00 sshfs :/Users/zhao /Users/zhao -o slave -o allow_root
zhao        1523  0.0  0.0 162148  3060 ?        Ssl  03:18   0:00 sshfs :/tmp/lima /tmp/lima -o slave -o allow_root
zhao        2678  0.0  0.0   8392   920 pts/1    S+   03:21   0:00 grep --color=auto sshfs
````

When creating some containers that runs applications using user other than `root` - for example, Apache2 running inside our dev-docker container with `www-data` user, and use mounted folders as the DocumentRoot, it complains about the missing permission

```
[Thu Sep 16 03:24:39.080127 2021] [core:error] [pid 61] (13)Permission denied: [client 10.4.2.2:35796] AH00035: access to /external/web/entry.php denied (filesystem path '/external') because search permissions are missing on a component of the path, referer: ...
```

And confirmed by switching to `www-data` user inside the `dev-docker` container, it lacks the permission to access the mounted volume.

```
root@dev-docker:/# su www-data -s /bin/bash
www-data@dev-docker:/$ ls -lh
ls: cannot access 'external': Permission denied
total 64K
drwxr-xr-x   2 root   root    4.0K Sep 14 23:34 bin
drwxr-xr-x   2 root   root    4.0K Apr 24  2018 boot
drwxr-xr-x   5 root   root     340 Sep 16 03:19 dev
drwxr-xr-x  65 root   root    4.0K Sep 16 03:19 etc
drwxr-xr-x   2 root   root    4.0K Apr 24  2018 home
d?????????   ? ?      ?          ?            ? external
drwxr-xr-x   9 root   root    4.0K Sep 14 23:34 lib
drwxr-xr-x   2 root   root    4.0K Aug 27 07:18 lib64
drwxr-xr-x   2 root   root    4.0K Aug 27 07:16 media
drwxr-xr-x   2 root   root    4.0K Aug 27 07:16 mnt
drwxr-xr-x   2 root   root    4.0K Aug 27 07:16 opt
dr-xr-xr-x 228 nobody nogroup    0 Sep 16 03:19 proc
drwx------   4 root   root    4.0K Sep 16 03:19 root
drwxr-xr-x  11 root   root    4.0K Sep 16 03:19 run
drwxr-xr-x   2 root   root    4.0K Sep 14 15:12 sbin
drwxr-xr-x   2 root   root    4.0K Aug 27 07:16 srv
dr-xr-xr-x  13 nobody nogroup    0 Sep 16 03:19 sys
drwxrwxrwt   4 root   root    4.0K Sep 16 03:19 tmp
drwxr-xr-x  10 root   root    4.0K Aug 27 07:16 usr
drwxr-xr-x  12 root   root    4.0K Sep 16 03:19 var
```

By switching to use `-o allow_other` solves the problem, as verified locally