### PR TITLE
nerdctl: update to v0.14.0; install bash completion; update {archlinux,debian}.yaml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,8 +132,8 @@ jobs:
       - name: Install vde_switch and vde_vmnet
         if: matrix.example == 'vmnet.yaml'
         env:
-          # 2021-08-31
-          VDE2_VERSION: 50964c3fb0776e82f8bd1ecdc527683966f3d52c
+          # 2021-09-21
+          VDE2_VERSION: 534a09453f956f8f545ba4fe37413be1a139314d
           # 2021-09-15
           VDE_VMNET_VERSION: v0.5.1
         run: |
@@ -145,7 +145,7 @@ jobs:
             cd vde-2
             git checkout $VDE2_VERSION
             autoreconf -fis
-            ./configure --prefix=/opt/vde
+            ./configure --prefix=/opt/vde --disable-python
             make
             sudo make install
           )

--- a/examples/archlinux.yaml
+++ b/examples/archlinux.yaml
@@ -2,9 +2,9 @@
 arch: "x86_64"
 images:
   # NOTE: the image is periodically rotated, if you face 404, see https://mirror.pkgbuild.com/images/ to find the latest image.
-  - location: "https://mirror.pkgbuild.com/images/v20211112.38968/Arch-Linux-x86_64-cloudimg-20211112.38968.qcow2"
+  - location: "https://mirror.pkgbuild.com/images/v20211115.39179/Arch-Linux-x86_64-cloudimg-20211115.39179.qcow2"
     arch: "x86_64"
-    digest: "sha256:196e58f1c4e4f3d5293cc0556a59182c3259d7acd7a910537c1a825d8876db82"
+    digest: "sha256:1f056b5e98e3b75179e71ec4f4237a945fb5043a1753889d6c850d2a8a517137"
 mounts:
   - location: "~"
     writable: false

--- a/examples/debian.yaml
+++ b/examples/debian.yaml
@@ -1,11 +1,11 @@
 # This example requires Lima v0.7.0 or later
 images:
-  - location: "https://cloud.debian.org/images/cloud/bullseye/daily/20211114-826/debian-11-generic-amd64-daily-20211114-826.qcow2"
+  - location: "https://cloud.debian.org/images/cloud/bullseye/daily/20211121-833/debian-11-generic-amd64-daily-20211121-833.qcow2"
     arch: "x86_64"
-    digest: "sha512:34920f6b80989642b84e18ee8cac63fc4909381fd8124f479b5e9fee5a0e7562e92465fc9e6b9a2200abded0d6f001c1950bfd9305a37aee9e405e5df28f3f27"
-  - location: "https://cloud.debian.org/images/cloud/bullseye/daily/20211114-826/debian-11-generic-arm64-daily-20211114-826.qcow2"
+    digest: "sha512:8ff4ae9aa2bf4c0a5c1ef894ea4ab5f095f5eb30bc6e7227b87c170a7a95ba9cadd4ffe3aa0b662c9d5c57b9cf2fb3f7269d6eeb5c013937b3cf0475f0f3459d"
+  - location: "https://cloud.debian.org/images/cloud/bullseye/daily/20211121-833/debian-11-generic-arm64-daily-20211121-833.qcow2"
     arch: "aarch64"
-    digest: "sha512:6c5937ad83bc72b08bc7c666f5a4d33c9b44289c6113c0a554afccbd49b68e792b180f0b756c6624fe4ba137941c117e1688cff97e633e42515f0b9188b6be8b"
+    digest: "sha512:1b5c68b5626fb6799b643bd7d79f8c082cbac9e2754a22d1b91f4dcb26cc7ce618b31504c36c5e0ec69ee5b3e312bc1882e73feff0ef89ad4a375b50572789f1"
 mounts:
   - location: "~"
     writable: false

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh
@@ -10,6 +10,10 @@ command -v systemctl >/dev/null 2>&1 || exit 0
 
 if [ ! -x /usr/local/bin/nerdctl ]; then
 	tar Cxzf /usr/local "${LIMA_CIDATA_MNT}"/nerdctl-full.tgz
+
+	mkdir -p /etc/bash_completion.d
+	nerdctl completion bash >/etc/bash_completion.d/nerdctl
+	# TODO: enable zsh completion too
 fi
 
 if [ "${LIMA_CIDATA_CONTAINERD_SYSTEM}" = 1 ]; then

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -20,7 +20,7 @@ import (
 )
 
 func defaultContainerdArchives() []File {
-	const nerdctlVersion = "0.13.0"
+	const nerdctlVersion = "0.14.0"
 	location := func(goarch string) string {
 		return "https://github.com/containerd/nerdctl/releases/download/v" + nerdctlVersion + "/nerdctl-full-" + nerdctlVersion + "-linux-" + goarch + ".tar.gz"
 	}
@@ -28,12 +28,12 @@ func defaultContainerdArchives() []File {
 		{
 			Location: location("amd64"),
 			Arch:     X8664,
-			Digest:   "sha256:ed2d3662fd2866875e107df20f7da6dd32fafa8fa3e8aa9b6b774af20af5ddaa",
+			Digest:   "sha256:3423cb589bb5058ff9ed55f6823adec1299fe2e576612fc6f706fe07eddd398b",
 		},
 		{
 			Location: location("arm64"),
 			Arch:     AARCH64,
-			Digest:   "sha256:8a744638b01cd53c437a0d2a54c66f0ec4a918b75e93056393e7076bbf06a173",
+			Digest:   "sha256:32898576fa89392d1af8c21ff3854c0f54d2c66c0de87598be813f25051366e5",
 		},
 	}
 }


### PR DESCRIPTION
https://github.com/containerd/nerdctl/releases/tag/v0.14.0

This release supports IPFS, but Lima does not install IPFS by default