### PR TITLE
Implement unix socket forwarding

### DIFF
--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -2,13 +2,7 @@
 # $ limactl start ./docker.yaml
 # $ limactl shell docker docker run -it -v $HOME:$HOME --rm alpine
 
-# Hint: To allow `docker` CLI on the host to connect to the Docker daemon running inside the guest,
-# add `NoHostAuthenticationForLocalhost yes` in ~/.ssh/config , and then run the following commands:
-# $ export DOCKER_HOST=ssh://localhost:60006
-# $ docker ...
-
-# If ssh:// ... does not work, try the following commands:
-# $ ssh -f -N -p 60006 -i ~/.lima/_config/user -o NoHostAuthenticationForLocalhost=yes -L $HOME/docker.sock:/run/user/$(id -u)/docker.sock 127.0.0.1
+# To run `docker` on the host (assumes docker-cli is installed):
 # $ export DOCKER_HOST=unix://$HOME/docker.sock
 # $ docker ...
 
@@ -63,3 +57,6 @@ probes:
         exit 1
       fi
     hint: See "/var/log/cloud-init-output.log". in the guest
+portForwards:
+  - guestSocket: "/run/user/{{.UID}}/docker.sock"
+    hostSocket: "{{.Home}}/docker.sock"

--- a/examples/podman.yaml
+++ b/examples/podman.yaml
@@ -2,14 +2,11 @@
 # $ limactl start ./podman.yaml
 # $ limactl shell podman podman run -it --rm -v $HOME:$HOME:ro docker.io/library/alpine
 
-# Hint: To allow `podman` CLI on the host to connect to the Podman daemon running inside the guest,
-# add `NoHostAuthenticationForLocalhost yes` in ~/.ssh/config , and then run the following commands:
-# $ export CONTAINER_HOST=ssh://$(id -un)@localhost:60906/run/user/$(id -u)/podman/podman.sock
-# $ export CONTAINER_SSHKEY=$HOME/.lima/_config/user
+# Hint: To allow `podman` CLI on the host to connect to the Podman daemon running inside the guest, run the following commands:
+# $ export CONTAINER_HOST=unix://$HOME/podman.sock
 # $ podman ...
 
 # Hint: To allow `docker` CLI on the host to connect to the Podman daemon running inside the guest, run the following commands:
-# $ ssh -f -N -p 60906 -i ~/.lima/_config/user -o NoHostAuthenticationForLocalhost=yes -L $HOME/podman.sock:/run/user/$(id -u)/podman/podman.sock 127.0.0.1
 # $ export DOCKER_HOST=unix://$HOME/podman.sock
 # $ docker ...
 
@@ -52,3 +49,6 @@ probes:
         exit 1
       fi
     hint: See "/var/log/cloud-init-output.log". in the guest
