### PR TITLE
Include hint to use `stop -f` if status isn't "Running"

### DIFF
--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -60,7 +60,7 @@ func stopAction(cmd *cobra.Command, args []string) error {
 
 func stopInstanceGracefully(inst *store.Instance) error {
 	if inst.Status != store.StatusRunning {
-		return fmt.Errorf("expected status %q, got %q", store.StatusRunning, inst.Status)
+		return fmt.Errorf("expected status %q, got %q (maybe use `limactl stop -f`?)", store.StatusRunning, inst.Status)
 	}
 
 	begin := time.Now() // used for logrus propagation


### PR DESCRIPTION
I at least didn't know that `stop` had a `--force` option.

Closes #357