### PR TITLE
Fix port forwarding of docker.sock in docker example

### DIFF
--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -65,4 +65,4 @@ probes:
     hint: See "/var/log/cloud-init-output.log". in the guest
 portForwards:
   - guestSocket: "/run/user/{{.UID}}/docker.sock"
-    hostSocket: "{{.Dir}}/sock/docker.sock"
+    hostSocket: "docker.sock"


### PR DESCRIPTION
When we start a lima-vm with the docker example file, we get the following output in the console.

> INFO[0038] [hostagent] Forwarding "/run/user/502/docker.sock" (guest) to "/Users/my-user/.lima/docker/sock/\<no value\>/sock/docker.sock" (host)

With the modification, now we have the following output

> INFO[0030] [hostagent] Forwarding "/run/user/502/docker.sock" (guest) to "/Users/my-user/.lima/docker/sock/docker.sock" (host)

After we can export DOCKER_HOST variable :

`export DOCKER_HOST=$(limactl list docker --format 'unix://{{.Dir}}/sock/docker.sock')`

Run the command `docker version` to get Docker server information.