### PR TITLE
Add config command for viewing yaml config

### DIFF
--- a/cmd/limactl/config.go
+++ b/cmd/limactl/config.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/lima-vm/lima/pkg/limayaml"
+	"github.com/lima-vm/lima/pkg/store"
+	"github.com/spf13/cobra"
+)
+
+func newConfigCommand() *cobra.Command {
+	var configCommand = &cobra.Command{
+		Use:   "config [FILE.yaml, ...]",
+		Short: "Evaluate YAML files",
+		RunE:  configAction,
+	}
+	configCommand.Flags().Bool("diff", false, "Show diff from default")
+	configCommand.Flags().String("default", "", "Default template file")
+	return configCommand
+}
+
+func configAction(cmd *cobra.Command, args []string) error {
+	diff, _ := cmd.Flags().GetBool("diff")
+	template, err := cmd.Flags().GetString("default")
+	if err != nil {
+		return err
+	}
+	var b []byte
+	if template != "" {
+		var err error
+		b, err = os.ReadFile(template)
+		if err != nil {
+			return err
+		}
+	} else {
+		b = limayaml.DefaultTemplate
+	}
+	c, err := store.LoadYAML(b)
+	if err != nil {
+		return fmt.Errorf("failed to load YAML: %w", err)
+	}
+	d, err := store.SaveYAML(c)
+	if err != nil {
+		return fmt.Errorf("failed to save YAML: %w", err)
+	}
+	if len(args) == 0 {
+		// show the default
+		fmt.Print(string(d))
+	}
+	for _, f := range args {
+		y, err := store.LoadYAMLByFilePath(f)
+		if err != nil {
+			return fmt.Errorf("failed to load YAML file %q: %w", f, err)
+		}
+		name, _ := instNameFromYAMLPath(f)
+		b, err := store.SaveYAML(y)
+		if err != nil {
+			return fmt.Errorf("failed to save YAML: %w", err)
+		}
+		if diff {
+			if len(args) > 1 {
+				fmt.Printf("# %s\n", name)
+			}
+			fmt.Print(cmp.Diff(string(d), string(b)))
+		} else {
+			if len(args) > 1 {
+				fmt.Printf("--- # %s.yaml\n", name)
+			}
+			fmt.Print(string(b))
+		}
+	}
+
+	return nil
+}

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -76,6 +76,7 @@ func newApp() *cobra.Command {
 		newListCommand(),
 		newDeleteCommand(),
 		newValidateCommand(),
+		newConfigCommand(),
 		newSudoersCommand(),
 		newPruneCommand(),
 		newHostagentCommand(),

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/go-cmp v0.5.5
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect

--- a/pkg/limayaml/save.go
+++ b/pkg/limayaml/save.go
@@ -1,0 +1,16 @@
+package limayaml
+
+import (
+	"gopkg.in/yaml.v2"
+)
+
+// Save saves the yaml.
+//
+// Save does not validate. Use Validate for validation.
+func Save(y *LimaYAML) ([]byte, error) {
+	b, err := yaml.Marshal(y)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -44,6 +44,15 @@ func InstanceDir(name string) (string, error) {
 	return dir, nil
 }
 
+// LoadYAML loads the yaml.
+func LoadYAML(b []byte) (*limayaml.LimaYAML, error) {
+	y, err := limayaml.Load(b, "")
+	if err != nil {
+		return nil, err
+	}
+	return y, nil
+}
+
 // LoadYAMLByFilePath loads and validates the yaml.
 func LoadYAMLByFilePath(filePath string) (*limayaml.LimaYAML, error) {
 	yContent, err := os.ReadFile(filePath)
@@ -58,4 +67,29 @@ func LoadYAMLByFilePath(filePath string) (*limayaml.LimaYAML, error) {
 		return nil, err
 	}
 	return y, nil
+}
+
+// SaveYAML saves the yaml.
+func SaveYAML(y *limayaml.LimaYAML) ([]byte, error) {
+	b, err := limayaml.Save(y)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// SaveYAMLByFilePath validates and saves the yaml.
+func SaveYAMLByFilePath(y *limayaml.LimaYAML, filePath string) ([]byte, error) {
+	if err := limayaml.Validate(*y, false); err != nil {
+		return nil, err
+	}
+	b, err := limayaml.Save(y)
+	if err != nil {
+		return nil, err
+	}
+	err = os.WriteFile(filePath, b, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
 }


### PR DESCRIPTION
Without arguments, show the parsed default config.

Add diff flag for comparing against default config.

Closes #443

Example:
```console
$ limactl config --diff examples/ubuntu.yaml 
  (
  	"""
  	arch: x86_64
  	images:
- 	- location: ~/Downloads/impish-server-cloudimg-amd64.img
- 	  arch: x86_64
- 	- location: ~/Downloads/impish-server-cloudimg-arm64.img
- 	  arch: aarch64
  	- location: https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img
  	  arch: x86_64
  	... // 27 identical lines
  	"""
  )
```

Shows the difference between "default" and "ubuntu" (not much)