### PR TITLE
Change default for `mounts.sshfs.cache` to `true`

### DIFF
--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -50,7 +50,9 @@ mounts:
   sshfs:
     # Enabling the SSHFS cache will increase performance of the mounted filesystem, at
     # the cost of potentially not reflecting changes made on the host in a timely manner.
-    # Default: false
+    # Warning: It looks like PHP filesystem access does not work correctly when
+    # the cache is disabled.
+    # Default: true
     cache: null
     # SSHFS has an optional flag called 'follow_symlinks'. This allows mounts
     # to be properly resolved in the guest os and allow for access to the

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -339,7 +339,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 	for i := range y.Mounts {
 		mount := &y.Mounts[i]
 		if mount.SSHFS.Cache == nil {
-			mount.SSHFS.Cache = pointer.Bool(false)
+			mount.SSHFS.Cache = pointer.Bool(true)
 		}
 		if mount.SSHFS.FollowSymlinks == nil {
 			mount.SSHFS.FollowSymlinks = pointer.Bool(false)

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -120,7 +120,7 @@ func TestFillDefault(t *testing.T) {
 	expect := builtin
 	expect.Mounts = y.Mounts
 	expect.Mounts[0].Writable = pointer.Bool(false)
-	expect.Mounts[0].SSHFS.Cache = pointer.Bool(false)
+	expect.Mounts[0].SSHFS.Cache = pointer.Bool(true)
 	expect.Mounts[0].SSHFS.FollowSymlinks = pointer.Bool(false)
 	// Only missing Mounts field is Writable, and the default value is also the null value: false
 
@@ -244,7 +244,7 @@ func TestFillDefault(t *testing.T) {
 	expect = d
 	// Also verify that archive arch is filled in
 	expect.Containerd.Archives[0].Arch = *d.Arch
-	expect.Mounts[0].SSHFS.Cache = pointer.Bool(false)
+	expect.Mounts[0].SSHFS.Cache = pointer.Bool(true)
 	expect.Mounts[0].SSHFS.FollowSymlinks = pointer.Bool(false)
 
 	y = LimaYAML{}
@@ -317,7 +317,7 @@ func TestFillDefault(t *testing.T) {
 				Location: "/var/log",
 				Writable: pointer.Bool(true),
 				SSHFS: SSHFS{
-					Cache:          pointer.Bool(true),
+					Cache:          pointer.Bool(false),
 					FollowSymlinks: pointer.Bool(true),
 				},
 			},
@@ -376,7 +376,7 @@ func TestFillDefault(t *testing.T) {
 	// o.Mounts just makes d.Mounts[0] writable because the Location matches
 	expect.Mounts = append(d.Mounts, y.Mounts...)
 	expect.Mounts[0].Writable = pointer.Bool(true)
-	expect.Mounts[0].SSHFS.Cache = pointer.Bool(true)
+	expect.Mounts[0].SSHFS.Cache = pointer.Bool(false)
 	expect.Mounts[0].SSHFS.FollowSymlinks = pointer.Bool(true)
 
 	// o.Networks[1] is overriding the d.Networks[0].Lima entry for the "def0" interface


### PR DESCRIPTION
This was changed to `false` in lima 0.8.1:

* https://github.com/lima-vm/lima/pull/538

It has generated multiple reports of breaking PHP package manager, unit tests, and file system access itself:

* https://github.com/lima-vm/lima/pull/556
* https://github.com/abiosoft/colima/issues/129
* https://github.com/rancher-sandbox/rancher-desktop/issues/1349

Given that the use cases that triggered the change in #538 were observed in automated environment / CI, and that the PHP breakages happens to people using Lima for interactive development, I think the default should be reverted.

Closes #600