### PR TITLE
Adapt scp source and target arguments for old openssh

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -178,7 +178,7 @@ func CommonOpts(useDotSSH bool) ([]string, error) {
 
 	sshInfo.Do(func() {
 		sshInfo.aesAccelerated = detectAESAcceleration()
-		sshInfo.openSSHVersion = detectOpenSSHVersion()
+		sshInfo.openSSHVersion = DetectOpenSSHVersion()
 	})
 
 	// Only OpenSSH version 8.1 and later support adding ciphers to the front of the default set
@@ -246,7 +246,7 @@ func ParseOpenSSHVersion(version []byte) *semver.Version {
 	return &semver.Version{}
 }
 
-func detectOpenSSHVersion() semver.Version {
+func DetectOpenSSHVersion() semver.Version {
 	var (
 		v      semver.Version
 		stderr bytes.Buffer


### PR DESCRIPTION
This commit does not make use of URIs in scp command, this way lima stays compatible with legacy openssh clients (older than v8.0)

Signed-off-by: David Cassany <dcassany@suse.com>