### PR TITLE
Replace `InstanceDir` with `Dir`

### DIFF
--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -22,7 +22,6 @@ import (
 type formatData struct {
 	store.Instance
 	LimaHome     string
-	InstanceDir  string
 	IdentityFile string
 }
 
@@ -40,7 +39,6 @@ func addGlobalFields(inst *store.Instance) (formatData, error) {
 	if err != nil {
 		return formatData{}, err
 	}
-	data.InstanceDir = filepath.Join(data.LimaHome, inst.Name)
 	return data, nil
 }
 

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -3,7 +3,7 @@
 # $ limactl shell docker docker run -it -v $HOME:$HOME --rm alpine
 
 # To run `docker` on the host (assumes docker-cli is installed):
-# $ export DOCKER_HOST=$(limactl list docker --format 'unix://{{.InstanceDir}}/sock/docker.sock')
+# $ export DOCKER_HOST=$(limactl list docker --format 'unix://{{.Dir}}/sock/docker.sock')
 # $ docker ...
 
 # This example requires Lima v0.7.3 or later
@@ -65,4 +65,4 @@ probes:
     hint: See "/var/log/cloud-init-output.log". in the guest
 portForwards:
   - guestSocket: "/run/user/{{.UID}}/docker.sock"
-    hostSocket: "{{.InstanceDir}}/sock/docker.sock"
+    hostSocket: "{{.Dir}}/sock/docker.sock"

--- a/examples/podman.yaml
+++ b/examples/podman.yaml
@@ -3,11 +3,11 @@
 # $ limactl shell podman podman run -it -v $HOME:$HOME --rm docker.io/library/alpine
 
 # To run `podman` on the host (assumes podman-remote is installed):
-# $ export CONTAINER_HOST=$(limactl list podman --format 'unix://{{.InstanceDir}}/sock/podman.sock')
+# $ export CONTAINER_HOST=$(limactl list podman --format 'unix://{{.Dir}}/sock/podman.sock')
 # $ podman --remote ...
 
 # To run `docker` on the host (assumes docker-cli is installed):
-# $ export DOCKER_HOST=$(limactl list podman --format 'unix://{{.InstanceDir}}/sock/podman.sock')
+# $ export DOCKER_HOST=$(limactl list podman --format 'unix://{{.Dir}}/sock/podman.sock')
 # $ docker ...
 
 # This example requires Lima v0.7.3 or later
@@ -52,4 +52,4 @@ probes:
     hint: See "/var/log/cloud-init-output.log". in the guest
 portForwards:
   - guestSocket: "/run/user/{{.UID}}/podman/podman.sock"
-    hostSocket: "{{.InstanceDir}}/sock/podman.sock"
+    hostSocket: "{{.Dir}}/sock/podman.sock"

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -183,8 +183,8 @@ networks:
 #   - guestSocket: "/run/user/{{.UID}}/my.sock"
 #     hostSocket: mysocket
 #   # "guestSocket" can include these template variables: {{.Home}}, {{.UID}}, and {{.User}}.
-#   # "hostSocket" can include {{.Home}}, {{.InstanceDir}}, {{.Name}}, {{.UID}}, and {{.User}}.
-#   # Put sockets into "{{.InstanceDir}}/sock" to avoid collision with Lima internal sockets!
+#   # "hostSocket" can include {{.Home}}, {{.Dir}}, {{.Name}}, {{.UID}}, and {{.User}}.
+#   # Put sockets into "{{.Dir}}/sock" to avoid collision with Lima internal sockets!
 #   # Sockets can also be forwarded to ports and vice versa, but not to/from a range of ports.
 #   # Forwarding requires the lima user to have rw access to the "guestsocket",
 #   # and the local user rwx access to the directory of the "hostsocket".

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -195,14 +195,14 @@ func FillPortForwardDefaults(rule *PortForward, instDir string) {
 			home, _ := os.UserHomeDir()
 			limaHome, _ := dirnames.LimaDir()
 			data := map[string]string{
-				"Home":        home,
-				"InstanceDir": instDir,
-				"Name":        filepath.Base(instDir),
-				"UID":         user.Uid,
-				"User":        user.Username,
+				"Dir":  instDir,
+				"Home": home,
+				"Name": filepath.Base(instDir),
+				"UID":  user.Uid,
+				"User": user.Username,
 
 				"Instance": filepath.Base(instDir), // DEPRECATED, use `{{.Name}}`
-				"LimaHome": limaHome,               // DEPRECATED, (use `InstanceDir` instead of `{{.LimaHome}}/{{.Instance}}`
+				"LimaHome": limaHome,               // DEPRECATED, (use `Dir` instead of `{{.LimaHome}}/{{.Instance}}`
 			}
 			var out bytes.Buffer
 			if err := tmpl.Execute(&out, data); err == nil {


### PR DESCRIPTION
`Dir` was already supported by `limactl list`, so the `InstanceDir` is redundant. It was never part of a release, so can be removed.

For `hostSocket` this commit renames `InstanceDir` to `Dir`, as again there never was a release supporting `InstanceDir` either.

Updated docker and podman examples to match.
