### PR TITLE
sshutil: prioritize aes128-gcm@openssh.com when AES acceleration is available (roughly 60% faster on Intel Mac)

### DIFF
--- a/pkg/sshutil/sshutil_darwin.go
+++ b/pkg/sshutil/sshutil_darwin.go
@@ -1,0 +1,28 @@
+package sshutil
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+)
+
+func detectAESAcceleration() bool {
+	switch runtime.GOARCH {
+	case "amd64":
+		const fallback = true
+		features, err := syscall.Sysctl("machdep.cpu.features") // not available on M1
+		if err != nil {
+			err = fmt.Errorf("failed to read sysctl \"machdep.cpu.features\": %w", err)
+			logrus.WithError(err).Warnf("failed to detect whether AES accelerator is available, assuming %v", fallback)
+			return fallback
+		}
+		return strings.Contains(features, "AES ")
+	default:
+		// According to https://gist.github.com/voluntas/fd279c7b4e71f9950cfd4a5ab90b722b ,
+		// aes-128-gcm is faster than chacha20-poly1305 on Apple M1.
+		return true
+	}
+}

--- a/pkg/sshutil/sshutil_linux.go
+++ b/pkg/sshutil/sshutil_linux.go
@@ -1,0 +1,20 @@
+package sshutil
+
+import (
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+func detectAESAcceleration() bool {
+	const fallback = runtime.GOARCH == "amd64"
+	cpuinfo, err := os.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		logrus.WithError(err).Warnf("failed to detect whether AES accelerator is available, assuming %v", fallback)
+		return fallback
+	}
+	// Checking "aes " should be enough for x86_64 and aarch64
+	return strings.Contains(string(cpuinfo), "aes ")
+}

--- a/pkg/sshutil/sshutil_others.go
+++ b/pkg/sshutil/sshutil_others.go
@@ -1,0 +1,16 @@
+//go:build !darwin && !linux
+// +build !darwin,!linux
+
+package sshutil
+
+import (
+	"runtime"
+
+	"github.com/sirupsen/logrus"
+)
+
+func detectAESAcceleration() bool {
+	const fallback = runtime.GOARCH == "amd64"
+	logrus.WithError(err).Warnf("cannot detect whether AES accelerator is available, assuming %v", fallback)
+	return fallback
+}


### PR DESCRIPTION
By default, `ssh` chooses `chacha20-poly1305@openssh.com`, even when AES acceleration is available.
(OpenSSH_8.1p1, macOS 11.6, MacBookPro 2020, Core i7-1068NG7)


AES accelerator is available on almost all recent Intel and AMD processors, but not on all ARM processors.
Probably available on Apple M1 too.  (https://github.com/lima-vm/lima/pull/299#issuecomment-938342611)

---

### Benchmark
sshfs becomes roughly 60% faster on Intel Mac.

#### Before
```console
suda@lima-default:/Users/suda/gopath/src/github.com/Homebrew/homebrew-core$ time git diff

real    0m34.332s
user    0m1.791s
sys     0m7.152s
suda@lima-default:/Users/suda/gopath/src/github.com/Homebrew/homebrew-core$ time git diff

real    0m15.637s
user    0m1.323s
sys     0m3.977s
suda@lima-default:/Users/suda/gopath/src/github.com/Homebrew/homebrew-core$ time git diff

real    0m12.478s
user    0m1.258s
sys     0m2.829s
suda@lima-default:/Users/suda/gopath/src/github.com/Homebrew/homebrew-core$ time git diff

real    0m13.237s
user    0m1.295s
sys     0m2.959s
```

#### After
```console
suda@lima-default:/Users/suda/gopath/src/github.com/Homebrew/homebrew-core$ time git diff

real    0m20.687s
user    0m2.473s
sys     0m4.218s
suda@lima-default:/Users/suda/gopath/src/github.com/Homebrew/homebrew-core$ time git diff

real    0m8.318s
user    0m1.175s
sys     0m2.095s
suda@lima-default:/Users/suda/gopath/src/github.com/Homebrew/homebrew-core$ time git diff

real    0m8.389s
user    0m1.336s
sys     0m1.866s
suda@lima-default:/Users/suda/gopath/src/github.com/Homebrew/homebrew-core$ time git diff

real    0m8.411s
user    0m1.287s
sys     0m1.982s

```

### Host info

- OS: macOS 11.6
- Model: MacBookPro 2020

```
machdep.cpu.brand_string: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
machdep.cpu.core_count: 4
machdep.cpu.cores_per_package: 8
machdep.cpu.logical_per_package: 16
machdep.cpu.thread_count: 8
machdep.cpu.features: FPU VME DE PSE TSC MSR PAE MCE CX8 APIC SEP MTRR PGE MCA CMOV PAT PSE36 CLFSH DS ACPI MMX FXSR SSE SSE2 SS HTT TM PBE SSE3 PCLMULQDQ DTES64 MON DSCPL VMX EST TM2 SSSE3 FMA CX16 TPR PDCM SSE4.1 SSE4.2 x2APIC MOVBE POPCNT AES PCID XSAVE OSXSAVE SEGLIM64 TSCTMR AVX1.0 RDRAND F16C
machdep.cpu.leaf7_features: RDWRFSGS TSC_THREAD_OFFSET SGX BMI1 AVX2 FDPEO SMEP BMI2 ERMS INVPCID FPU_CSDS AVX512F AVX512DQ RDSEED ADX SMAP AVX512IFMA CLFSOPT IPT AVX512CD SHA AVX512BW AVX512VL AVX512VBMI UMIP PKU GFNI VAES VPCLMULQDQ AVX512VNNI AVX512BITALG AVX512VPOPCNTDQ RDPID SGXLC FSREPMOV MDCLEAR IBRS STIBP L1DF ACAPMSR SSBD
```

