### PR TITLE
Chipers '^' syntax was added in v8.1 instead of v8.0

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -181,8 +181,8 @@ func CommonOpts(useDotSSH bool) ([]string, error) {
 		sshInfo.openSSHVersion = detectOpenSSHVersion()
 	})
 
-	// Only OpenSSH version 8.0 and later support adding ciphers to the front of the default set
-	if !sshInfo.openSSHVersion.LessThan(*semver.New("8.0.0")) {
+	// Only OpenSSH version 8.1 and later support adding ciphers to the front of the default set
+	if !sshInfo.openSSHVersion.LessThan(*semver.New("8.1.0")) {
 		// By default, `ssh` choose chacha20-poly1305@openssh.com, even when AES accelerator is available.
 		// (OpenSSH_8.1p1, macOS 11.6, MacBookPro 2020, Core i7-1068NG7)
 		//


### PR DESCRIPTION
This fixes command complaints on clients using ssh v8.0, for instance, CentOS 8.4.

If you check the ChangeLog from [openssh release v8.1p1](https://mirror.fsrv.services/pub/OpenBSD/OpenSSH/portable/openssh-8.1p1.tar.gz) you will see the `Ciphers` syntax change is added there.