### PR TITLE
fix port forwarding of docker socket inside docker example file

### DIFF
--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -3,7 +3,7 @@
 # $ limactl shell docker docker run -it -v $HOME:$HOME --rm alpine
 
 # To run `docker` on the host (assumes docker-cli is installed):
-# $ export DOCKER_HOST=$(limactl list docker --format 'unix://{{.InstanceDir}}/sock/docker.sock')
+# $ export DOCKER_HOST="`limactl list docker --format 'unix://{{.Dir}}/sock/docker.sock'`"
 # $ docker ...
 
 # This example requires Lima v0.7.3 or later
@@ -65,4 +65,4 @@ probes:
     hint: See "/var/log/cloud-init-output.log". in the guest
 portForwards:
   - guestSocket: "/run/user/{{.UID}}/docker.sock"
-    hostSocket: "{{.InstanceDir}}/sock/docker.sock"
+    hostSocket: "docker.sock"


### PR DESCRIPTION
## Issue i try to fix
for me it seems like the current docker.example file has some socket forwarding issues with the latest lima version
(at least that's what i have tested)

The port forward was bind to: `~/.lima/docker/sock/<no value>/sock/docker.sock`
I guess this `<no value>` is related to an unknown mapping for `{{.InstanceDir}}` which is used in the forward definition.

This assumption fits to another issue i had, when i call:
`limactl list docker --format 'unix://{{.InstanceDir}}/sock/docker.sock`

I get this kind of error message:

```
template: format:1:9: executing "format" at <.InstanceDir>: can't evaluate field InstanceDir in type *store.Instance
```

So, it seems that the variable is not defined in the current version.

## How I fixed it
it seems like the correct folder is already used for `hostSocket` if i just define the filename inside `hostSocket` section.

In addition I also adjusted the DOCKER_HOST export comment.
I define now the main lima docker configuration folder via variable `.Dir`  and then i rely on the convention (i hope this is really a convention) that the socket is in the subfolder `sock` which finally looks like this:

```
export DOCKER_HOST="`limactl list docker --format 'unix://{{.Dir}}/sock/docker.sock'`"
```

This new setup works know out of the box (for me) and from my understanding this should also work for everyone else with this adjustments.