### PR TITLE
Remove default mounts for orchestrators

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -17,11 +17,8 @@ images:
     arch: "x86_64"
   - location: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-arm64.img"
     arch: "aarch64"
-mounts:
-  - location: "~"
-    writable: false
-  - location: "/tmp/lima"
-    writable: true
+# Mounts are disabled in this example, but can be enabled optionally.
+mounts: []
 containerd:
   system: true
   user: false

--- a/examples/nomad.yaml
+++ b/examples/nomad.yaml
@@ -15,11 +15,8 @@ images:
     arch: "x86_64"
   - location: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-arm64.img"
     arch: "aarch64"
-mounts:
-  - location: "~"
-    writable: false
-  - location: "/tmp/lima"
-    writable: true
+# Mounts are disabled in this example, but can be enabled optionally.
+mounts: []
 containerd:
   system: true
   user: false


### PR DESCRIPTION
Make k8s and nomad more similar to k3s