### PR TITLE
read ecdsa public keys to ssh-authorized-keys

### DIFF
--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -27,3 +27,16 @@ func TestParseOpenSSHVersion(t *testing.T) {
 	// OpenBSD 5.8
 	assert.Check(t, ParseOpenSSHVersion([]byte("OpenSSH_7.0, LibreSSL")).Equal(*semver.New("7.0.0")))
 }
+
+func Test_detectValidPublicKey(t *testing.T) {
+	assert.Check(t, detectValidPublicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAACQDf2IooTVPDBw== 64bit"))
+	assert.Check(t, detectValidPublicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAACQDf2IooTVPDBw=="))
+	assert.Check(t, detectValidPublicKey("ssh-dss AAAAB3NzaC1kc3MAAACBAP/yAytaYzqXq01uTd5+1RC=" /* truncate */))
+	assert.Check(t, detectValidPublicKey("ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTY=" /* truncate */))
+	assert.Check(t, detectValidPublicKey("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICs1tSO/jx8oc4O=" /* truncate */))
+
+	assert.Check(t, !detectValidPublicKey("wrong-algo AAAAB3NzaC1kc3MAAACBAP/yAytaYzqXq01uTd5+1RC="))
+	assert.Check(t, !detectValidPublicKey("huge-length AAAD6A=="))
+	assert.Check(t, !detectValidPublicKey("arbitrary content"))
+	assert.Check(t, !detectValidPublicKey(""))
+}


### PR DESCRIPTION
I use [Secretive](https://github.com/maxgoedjen/secretive) to manage SSH keys, and it defaults to `ecdsa-sha2-nistp256` algorithm. 
After following the instruction about [putting public key in your ~/.ssh/ directory](https://github.com/maxgoedjen/secretive/blob/main/FAQ.md#how-do-i-tell-ssh-to-use-a-specific-key), `limactl start` give these output
```
WARN[0000] [hostagent] public key "/Users/enihsyou/.ssh/id_rsa.pub" doesn't seem to be in ssh format 
WARN[0000] [hostagent] public key "/Users/enihsyou/.ssh/secretive.pub" doesn't seem to be in ssh format 
```

Those OpenSSH public key format should be picked up, so I learned from what [golang.org/x/crypto/ssh.ParsePublicKey](https://github.com/golang/crypto/blob/089bfa5675191fd96a44247682f76ebca03d7916/ssh/keys.go#L265) do to make a soft public key check.