### PR TITLE
Don't include default settings in example configs

### DIFF
--- a/examples/alpine.yaml
+++ b/examples/alpine.yaml
@@ -9,7 +9,6 @@ images:
 
 mounts:
 - location: "~"
-  writable: false
 - location: "/tmp/lima"
   writable: true
 

--- a/examples/archlinux.yaml
+++ b/examples/archlinux.yaml
@@ -7,7 +7,6 @@ images:
     digest: "sha256:90fb8ea170be6fcfff0821b7544ccc8c3c1282fd0d08fcc0432a72552b929999"
 mounts:
   - location: "~"
-    writable: false
   - location: "/tmp/lima"
     writable: true
 firmware:

--- a/examples/debian.yaml
+++ b/examples/debian.yaml
@@ -8,6 +8,5 @@ images:
     digest: "sha512:920f0397911017bebf0df5972450beb041813825cc5820d6ae5a351c00d1c25fb93955abd85f0444e5bf04ac00b19e77bfc4352c6f4c5aad2ddd50a071f842de"
 mounts:
   - location: "~"
-    writable: false
   - location: "/tmp/lima"
     writable: true

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -15,7 +15,6 @@ images:
     arch: "aarch64"
 mounts:
   - location: "~"
-    writable: false
   - location: "/tmp/lima"
     writable: true
 ssh:

--- a/examples/fedora.yaml
+++ b/examples/fedora.yaml
@@ -8,6 +8,5 @@ images:
     digest: "sha256:c71f2e6ce75b516d565e2c297ea9994c69b946cb3eaa0a4bbea400dbd6f59ae6"
 mounts:
   - location: "~"
-    writable: false
   - location: "/tmp/lima"
     writable: true

--- a/examples/opensuse.yaml
+++ b/examples/opensuse.yaml
@@ -6,6 +6,5 @@ images:
   # No aarch64 OpenStack build found :(
 mounts:
   - location: "~"
-    writable: false
   - location: "/tmp/lima"
     writable: true

--- a/examples/podman.yaml
+++ b/examples/podman.yaml
@@ -19,7 +19,6 @@ images:
     arch: "aarch64"
 mounts:
   - location: "~"
-    writable: false
   - location: "/tmp/lima"
     writable: true
 ssh:

--- a/examples/rocky.yaml
+++ b/examples/rocky.yaml
@@ -12,7 +12,6 @@ images:
     digest: "sha256:f13cfa7b5e449cc165181a1efbea5b1cdce73ef6a5d6bb24c22b50f67f1f8fe2"
 mounts:
   - location: "~"
-    writable: false
   - location: "/tmp/lima"
     writable: true
 firmware:

--- a/examples/singularity.yaml
+++ b/examples/singularity.yaml
@@ -13,7 +13,6 @@ images:
     digest: "sha256:c71f2e6ce75b516d565e2c297ea9994c69b946cb3eaa0a4bbea400dbd6f59ae6"
 mounts:
   - location: "~"
-    writable: false
   - location: "/tmp/lima"
     writable: true
 ssh:

--- a/examples/ubuntu.yaml
+++ b/examples/ubuntu.yaml
@@ -7,6 +7,5 @@ images:
     arch: "aarch64"
 mounts:
   - location: "~"
-    writable: false
   - location: "/tmp/lima"
     writable: true

--- a/examples/vmnet.yaml
+++ b/examples/vmnet.yaml
@@ -9,7 +9,6 @@ images:
     arch: "aarch64"
 mounts:
   - location: "~"
-    writable: false
   - location: "/tmp/lima"
     writable: true
 networks:

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -2,9 +2,13 @@
 # BASIC CONFIGURATION
 # ===================================================================== #
 
+# Default values are specified by `null` instead of the builtin default value,
+# so they can be overridden by the default.yaml mechanism documented at the
+# end of this file.
+
 # Arch: "default", "x86_64", "aarch64".
-# "default" corresponds to the host architecture.
-arch: "default"
+# Default: "default" (corresponds to the host architecture)
+arch: null
 
 # An image must support systemd and cloud-init.
 # Ubuntu and Fedora are known to work.
