### PR TITLE
Replace localhost in proxy settings with the gateway address

### DIFF
--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -189,6 +189,14 @@ networks:
 # env:
 #   KEY: value
 
+# Lima will override the proxy environment variables with values from the current process
+# environment (the environment in effect when you run `limactl start`). It will automatically
+# replace the strings "localhost" and "127.0.0.1" with the host gateway address from inside
+# the VM, so it stays routable. Use of the process environment can be disabled by setting
+# propagateProxyEnv to false.
+# Default: true
+propagateProxyEnv: true
+
 # The host agent implements a DNS server that looks up host names on the host
 # using the local system resolver. This means changing VPN and network settings
 # are reflected automatically into the guest, including conditional forward,

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -104,6 +104,9 @@ func FillDefault(y *LimaYAML, filePath string) {
 	if y.UseHostResolver == nil {
 		y.UseHostResolver = &[]bool{true}[0]
 	}
+	if y.PropagateProxyEnv == nil {
+		y.PropagateProxyEnv = &[]bool{true}[0]
+	}
 
 	if len(y.Network.VDEDeprecated) > 0 && len(y.Networks) == 0 {
 		for _, vde := range y.Network.VDEDeprecated {

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -7,24 +7,25 @@ import (
 )
 
 type LimaYAML struct {
-	Arch            Arch              `yaml:"arch,omitempty" json:"arch,omitempty"`
-	Images          []File            `yaml:"images" json:"images"` // REQUIRED
-	CPUs            int               `yaml:"cpus,omitempty" json:"cpus,omitempty"`
-	Memory          string            `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
-	Disk            string            `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes
-	Mounts          []Mount           `yaml:"mounts,omitempty" json:"mounts,omitempty"`
-	SSH             SSH               `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
-	Firmware        Firmware          `yaml:"firmware,omitempty" json:"firmware,omitempty"`
-	Video           Video             `yaml:"video,omitempty" json:"video,omitempty"`
-	Provision       []Provision       `yaml:"provision,omitempty" json:"provision,omitempty"`
-	Containerd      Containerd        `yaml:"containerd,omitempty" json:"containerd,omitempty"`
-	Probes          []Probe           `yaml:"probes,omitempty" json:"probes,omitempty"`
-	PortForwards    []PortForward     `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
-	Networks        []Network         `yaml:"networks,omitempty" json:"networks,omitempty"`
-	Network         NetworkDeprecated `yaml:"network,omitempty" json:"network,omitempty"` // DEPRECATED, use `networks` instead
-	Env             map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
-	DNS             []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`
-	UseHostResolver *bool             `yaml:"useHostResolver,omitempty" json:"useHostResolver,omitempty"`
+	Arch              Arch              `yaml:"arch,omitempty" json:"arch,omitempty"`
+	Images            []File            `yaml:"images" json:"images"` // REQUIRED
+	CPUs              int               `yaml:"cpus,omitempty" json:"cpus,omitempty"`
+	Memory            string            `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
+	Disk              string            `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes
+	Mounts            []Mount           `yaml:"mounts,omitempty" json:"mounts,omitempty"`
+	SSH               SSH               `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
+	Firmware          Firmware          `yaml:"firmware,omitempty" json:"firmware,omitempty"`
+	Video             Video             `yaml:"video,omitempty" json:"video,omitempty"`
+	Provision         []Provision       `yaml:"provision,omitempty" json:"provision,omitempty"`
+	Containerd        Containerd        `yaml:"containerd,omitempty" json:"containerd,omitempty"`
+	Probes            []Probe           `yaml:"probes,omitempty" json:"probes,omitempty"`
+	PortForwards      []PortForward     `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
+	Networks          []Network         `yaml:"networks,omitempty" json:"networks,omitempty"`
+	Network           NetworkDeprecated `yaml:"network,omitempty" json:"network,omitempty"` // DEPRECATED, use `networks` instead
+	Env               map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+	DNS               []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`
+	UseHostResolver   *bool             `yaml:"useHostResolver,omitempty" json:"useHostResolver,omitempty"`
+	PropagateProxyEnv *bool             `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty"`
 }
 
 type Arch = string


### PR DESCRIPTION
Lima uses process environment settings to override system proxy settings, and settings from the `env` key in lima.yaml.

This does not work when the proxy is running on a localhost address, so this commit replaces localhost with the slirp gateway address.

The new `useProcessProxies` setting can also be used to disable using the process environment variables to override proxy settings completely.

Motivation: https://github.com/rancher-sandbox/rancher-desktop/pull/431#issuecomment-946475918