### PR TITLE
Add COLORTERM to the lima shell environment

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -127,6 +127,10 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		// required for showing the shell prompt: https://stackoverflow.com/a/626574
 		sshArgs = append(sshArgs, "-t")
 	}
+	if _, present := os.LookupEnv("COLORTERM"); present {
+		// SendEnv config is cumulative, with already existing options in ssh_config
+		sshArgs = append(sshArgs, "-o", "SendEnv=\"COLORTERM\"")
+	}
 	sshArgs = append(sshArgs, []string{
 		"-q",
 		"-p", strconv.Itoa(inst.SSHLocalPort),

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/11-colorterm-environment.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/11-colorterm-environment.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eux
+
+if grep -q "COLORTERM" /etc/ssh/sshd_config; then
+	exit 0
+fi
+
+# accept any incoming COLORTERM environment variable
+sed -i 's/^AcceptEnv LANG LC_\*$/AcceptEnv COLORTERM LANG LC_*/' /etc/ssh/sshd_config
+if [ -f /sbin/openrc-init ]; then
+	rc-service --ifstarted sshd reload
+elif command -v systemctl >/dev/null 2>&1; then
+	if systemctl -q is-active ssh; then
+		systemctl reload ssh
+	elif systemctl -q is-active sshd; then
+		systemctl reload sshd
+	fi
+fi


### PR DESCRIPTION
If the variable is set on the host, forward it.

Typical value if set would be COLORTERM=truecolor

Closes #434 