### PR TITLE
Fix required version for examples/{docker,podman}.yaml

### DIFF
--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -6,7 +6,7 @@
 # $ export DOCKER_HOST=$(limactl list docker --format 'unix://{{.Dir}}/sock/docker.sock')
 # $ docker ...
 
-# This example requires Lima v0.7.3 or later
+# This example requires Lima v0.7.5 or later
 images:
   # Hint: run `limactl prune` to invalidate the "current" cache
   - location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"

--- a/examples/podman.yaml
+++ b/examples/podman.yaml
@@ -10,7 +10,7 @@
 # $ export DOCKER_HOST=$(limactl list podman --format 'unix://{{.Dir}}/sock/podman.sock')
 # $ docker ...
 
-# This example requires Lima v0.7.3 or later
+# This example requires Lima v0.7.5 or later
 images:
   # Hint: run `limactl prune` to invalidate the "current" cache
   - location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"


### PR DESCRIPTION
They use new templating variables that don't exist in older releases.

Ref https://github.com/lima-vm/lima/pull/462#pullrequestreview-826003326