### PR TITLE
Setup proxy environment variables from system settings

### DIFF
--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -38,7 +38,7 @@ type TemplateArgs struct {
 	SlirpNICName string
 	SlirpGateway string
 	SlirpDNS     string
-	Env          map[string]*string
+	Env          map[string]string
 	DNSAddresses []string
 }
 

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -177,9 +177,10 @@ networks:
 #   # Any port still not matched by a rule will not be forwarded (ignored)
 
 # Extra environment variables that will be loaded into the VM at start up.
-# These variables are currently only consumed by internal init scripts, not by the user shell.
-# This field is experimental and may change in a future release of Lima.
-# https://github.com/lima-vm/lima/pull/200
+# These variables are consumed by internal init scripts, and also added
+# to /etc/environment.
+# If you set any of "ftp_proxy", "http_proxy", "https_proxy", or "no_proxy", then
+# Lima will automatically set an uppercase variant to the same value as well.
 # env:
 #   KEY: value
 

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -7,23 +7,23 @@ import (
 )
 
 type LimaYAML struct {
-	Arch         Arch               `yaml:"arch,omitempty"`
-	Images       []File             `yaml:"images"` // REQUIRED
-	CPUs         int                `yaml:"cpus,omitempty"`
-	Memory       string             `yaml:"memory,omitempty"` // go-units.RAMInBytes
-	Disk         string             `yaml:"disk,omitempty"`   // go-units.RAMInBytes
-	Mounts       []Mount            `yaml:"mounts,omitempty"`
-	SSH          SSH                `yaml:"ssh,omitempty"` // REQUIRED (FIXME)
-	Firmware     Firmware           `yaml:"firmware,omitempty"`
-	Video        Video              `yaml:"video,omitempty"`
-	Provision    []Provision        `yaml:"provision,omitempty"`
-	Containerd   Containerd         `yaml:"containerd,omitempty"`
-	Probes       []Probe            `yaml:"probes,omitempty"`
-	PortForwards []PortForward      `yaml:"portForwards,omitempty"`
-	Networks     []Network          `yaml:"networks,omitempty"`
-	Network      NetworkDeprecated  `yaml:"network,omitempty"` // DEPRECATED, use `networks` instead
-	Env          map[string]*string `yaml:"env,omitempty"`     // EXPERIMENAL, see default.yaml
-	DNS          []net.IP           `yaml:"dns,omitempty"`
+	Arch         Arch              `yaml:"arch,omitempty"`
+	Images       []File            `yaml:"images"` // REQUIRED
+	CPUs         int               `yaml:"cpus,omitempty"`
+	Memory       string            `yaml:"memory,omitempty"` // go-units.RAMInBytes
+	Disk         string            `yaml:"disk,omitempty"`   // go-units.RAMInBytes
+	Mounts       []Mount           `yaml:"mounts,omitempty"`
+	SSH          SSH               `yaml:"ssh,omitempty"` // REQUIRED (FIXME)
+	Firmware     Firmware          `yaml:"firmware,omitempty"`
+	Video        Video             `yaml:"video,omitempty"`
+	Provision    []Provision       `yaml:"provision,omitempty"`
+	Containerd   Containerd        `yaml:"containerd,omitempty"`
+	Probes       []Probe           `yaml:"probes,omitempty"`
+	PortForwards []PortForward     `yaml:"portForwards,omitempty"`
+	Networks     []Network         `yaml:"networks,omitempty"`
+	Network      NetworkDeprecated `yaml:"network,omitempty"` // DEPRECATED, use `networks` instead
+	Env          map[string]string `yaml:"env,omitempty"`
+	DNS          []net.IP          `yaml:"dns,omitempty"`
 }
 
 type Arch = string

--- a/pkg/osutil/dns_darwin.go
+++ b/pkg/osutil/dns_darwin.go
@@ -1,6 +1,11 @@
 package osutil
 
-import "github.com/lima-vm/lima/pkg/sysprof"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lima-vm/lima/pkg/sysprof"
+)
 
 func DNSAddresses() ([]string, error) {
 	nwData, err := sysprof.NetworkData()
@@ -22,4 +27,48 @@ func DNSAddresses() ([]string, error) {
 		}
 	}
 	return addresses, nil
