### PR TITLE
Show more VM details in the limactl list command

### DIFF
--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"text/tabwriter"
 
+	"github.com/docker/go-units"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -70,7 +71,7 @@ func listAction(cmd *cobra.Command, args []string) error {
 	}
 
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 4, 8, 4, ' ', 0)
-	fmt.Fprintln(w, "NAME\tSTATUS\tSSH\tARCH\tDIR")
+	fmt.Fprintln(w, "NAME\tSTATUS\tSSH\tARCH\tCPUS\tMEMORY\tDISK\tDIR")
 
 	if len(instances) == 0 {
 		logrus.Warn("No instance found. Run `limactl start` to create an instance.")
@@ -85,11 +86,14 @@ func listAction(cmd *cobra.Command, args []string) error {
 		if len(inst.Errors) > 0 {
 			logrus.WithField("errors", inst.Errors).Warnf("instance %q has errors", instName)
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\n",
 			inst.Name,
 			inst.Status,
 			fmt.Sprintf("127.0.0.1:%d", inst.SSHLocalPort),
 			inst.Arch,
+			inst.CPUs,
+			units.BytesSize(float64(inst.Memory)),
+			units.BytesSize(float64(inst.Disk)),
 			inst.Dir,
 		)
 	}

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/docker/go-units"
 	hostagentclient "github.com/lima-vm/lima/pkg/hostagent/api/client"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/store/filenames"
@@ -30,6 +31,9 @@ type Instance struct {
 	Status       Status             `json:"status"`
 	Dir          string             `json:"dir"`
 	Arch         limayaml.Arch      `json:"arch"`
+	CPUs         int                `json:"cpus,omitempty"`
+	Memory       int64              `json:"memory,omitempty"` // bytes
+	Disk         int64              `json:"disk,omitempty"`   // bytes
 	Networks     []limayaml.Network `json:"network,omitempty"`
 	SSHLocalPort int                `json:"sshLocalPort,omitempty"`
 	HostAgentPID int                `json:"hostAgentPID,omitempty"`
@@ -68,6 +72,15 @@ func Inspect(instName string) (*Instance, error) {
 	}
 	inst.Dir = instDir
 	inst.Arch = y.Arch
+	inst.CPUs = y.CPUs
+	memory, err := units.RAMInBytes(y.Memory)
+	if err == nil {
+		inst.Memory = memory
+	}
+	disk, err := units.RAMInBytes(y.Disk)
+	if err == nil {
+		inst.Disk = disk
+	}
 	inst.Networks = y.Networks
 	inst.SSHLocalPort = y.SSH.LocalPort // maybe 0
 


### PR DESCRIPTION
Add cpus / memory / disk, in addition to the arch.

```
NAME         STATUS     SSH                ARCH      CPUS    MEMORY    DISK      DIR
alpine       Stopped    127.0.0.1:60020    x86_64    4       4GiB      100GiB    /home/anders/.lima/alpine
default      Running    127.0.0.1:60022    x86_64    4       4GiB      100GiB    /home/anders/.lima/default
```

Use numbers for the machine-readable representation.

```yaml
{
  "name": "alpine",
  "status": "Stopped",
  "dir": "/home/anders/.lima/alpine",
  "arch": "x86_64",
  "cpus": 4,
  "memory": 4294967296,
  "disk": 107374182400,
  "sshLocalPort": 60020
}
{
  "name": "default",
  "status": "Running",
  "dir": "/home/anders/.lima/default",
  "arch": "x86_64",
  "cpus": 4,
  "memory": 4294967296,
  "disk": 107374182400,
  "sshLocalPort": 60022,
  "hostAgentPID": 271631,
  "qemuPID": 271649
}
```