### PR TITLE
Add hwclock sync loop to the guestagent

### DIFF
--- a/pkg/guestagent/guestagent_linux.go
+++ b/pkg/guestagent/guestagent_linux.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lima-vm/lima/pkg/guestagent/api"
 	"github.com/lima-vm/lima/pkg/guestagent/iptables"
 	"github.com/lima-vm/lima/pkg/guestagent/procnettcp"
+	"github.com/lima-vm/lima/pkg/guestagent/timesync"
 	"github.com/sirupsen/logrus"
 	"github.com/yalue/native_endian"
 )
@@ -37,6 +38,7 @@ func New(newTicker func() (<-chan time.Time, func()), iptablesIdle time.Duration
 	}
 
 	go a.setWorthCheckingIPTablesRoutine(auditClient, iptablesIdle)
+	go a.fixSystemTimeSkew()
 	return a, nil
 }
 
@@ -243,4 +245,31 @@ func (a *agent) Info(ctx context.Context) (*api.Info, error) {
 		return nil, err
 	}
 	return &info, nil
+}
+
+const deltaLimit = 2 * time.Second
+
+func (a *agent) fixSystemTimeSkew() {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	for now := range ticker.C {
+		rtc, err := timesync.GetRTCTime()
+		if err != nil {
+			logrus.Warnf("fixSystemTimeSkew: lookup error: %s", err.Error())
+			continue
+		}
+		d := rtc.Sub(now)
+		logrus.Debugf("fixSystemTimeSkew: rtc=%s systime=%s delta=%s",
+			rtc.Format(time.RFC3339), now.Format(time.RFC3339), d)
+		if d > deltaLimit || d < -deltaLimit {
+			err = timesync.SetSystemTime(rtc)
+			if err != nil {
+				logrus.Warnf("fixSystemTimeSkew: set system clock error: %s", err.Error())
+				continue
+			}
+			logrus.Infof("fixSystemTimeSkew: system time synchronized with rtc")
+			break
+		}
+	}
+	go a.fixSystemTimeSkew()
 }

--- a/pkg/guestagent/timesync/timesync_linux.go
+++ b/pkg/guestagent/timesync/timesync_linux.go
@@ -1,0 +1,29 @@
+package timesync
+
+import (
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const rtc = "/dev/rtc"
+
+func GetRTCTime() (t time.Time, err error) {
+	f, err := os.Open(rtc)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	obj, err := unix.IoctlGetRTCTime(int(f.Fd()))
+	if err != nil {
+		return
+	}
+	t = time.Date(int(obj.Year+1900), time.Month(obj.Mon+1), int(obj.Mday), int(obj.Hour), int(obj.Min), int(obj.Sec), 0, time.UTC)
+	return t, nil
+}
+
+func SetSystemTime(t time.Time) error {
+	v := unix.NsecToTimeval(t.UnixNano())
+	return unix.Settimeofday(&v)
+}


### PR DESCRIPTION
Addresses #355

Running qemu guest agent alone doesn't solve the problem. With that approach, there must be an actor on the host side which catches wakeup events and executes RPC calls on the guest agent socket. As it stands, lima doesn't have any permanently running process to relay wake up events.

This PR offers different approach. It turns out that hardware clock device (`/dev/rtc0`) forwarded into a guest by QEMU always contains correct host time. The PR adds a loop into lima guest agent. That loop periodically checks the difference between hw clock time and system time. If the diff turns out to be over certain limit (hardcoded 5 seconds for now), the loop launches time sync from hw clock to system time. 