### PR TITLE
Change instance id on every start

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/meta-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/meta-data
@@ -1,1 +1,2 @@
+instance-id: {{.IID}}
 local-hostname: lima-{{.Name}}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/lima-vm/lima/pkg/downloader"
 	"github.com/lima-vm/lima/pkg/iso9660util"
@@ -56,6 +57,9 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML) error {
 		SlirpDNS:     qemu.SlirpDNS,
 		Env:          y.Env,
 	}
+
+	// change instance id on every boot so network config will be processed again
+	args.IID = fmt.Sprintf("iid-%d", time.Now().Unix())
 
 	pubKeys, err := sshutil.DefaultPubKeys(*y.SSH.LoadDotSSHPubKeys)
 	if err != nil {

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -29,6 +29,7 @@ type Network struct {
 }
 type TemplateArgs struct {
 	Name         string // instance name
+	IID          string // instance id
 	User         string // user name
 	UID          int
 	SSHPubKeys   []string


### PR DESCRIPTION
That way cloud-init will do all the first-boot processing again to apply e.g. updated network configuration.

Fixes #270