### PR TITLE
Fixes needed for running fedora linux distribution on aarch64

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -422,6 +422,8 @@ func getFirmware(qemuExe string, arch limayaml.Arch) (string, error) {
 		candidates = append(candidates, "/usr/share/qemu/ovmf-x86_64-code.bin")
 	case limayaml.AARCH64:
 		// Debian package "qemu-efi-aarch64"
+		candidates = append(candidates, "/usr/share/AAVMF/AAVMF_CODE.fd")
+		// Debian package "qemu-efi-aarch64" (unpadded, backwards compatibility)
 		candidates = append(candidates, "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd")
 	}
 


### PR DESCRIPTION

The distribution uses BIOS for x86_64 and UEFI for aarch64, so needs to fallback gracefully.

There was also some problem with the old param, fixed in https://wiki.debian.org/Arm64Qemu


Tested on the Raspberry Pi.

Hopefully also works on M1 ?

Closes #327

Closes #328