### PR TITLE
Enabled symbolic link following in mounts

### DIFF
--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -42,8 +42,17 @@ mounts:
     # CAUTION: `writable` SHOULD be false for the home directory.
     # Setting `writable` to true is possible, but untested and dangerous.
     writable: false
+    # SSHFS has an optional flag called 'follow_symlinks'. This allows mounts
+    # to be properly resolved in the guest os and allow for access to the
+    # contents of the symlnk. This defaults to false if not supplied. As a result,
+    # symlinked files & folders on the Host system will look and feel like regular
+    # files directories in the Guest OS.
+    sshfs:
+      followSymlinks: false
   - location: "/tmp/lima"
     writable: true
+    sshfs:
+      followSymlinks: false
 
 ssh:
   # A localhost port of the host. Forwarded to port 22 of the guest.

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -298,6 +298,9 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 	location := make(map[string]int)
 	for _, mount := range append(append(d.Mounts, y.Mounts...), o.Mounts...) {
 		if i, ok := location[mount.Location]; ok {
+			if mount.SSHFS.FollowSymlinks != nil {
+				mounts[i].SSHFS.FollowSymlinks = mount.SSHFS.FollowSymlinks
+			}
 			mounts[i].Writable = mount.Writable
 		} else {
 			location[mount.Location] = len(mounts)
@@ -305,6 +308,13 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		}
 	}
 	y.Mounts = mounts
+
+	for i := range y.Mounts {
+		mount := &y.Mounts[i]
+		if mount.SSHFS.FollowSymlinks == nil {
+			mount.SSHFS.FollowSymlinks = pointer.Bool(false)
+		}
+	}
 
 	// Note: DNS lists are not combined; highest priority setting is picked
 	if len(y.DNS) == 0 {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -116,6 +116,7 @@ func TestFillDefault(t *testing.T) {
 
 	expect := builtin
 	expect.Mounts = y.Mounts
+	expect.Mounts[0].SSHFS.FollowSymlinks = pointer.Bool(false)
 	// Only missing Mounts field is Writable, and the default value is also the null value: false
 
 	expect.Provision = y.Provision
@@ -235,6 +236,7 @@ func TestFillDefault(t *testing.T) {
 	expect = d
 	// Also verify that archive arch is filled in
 	expect.Containerd.Archives[0].Arch = *d.Arch
+	expect.Mounts[0].SSHFS.FollowSymlinks = pointer.Bool(false)
 
 	y = LimaYAML{}
 	FillDefault(&y, &d, &LimaYAML{}, filePath)
@@ -302,6 +304,7 @@ func TestFillDefault(t *testing.T) {
 			{
 				Location: "/var/log",
 				Writable: true,
+				SSHFS:    SSHFS{FollowSymlinks: pointer.Bool(true)},
 			},
 		},
 		Provision: []Provision{
@@ -358,6 +361,7 @@ func TestFillDefault(t *testing.T) {
 	// o.Mounts just makes d.Mounts[0] writable because the Location matches
 	expect.Mounts = append(d.Mounts, y.Mounts...)
 	expect.Mounts[0].Writable = true
+	expect.Mounts[0].SSHFS.FollowSymlinks = pointer.Bool(true)
 
 	// o.Networks[1] is overriding the d.Networks[0].Lima entry for the "def0" interface
 	expect.Networks = append(append(d.Networks, y.Networks...), o.Networks[0])

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -45,6 +45,11 @@ type File struct {
 type Mount struct {
 	Location string `yaml:"location" json:"location"` // REQUIRED
 	Writable bool   `yaml:"writable,omitempty" json:"writable,omitempty"`
+	SSHFS    SSHFS  `yaml:"sshfs,omitempty" json:"sshfs,omitempty"`
+}
+
+type SSHFS struct {
+	FollowSymlinks *bool `yaml:"followSymlinks,omitempty" json:"followSymlinks,omitempty"`
 }
 
 type SSH struct {


### PR DESCRIPTION
This update will allow for symbolic links to be followed in mounts in sshfs.