### PR TITLE
Make scripts use bourne shell and not bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ _output/share/lima/lima-guestagent.Linux-aarch64:
 install:
 	mkdir -p "$(DEST)"
 	cp -av _output/* "$(DEST)"
-	if [[ $(shell uname -s ) != Linux && ! -e "$(DEST)/bin/nerdctl" ]]; then ln -sf nerdctl.lima "$(DEST)/bin/nerdctl"; fi
+	if [ "$(shell uname -s )" != "Linux" -a ! -e "$(DEST)/bin/nerdctl" ]; then ln -sf nerdctl.lima "$(DEST)/bin/nerdctl"; fi
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
So "make install" failed on Ubuntu (and Debian)

`/bin/sh -> dash`

See https://github.com/lima-vm/lima/issues/291#issuecomment-933782381