### PR TITLE
Add message on how to run kubectl remotely

### DIFF
--- a/examples/k3s.yaml
+++ b/examples/k3s.yaml
@@ -46,3 +46,9 @@ probes:
     The k3s kubeconfig file has not yet been created.
     Run "limactl shell k3s sudo journalctl -u k3s" to check the log.
     If that is still empty, check the bottom of the log at "/var/log/cloud-init-output.log".
+message: |
+  To run `kubectl` on the host (assumes kubectl is installed):
+  $ mkdir -p "{{.Dir}}/conf"
+  $ export KUBECONFIG="{{.Dir}}/conf/kubeconfig.yaml"
+  $ limactl shell {{.Name}} sudo cat /etc/rancher/k3s/k3s.yaml >$KUBECONFIG
+  $ kubectl ...

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -103,3 +103,9 @@ probes:
       echo >&2 "kubernetes cluster is not up and running yet"
       exit 1
     fi
+message: |
+  To run `kubectl` on the host (assumes kubectl is installed):
+  $ mkdir -p "{{.Dir}}/conf"
+  $ export KUBECONFIG="{{.Dir}}/conf/kubeconfig.yaml"
+  $ limactl shell {{.Name}} sudo cat /etc/kubernetes/admin.conf >$KUBECONFIG
+  $ kubectl ...


### PR DESCRIPTION
Currently this information is hidden in the YAML file.

Show "actionable" output, similar to docker and podman.

Instead of: https://github.com/lima-vm/lima/pull/516

See: https://github.com/lima-vm/lima/issues/514#issuecomment-1008290440