### PR TITLE
Fix broken brackets

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh
@@ -43,7 +43,7 @@ EOF
 	if command -v selinuxenabled >/dev/null 2>&1 && selinuxenabled; then
 		selinux=1
 	fi
-	if [ ! -e "/home/${LIMA_CIDATA_USER}}}.linux/.config/systemd/user/containerd.service" ]; then
+	if [ ! -e "/home/${LIMA_CIDATA_USER}.linux/.config/systemd/user/containerd.service" ]; then
 		until [ -e "/run/user/${LIMA_CIDATA_UID}/systemd/private" ]; do sleep 3; done
 		if [ -n "$selinux" ]; then
 			echo "Temporarily disabling SELinux, during installing containerd units"


### PR DESCRIPTION
## Summary
- There's a broken brackets in `40-install-containerd.sh`, which makes containerd-setup process to be always executed