### PR TITLE
Use crun instead of runc for podman example

### DIFF
--- a/examples/podman.yaml
+++ b/examples/podman.yaml
@@ -35,7 +35,7 @@ provision:
       command -v podman >/dev/null 2>&1 && exit 0
       export DEBIAN_FRONTEND=noninteractive
       apt-get update
-      apt-get install -y podman
+      apt-get install -y podman crun
   - mode: user
     script: |
       #!/bin/bash


### PR DESCRIPTION
It seems like podman has issues using runc with cgroups v2.

So use crun instead, which is the podman default (with v2).

```go
        if conf.Engine.OCIRuntime == "" {
                conf.Engine.OCIRuntime = "runc"
                // If we're running on cgroups v2, default to using crun.
                if onCgroupsv2, _ := cgroups.IsCgroup2UnifiedMode(); onCgroupsv2 {
                        conf.Engine.OCIRuntime = "crun"
                }
        }
```

Closes #398