### PR TITLE
Run golangci-lint as part of lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ uninstall:
 
 .PHONY: lint
 lint:
+	golangci-lint run ./...
 	yamllint .
 
 .PHONY: clean


### PR DESCRIPTION
This is just an optional local step, to help avoid getting errors in CI later by checking locally first.

Closes #416 