### PR TITLE
HostResolver shouldn't return IPv6 addresses by default

### DIFF
--- a/cmd/limactl/debug.go
+++ b/cmd/limactl/debug.go
@@ -27,22 +27,27 @@ func newDebugDNSCommand() *cobra.Command {
 		Args:  cobra.RangeArgs(1, 2),
 		RunE:  debugDNSAction,
 	}
+	cmd.Flags().BoolP("ipv6", "6", false, "lookup IPv6 addresses too")
 	return cmd
 }
 
 func debugDNSAction(cmd *cobra.Command, args []string) error {
+	ipv6, err := cmd.Flags().GetBool("ipv6")
+	if err != nil {
+		return err
+	}
 	udpLocalPort, err := strconv.Atoi(args[0])
 	if err != nil {
 		return err
 	}
 	tcpLocalPort := 0
-	if len(args) > 2 {
+	if len(args) > 1 {
 		tcpLocalPort, err = strconv.Atoi(args[1])
 		if err != nil {
 			return err
 		}
 	}
-	srv, err := dns.Start(udpLocalPort, tcpLocalPort)
+	srv, err := dns.Start(udpLocalPort, tcpLocalPort, ipv6)
 	if err != nil {
 		return err
 	}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -138,7 +138,7 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 	if err != nil {
 		return err
 	}
-	if *y.UseHostResolver {
+	if *y.HostResolver.Enabled {
 		args.UDPDNSLocalPort = udpDNSLocalPort
 		args.TCPDNSLocalPort = tcpDNSLocalPort
 		args.DNSAddresses = append(args.DNSAddresses, qemu.SlirpDNS)

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -92,7 +92,7 @@ func New(instName string, stdout io.Writer, sigintCh chan os.Signal, opts ...Opt
 	}
 
 	var udpDNSLocalPort, tcpDNSLocalPort int
-	if *y.UseHostResolver {
+	if *y.HostResolver.Enabled {
 		udpDNSLocalPort, err = findFreeUDPLocalPort()
 		if err != nil {
 			return nil, err
@@ -248,8 +248,8 @@ func (a *HostAgent) Run(ctx context.Context) error {
 		a.emitEvent(ctx, exitingEv)
 	}()
 
-	if *a.y.UseHostResolver {
-		dnsServer, err := dns.Start(a.udpDNSLocalPort, a.tcpDNSLocalPort)
+	if *a.y.HostResolver.Enabled {
+		dnsServer, err := dns.Start(a.udpDNSLocalPort, a.tcpDNSLocalPort, *a.y.HostResolver.IPv6)
 		if err != nil {
 			return fmt.Errorf("cannot start DNS server: %w", err)
 		}

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -236,9 +236,14 @@ propagateProxyEnv: null
 # The host agent implements a DNS server that looks up host names on the host
 # using the local system resolver. This means changing VPN and network settings
 # are reflected automatically into the guest, including conditional forward,
-# and mDNS lookup:
-# Default: true
-useHostResolver: null
+# and mDNS lookup. By default only IPv4 addresses will be returned. IPv6 addresses
+# can only work when using a vmnet network interface and the host has working
+# IPv6 configured as well.
+hostResolver:
+  # Default: true
+  enabled: null
+  # Default: false
+  ipv6: null
 
 # If useHostResolver is false, then the following rules apply for configuring dns:
 # Explicitly set DNS addresses for qemu user-mode networking. By default qemu picks *one*

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -217,14 +217,36 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		// After defaults processing the singular HostPort and GuestPort values should not be used again.
 	}
 
-	if y.UseHostResolver == nil {
-		y.UseHostResolver = d.UseHostResolver
+	// If both `useHostResolved` and `HostResolver.Enabled` are defined in the same config,
+	// then the deprecated `useHostResolved` setting is silently ignored.
+	if y.HostResolver.Enabled == nil {
+		y.HostResolver.Enabled = y.UseHostResolver
 	}
-	if o.UseHostResolver != nil {
-		y.UseHostResolver = o.UseHostResolver
+	if d.HostResolver.Enabled == nil {
+		d.HostResolver.Enabled = d.UseHostResolver
 	}
-	if y.UseHostResolver == nil {
-		y.UseHostResolver = pointer.Bool(true)
+	if o.HostResolver.Enabled == nil {
+		o.HostResolver.Enabled = o.UseHostResolver
+	}
+
+	if y.HostResolver.Enabled == nil {
+		y.HostResolver.Enabled = d.HostResolver.Enabled
+	}
+	if o.HostResolver.Enabled != nil {
+		y.HostResolver.Enabled = o.HostResolver.Enabled
+	}
+	if y.HostResolver.Enabled == nil {
+		y.HostResolver.Enabled = pointer.Bool(true)
+	}
+
+	if y.HostResolver.IPv6 == nil {
+		y.HostResolver.IPv6 = d.HostResolver.IPv6
+	}
+	if o.HostResolver.IPv6 != nil {
+		y.HostResolver.IPv6 = o.HostResolver.IPv6
+	}
+	if y.HostResolver.IPv6 == nil {
+		y.HostResolver.IPv6 = pointer.Bool(false)
 	}
 
 	if y.PropagateProxyEnv == nil {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -67,7 +67,10 @@ func TestFillDefault(t *testing.T) {
 		Video: Video{
 			Display: pointer.String("none"),
 		},
-		UseHostResolver:   pointer.Bool(true),
+		HostResolver: HostResolver{
+			Enabled: pointer.Bool(true),
+			IPv6:    pointer.Bool(false),
+		},
 		PropagateProxyEnv: pointer.Bool(true),
 	}
 
@@ -186,7 +189,10 @@ func TestFillDefault(t *testing.T) {
 		Video: Video{
 			Display: pointer.String("cocoa"),
 		},
-		UseHostResolver:   pointer.Bool(false),
+		HostResolver: HostResolver{
+			Enabled: pointer.Bool(false),
+			IPv6:    pointer.Bool(true),
+		},
 		PropagateProxyEnv: pointer.Bool(false),
 
 		Mounts: []Mount{
@@ -298,7 +304,10 @@ func TestFillDefault(t *testing.T) {
 		Video: Video{
 			Display: pointer.String("cocoa"),
 		},
-		UseHostResolver:   pointer.Bool(false),
+		HostResolver: HostResolver{
+			Enabled: pointer.Bool(false),
+			IPv6:    pointer.Bool(false),
+		},
 		PropagateProxyEnv: pointer.Bool(false),
 
 		Mounts: []Mount{

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -25,7 +25,8 @@ type LimaYAML struct {
 	Network           NetworkDeprecated `yaml:"network,omitempty" json:"network,omitempty"` // DEPRECATED, use `networks` instead
 	Env               map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 	DNS               []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`
-	UseHostResolver   *bool             `yaml:"useHostResolver,omitempty" json:"useHostResolver,omitempty"`
+	HostResolver      HostResolver      `yaml:"hostResolver,omitempty" json:"hostResolver,omitempty"`
+	UseHostResolver   *bool             `yaml:"useHostResolver,omitempty" json:"useHostResolver,omitempty"` // DEPRECATED, use `HostResolver.Enabled` instead
 	PropagateProxyEnv *bool             `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty"`
 }
 
@@ -130,6 +131,11 @@ type Network struct {
 	SwitchPort uint16 `yaml:"switchPort,omitempty" json:"switchPort,omitempty"` // VDE Switch port, not TCP/UDP port (only used by VDE networking)
 	MACAddress string `yaml:"macAddress,omitempty" json:"macAddress,omitempty"`
 	Interface  string `yaml:"interface,omitempty" json:"interface,omitempty"`
+}
+
+type HostResolver struct {
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	IPv6    *bool `yaml:"ipv6,omitempty" json:"ipv6,omitempty"`
 }
 
 // DEPRECATED types below

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -194,8 +194,8 @@ func Validate(y LimaYAML, warn bool) error {
 		// processed sequentially and the first matching rule for a guest port determines forwarding behavior.
 	}
 
-	if y.UseHostResolver != nil && *y.UseHostResolver && len(y.DNS) > 0 {
-		return fmt.Errorf("field `dns` must be empty when field `useHostResolver` is true")
+	if y.HostResolver.Enabled != nil && *y.HostResolver.Enabled && len(y.DNS) > 0 {
+		return fmt.Errorf("field `dns` must be empty when field `HostResolver.Enabled` is true")
 	}
 
 	if err := validateNetwork(y, warn); err != nil {


### PR DESCRIPTION
They don't work over the SLIRP interface, and sometimes don't even work over a bridged vmnet interface.

See also https://github.com/rancher-sandbox/rancher-desktop/issues/1193

This PR deprecates the `useHostResolver` setting and replaces it with `hostResolver.enabled`. The old setting can still be used, but if the new property is set, any old setting in the same file is being ignored. Generating proper warnings gets pretty complex when the interaction between `default.yaml`, `lima.yaml`, and `override.yaml` have to be considered.

It could be argued that `HostResolver.LookupIPv6` should default to `true` for compatibility with previous releases. However, given that it seems to be broken in some setups, disabling IPv6 by default seems like a safer choice to me.

Also includes one bug fix for `limactl debug dns 5533 5533`, which previously ignored the TCP port.

Aside: I needed to include the TCP port during testing because `limactl debug dns 5533` (without `-6`) option resulted in:

```console
$ dig @127.0.0.1 -p 5533 AAAA google.com
;; Truncated, retrying in TCP mode.
;; Connection to 127.0.0.1#5533(127.0.0.1) for google.com failed: connection refused.
```