### PR TITLE
Delete closed issue link on help wanted section

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,6 @@ The current default spec:
 
 ### Help wanted
 :pray:
-- [Test on ARM Mac](https://github.com/lima-vm/lima/issues/42)
 - Performance optimization
 - More guest distros
 - Windows hosts


### PR DESCRIPTION
## Why

I see `Help wanted` on README.
I was interested in `Test on ARM Mac`, so I accessed it, but closed (solved?)

I deleted it because I thought it was not good for the solved issue to remain.