### PR TITLE
Add kubernetes with containerd example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,9 +13,12 @@ Distro:
 Container engines:
 - [`docker.yaml`](./docker.yaml): Docker
 - [`podman.yaml`](./podman.yaml): Podman
-- [`k3s.yaml`](./k3s.yaml): k3s
 - [`singularity.yaml`](./singularity.yaml): Singularity
 - LXD is installed in the default Ubuntu template, so there is no `lxd.yaml`
+
+Container orchestration:
+- [`k8s.yaml`](./k8s.yaml): Kubernetes via kubeadm
+- [`k3s.yaml`](./k3s.yaml): Kubernetes via k3s
 
 Others:
 - [`vmnet.yaml`](./vmnet.yaml): enable [`vmnet.framework`](../docs/network.md)

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -1,0 +1,99 @@
+# Example to use Kubernetes instead of nerdctl
+# $ limactl start ./k8s.yaml
+# $ limactl shell k8s kubectl
+
+# This example requires Lima v0.7.0 or later.
+images:
+  # Image is set to focal (20.04 LTS) for long-term stability
+  # Hint: run `limactl prune` to invalidate the "current" cache
+  - location: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-arm64.img"
+    arch: "aarch64"
+mounts:
+  - location: "~"
+    writable: false
+  - location: "/tmp/lima"
+    writable: true
+containerd:
+  system: true
+  user: false
+# See https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      command -v kubectl  >/dev/null 2>&1 && exit 0
+      # Installing kubeadm on your hosts
+      cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+      overlay
+      br_netfilter
+      EOF
+      modprobe overlay
+      modprobe br_netfilter
+      cat <<EOF | sudo tee /etc/sysctl.d/99-kubernetes-cri.conf
+      net.bridge.bridge-nf-call-iptables  = 1
+      net.ipv4.ip_forward                 = 1
+      net.bridge.bridge-nf-call-ip6tables = 1
+      EOF
+      sysctl --system
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      apt-get install -y apt-transport-https ca-certificates curl
+      curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+      echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+      apt-get update
+      # cri-tools
+      apt-get install -y cri-tools
+      cat  <<EOF | sudo tee /etc/crictl.yaml
+      runtime-endpoint: unix:///run/containerd/containerd.sock
+      image-endpoint: unix:///run/containerd/containerd.sock
+      EOF
+      # cni-plugins
+      apt-get install -y kubernetes-cni
+      rm -f /etc/cni/net.d/*.conf*
+      apt-get install -y kubelet kubeadm kubectl && apt-mark hold kubelet kubeadm kubectl
+      systemctl enable --now kubelet
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      test -e /etc/kubernetes/admin.conf && exit 0
+      export KUBECONFIG=/etc/kubernetes/admin.conf
+      # Initializing your control-plane node
+      kubeadm init --cri-socket=/run/containerd/containerd.sock --pod-network-cidr=10.244.0.0/16
+      # Installing a Pod network add-on
+      kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/v0.14.0/Documentation/kube-flannel.yml
+      # Control plane node isolation
+      kubectl taint nodes --all node-role.kubernetes.io/master-
+  - mode: user
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      mkdir -p $HOME/.kube
+      sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+      sudo chown $(id -u):$(id -g) $HOME/.kube/config
+probes:
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until command -v kubectl >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "kubectl is not installed yet"
+        exit 1
+      fi
+    hint: See "/var/log/cloud-init-output.log". in the guest
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 300s bash -c "until test -e /etc/kubernetes/admin.conf >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "/etc/kubernetes/admin.conf is not there yet"
+        exit 1
+      fi
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 300s bash -c "until kubectl version >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "kubernetes cluster is not up and running yet"
+        exit 1
+      fi


### PR DESCRIPTION
Will set up a single-node (i.e. no workers) Kubernetes "cluster"
with `kubeadm`, using containerd as the CRI and flannel as the CNI.

```console
$ lima kubectl version
Client Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.2", GitCommit:"8b5a19147530eaac9476b0ab82980b4088bbc1b2", GitTreeState:"clean", BuildDate:"2021-09-15T21:38:50Z", GoVersion:"go1.16.8", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.2", GitCommit:"8b5a19147530eaac9476b0ab82980b4088bbc1b2", GitTreeState:"clean", BuildDate:"2021-09-15T21:32:41Z", GoVersion:"go1.16.8", Compiler:"gc", Platform:"linux/amd64"}
$ lima sudo crictl version
Version:  0.1.0
RuntimeName:  containerd
RuntimeVersion:  v1.5.7
RuntimeApiVersion:  v1alpha2
```

https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/
(this is _still_ the simplest networking: https://github.com/flannel-io/flannel)

```console
$ limactl shell kubernetes kubectl get pods -A
NAMESPACE     NAME                                      READY   STATUS    RESTARTS   AGE
kube-system   coredns-78fcd69978-b2rn5                  1/1     Running   0          12h
kube-system   coredns-78fcd69978-d5qdg                  1/1     Running   0          12h
kube-system   etcd-lima-kubernetes                      1/1     Running   0          12h
kube-system   kube-apiserver-lima-kubernetes            1/1     Running   0          12h
kube-system   kube-controller-manager-lima-kubernetes   1/1     Running   0          12h
kube-system   kube-flannel-ds-trwr2                     1/1     Running   0          12h
kube-system   kube-proxy-tgggv                          1/1     Running   0          12h
kube-system   kube-scheduler-lima-kubernetes            1/1     Running   0          12h
$ limactl shell kubernetes sudo crictl images
IMAGE                                TAG                 IMAGE ID            SIZE
k8s.gcr.io/coredns/coredns           v1.8.4              8d147537fb7d1       13.7MB
k8s.gcr.io/etcd                      3.5.0-0             0048118155842       99.9MB
k8s.gcr.io/kube-apiserver            v1.22.2             e64579b7d8862       31.3MB
k8s.gcr.io/kube-controller-manager   v1.22.2             5425bcbd23c54       29.8MB
k8s.gcr.io/kube-proxy                v1.22.2             873127efbc8a7       35.9MB
k8s.gcr.io/kube-scheduler            v1.22.2             b51ddc1014b04       15MB
k8s.gcr.io/pause                     3.5                 ed210e3e4a5ba       301kB
quay.io/coreos/flannel               v0.14.0             8522d622299ca       21.1MB
```