### PR TITLE
Add SSHIdentityFile to the list output

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -102,13 +102,22 @@ func DefaultPubKeys(loadDotSSH bool) ([]PubKey, error) {
 	return res, nil
 }
 
-func CommonArgs(useDotSSH bool) ([]string, error) {
+// PrivateKeyPath returns the path to the private key
+func PrivateKeyPath() (string, error) {
 	configDir, err := dirnames.LimaConfigDir()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	privateKeyPath := filepath.Join(configDir, filenames.UserPrivateKey)
 	_, err = os.Stat(privateKeyPath)
+	if err != nil {
+		return "", err
+	}
+	return privateKeyPath, nil
+}
+
+func CommonArgs(useDotSSH bool) ([]string, error) {
+	privateKeyPath, err := PrivateKeyPath()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/go-units"
 	hostagentclient "github.com/lima-vm/lima/pkg/hostagent/api/client"
 	"github.com/lima-vm/lima/pkg/limayaml"
+	"github.com/lima-vm/lima/pkg/sshutil"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 )
 
@@ -27,18 +28,19 @@ const (
 )
 
 type Instance struct {
-	Name         string             `json:"name"`
-	Status       Status             `json:"status"`
-	Dir          string             `json:"dir"`
-	Arch         limayaml.Arch      `json:"arch"`
-	CPUs         int                `json:"cpus,omitempty"`
-	Memory       int64              `json:"memory,omitempty"` // bytes
-	Disk         int64              `json:"disk,omitempty"`   // bytes
-	Networks     []limayaml.Network `json:"network,omitempty"`
-	SSHLocalPort int                `json:"sshLocalPort,omitempty"`
-	HostAgentPID int                `json:"hostAgentPID,omitempty"`
-	QemuPID      int                `json:"qemuPID,omitempty"`
-	Errors       []error            `json:"errors,omitempty"`
+	Name            string             `json:"name"`
+	Status          Status             `json:"status"`
+	Dir             string             `json:"dir"`
+	Arch            limayaml.Arch      `json:"arch"`
+	CPUs            int                `json:"cpus,omitempty"`
+	Memory          int64              `json:"memory,omitempty"` // bytes
+	Disk            int64              `json:"disk,omitempty"`   // bytes
+	Networks        []limayaml.Network `json:"network,omitempty"`
+	SSHLocalPort    int                `json:"sshLocalPort,omitempty"`
+	SSHIdentityFile string             `json:"sshIdentityFile,omitempty"`
+	HostAgentPID    int                `json:"hostAgentPID,omitempty"`
+	QemuPID         int                `json:"qemuPID,omitempty"`
+	Errors          []error            `json:"errors,omitempty"`
 }
 
 func (inst *Instance) LoadYAML() (*limayaml.LimaYAML, error) {
@@ -83,6 +85,11 @@ func Inspect(instName string) (*Instance, error) {
 	}
 	inst.Networks = y.Networks
 	inst.SSHLocalPort = y.SSH.LocalPort // maybe 0
+
+	identity, err := sshutil.PrivateKeyPath()
+	if err == nil {
+		inst.SSHIdentityFile = identity
+	}
 
 	inst.HostAgentPID, err = ReadPIDFile(filepath.Join(instDir, filenames.HostAgentPID))
 	if err != nil {


### PR DESCRIPTION
In order to connect to lima with an external ssh tool,
nice to have both the ssh port and the ssh identity...

Avoids hardcoding any dependencies on lima internals,
and the identity can be empty if using default keys.