### PR TITLE
yaml: support overriding the location of `nerdctl-full-X.Y.Z-linux-ARCH.tar.gz`

### DIFF
--- a/cmd/limactl/info.go
+++ b/cmd/limactl/info.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/lima-vm/lima/pkg/limayaml"
+	"github.com/lima-vm/lima/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+func newInfoCommand() *cobra.Command {
+	infoCommand := &cobra.Command{
+		Use:   "info",
+		Short: "Show diagnostic information",
+		Args:  cobra.NoArgs,
+		RunE:  infoAction,
+	}
+	return infoCommand
+}
+
+type Info struct {
+	Version         string             `json:"version"`
+	DefaultTemplate *limayaml.LimaYAML `json:"defaultTemplate"`
+	// TODO: add diagnostic info of QEMU
+}
+
+func infoAction(cmd *cobra.Command, args []string) error {
+	y, err := limayaml.Load(limayaml.DefaultTemplate, "")
+	if err != nil {
+		return err
+	}
+	info := &Info{
+		Version:         version.Version,
+		DefaultTemplate: y,
+	}
+	j, err := json.MarshalIndent(info, "", "    ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), string(j))
+	return err
+}

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -79,6 +79,7 @@ func newApp() *cobra.Command {
 		newSudoersCommand(),
 		newPruneCommand(),
 		newHostagentCommand(),
+		newInfoCommand(),
 	)
 	return rootCmd
 }

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -70,6 +70,12 @@ containerd:
   # Enable user-scoped (aka rootless) containerd and its dependencies
   # Default: true
   user: true
+#  # Override containerd archive
+#  # Default: hard-coded URL with hard-coded digest
+#  archives:
+#    - location: "~/Downloads/nerdctl-full-X.Y.Z-linux-amd64.tar.gz"
+#      arch: "x86_64"
+#      digest: "sha256:..."
 
 # Provisioning scripts need to be idempotent because they might be called
 # multiple times, e.g. when the host VM is being restarted.

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -71,7 +71,7 @@ containerd:
   # Default: true
   user: true
 #  # Override containerd archive