+}
+
+func proxyURL(proxy string, port int) string {
+	if !strings.Contains(proxy, "://") {
+		proxy = "http://" + proxy
+	}
+	if port != 0 {
+		proxy = fmt.Sprintf("%s:%d", proxy, port)
+	}
+	return proxy
+}
+
+func ProxySettings() (map[string]string, error) {
+	nwData, err := sysprof.NetworkData()
+	if err != nil {
+		return nil, err
+	}
+	env := make(map[string]string)
+	if len(nwData) > 0 {
+		// In case "en0" is not found, use the proxies of the first interface
+		proxies := nwData[0].Proxies
+		for _, nw := range nwData {
+			if nw.Interface == "en0" {
+				proxies = nw.Proxies
+				break
+			}
+		}
+		// Proxies with a username are not going to work because the password is stored in a keychain.
+		// If users are fine with exposing the username/password, they can set the proxy to
+		// "http://username:password@proxyhost.com" in the system settings (or in lima.yaml).
+		if proxies.FTPEnable == "yes" && proxies.FTPUser == "" {
+			env["ftp_proxy"] = proxyURL(proxies.FTPProxy, proxies.FTPPort)
+		}
+		if proxies.HTTPEnable == "yes" && proxies.HTTPUser == "" {
+			env["http_proxy"] = proxyURL(proxies.HTTPProxy, proxies.HTTPPort)
+		}
+		if proxies.HTTPSEnable == "yes" && proxies.HTTPSUser == "" {
+			env["https_proxy"] = proxyURL(proxies.HTTPSProxy, proxies.HTTPSPort)
+		}
+		// Not setting up "no_proxy" variable; the values from the proxies.ExceptionList are
+		// not understood by most applications checking "no_proxy". The default value would
+		// be "*.local,169.254/16". Users can always specify env.no_proxy in lima.yaml.
+	}
+	return env, nil
 }

--- a/pkg/osutil/dns_others.go
+++ b/pkg/osutil/dns_others.go
@@ -7,3 +7,7 @@ func DNSAddresses() ([]string, error) {
 	// TODO: parse /etc/resolv.conf?
 	return []string{}, nil
 }
+
+func ProxySettings() (map[string]string, error) {
+		return make(map[string]string), nil
+}

--- a/pkg/sysprof/network_darwin.go
+++ b/pkg/sysprof/network_darwin.go
@@ -5,10 +5,27 @@ type SPNetworkDataType struct {
 }
 
 type NetworkDataType struct {
-	DNS       DNS    `json:"DNS"`
-	Interface string `json:"interface"`
+	DNS       DNS     `json:"DNS"`
+	Interface string  `json:"interface"`
+	Proxies   Proxies `json:"Proxies"`
 }
 
 type DNS struct {
 	ServerAddresses []string `json:"ServerAddresses"`
+}
+
+type Proxies struct {
+	ExceptionList []string `json:"ExceptionList"` // default: ["*.local", "169.254/16"]
+	FTPEnable     string   `json:"FTPEnable"`
+	FTPPort       int      `json:"FTPPort"`
+	FTPProxy      string   `json:"FTPProxy"`
+	FTPUser       string   `json:"FTPUser"`
+	HTTPEnable    string   `json:"HTTPEnable"`
+	HTTPPort      int      `json:"HTTPPort"`
+	HTTPProxy     string   `json:"HTTPProxy"`
+	HTTPUser      string   `json:"HTTPUser"`
+	HTTPSEnable   string   `json:"HTTPSEnable"`
+	HTTPSPort     int      `json:"HTTPSPort"`
+	HTTPSProxy    string   `json:"HTTPSProxy"`
+	HTTPSUser     string   `json:"HTTPSUser"`
 }


### PR DESCRIPTION
Implement the changes suggested in https://github.com/lima-vm/lima/issues/189#issuecomment-911972759.

`env.*` settings from `lima.yaml` will override system settings.

Process environment during instance creation override all.

Fixes https://github.com/lima-vm/lima/issues/189#issuecomment-911972759
