### PR TITLE
Allow installing system containerd for alpine

### DIFF
--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -137,7 +137,7 @@ A possible workaround is to run "lima-guestagent install-systemd" in the guest.
 
 func (a *HostAgent) optionalRequirements() []requirement {
 	req := make([]requirement, 0)
-	if *a.y.Containerd.System || *a.y.Containerd.User {
+	if *a.y.Containerd.User {
 		req = append(req,
 			requirement{
 				description: "systemd must be available",
@@ -149,10 +149,10 @@ if ! command -v systemctl 2>&1 >/dev/null; then
     exit 1
 fi
 `,
-				debugHint: `systemd is required to run containerd, but does not seem to be available.
+				debugHint: `systemd is required to run containerd rootless, but does not seem to be available.
 Make sure that you use an image that supports systemd. If you do not want to run
-containerd, please make sure that both 'container.system' and 'containerd.user'
-are set to 'false' in the config file.
+containerd, please make sure that 'containerd.user' is set to 'false' in the
+config file.
 `,
 			},
 			requirement{


### PR DESCRIPTION
Allows installing containerd/buildkitd, and then using `sudo nerdctl`:

```yaml
containerd:
  system: true
  user: false
```

Unfortunately it doesn't respect the socket variables and give weird errors:

```console
$ nerdctl ps
WARN[0000] environment variable XDG_RUNTIME_DIR is not set, see https://rootlesscontaine.rs/getting-started/common/login/ 
WARN[0000] environment variable XDG_RUNTIME_DIR is not set, see https://rootlesscontaine.rs/getting-started/common/login/ 
FATA[0000] rootless containerd not running? (hint: use `containerd-rootless-setuptool.sh install` to start rootless containerd): stat /tmp/runtime-anders/containerd-rootless: no such file or directory 
$ containerd-rootless-setuptool.sh install
[ERROR] Needs systemd (systemctl --user)
```

The error messages from `ctr` and `buildctl` are much more understandable.

`ctr: failed to dial "/run/containerd/containerd.sock": connection error: desc = "transport: error while dialing: dial unix /run/containerd/containerd.sock: connect: permission denied"`

`error: failed to list workers: Unavailable: connection error: desc = "transport: error while dialing: dial unix /run/buildkit/buildkitd.sock: connect: permission denied"`


Closes #489

----

There is a backlog item in alpine-lima, to provide packages for buildkit.

* https://github.com/lima-vm/alpine-lima/issues/37

Including a proper OpenRC service, to run with the `supervise-daemon`:

```
init-+-acpid
     |-buildkitd---10*[{buildkitd}]
     |-7*[getty]
     |-sshd.pam---sshd.pam---sshd.pam-+-ash---pstree
     |                                |-sshfs---4*[{sshfs}]
     |                                `-sshfs---3*[{sshfs}]
     |-supervise-daemo---lima-guestagent---7*[{lima-guestagent}]
     |-supervise-daemo---containerd---11*[{containerd}]
     |-syslogd
     |-udevd
     `-udhcpc
```

But otherwise, seems to work OK:

```console
$ sudo nerdctl version
Client:
 Version:	v0.15.0
 Git commit:	b72b5ca14550b2e23a42787664b6182524c5053f

Server:
 containerd:
  Version:	v1.5.8
  GitCommit:	1e5ef943eb76627a6d3b6de8cd1ef6537f393a71
```

One nice feature is when building:

```
sudo nerdctl build --output type=image,name=test:latest .
```

https://github.com/moby/buildkit#containerd-image-store

To not having to save the image to a tarball and load it.