@@ -25,34 +29,35 @@ images:
 
 # CPUs: if you see performance issues, try limiting cpus to 1.
 # Default: 4
-cpus: 4
+cpus: null
 
 # Memory size
 # Default: "4GiB"
-memory: "4GiB"
+memory: null
 
 # Disk size
 # Default: "100GiB"
-disk: "100GiB"
+disk: null
 
 # Expose host directories to the guest, the mount point might be accessible from all UIDs in the guest
-# Default: none
+# Default: null
 mounts:
   - location: "~"
     # CAUTION: `writable` SHOULD be false for the home directory.
     # Setting `writable` to true is possible, but untested and dangerous.
-    writable: false
+    # Default: false
+    writable: null
     # SSHFS has an optional flag called 'follow_symlinks'. This allows mounts
     # to be properly resolved in the guest os and allow for access to the
-    # contents of the symlnk. This defaults to false if not supplied. As a result,
-    # symlinked files & folders on the Host system will look and feel like regular
-    # files directories in the Guest OS.
+    # contents of the symlink. As a result, symlinked files & folders on the Host
+    # system will look and feel like regular files directories in the Guest OS.
     sshfs:
-      followSymlinks: false
+      # Default: false
+      followSymlinks: null
   - location: "/tmp/lima"
     writable: true
     sshfs:
-      followSymlinks: false
+      followSymlinks: null
 
 ssh:
   # A localhost port of the host. Forwarded to port 22 of the guest.
@@ -63,10 +68,10 @@ ssh:
   # applications such as rsync with the Lima instance.
   # If you have an insecure key under ~/.ssh, do not use this option.
   # Default: true
-  loadDotSSHPubKeys: true
+  loadDotSSHPubKeys: null
   # Forward ssh agent into the instance.
   # Default: false
-  forwardAgent: false
+  forwardAgent: null
 
 # ===================================================================== #
 # ADVANCED CONFIGURATION
@@ -75,10 +80,10 @@ ssh:
 containerd:
   # Enable system-wide (aka rootful)  containerd and its dependencies (BuildKit, Stargz Snapshotter)
   # Default: false
-  system: false
+  system: null
   # Enable user-scoped (aka rootless) containerd and its dependencies
   # Default: true
-  user: true
+  user: null
 #  # Override containerd archive
 #  # Default: hard-coded URL with hard-coded digest (see the output of `limactl info | jq .defaultTemplate.containerd.archives`)
 #  archives:
@@ -127,14 +132,14 @@ containerd:
 firmware:
   # Use legacy BIOS instead of UEFI.
   # Default: false
-  legacyBIOS: false
+  legacyBIOS: null
 
 video:
   # QEMU display, e.g., "none", "cocoa", "sdl", "gtk".
   # As of QEMU v5.2, enabling this is known to have negative impact
   # on performance on macOS hosts: https://gitlab.com/qemu-project/qemu/-/issues/334
   # Default: "none"
-  display: "none"
+  display: null
 
 # The instance can get routable IP addresses from the vmnet framework using
 # https://github.com/lima-vm/vde_vmnet.
@@ -226,14 +231,14 @@ networks:
 # the VM, so it stays routable. Use of the process environment can be disabled by setting
 # propagateProxyEnv to false.
 # Default: true
-propagateProxyEnv: true
+propagateProxyEnv: null
 
 # The host agent implements a DNS server that looks up host names on the host
 # using the local system resolver. This means changing VPN and network settings
 # are reflected automatically into the guest, including conditional forward,
 # and mDNS lookup:
 # Default: true
-useHostResolver: true
+useHostResolver: null
 
 # If useHostResolver is false, then the following rules apply for configuring dns:
 # Explicitly set DNS addresses for qemu user-mode networking. By default qemu picks *one*


### PR DESCRIPTION
Setting the fields to `null` instead makes them overridable via the `_config/default.yaml` mechanism.

For example, I want to make the home directory writable by default. Right now the only mechanism is:

```console
$ cat ~/.lima/_config/override.yaml
mounts:
- location: "~"
  writable: true
```

But that means it is now impossible to make the home directory read-only in a specific VM; `override.yaml` always takes precedence. With the changes in this PR, the setting above can be moved to `default.yaml`, and can still be overridden by individual VMs.