-#  # Default: hard-coded URL with hard-coded digest
+#  # Default: hard-coded URL with hard-coded digest (see the output of `limactl info | jq .defaultTemplate.containerd.archives`)
 #  archives:
 #    - location: "~/Downloads/nerdctl-full-X.Y.Z-linux-amd64.tar.gz"
 #      arch: "x86_64"

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -77,8 +77,9 @@ type Provision struct {
 }
 
 type Containerd struct {
-	System *bool `yaml:"system,omitempty"` // default: false
-	User   *bool `yaml:"user,omitempty"`   // default: true
+	System   *bool  `yaml:"system,omitempty"`   // default: false
+	User     *bool  `yaml:"user,omitempty"`     // default: true
+	Archives []File `yaml:"archives,omitempty"` // default: see defaultContainerdArchives
 }
 
 type ProbeMode = string

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -7,24 +7,24 @@ import (
 )
 
 type LimaYAML struct {
-	Arch            Arch              `yaml:"arch,omitempty"`
-	Images          []File            `yaml:"images"` // REQUIRED
-	CPUs            int               `yaml:"cpus,omitempty"`
-	Memory          string            `yaml:"memory,omitempty"` // go-units.RAMInBytes
-	Disk            string            `yaml:"disk,omitempty"`   // go-units.RAMInBytes
-	Mounts          []Mount           `yaml:"mounts,omitempty"`
-	SSH             SSH               `yaml:"ssh,omitempty"` // REQUIRED (FIXME)
-	Firmware        Firmware          `yaml:"firmware,omitempty"`
-	Video           Video             `yaml:"video,omitempty"`
-	Provision       []Provision       `yaml:"provision,omitempty"`
-	Containerd      Containerd        `yaml:"containerd,omitempty"`
-	Probes          []Probe           `yaml:"probes,omitempty"`
-	PortForwards    []PortForward     `yaml:"portForwards,omitempty"`
-	Networks        []Network         `yaml:"networks,omitempty"`
-	Network         NetworkDeprecated `yaml:"network,omitempty"` // DEPRECATED, use `networks` instead
-	Env             map[string]string `yaml:"env,omitempty"`
-	DNS             []net.IP          `yaml:"dns,omitempty"`
-	UseHostResolver *bool             `yaml:"useHostResolver,omitempty"`
+	Arch            Arch              `yaml:"arch,omitempty" json:"arch,omitempty"`
+	Images          []File            `yaml:"images" json:"images"` // REQUIRED
+	CPUs            int               `yaml:"cpus,omitempty" json:"cpus,omitempty"`
+	Memory          string            `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
+	Disk            string            `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes
+	Mounts          []Mount           `yaml:"mounts,omitempty" json:"mounts,omitempty"`
+	SSH             SSH               `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
+	Firmware        Firmware          `yaml:"firmware,omitempty" json:"firmware,omitempty"`
+	Video           Video             `yaml:"video,omitempty" json:"video,omitempty"`
+	Provision       []Provision       `yaml:"provision,omitempty" json:"provision,omitempty"`
+	Containerd      Containerd        `yaml:"containerd,omitempty" json:"containerd,omitempty"`
+	Probes          []Probe           `yaml:"probes,omitempty" json:"probes,omitempty"`
+	PortForwards    []PortForward     `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
+	Networks        []Network         `yaml:"networks,omitempty" json:"networks,omitempty"`
+	Network         NetworkDeprecated `yaml:"network,omitempty" json:"network,omitempty"` // DEPRECATED, use `networks` instead
+	Env             map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+	DNS             []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`
+	UseHostResolver *bool             `yaml:"useHostResolver,omitempty" json:"useHostResolver,omitempty"`
 }
 
 type Arch = string
@@ -35,33 +35,33 @@ const (
 )
 
 type File struct {
-	Location string        `yaml:"location"` // REQUIRED
-	Arch     Arch          `yaml:"arch,omitempty"`
-	Digest   digest.Digest `yaml:"digest,omitempty"`
+	Location string        `yaml:"location" json:"location"` // REQUIRED
+	Arch     Arch          `yaml:"arch,omitempty" json:"arch,omitempty"`
+	Digest   digest.Digest `yaml:"digest,omitempty" json:"digest,omitempty"`
 }
 
 type Mount struct {
-	Location string `yaml:"location"` // REQUIRED
-	Writable bool   `yaml:"writable,omitempty"`
+	Location string `yaml:"location" json:"location"` // REQUIRED
+	Writable bool   `yaml:"writable,omitempty" json:"writable,omitempty"`
 }
 
 type SSH struct {
-	LocalPort int `yaml:"localPort,omitempty"` // REQUIRED (FIXME: auto assign)
+	LocalPort int `yaml:"localPort,omitempty" json:"localPort,omitempty"` // REQUIRED (FIXME: auto assign)
 
 	// LoadDotSSHPubKeys loads ~/.ssh/*.pub in addition to $LIMA_HOME/_config/user.pub .
 	// Default: true
-	LoadDotSSHPubKeys *bool `yaml:"loadDotSSHPubKeys,omitempty"`
+	LoadDotSSHPubKeys *bool `yaml:"loadDotSSHPubKeys,omitempty" json:"loadDotSSHPubKeys,omitempty"`
 }
 
 type Firmware struct {
 	// LegacyBIOS disables UEFI if set.
 	// LegacyBIOS is ignored for aarch64.
-	LegacyBIOS bool `yaml:"legacyBIOS,omitempty"`
+	LegacyBIOS bool `yaml:"legacyBIOS,omitempty" json:"legacyBIOS,omitempty"`
 }
 
 type Video struct {
 	// Display is a QEMU display string
-	Display string `yaml:"display,omitempty"`
+	Display string `yaml:"display,omitempty" json:"display,omitempty"`
 }
 
 type ProvisionMode = string
@@ -72,14 +72,14 @@ const (
 )
 
 type Provision struct {
-	Mode   ProvisionMode `yaml:"mode"` // default: "system"
-	Script string        `yaml:"script"`
+	Mode   ProvisionMode `yaml:"mode" json:"mode"` // default: "system"
+	Script string        `yaml:"script" json:"script"`
 }
 
 type Containerd struct {
-	System   *bool  `yaml:"system,omitempty"`   // default: false
-	User     *bool  `yaml:"user,omitempty"`     // default: true
-	Archives []File `yaml:"archives,omitempty"` // default: see defaultContainerdArchives
+	System   *bool  `yaml:"system,omitempty" json:"system,omitempty"`     // default: false
+	User     *bool  `yaml:"user,omitempty" json:"user,omitempty"`         // default: true
+	Archives []File `yaml:"archives,omitempty" json:"archives,omitempty"` // default: see defaultContainerdArchives
 }
 
 type ProbeMode = string
@@ -102,25 +102,25 @@ const (
 )
 
 type PortForward struct {
-	GuestIP        net.IP `yaml:"guestIP,omitempty"`
-	GuestPort      int    `yaml:"guestPort,omitempty"`
-	GuestPortRange [2]int `yaml:"guestPortRange,omitempty"`
-	HostIP         net.IP `yaml:"hostIP,omitempty"`
-	HostPort       int    `yaml:"hostPort,omitempty"`
-	HostPortRange  [2]int `yaml:"hostPortRange,omitempty"`
-	Proto          Proto  `yaml:"proto,omitempty"`
-	Ignore         bool   `yaml:"ignore,omitempty"`
+	GuestIP        net.IP `yaml:"guestIP,omitempty" json:"guestIP,omitempty"`
+	GuestPort      int    `yaml:"guestPort,omitempty" json:"guestPort,omitempty"`
+	GuestPortRange [2]int `yaml:"guestPortRange,omitempty" json:"guestPortRange,omitempty"`
+	HostIP         net.IP `yaml:"hostIP,omitempty" json:"hostIP,omitempty"`
+	HostPort       int    `yaml:"hostPort,omitempty" json:"hostPort,omitempty"`
+	HostPortRange  [2]int `yaml:"hostPortRange,omitempty" json:"hostPortRange,omitempty"`
+	Proto          Proto  `yaml:"proto,omitempty" json:"proto,omitempty"`
+	Ignore         bool   `yaml:"ignore,omitempty" json:"ignore,omitempty"`
 }
 
 type Network struct {
 	// `Lima` and `VNL` are mutually exclusive; exactly one is required
-	Lima string `yaml:"lima,omitempty"`
+	Lima string `yaml:"lima,omitempty" json:"lima,omitempty"`
 	// VNL is a Virtual Network Locator (https://github.com/rd235/vdeplug4/commit/089984200f447abb0e825eb45548b781ba1ebccd).
 	// On macOS, only VDE2-compatible form (optionally with vde:// prefix) is supported.
-	VNL        string `yaml:"vnl,omitempty"`
-	SwitchPort uint16 `yaml:"switchPort,omitempty"` // VDE Switch port, not TCP/UDP port (only used by VDE networking)
-	MACAddress string `yaml:"macAddress,omitempty"`
-	Interface  string `yaml:"interface,omitempty"`
+	VNL        string `yaml:"vnl,omitempty" json:"vnl,omitempty"`
+	SwitchPort uint16 `yaml:"switchPort,omitempty" json:"switchPort,omitempty"` // VDE Switch port, not TCP/UDP port (only used by VDE networking)
+	MACAddress string `yaml:"macAddress,omitempty" json:"macAddress,omitempty"`
+	Interface  string `yaml:"interface,omitempty" json:"interface,omitempty"`
 }
 
 // DEPRECATED types below
@@ -129,14 +129,14 @@ type Network struct {
 // and to avoid accidental usage in new code.
 
 type NetworkDeprecated struct {
-	VDEDeprecated []VDEDeprecated `yaml:"vde,omitempty"`
+	VDEDeprecated []VDEDeprecated `yaml:"vde,omitempty" json:"vde,omitempty"`
 	// migrate will be true when `network.VDE` has been copied to `networks` by FillDefaults()
 	migrated bool
 }
 
 type VDEDeprecated struct {
-	VNL        string `yaml:"vnl,omitempty"`
-	SwitchPort uint16 `yaml:"switchPort,omitempty"` // VDE Switch port, not TCP/UDP port
-	MACAddress string `yaml:"macAddress,omitempty"`
-	Name       string `yaml:"name,omitempty"`
+	VNL        string `yaml:"vnl,omitempty" json:"vnl,omitempty"`
+	SwitchPort uint16 `yaml:"switchPort,omitempty" json:"switchPort,omitempty"` // VDE Switch port, not TCP/UDP port
+	MACAddress string `yaml:"macAddress,omitempty" json:"macAddress,omitempty"`
+	Name       string `yaml:"name,omitempty" json:"name,omitempty"`
 }

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -14,7 +14,7 @@ import (
 	"github.com/lima-vm/lima/pkg/localpathutil"
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/osutil"
-	"github.com/lima-vm/lima/pkg/qemu/const"
+	qemu "github.com/lima-vm/lima/pkg/qemu/const"
 	"github.com/sirupsen/logrus"
 )
 
@@ -108,6 +108,10 @@ func Validate(y LimaYAML, warn bool) error {
 			return fmt.Errorf("field `provision[%d].mode` must be either %q or %q",
 				i, ProvisionModeSystem, ProvisionModeUser)
 		}
+	}
+	needsContainerdArchives := (y.Containerd.User != nil && *y.Containerd.User) || (y.Containerd.System != nil && *y.Containerd.System)
+	if needsContainerdArchives && len(y.Containerd.Archives) == 0 {
+		return fmt.Errorf("field `containerd.archives` must be provided")
 	}
 	for i, p := range y.Probes {
 		switch p.Mode {

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -165,7 +165,7 @@ func Validate(y LimaYAML, warn bool) error {
 		// processed sequentially and the first matching rule for a guest port determines forwarding behavior.
 	}
 
-	if *y.UseHostResolver && len(y.DNS) > 0 {
+	if y.UseHostResolver != nil && *y.UseHostResolver && len(y.DNS) > 0 {
 		return fmt.Errorf("field `dns` must be empty when field `useHostResolver` is true")
 	}
 


### PR DESCRIPTION
e.g.,
```yaml
containerd:
  system: false
  user: true
  archives:
    - location: "~/Downloads/nerdctl-full-X.Y.Z-linux-amd64.tar.gz"
       arch: "x86_64"
       digest: "sha256:..."
```

The default archive URL can be inspected with `limactl info`
```console
$ limactl info
{
    "version": "v0.6.4-63-g8dfd9d8",
    "defaultTemplate": {
        "arch": "x86_64",
        "images": [
            {
                "location": "~/Downloads/hirsute-server-cloudimg-amd64.img",
                "arch": "x86_64"
            },
            {
                "location": "~/Downloads/hirsute-server-cloudimg-arm64.img",
                "arch": "aarch64"
            },
            {
                "location": "https://cloud-images.ubuntu.com/hirsute/current/hirsute-server-cloudimg-amd64.img",
                "arch": "x86_64"
            },
            {
                "location": "https://cloud-images.ubuntu.com/hirsute/current/hirsute-server-cloudimg-arm64.img",
                "arch": "aarch64"
            }
        ],
        "cpus": 4,
        "memory": "4GiB",
        "disk": "100GiB",
        "mounts": [
            {
                "location": "~"
            },
            {
                "location": "/tmp/lima",
                "writable": true
            }
        ],
        "ssh": {
            "localPort": 60022,
            "loadDotSSHPubKeys": true
        },
        "firmware": {},
        "video": {
            "display": "none"
        },
        "containerd": {
            "system": false,
            "user": true,
            "archives": [
                {
                    "location": "https://github.com/containerd/nerdctl/releases/download/v0.11.2/nerdctl-full-0.11.2-linux-amd64.tar.gz",
                    "arch": "x86_64",
                    "digest": "sha256:27dbb238f9eb248ca68f11b412670db51db84905e3583834400305b2149915f2"
                },
                {
                    "location": "https://github.com/containerd/nerdctl/releases/download/v0.11.2/nerdctl-full-0.11.2-linux-arm64.tar.gz",
                    "arch": "aarch64",
                    "digest": "sha256:fe6322a88cb15d8a502e649827e3d1570210bb038b7a4a52820bce0fec86a637"
                }
            ]
        },
        "network": {}
    }
}
```