### PR TITLE
start.ShowMessage: remove the logrus INFO header, for ease of copypasting

### DIFF
--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -60,6 +60,9 @@ portForwards:
 - guestSocket: "/run/user/{{.UID}}/docker.sock"
   hostSocket: "{{.Dir}}/sock/docker.sock"
 message: |
-  To run `docker` on the host (assumes docker-cli is installed):
-  $ export DOCKER_HOST=unix://{{.Dir}}/sock/docker.sock
-  $ docker ...
+  To run `docker` on the host (assumes docker-cli is installed), run the following commands:
+  ------
+  docker context create lima --docker "host=unix://{{.Dir}}/sock/docker.sock"
+  docker context use lima
+  docker run hello-world
+  ------

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -261,8 +261,10 @@ func ShowMessage(inst *store.Instance) error {
 		return err
 	}
 	scanner := bufio.NewScanner(&b)
+	logrus.Infof("Message from the instance %q:", inst.Name)
 	for scanner.Scan() {
-		logrus.Info(scanner.Text())
+		// Avoid prepending logrus "INFO" header, for ease of copypasting
+		fmt.Println(scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
 		return err


### PR DESCRIPTION
- Commit 1: `start.ShowMessage: remove the logrus INFO header, for ease of copypasting`
- Commit 2: `examples/docker.yaml: recommend CLI context, not DOCKER_HOST env var`


Example output:
```console
$ limactl start ./examples/docker.yaml 
? Creating an instance "docker" Proceed with the default configuration
INFO[0001] Attempting to download the image from "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"  digest=
INFO[0002] Using cache "/Users/suda/Library/Caches/lima/download/by-url-sha256/ac74da77a6828e35de7edaa06fdbb33d12ef97cce2726550017e3c1066c88fb1/data" 
INFO[0003] [hostagent] Starting QEMU (hint: to watch the boot progress, see "/Users/suda/.lima/docker/serial.log") 
INFO[0003] SSH Local Port: 58833                        
INFO[0003] [hostagent] Waiting for the essential requirement 1 of 5: "ssh" 
INFO[0031] [hostagent] Waiting for the essential requirement 1 of 5: "ssh" 
INFO[0066] [hostagent] The essential requirement 1 of 5 is satisfied 
INFO[0066] [hostagent] Waiting for the essential requirement 2 of 5: "user session is ready for ssh" 
INFO[0066] [hostagent] The essential requirement 2 of 5 is satisfied 
INFO[0066] [hostagent] Waiting for the essential requirement 3 of 5: "sshfs binary to be installed" 
INFO[0066] [hostagent] The essential requirement 3 of 5 is satisfied 
INFO[0066] [hostagent] Waiting for the essential requirement 4 of 5: "/etc/fuse.conf to contain \"user_allow_other\"" 
INFO[0069] [hostagent] The essential requirement 4 of 5 is satisfied 
INFO[0069] [hostagent] Waiting for the essential requirement 5 of 5: "the guest agent to be running" 
INFO[0069] [hostagent] The essential requirement 5 of 5 is satisfied 
INFO[0069] [hostagent] Mounting "/Users/suda"           
INFO[0070] [hostagent] Mounting "/tmp/lima"             
INFO[0070] [hostagent] Waiting for the optional requirement 1 of 1: "user probe 1/1" 
INFO[0070] [hostagent] Forwarding "/run/user/501/docker.sock" (guest) to "/Users/suda/.lima/docker/sock/docker.sock" (host) 
INFO[0070] [hostagent] Forwarding "/run/lima-guestagent.sock" (guest) to "/Users/suda/.lima/docker/ga.sock" (host) 
INFO[0070] [hostagent] Not forwarding TCP 127.0.0.53:53 
INFO[0070] [hostagent] Not forwarding TCP 0.0.0.0:22    
INFO[0070] [hostagent] Not forwarding TCP [::]:22       
INFO[0109] [hostagent] The optional requirement 1 of 1 is satisfied 
INFO[0109] [hostagent] Waiting for the final requirement 1 of 1: "boot scripts must have finished" 
INFO[0115] [hostagent] The final requirement 1 of 1 is satisfied 
INFO[0115] READY. Run `limactl shell docker` to open the shell. 
INFO[0115] Message from the instance "docker":          
To run `docker` on the host (assumes docker-cli is installed), run the following commands:
------
docker context create lima --docker "host=unix:///Users/suda/.lima/docker/sock/docker.sock"
docker context use lima
docker run hello-world
------
```