### PR TITLE
Running kubectl requires using sudo kubectl

### DIFF
--- a/examples/k3s.yaml
+++ b/examples/k3s.yaml
@@ -1,4 +1,6 @@
 # Deploy kubernetes via k3s (which installs a bundled containerd).
+# $ limactl start ./k3s.yaml
+# $ limactl shell k3s sudo kubectl
 #
 # It can be accessed from the host by exporting the kubeconfig file;
 # the ports are already forwarded automatically by lima:

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -4,7 +4,7 @@
 # the ports are already forwarded automatically by lima:
 #
 # $ export KUBECONFIG=$PWD/kubeconfig.yaml
-# $ limactl shell k8s sudo cat /etc/kubernetes/admin.conf | sed -e 's/192.168.5.15/127.0.0.1/' >$KUBECONFIG
+# $ limactl shell k8s sudo cat /etc/kubernetes/admin.conf >$KUBECONFIG
 # $ kubectl get no
 # NAME       STATUS   ROLES                  AGE   VERSION
 # lima-k8s   Ready    control-plane,master   44s   v1.22.3
@@ -73,6 +73,7 @@ provision:
     kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/v0.14.0/Documentation/kube-flannel.yml
     # Control plane node isolation
     kubectl taint nodes --all node-role.kubernetes.io/master-
+    sed -e "s/${LIMA_CIDATA_SLIRP_IP_ADDRESS:-192.168.5.15}/127.0.0.1/" -i $KUBECONFIG
 - mode: user
   script: |
     #!/bin/bash

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -1,4 +1,6 @@
 # Deploy kubernetes via kubeadm.
+# $ limactl start ./k8s.yaml
+# $ limactl shell k8s sudo kubectl
 
 # It can be accessed from the host by exporting the kubeconfig file;
 # the ports are already forwarded automatically by lima:
@@ -74,13 +76,7 @@ provision:
     # Control plane node isolation
     kubectl taint nodes --all node-role.kubernetes.io/master-
     sed -e "s/${LIMA_CIDATA_SLIRP_IP_ADDRESS:-192.168.5.15}/127.0.0.1/" -i $KUBECONFIG
-- mode: user
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    mkdir -p $HOME/.kube
-    sudo cp -f /etc/kubernetes/admin.conf $HOME/.kube/config
-    sudo chown $(id -u):$(id -g) $HOME/.kube/config
+    mkdir -p ${HOME:-/root}/.kube && cp -f $KUBECONFIG ${HOME:-/root}/.kube/config
 probes:
 - script: |
     #!/bin/bash


### PR DESCRIPTION
A bit of mismatch between k3s and k8s, and needs better documentation...

Make it easier to set up user config, and make `sudo kubectl` work as well.

i.e. running directly on the guest, is _supposed_ to require sudo

running remotely from the host, is configured to **not** use sudo

----

k3s, when not using `sudo`
```
WARN[0000] Unable to read /etc/rancher/k3s/k3s.yaml, please start server with --write-kubeconfig-mode to modify kube config permissions 
error: error loading config file "/etc/rancher/k3s/k3s.yaml": open /etc/rancher/k3s/k3s.yaml: permission denied
```

k8s, without $KUBECONFIG
```
The connection to the server localhost:8080 was refused - did you specify the right host or port?
```