### PR TITLE
Don't use dockerhub to avoid hitting rate limits in CI

### DIFF
--- a/hack/test-example.sh
+++ b/hack/test-example.sh
@@ -170,10 +170,11 @@ if [[ -n ${CHECKS["containerd-user"]} ]]; then
 		mkdir -p "$hometmp"
 		defer "rm -rf \"$hometmp\""
 		set -x
-		limactl shell "$NAME" nerdctl pull alpine
+		alpine_image="ghcr.io/containerd/alpine:3.14.0"
+		limactl shell "$NAME" nerdctl pull ${alpine_image}
 		echo "random-content-${RANDOM}" >"$hometmp/random"
 		expected="$(cat "$hometmp/random")"
-		got="$(limactl shell "$NAME" nerdctl run --rm -v "$hometmp/random":/mnt/foo alpine cat /mnt/foo)"
+		got="$(limactl shell "$NAME" nerdctl run --rm -v "$hometmp/random":/mnt/foo ${alpine_image} cat /mnt/foo)"
 		INFO "$hometmp/random: expected=${expected}, got=${got}"
 		if [ "$got" != "$expected" ]; then
 			ERROR "Home directory is not shared?"

--- a/pkg/networks/networks.go
+++ b/pkg/networks/networks.go
@@ -2,10 +2,6 @@ package networks
 
 import "net"
 
-const (
-	LimaScheme = "lima://"
-)
-
 type NetworksConfig struct {
 	Paths    Paths              `yaml:"paths"`
 	Group    string             `yaml:"group,omitempty"` // default: "staff"


### PR DESCRIPTION
Fixes #260

Also removes unused `networks.LimaScheme` constant.