### PR TITLE
Allow Proxy ports to be marshalled as strings

### DIFF
--- a/pkg/osutil/dns_darwin.go
+++ b/pkg/osutil/dns_darwin.go
@@ -29,12 +29,14 @@ func DNSAddresses() ([]string, error) {
 	return addresses, nil
 }
 
-func proxyURL(proxy string, port int) string {
+func proxyURL(proxy string, port interface{}) string {
 	if !strings.Contains(proxy, "://") {
 		proxy = "http://" + proxy
 	}
-	if port != 0 {
-		proxy = fmt.Sprintf("%s:%d", proxy, port)
+	if portNumber, ok := port.(float64); ok && portNumber != 0 {
+		proxy = fmt.Sprintf("%s:%.0f", proxy, portNumber)
+	} else if portString, ok := port.(string); ok && portString != "" {
+		proxy = fmt.Sprintf("%s:%s", proxy, portString)
 	}
 	return proxy
 }

--- a/pkg/sysprof/network_darwin.go
+++ b/pkg/sysprof/network_darwin.go
@@ -15,17 +15,17 @@ type DNS struct {
 }
 
 type Proxies struct {
-	ExceptionList []string `json:"ExceptionList"` // default: ["*.local", "169.254/16"]
-	FTPEnable     string   `json:"FTPEnable"`
-	FTPPort       int      `json:"FTPPort"`
-	FTPProxy      string   `json:"FTPProxy"`
-	FTPUser       string   `json:"FTPUser"`
-	HTTPEnable    string   `json:"HTTPEnable"`
-	HTTPPort      int      `json:"HTTPPort"`
-	HTTPProxy     string   `json:"HTTPProxy"`
-	HTTPUser      string   `json:"HTTPUser"`
-	HTTPSEnable   string   `json:"HTTPSEnable"`
-	HTTPSPort     int      `json:"HTTPSPort"`
-	HTTPSProxy    string   `json:"HTTPSProxy"`
-	HTTPSUser     string   `json:"HTTPSUser"`
+	ExceptionList []string    `json:"ExceptionList"` // default: ["*.local", "169.254/16"]
+	FTPEnable     string      `json:"FTPEnable"`
+	FTPPort       interface{} `json:"FTPPort"`
+	FTPProxy      string      `json:"FTPProxy"`
+	FTPUser       string      `json:"FTPUser"`
+	HTTPEnable    string      `json:"HTTPEnable"`
+	HTTPPort      interface{} `json:"HTTPPort"`
+	HTTPProxy     string      `json:"HTTPProxy"`
+	HTTPUser      string      `json:"HTTPUser"`
+	HTTPSEnable   string      `json:"HTTPSEnable"`
+	HTTPSPort     interface{} `json:"HTTPSPort"`
+	HTTPSProxy    string      `json:"HTTPSProxy"`
+	HTTPSUser     string      `json:"HTTPSUser"`
 }


### PR DESCRIPTION
It is not clear how/why this can happen, but we have seen at least 2 reports from users where a missing port was encoded as an empty string, and not as the number 0. It is unclear if on those systems non-0 ports would be encoded as strings or numbers, so this commit will handle both.

Fixes #403
