### PR TITLE
Add kubernetes with kind example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,7 @@ Container engines:
 Container orchestration:
 - [`k3s.yaml`](./k3s.yaml): Kubernetes via k3s
 - [`k8s.yaml`](./k8s.yaml): Kubernetes via kubeadm
+- [`kind.yaml`](./kind.yaml): Kubernetes via [kind](https://kind.sigs.k8s.io/)
 - [`nomad.yaml`](./nomad.yaml): Nomad
 - [`faasd.yaml`](./faasd.yaml): [Faasd](https://docs.openfaas.com/deployment/faasd/)
 

--- a/examples/kind.yaml
+++ b/examples/kind.yaml
@@ -1,0 +1,109 @@
+# Deploy kubernetes via kind (kubernetes-in-docker)
+# $ limactl start ./kind.yaml
+# $ limactl shell kind kubectl cluster-info
+# $ limactl shell kind docker container ps
+
+# This example requires Lima v0.8.0 or later
+images:
+# Hint: run `limactl prune` to invalidate the "current" cache
+- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-arm64.img"
+  arch: "aarch64"
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+# containerd is managed by Docker, not by Lima, so the values are set to false here.
+containerd:
+  system: false
+  user: false
+provision:
+- mode: system
+  script: |
+    #!/bin/sh
+    sed -i 's/host.lima.internal.*/host.lima.internal host.docker.internal/' /etc/hosts
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    command -v docker >/dev/null 2>&1 && exit 0
+    export DEBIAN_FRONTEND=noninteractive
+    curl -fsSL https://get.docker.com | sh
+# See https://docs.docker.com/engine/install/linux-postinstall/
+- mode: user
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    sudo usermod -aG docker $USER
+# See https://kind.sigs.k8s.io/docs/user/quick-start/#installation
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    command -v kind >/dev/null 2>&1 && exit 0
+    kind_version=latest
+    case $(uname -m) in
+      x86_64)
+        curl -sSL -o kind https://kind.sigs.k8s.io/dl/${kind_version}/kind-linux-amd64
+        ;;
+      aarch64)
+        curl -sSL -o kind https://kind.sigs.k8s.io/dl/${kind_version}/kind-linux-arm64
+        ;;
+    esac
+    chmod +x ./kind
+    mv ./kind /usr/local/bin/kind
+    kind completion bash >/etc/bash_completion.d/kind
+# See https://kubernetes.io/docs/tasks/tools/#kubectl
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    command -v kubectl >/dev/null 2>&1 && exit 0
+    kube_version=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+    case $(uname -m) in
+      x86_64)
+        curl -sSL -o kubectl https://dl.k8s.io/release/${kube_version}/bin/linux/amd64/kubectl
+        ;;
+      aarch64)
+        curl -sSL -o kubectl https://dl.k8s.io/release/${kube_version}/bin/linux/arm64/kubectl
+        ;;
+    esac
+    install kubectl /usr/local/bin/kubectl
+    rm -f kubectl
+    kubectl completion bash >/etc/bash_completion.d/kubectl
+- mode: user
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    docker container inspect -f '{{.Id}}' kind-control-plane && exit 0
+    kind create cluster
+probes:
+- script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! timeout 30s bash -c "until command -v docker >/dev/null 2>&1; do sleep 3; done"; then
+      echo >&2 "docker is not installed yet"
+      exit 1
+    fi
+    if ! timeout 30s bash -c "until command -v kind >/dev/null 2>&1; do sleep 3; done"; then
+      echo >&2 "kind is not installed yet"
+      exit 1
+    fi
+    if ! timeout 30s bash -c "until command -v kubectl >/dev/null 2>&1; do sleep 3; done"; then
+      echo >&2 "kubectl is not installed yet"
+      exit 1
+    fi
+  hint: See "/var/log/cloud-init-output.log". in the guest
+portForwards:
+- guestSocket: "/var/run/docker.sock"
+  hostSocket: "{{.Dir}}/sock/docker.sock"
+message: |
+  To run `kubectl` on the host (assumes kubectl is installed):
+  $ mkdir -p "{{.Dir}}/conf"
+  $ export KUBECONFIG="{{.Dir}}/conf/kubeconfig.yaml"
+  $ limactl shell {{.Name}} cat '$HOME/.kube/config' >$KUBECONFIG
+  $ kubectl ...
+  To run `docker` on the host (assumes docker-cli is installed):
+  $ export DOCKER_HOST=unix://{{.Dir}}/sock/docker.sock
+  $ docker ...


### PR DESCRIPTION
### kind (kubernetes in docker)
https://kind.sigs.k8s.io/

Sets up an instance with docker, kind and kubectl.

Then uses "kind create cluster" to start a container.

Requested by some people on the Kubernetes slack.

Mostly based on docker.yaml and the upstream docs.
