### PR TITLE
examples: centos.yaml (8.4) -> rocky.yaml (8.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Lima is expected to be used on macOS hosts, but can be used on Linux hosts as we
 
 ✅ [Intel on ARM](./docs/multi-arch.md)
 
-✅ Various guest Linux distributions: [Alpine](./examples/alpine.yaml), [Arch Linux](./examples/archlinux.yaml), [CentOS](./examples/centos.yaml), [Debian](./examples/debian.yaml), [Fedora](./examples/fedora.yaml), [openSUSE](./examples/opensuse.yaml), [Ubuntu](./examples/ubuntu.yaml) (default), ...
+✅ Various guest Linux distributions: [Alpine](./examples/alpine.yaml), [Arch Linux](./examples/archlinux.yaml), [Debian](./examples/debian.yaml), [Fedora](./examples/fedora.yaml), [openSUSE](./examples/opensuse.yaml), [Rocky](./examples/rocky.yaml), [Ubuntu](./examples/ubuntu.yaml) (default), ...
 
 Related project: [sshocker (ssh with file sharing and port forwarding)](https://github.com/lima-vm/sshocker)
 
@@ -243,7 +243,7 @@ Alternatively, you may also directly ssh into the guest: `ssh -p 60022 -i ~/.lim
 Yes, it should work, but not regularly tested on ARM (due to lack of CI).
 
 #### "Can I run non-Ubuntu guests?"
-Alpine, Arch Linux, CentOS, Debian, Fedora, and openSUSE are also known to work.
+Alpine, Arch Linux, Debian, Fedora, openSUSE, and Rocky are also known to work.
 See [`./examples/`](./examples/).
 
 An image has to satisfy the following requirements:
@@ -328,7 +328,7 @@ Note: **Only** on macOS versions **before** 10.15.7 you might need to add this e
 - if you are on macOS 10.15.7 or 11.0 or later make sure the entitlement `com.apple.vm.hypervisor` is **not** added. It only works on older macOS versions. You can clear the codesigning with `codesign --remove-signature /usr/local/bin/qemu-system-x86_64` and [start over](#getting-started).
 
 #### "QEMU crashes with `vmx_write_mem: mmu_gva_to_gpa XXXXXXXXXXXXXXXX failed`"
-This error is known to happen when running an image of RHEL8-compatible distribution such as CentOS 8 on Intel Mac.
+This error is known to happen when running an image of RHEL8-compatible distribution such as Rocky Linux 8.x on Intel Mac.
 A workaround is to set environment variable `QEMU_SYSTEM_X86_64="qemu-system-x86_64 -cpu Haswell-v4"`.
 
 https://bugs.launchpad.net/qemu/+bug/1838390

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,10 +5,10 @@ Default: [`default.yaml`](../pkg/limayaml/default.yaml) (Ubuntu, with containerd
 Distro:
 - [`alpine.yaml`](./alpine.yaml): Alpine Linux
 - [`archlinux.yaml`](./archlinux.yaml): Arch Linux
-- [`centos.yaml`](./centos.yaml): CentOS Linux
 - [`debian.yaml`](./debian.yaml): Debian GNU/Linux
 - [`fedora.yaml`](./fedora.yaml): Fedora
 - [`opensuse.yaml`](./opensuse.yaml): openSUSE Leap
+- [`rocky.yaml`](./rocky.yaml): Rocky Linux
 - [`ubuntu.yaml`](./ubuntu.yaml): Ubuntu (same as `default.yaml` but without extra YAML lines)
 
 Container engines:

--- a/examples/rocky.yaml
+++ b/examples/rocky.yaml
@@ -4,12 +4,12 @@
 # try setting environment variable QEMU_SYSTEM_X86_64="qemu-system-x86_64 -cpu Haswell-v4"
 # https://bugs.launchpad.net/qemu/+bug/1838390
 images:
-  - location: "https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2"
+  - location: "https://dl.rockylinux.org/pub/rocky/8.5/images/Rocky-8-GenericCloud-8.5-20211114.2.x86_64.qcow2"
     arch: "x86_64"
-    digest: "sha256:3510fc7deb3e1939dbf3fe6f65a02ab1efcc763480bc352e4c06eca2e4f7c2a2"
-  - location: "https://cloud.centos.org/centos/8/aarch64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.aarch64.qcow2"
+    digest: "sha256:c23f58f26f73fb9ae92bfb4cf881993c23fdce1bbcfd2881a5831f90373ce0c8"
+  - location: "https://dl.rockylinux.org/pub/rocky/8.5/images/Rocky-8-GenericCloud-8.5.20211114.1.aarch64.qcow2"
     arch: "aarch64"
-    digest: "sha256:8029d9ec018c54dc48f02d01200002b36ba69c6c6ea58334857eb172ab32e5d7"
+    digest: "sha256:f13cfa7b5e449cc165181a1efbea5b1cdce73ef6a5d6bb24c22b50f67f1f8fe2"
 mounts:
   - location: "~"
     writable: false


### PR DESCRIPTION
CentOS 8 is going to reach EOL soon, so replace CentOS with Rocky.


I didn't choose CentOS 8 Stream, because it's not stable as the legacy CentOS 8, and yet it's not progressive as Fedora.
