### PR TITLE
Make sure that environment file exists

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.sh
@@ -12,7 +12,9 @@ WARNING() {
 # shellcheck disable=SC2163
 while read -r line; do export "$line"; done <"${LIMA_CIDATA_MNT}"/lima.env
 
-sed -i '/#LIMA-START/,/#LIMA-END/d' /etc/environment
+if [ -e /etc/environment ]; then
+	sed -i '/#LIMA-START/,/#LIMA-END/d' /etc/environment
+fi
 cat "${LIMA_CIDATA_MNT}/etc_environment" >>/etc/environment
 
 # shellcheck disable=SC2163


### PR DESCRIPTION
Before trying to append new things to it

Think I only had `/etc/profile` around ?

So it failed the boot.sh shell script...