### PR TITLE
Evaluate symlinks in LIMA_HOME

### DIFF
--- a/pkg/store/dirnames/dirnames.go
+++ b/pkg/store/dirnames/dirnames.go
@@ -1,8 +1,10 @@
 package dirnames
 
 import (
-	"path/filepath"
+	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/lima-vm/lima/pkg/store/filenames"
 )
@@ -24,7 +26,14 @@ func LimaDir() (string, error) {
 		}
 		dir = filepath.Join(homeDir, DotLima)
 	}
-	return dir, nil
+	if _, err := os.Stat(dir); errors.Is(err, os.ErrNotExist) {
+		return dir, nil
+	}
+	realdir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return "", fmt.Errorf("cannot evaluate symlinks in %q: %w", dir, err)
+	}
+	return realdir, nil
 }
 
 // LimaConfigDir returns the path of the config directory, $LIMA_HOME/_config.


### PR DESCRIPTION
This allows the user to replace the directory with a symlink in case the path is too long to successfully create a socket underneath.

This would provide the user with a workaround in https://github.com/rancher-sandbox/rancher-desktop/issues/797