### PR TITLE
Fix the probe for kubernetes example

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -78,7 +78,8 @@ provision:
     sed -e "s/${LIMA_CIDATA_SLIRP_IP_ADDRESS:-192.168.5.15}/127.0.0.1/" -i $KUBECONFIG
     mkdir -p ${HOME:-/root}/.kube && cp -f $KUBECONFIG ${HOME:-/root}/.kube/config
 probes:
-- script: |
+- description: "kubectl to be installed"
+  script: |
     #!/bin/bash
     set -eux -o pipefail
     if ! timeout 30s bash -c "until command -v kubectl >/dev/null 2>&1; do sleep 3; done"; then
@@ -87,7 +88,8 @@ probes:
     fi
   hint: |
     See "/var/log/cloud-init-output.log". in the guest
-- script: |
+- description: "kubeadm to be completed"
+  script: |
     #!/bin/bash
     set -eux -o pipefail
     if ! timeout 300s bash -c "until test -f /etc/kubernetes/admin.conf; do sleep 3; done"; then
@@ -96,10 +98,11 @@ probes:
     fi
   hint: |
     The k8s kubeconfig file has not yet been created.
-- script: |
+- description: "kubernetes cluster to be running"
+  script: |
     #!/bin/bash
     set -eux -o pipefail
-    if ! timeout 300s bash -c "until kubectl version >/dev/null 2>&1; do sleep 3; done"; then
+    if ! timeout 300s bash -c "until sudo kubectl version >/dev/null 2>&1; do sleep 3; done"; then
       echo >&2 "kubernetes cluster is not up and running yet"
       exit 1
     fi


### PR DESCRIPTION
Need to use "sudo kubectl" now, to get the config...

It was hanging forever, trying to run `kubectl version`:

```console
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.1", GitCommit:"86ec240af8cbd1b60bcc4c03c20da9b98005b92e", GitTreeState:"clean", BuildDate:"2021-12-16T11:41:01Z", GoVersion:"go1.17.5", Compiler:"gc", Platform:"linux/amd64"}
The connection to the server localhost:8080 was refused - did you specify the right host or port?
```

The config was moved to be root-only, in a5427ddca0f87cf60235400feeac514782f57b80

`/root/.kube/config`

Add some descriptions, instead of just "user probe".

```
INFO[0028] [hostagent] Waiting for the optional requirement 1 of 5: "systemd must be available" 
INFO[0028] [hostagent] Waiting for the optional requirement 2 of 5: "containerd binaries to be installed" 
INFO[0028] [hostagent] Waiting for the optional requirement 3 of 5: "kubectl to be installed" 
INFO[0028] [hostagent] Waiting for the optional requirement 4 of 5: "kubeadm to be completed" 
INFO[0028] [hostagent] Waiting for the optional requirement 5 of 5: "kubernetes cluster to be running" 
```

Closes #535