### PR TITLE
Don't cache sshfs directory, fixes abiosoft/colima#99

### DIFF
--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -3,8 +3,9 @@ package hostagent
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-multierror"
 	"os"
+
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/localpathutil"

--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -3,9 +3,9 @@ package hostagent
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/go-multierror"
 	"os"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/localpathutil"
 	"github.com/lima-vm/sshocker/pkg/reversesshfs"
@@ -41,7 +41,7 @@ func (a *HostAgent) setupMount(ctx context.Context, m limayaml.Mount) (*mount, e
 		return nil, err
 	}
 	// NOTE: allow_other requires "user_allow_other" in /etc/fuse.conf
-	sshfsOptions := "allow_other"
+	sshfsOptions := "allow_other,cache=no"
 	if *m.SSHFS.FollowSymlinks {
 		sshfsOptions = sshfsOptions + ",follow_symlinks"
 	}


### PR DESCRIPTION
* abiosoft/colima#99

sshfs caching can cause asynchronous behaviors that aren't very happy, as discussed in https://stackoverflow.com/questions/3671350/any-way-to-eliminate-time-lag-with-sshfs

This adds the `cache=no` option to sshfs mounts to prevent this issue

In my case, a [ddev](https://github.com/drud/ddev) test was adding a bunch of files to a mounted directory before starting a container that bind-mounted them. On the way up, it tried to access those files inside the container and got interesting behaviors where the files were listable, but not yet readable. SO
```
file /mnt/ddev_config/.homeadditions/.composer/auth.json
/mnt/ddev_config/.homeadditions/.composer/auth.json: regular file, no read permission
```

but

```
cat /mnt/ddev_config/.homeadditions/.composer/auth.json
cat: /mnt/ddev_config/.homeadditions/.composer/auth.json: No such file or directory
```

and of course a `cp -r` would fail. 