### PR TITLE
Add `IdentityFile` and `LimaHome` fields to `limactl list` format

### DIFF
--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -3,7 +3,7 @@
 # $ limactl shell docker docker run -it -v $HOME:$HOME --rm alpine
 
 # To run `docker` on the host (assumes docker-cli is installed):
-# $ export DOCKER_HOST=unix://$HOME/docker.sock
+# $ export DOCKER_HOST=$(limactl list docker --format 'unix://{{.InstanceDir}}/sock/docker.sock')
 # $ docker ...
 
 # This example requires Lima v0.7.3 or later
@@ -61,4 +61,4 @@ probes:
     hint: See "/var/log/cloud-init-output.log". in the guest
 portForwards:
   - guestSocket: "/run/user/{{.UID}}/docker.sock"
-    hostSocket: "{{.Home}}/docker.sock"
+    hostSocket: "{{.InstanceDir}}/sock/docker.sock"

--- a/examples/podman.yaml
+++ b/examples/podman.yaml
@@ -3,11 +3,11 @@
 # $ limactl shell podman podman run -it --rm -v $HOME:$HOME:ro docker.io/library/alpine
 
 # Hint: To allow `podman` CLI on the host to connect to the Podman daemon running inside the guest, run the following commands:
-# $ export CONTAINER_HOST=unix://$HOME/podman.sock
+# $ export CONTAINER_HOST=$(limactl list docker --format 'unix://{{.InstanceDir}}/sock/podman.sock')
 # $ podman ...
 
 # Hint: To allow `docker` CLI on the host to connect to the Podman daemon running inside the guest, run the following commands:
-# $ export DOCKER_HOST=unix://$HOME/podman.sock
+# $ export DOCKER_HOST=$(limactl list docker --format 'unix://{{.InstanceDir}}/sock/podman.sock')
 # $ docker ...
 
 # This example requires Lima v0.7.3 or later
@@ -52,4 +52,4 @@ probes:
     hint: See "/var/log/cloud-init-output.log". in the guest
 portForwards:
   - guestSocket: "/run/user/{{.UID}}/podman/podman.sock"
-    hostSocket: "{{.Home}}/podman.sock"
+    hostSocket: "{{.InstanceDir}}/sock/podman.sock"

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -183,8 +183,8 @@ networks:
 #   - guestSocket: "/run/user/{{.UID}}/my.sock"
 #     hostSocket: mysocket
 #   # "guestSocket" can include these template variables: {{.Home}}, {{.UID}}, and {{.User}}.
-#   # "hostSocket" can include {{.LimaHome}}, {{.Instance}}, {{.Home}}, {{.UID}}, and {{.User}}.
-#   # Relative "hostSocket" will be based of "{{.LimaHome}}/{{.Instance}}/sock/".
+#   # "hostSocket" can include {{.Home}}, {{.InstanceDir}}, {{.Name}}, {{.UID}}, and {{.User}}.
+#   # Put sockets into "{{.InstanceDir}}/sock" to avoid collision with Lima internal sockets!
 #   # Sockets can also be forwarded to ports and vice versa, but not to/from a range of ports.
 #   # Forwarding requires the lima user to have rw access to the "guestsocket",
 #   # and the local user rwx access to the directory of the "hostsocket".

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -195,11 +195,14 @@ func FillPortForwardDefaults(rule *PortForward, instDir string) {
 			home, _ := os.UserHomeDir()
 			limaHome, _ := dirnames.LimaDir()
 			data := map[string]string{
-				"Home":     home,
-				"Instance": filepath.Base(instDir),
-				"LimaHome": limaHome,
-				"UID":      user.Uid,
-				"User":     user.Username,
+				"Home":        home,
+				"InstanceDir": instDir,
+				"Name":        filepath.Base(instDir),
+				"UID":         user.Uid,
+				"User":        user.Username,
+
+				"Instance": filepath.Base(instDir), // DEPRECATED, use `{{.Name}}`
+				"LimaHome": limaHome,               // DEPRECATED, (use `InstanceDir` instead of `{{.LimaHome}}/{{.Instance}}`
 			}
 			var out bytes.Buffer
 			if err := tmpl.Execute(&out, data); err == nil {

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -177,7 +177,7 @@ func Validate(y LimaYAML, warn bool) error {
 		if rule.HostSocket != "" {
 			if !filepath.IsAbs(rule.HostSocket) {
 				// should be unreachable because FillDefault() will prepend the instance directory to relative names
-				return fmt.Errorf("field `%s.hostSocket` must be an absolute path", field)
+				return fmt.Errorf("field `%s.hostSocket` must be an absolute path, but is %q", field, rule.HostSocket)
 			}
 			if rule.GuestSocket == "" && rule.GuestPortRange[1]-rule.GuestPortRange[0] > 0 {
 				return fmt.Errorf("field `%s.hostSocket` can only be mapped from a single port or socket. not a range", field)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -46,11 +46,16 @@ func InstanceDir(name string) (string, error) {
 
 // LoadYAMLByFilePath loads and validates the yaml.
 func LoadYAMLByFilePath(filePath string) (*limayaml.LimaYAML, error) {
-	yContent, err := os.ReadFile(filePath)
+	// We need to use the absolute path because it may be used to determine hostSocket locations.
+	absPath, err := filepath.Abs(filePath)
 	if err != nil {
 		return nil, err
 	}
-	y, err := limayaml.Load(yContent, filePath)
+	yContent, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil, err
+	}
+	y, err := limayaml.Load(yContent, absPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Based on the suggestion in https://github.com/lima-vm/lima/pull/324#issuecomment-942611305.

Update examples/docker.yaml to show how this can be used to construct the instance-specific path of forwarded sockets.

```console
$ export DOCKER_HOST=$(limactl list docker --format 'unix://{{.LimaHome}}/{{.Name}}/sock/docker')
$ docker info
```

When the port forwards don't specify an absolute path:

```yaml
portForwards:
  - guestSocket: "/run/user/{{.UID}}/docker.sock"
    hostSocket: docker
```
