### PR TITLE
XHCI over EHCI for better performance as well as aarch64 support

### DIFF
--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -49,7 +49,7 @@ func (a *HostAgent) setupMount(ctx context.Context, m limayaml.Mount) (*mount, e
 		RemotePath: expanded,
 		Readonly:   !m.Writable,
 		// NOTE: allow_other requires "user_allow_other" in /etc/fuse.conf
-		SSHFSAdditionalArgs: []string{"-o", "allow_other"},
+		SSHFSAdditionalArgs: []string{"-o", "allow_other,follow_symlinks"},
 	}
 	if err := rsf.Prepare(); err != nil {
 		return nil, fmt.Errorf("failed to prepare reverse sshfs for %q: %w", expanded, err)

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -324,9 +324,9 @@ func Cmdline(cfg Config) (string, []string, error) {
 	default:
 		// QEMU does not seem to support virtio-vga for aarch64
 		args = append(args, "-vga", "none", "-device", "ramfb")
-		args = append(args, "-device", "usb-ehci")
-		args = append(args, "-device", "usb-kbd")
-		args = append(args, "-device", "usb-mouse")
+		args = append(args, "-device", "qemu-xhci,id=usb-bus")
+		args = append(args, "-device", "usb-kbd,bus=usb-bus.0")
+		args = append(args, "-device", "usb-mouse,bus=usb-bus.0")
 	}
 
 	// Parallel


### PR DESCRIPTION
Update to use a more friendly version USB that works with aarch64


Notes:
```
XHCI controller support
QEMU has XHCI host adapter support. The XHCI hardware design is much more virtualization-friendly when compared to EHCI and UHCI, thus XHCI emulation uses less resources (especially CPU). So if your guest supports XHCI (which should be the case for any operating system released around 2010 or later) we recommend using 
```
https://qemu-project.gitlab.io/qemu/system/devices/usb.html