### PR TITLE
Add make target for running more checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,8 @@ uninstall:
 lint:
 	golangci-lint run ./...
 	yamllint .
+	find . -name '*.sh' | xargs shellcheck
+	find . -name '*.sh' | xargs shfmt -s -d
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Might as well catch those locally instead

Seem to be getting the same GitHub warnings over and over, probably would be a good idea to check it locally first...

I am not sure if there is a better way to share tests, the other YAML looked pretty specific (including custom "actions")

Just don't want to waste test resources, on whitespace and typos.