### PR TITLE
The sdl display is not enabled by default on linux

### DIFF
--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -120,7 +120,7 @@ firmware:
   legacyBIOS: false
 
 video:
-  # QEMU display, e.g., "none", "cocoa", "sdl".
+  # QEMU display, e.g., "none", "cocoa", "sdl", "gtk".
   # As of QEMU v5.2, enabling this is known to have negative impact
   # on performance on macOS hosts: https://gitlab.com/qemu-project/qemu/-/issues/334
   # Default: "none"


### PR DESCRIPTION
`qemu-system-x86_64: Display 'sdl' is not available.`

But one can use the gtk display instead, for video