### PR TITLE
Revert "Don't cache sshfs directory, #538"

### DIFF
--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -42,7 +42,7 @@ func (a *HostAgent) setupMount(ctx context.Context, m limayaml.Mount) (*mount, e
 		return nil, err
 	}
 	// NOTE: allow_other requires "user_allow_other" in /etc/fuse.conf
-	sshfsOptions := "allow_other,cache=no"
+	sshfsOptions := "allow_other"
 	if *m.SSHFS.FollowSymlinks {
 		sshfsOptions = sshfsOptions + ",follow_symlinks"
 	}


### PR DESCRIPTION
Unfortunately, 
* #538 

Seems to cause enormous filesystem instability, far more than the problem it was solving (which it did solve).

I found that trying to do `composer install` or `composer create-project` operations on a mounted filesystem caused horrendous misbehavior.  Files and directories weren't found, then they were found when they shouldn't be there, etc.

Reverting seems to fix the behavior. The overall problems with sshfs will certainly add urgency to a better filesharing technique.

Examples of misbehavior (which I don't totally understand, but which is fixed by reverting):
```
rfay@junk-web:/var/www/html$ composer create-project --no-install drupal/recommended-project a
Creating a "drupal/recommended-project" project at "./a"
Installing drupal/recommended-project (9.3.2)
  - Installing drupal/recommended-project (9.3.2): Extracting archive
    Install of drupal/recommended-project failed


  [RuntimeException]
  Could not delete /var/www/html/a:
```

```
rfay@junk-web:/var/www/html/b/drupal-recommended-project-1438091$ composer install
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Package operations: 62 installs, 0 updates, 0 removals
  - Installing composer/installers (v1.12.0): Extracting archive
composer/installers contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "composer/installers" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
Plugin initialization failed (Plugin composer/installers could not be initialized, class not found: Composer\Installers\Plugin), uninstalling plugin
  - Removing composer/installers (v1.12.0)
    Install of composer/installers failed


  [RuntimeException]
  Could not delete /var/www/html/b/drupal-recommended-project-1438091/vendor/
  composer/:
```

I'm quite sure there is some misbehavior of composer here as well that is triggered by whatever's going on with the mounted filesystem.


This reverts commit b80a4d260777919783497a126977dcd08b3473d6.

Signed-off-by: Randy Fay <randy@randyfay.com>