### PR TITLE
docs: ensure install command just works

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For the usage of containerd and nerdctl (contaiNERD ctl), visit https://github.c
 [Homebrew package](https://github.com/Homebrew/homebrew-core/blob/master/Formula/lima.rb) is available.
 
 ```console
-$ brew install lima
+brew install lima
 ```
 
 <details>


### PR DESCRIPTION
GitHub's web UI provides a button you can click to copy the code
example.

I did that this morning but was surprised by an error from the leading
`$`.

By removing the leading `$`, users can copy it and have the command work
seamlessly.
