### PR TITLE
Don't set localPort in example configs

### DIFF
--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -17,12 +17,6 @@ mounts:
   - location: "~"
   - location: "/tmp/lima"
     writable: true
-ssh:
-  localPort: 60006
-  # Load ~/.ssh/*.pub in addition to $LIMA_HOME/_config/user.pub , for allowing DOCKER_HOST=ssh:// .
-  # This option is enabled by default.
-  # If you have an insecure key under ~/.ssh, do not use this option.
-  loadDotSSHPubKeys: true
 # containerd is managed by Docker, not by Lima, so the values are set to false here.
 containerd:
   system: false

--- a/examples/podman.yaml
+++ b/examples/podman.yaml
@@ -21,8 +21,6 @@ mounts:
   - location: "~"
   - location: "/tmp/lima"
     writable: true
-ssh:
-  localPort: 60906
 containerd:
   system: false
   user: false

--- a/examples/singularity.yaml
+++ b/examples/singularity.yaml
@@ -15,8 +15,6 @@ mounts:
   - location: "~"
   - location: "/tmp/lima"
     writable: true
-ssh:
-  localPort: 62045
 containerd:
   system: false
   user: false


### PR DESCRIPTION
lima will automatically pick an unused port.

Fixes #511 