+portForwards:
+  - guestSocket: "/run/user/{{.UID}}/podman/podman.sock"
+    hostSocket: "{{.Home}}/podman.sock"

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -127,13 +128,13 @@ func New(instName string, stdout io.Writer, sigintCh chan os.Signal, opts ...Opt
 	// Block ports 22 and sshLocalPort on all IPs
 	for _, port := range []int{sshGuestPort, sshLocalPort} {
 		rule := limayaml.PortForward{GuestIP: net.IPv4zero, GuestPort: port, Ignore: true}
-		limayaml.FillPortForwardDefaults(&rule)
+		limayaml.FillPortForwardDefaults(&rule, inst.Dir)
 		rules = append(rules, rule)
 	}
 	rules = append(rules, y.PortForwards...)
 	// Default forwards for all non-privileged ports from "127.0.0.1" and "::1"
 	rule := limayaml.PortForward{GuestIP: guestagentapi.IPv4loopback1}
-	limayaml.FillPortForwardDefaults(&rule)
+	limayaml.FillPortForwardDefaults(&rule, inst.Dir)
 	rules = append(rules, rule)
 
 	a := &HostAgent{
@@ -400,33 +401,42 @@ func (a *HostAgent) close() error {
 func (a *HostAgent) watchGuestAgentEvents(ctx context.Context) {
 	// TODO: use vSock (when QEMU for macOS gets support for vSock)
 
+	// Setup all socket forwards and defer their teardown
+	logrus.Debugf("Forwarding unix sockets")
+	for _, rule := range a.y.PortForwards {
+		if rule.GuestSocket != "" {
+			local := hostAddress(rule, guestagentapi.IPPort{})
+			_ = forwardSSH(ctx, a.sshConfig, a.sshLocalPort, local, rule.GuestSocket, verbForward)
+		}
+	}
+
 	localUnix := filepath.Join(a.instDir, filenames.GuestAgentSock)
-	// guest should have same UID as the host (specified in cidata)
 	remoteUnix := "/run/lima-guestagent.sock"
+
+	a.onClose = append(a.onClose, func() error {
+		logrus.Debugf("Stop forwarding unix sockets")
+		var mErr error
+		for _, rule := range a.y.PortForwards {
+			if rule.GuestSocket != "" {
+				local := hostAddress(rule, guestagentapi.IPPort{})
+				if err := forwardSSH(ctx, a.sshConfig, a.sshLocalPort, local, rule.GuestSocket, verbCancel); err != nil {
+					mErr = multierror.Append(mErr, err)
+				}
+			}
+		}
+		return mErr
+	})
 
 	for {
 		if !isGuestAgentSocketAccessible(ctx, localUnix) {
-			if err := os.RemoveAll(localUnix); err != nil {
-				logrus.WithError(err).Warnf("failed to clean up %q (host) before setting up forwarding", localUnix)
-			}
-			logrus.Infof("Forwarding %q (guest) to %q (host)", remoteUnix, localUnix)
-			if err := forwardSSH(ctx, a.sshConfig, a.sshLocalPort, localUnix, remoteUnix, false); err != nil {
-				logrus.WithError(err).Warnf("failed to setting up forward from %q (guest) to %q (host)", remoteUnix, localUnix)
-			}
+			_ = forwardSSH(ctx, a.sshConfig, a.sshLocalPort, localUnix, remoteUnix, verbForward)
 		}
 		if err := a.processGuestAgentEvents(ctx, localUnix); err != nil {
 			logrus.WithError(err).Warn("connection to the guest agent was closed unexpectedly")
 		}
 		select {
 		case <-ctx.Done():
-			logrus.Infof("Stopping forwarding %q to %q", remoteUnix, localUnix)
-			verbCancel := true
-			if err := forwardSSH(ctx, a.sshConfig, a.sshLocalPort, localUnix, remoteUnix, verbCancel); err != nil {
-				logrus.WithError(err).Warnf("failed to stop forwarding %q (remote) to %q (local)", remoteUnix, localUnix)
-			}
-			if err := os.RemoveAll(localUnix); err != nil {
-				logrus.WithError(err).Warnf("failed to clean up %q (host) after stopping forwarding", localUnix)
-			}
+			_ = forwardSSH(ctx, a.sshConfig, a.sshLocalPort, localUnix, remoteUnix, verbCancel)
 			return
 		case <-time.After(10 * time.Second):
 		}
@@ -469,12 +479,13 @@ func (a *HostAgent) processGuestAgentEvents(ctx context.Context, localUnix strin
 	return io.EOF
 }
 
-func forwardSSH(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote string, cancel bool) error {
+const (
+	verbForward = "forward"
+	verbCancel  = "cancel"
+)
+
+func forwardSSH(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote string, verb string) error {
 	args := sshConfig.Args()
-	verb := "forward"
-	if cancel {
-		verb = "cancel"
-	}
 	args = append(args,
 		"-T",
 		"-O", verb,
@@ -485,8 +496,35 @@ func forwardSSH(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, 
 		"127.0.0.1",
 		"--",
 	)
+	if strings.HasPrefix(local, "/") {
+		switch verb {
+		case verbForward:
+			logrus.Infof("Forwarding %q (guest) to %q (host)", remote, local)
+			if err := os.RemoveAll(local); err != nil {
+				logrus.WithError(err).Warnf("Failed to clean up %q (host) before setting up forwarding", local)
+			}
+			if err := os.MkdirAll(filepath.Dir(local), 0750); err != nil {
+				return fmt.Errorf("can't create directory for local socket %q: %w", local, err)
+			}
+		case verbCancel:
+			logrus.Infof("Stopping forwarding %q (guest) to %q (host)", remote, local)
+			defer func() {
+				if err := os.RemoveAll(local); err != nil {
+					logrus.WithError(err).Warnf("Failed to clean up %q (host) after stopping forwarding", local)
+				}
+			}()
+		default:
+			panic(fmt.Errorf("invalid verb %q", verb))
+		}
+	}
 	cmd := exec.CommandContext(ctx, sshConfig.Binary(), args...)
 	if out, err := cmd.Output(); err != nil {
+		if verb == verbForward && strings.HasPrefix(local, "/") {
+			logrus.WithError(err).Warnf("Failed to set up forward from %q (guest) to %q (host)", remote, local)
+			if removeErr := os.RemoveAll(local); err != nil {
+				logrus.WithError(removeErr).Warnf("Failed to clean up %q (host) after forwarding failed", local)
+			}
+		}
 		return fmt.Errorf("failed to run %v: %q: %w", cmd.Args, string(out), err)
 	}
 	return nil

--- a/pkg/hostagent/port_others.go
+++ b/pkg/hostagent/port_others.go
@@ -9,6 +9,6 @@ import (
 	"github.com/lima-vm/sshocker/pkg/ssh"
 )
 
-func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote string, cancel bool) error {
-	return forwardSSH(ctx, sshConfig, port, local, remote, cancel)
+func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote string, verb string) error {
+	return forwardSSH(ctx, sshConfig, port, local, remote, verb)
 }

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -166,17 +166,29 @@ networks:
 #   # default: hostPort: 443 (same as guestPort)
 #   # default: guestIP: "127.0.0.1" (also matches bind addresses "0.0.0.0", "::", and "::1")
 #   # default: proto: "tcp" (only valid value right now)
+#
 #   - guestPortRange: [4000, 4999]
 #     hostIP:  "0.0.0.0" # overrides the default value "127.0.0.1"
 #   # default: hostPortRange: [4000, 4999] (must specify same number of ports as guestPortRange)
+#
 #   - guestPort: 80
 #     hostPort: 8080 # overrides the default value 80
+#
 #   - guestIP: "127.0.0.2" # overrides the default value "127.0.0.1"
 #     hostIP: "127.0.0.2" # overrides the default value "127.0.0.1"
 #   # default: guestPortRange: [1, 65535]
 #   # default: hostPortRange: [1, 65535]
+#
 #   - guestPort: 8888
 #     ignore: true (don't forward this port)
+#
+#   - guestSocket: /var/run/socket
+#     hostSocket: mysocket
+#   # hostSocket will be "$LIMA_HOME/$INSTANCE/sock/mysocket"
+#   # Sockets can also be forwarded to ports and vice versa, but not to/from a range of ports.
+#   # Forwarding requires the lima user to have rw access to the guestsocket,
+#   # and the local user rwx access to the directory of the hostsocket.
+#
 #   # Lima internally appends this fallback rule at the end:
 #   - guestIP: "127.0.0.1"
 #     guestPortRange: [1, 65535]

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -182,12 +182,14 @@ networks:
 #   - guestPort: 8888
 #     ignore: true (don't forward this port)
 #
-#   - guestSocket: /var/run/socket
+#   - guestSocket: "/run/user/{{.UID}}/my.sock"
 #     hostSocket: mysocket
-#   # hostSocket will be "$LIMA_HOME/$INSTANCE/sock/mysocket"
+#   # "guestSocket" can include these template variables: {{.Home}}, {{.UID}}, and {{.User}}.
+#   # "hostSocket" can include {{.LimaHome}}, {{.Instance}}, {{.Home}}, {{.UID}}, and {{.User}}.
+#   # Relative "hostSocket" will be based of "{{.LimaHome}}/{{.Instance}}/sock/".
 #   # Sockets can also be forwarded to ports and vice versa, but not to/from a range of ports.
-#   # Forwarding requires the lima user to have rw access to the guestsocket,
-#   # and the local user rwx access to the directory of the hostsocket.
+#   # Forwarding requires the lima user to have rw access to the "guestsocket",
+#   # and the local user rwx access to the directory of the "hostsocket".
 #
 #   # Lima internally appends this fallback rule at the end:
 #   - guestIP: "127.0.0.1"

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -106,9 +106,11 @@ type PortForward struct {
 	GuestIP        net.IP `yaml:"guestIP,omitempty" json:"guestIP,omitempty"`
 	GuestPort      int    `yaml:"guestPort,omitempty" json:"guestPort,omitempty"`
 	GuestPortRange [2]int `yaml:"guestPortRange,omitempty" json:"guestPortRange,omitempty"`
+	GuestSocket    string `yaml:"guestSocket,omitempty" json:"guestSocket,omitempty"`
 	HostIP         net.IP `yaml:"hostIP,omitempty" json:"hostIP,omitempty"`
 	HostPort       int    `yaml:"hostPort,omitempty" json:"hostPort,omitempty"`
 	HostPortRange  [2]int `yaml:"hostPortRange,omitempty" json:"hostPortRange,omitempty"`
+	HostSocket     string `yaml:"hostSocket,omitempty" json:"hostSocket,omitempty"`
 	Proto          Proto  `yaml:"proto,omitempty" json:"proto,omitempty"`
 	Ignore         bool   `yaml:"ignore,omitempty" json:"ignore,omitempty"`
 }

--- a/pkg/store/filenames/filenames.go
+++ b/pkg/store/filenames/filenames.go
@@ -37,6 +37,9 @@ const (
 	HostAgentSock      = "ha.sock"
 	HostAgentStdoutLog = "ha.stdout.log"
 	HostAgentStderrLog = "ha.stderr.log"
+
+	// SocketDir is the default location for forwarded sockets with a relative paths in HostSocket
+	SocketDir = "sock"
 )
 
 // LongestSock is the longest socket name.


### PR DESCRIPTION
This is an alternative to #367. It doesn't parse `/proc/net/unix` at all, but just sets up any configured socket forwards when the guestagent is started, and tears them down when the hostagent exits.

This is now my preferred implementation.

```console
$ limactl start --tty=false examples/docker.yaml
[...]
$ DOCKER_HOST=unix://$HOME/docker.sock docker info | grep -E 'Root|System'
 Operating System: Ubuntu Impish Indri (development branch)
 Docker Root Dir: /home/jan.linux/.local/share/docker
WARNING: Running in rootless-mode without cgroups. To enable cgroups in rootless-mode, you need to boot the system in cgroup v2 mode.
```

Fixes #221