### PR TITLE
nerdctl: update to v0.16.0

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -21,7 +21,7 @@ import (
 )
 
 func defaultContainerdArchives() []File {
-	const nerdctlVersion = "0.15.0"
+	const nerdctlVersion = "0.16.0"
 	location := func(goarch string) string {
 		return "https://github.com/containerd/nerdctl/releases/download/v" + nerdctlVersion + "/nerdctl-full-" + nerdctlVersion + "-linux-" + goarch + ".tar.gz"
 	}
@@ -29,12 +29,12 @@ func defaultContainerdArchives() []File {
 		{
 			Location: location("amd64"),
 			Arch:     X8664,
-			Digest:   "sha256:ca40d99d257e69f0220bb1cbdab1b602032692f45f713c901f328d2f4e3c12b3",
+			Digest:   "sha256:6dd955393fd781601a1cc7655d178fa539543f7a62f29e7c34a00e31ff4dddcf",
 		},
 		{
 			Location: location("arm64"),
 			Arch:     AARCH64,
-			Digest:   "sha256:dd8639ce868bab394467576f55375c4b40a8288badb579d2e30c3487da6004ea",
+			Digest:   "sha256:b342f6bec1bc0452148e9d8ec4afdf9de7b1e442e58e55fcf5330702e2fea62f",
 		},
 	}
 }


### PR DESCRIPTION
https://github.com/containerd/nerdctl/releases/tag/v0.16.0