### PR TITLE
update nerdctl (v0.12.1), archlinux, debian

### DIFF
--- a/examples/archlinux.yaml
+++ b/examples/archlinux.yaml
@@ -2,9 +2,9 @@
 arch: "x86_64"
 images:
   # NOTE: the image is periodically rotated, if you face 404, see https://mirror.pkgbuild.com/images/ to find the latest image.
-  - location: "https://mirror.pkgbuild.com/images/v20210915.34349/Arch-Linux-x86_64-cloudimg-20210915.0.qcow2"
+  - location: "https://mirror.pkgbuild.com/images/v20211001.35402/Arch-Linux-x86_64-cloudimg-20211001.0.qcow2"
     arch: "x86_64"
-    digest: "sha256:de8de860fec1efbae75418948f5bc7873ca53a2f4c31b0e9306facc94fffd5a8"
+    digest: "sha256:bee4dbb88c2e9e2306cf1de92e40797b892c937557e5986a65153e16f9037878"
 mounts:
   - location: "~"
     writable: false

--- a/examples/debian.yaml
+++ b/examples/debian.yaml
@@ -1,10 +1,10 @@
 images:
-  - location: "https://cloud.debian.org/images/cloud/bullseye/daily/20210916-767/debian-11-generic-amd64-daily-20210916-767.qcow2"
+  - location: "https://cloud.debian.org/images/cloud/bullseye/daily/20211005-786/debian-11-generic-amd64-daily-20211005-786.qcow2"
     arch: "x86_64"
-    digest: "sha512:ed3a2631488eb4b31eed3757f936928322f2e6bc5717844173b41db0a77847ef9602e715fd16faf0b46aba2ff990d29cc79167d3940fbd1fdd9161866dee90ff"
-  - location: "https://cloud.debian.org/images/cloud/bullseye/daily/20210916-767/debian-11-generic-arm64-daily-20210916-767.qcow2"
+    digest: "sha512:e1f3e543774ca428c1f308d8636330d2371ced4c2042bc8fbce2048757907d5fa32663c2f6afcd4ed8efc0cba1c45c2a2d8556cd2b4f17f06517ad5c3a3c52b8"
+  - location: "https://cloud.debian.org/images/cloud/bullseye/daily/20211005-786/debian-11-generic-arm64-daily-20211005-786.qcow2"
     arch: "aarch64"
-    digest: "sha512:8cb39915c402956b1e3ffd0c4e16d4cae61ed6521e65b3c578d8f099bf710297a5c51881e6ca7d0840f0cc2b4417c663a0e67c25695d560a2dabde58f4e6bd7d"
+    digest: "sha512:9ff3b67aac3aac605bdcc8ec0d4b12ac73b6102c4878ca4ba338978a16bf76db67a929efb2e2a5b03729bc6880b19914c1d4385f38903a352f523c03353c974f"
 mounts:
   - location: "~"
     writable: false

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -12,7 +12,7 @@ import (
 )
 
 func defaultContainerdArchives() []File {
-	const nerdctlVersion = "0.12.0"
+	const nerdctlVersion = "0.12.1"
 	location := func(goarch string) string {
 		return "https://github.com/containerd/nerdctl/releases/download/v" + nerdctlVersion + "/nerdctl-full-" + nerdctlVersion + "-linux-" + goarch + ".tar.gz"
 	}
@@ -20,12 +20,12 @@ func defaultContainerdArchives() []File {
 		{
 			Location: location("amd64"),
 			Arch:     X8664,
-			Digest:   "sha256:7789800cfdd19fa9eccadb5e4a911e4ba759799ad9ec0b7929c983b9d149bc98",
+			Digest:   "sha256:fe9e7e63554795fc4b984c178609a2a9dffa6d69925356f919b8fa30a2f36210",
 		},
 		{
 			Location: location("arm64"),
 			Arch:     AARCH64,
-			Digest:   "sha256:ebb05e22ac6a3c25ac88ca4f747feed89bfae8e447a626d0fedf3b4f40ac3303",
+			Digest:   "sha256:47fb7f904cd541c5761ae9f4fd385bfa93fa4b36a963a5a54f7c8df647f5d6fc",
 		},
 	}
 }


### PR DESCRIPTION
https://github.com/containerd/nerdctl/releases/tag/v0.12.1