### PR TITLE
Use alternative sshfs install locations on centos

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -41,7 +41,11 @@ if command -v apt-get >/dev/null 2>&1; then
 elif command -v dnf >/dev/null 2>&1; then
 	if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ]; then
 		if ! command -v sshfs >/dev/null 2>&1; then
-			dnf install -y fuse-sshfs
+			if grep -q "release 8" /etc/system-release; then
+				dnf install --enablerepo powertools -y fuse-sshfs
+			else
+				dnf install -y fuse-sshfs
+			fi
 		fi
 	fi
 	if [ "${INSTALL_IPTABLES}" = 1 ]; then


### PR DESCRIPTION
The fuse-sshfs package is not available in the main CentOS
distribution repositories, so temporarly enable extra repos.

~~Also use "yum install" instead of "dnf install", which is
the same thing on newer OS but backwards-compatible on old.~~

Closes #342