### PR TITLE
Download the needed images before kubeadm init

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -65,6 +65,8 @@ provision:
     set -eux -o pipefail
     test -e /etc/kubernetes/admin.conf && exit 0
     export KUBECONFIG=/etc/kubernetes/admin.conf
+    kubeadm config images list
+    kubeadm config images pull
     # Initializing your control-plane node
     kubeadm init --cri-socket=/run/containerd/containerd.sock --pod-network-cidr=10.244.0.0/16 --apiserver-cert-extra-sans 127.0.0.1
     # Installing a Pod network add-on


### PR DESCRIPTION
Makes it easier to troubleshoot, should the "pull" fail.

Also makes the total cluster startup time more accurate.

Closes #521 

----

```console
anders@lima-k8s:~$ sudo nerdctl -n k8s.io images
REPOSITORY                            TAG                                                                 IMAGE ID        CREATED        PLATFORM       SIZE
k8s.gcr.io/coredns/coredns            v1.8.6                                                              5b6ec0d6de9b    3 hours ago    linux/amd64    45.1 MiB
k8s.gcr.io/coredns/coredns            <none>                                                              5b6ec0d6de9b    3 hours ago    linux/amd64    45.1 MiB
k8s.gcr.io/etcd                       3.5.1-0                                                             64b9ea357325    3 hours ago    linux/amd64    282.7 MiB
k8s.gcr.io/etcd                       <none>                                                              64b9ea357325    3 hours ago    linux/amd64    282.7 MiB
k8s.gcr.io/kube-apiserver             v1.23.1                                                             f54681a71cce    3 hours ago    linux/amd64    132.6 MiB
k8s.gcr.io/kube-apiserver             <none>                                                              f54681a71cce    3 hours ago    linux/amd64    132.6 MiB
k8s.gcr.io/kube-controller-manager    v1.23.1                                                             a7ed87380108    3 hours ago    linux/amd64    122.9 MiB
k8s.gcr.io/kube-controller-manager    <none>                                                              a7ed87380108    3 hours ago    linux/amd64    122.9 MiB
k8s.gcr.io/kube-proxy                 v1.23.1                                                             e40f3a287215    3 hours ago    linux/amd64    113.5 MiB
k8s.gcr.io/kube-proxy                 <none>                                                              e40f3a287215    3 hours ago    linux/amd64    113.5 MiB
k8s.gcr.io/kube-scheduler             v1.23.1                                                             8be4eb1593cf    3 hours ago    linux/amd64    54.7 MiB
k8s.gcr.io/kube-scheduler             <none>                                                              8be4eb1593cf    3 hours ago    linux/amd64    54.7 MiB
k8s.gcr.io/pause                      3.5                                                                 1ff6c18fbef2    3 hours ago    linux/amd64    672.0 KiB
k8s.gcr.io/pause                      3.6                                                                 3d380ca88645    3 hours ago    linux/amd64    672.0 KiB
k8s.gcr.io/pause                      <none>                                                              1ff6c18fbef2    3 hours ago    linux/amd64    672.0 KiB
k8s.gcr.io/pause                      <none>                                                              3d380ca88645    3 hours ago    linux/amd64    672.0 KiB
quay.io/coreos/flannel                v0.14.0                                                             4a330b2f2e74    3 hours ago    linux/amd64    67.7 MiB
quay.io/coreos/flannel                <none>                                                              4a330b2f2e74    3 hours ago    linux/amd64    67.7 MiB
sha256                                25f8c7f3da61c2a810effe5fa779cf80ca171afb0adf94c7cb51eb9a8546629d    64b9ea357325    3 hours ago    linux/amd64    282.7 MiB
sha256                                6270bb605e12e581514ada5fd5b3216f727db55dc87d5889c790e4c760683fee    3d380ca88645    3 hours ago    linux/amd64    672.0 KiB
sha256                                71d575efe62835f4882115d409a676dd24102215eee650bf23b9cf42af0e7c05    8be4eb1593cf    3 hours ago    linux/amd64    54.7 MiB
sha256                                8522d622299ca431311ac69992419c956fbaca6fa8289c76810c9399d17c69de    4a330b2f2e74    3 hours ago    linux/amd64    67.7 MiB
sha256                                a4ca41631cc7ac19ce1be3ebf0314ac5f47af7c711f17066006db82ee3b75b03    5b6ec0d6de9b    3 hours ago    linux/amd64    45.1 MiB
sha256                                b46c42588d5116766d0eb259ff372e7c1e3ecc41a842b0c18a8842083e34d62e    e40f3a287215    3 hours ago    linux/amd64    113.5 MiB
sha256                                b6d7abedde39968d56e9f53aaeea02a4fe6413497c4dedf091868eae09dcc320    f54681a71cce    3 hours ago    linux/amd64    132.6 MiB
sha256                                ed210e3e4a5bae1237f1bb44d72a05a2f1e5c6bfe7a7e73da179e2534269c459    1ff6c18fbef2    3 hours ago    linux/amd64    672.0 KiB
sha256                                f51846a4fd28801f333d9a13e4a77a96bd52f06e587ba664c2914f015c38e5d1    a7ed87380108    3 hours ago    linux/amd64    122.9 MiB
```


The second "pause" image is from the cri plugin to containerd: `k8s.gcr.io/pause:3.5`

https://github.com/containerd/containerd/blob/v1.5.8/pkg/cri/config/config_unix.go#L94