### PR TITLE
Fix SSH command escaping

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -110,7 +110,10 @@ func shellAction(cmd *cobra.Command, args []string) error {
 
 	script := fmt.Sprintf("%s ; exec bash --login", changeDirCmd)
 	if len(args) > 1 {
-		script += fmt.Sprintf(" -c %q", shellescape.QuoteCommand(args[1:]))
+		script += fmt.Sprintf(
+			" -c %s",
+			shellescape.Quote(shellescape.QuoteCommand(args[1:])),
+		)
 	}
 
 	arg0, err := exec.LookPath("ssh")

--- a/hack/test-example.sh
+++ b/hack/test-example.sh
@@ -132,6 +132,12 @@ if [ "$got" != "$expected" ]; then
 	exit 1
 fi
 
+INFO "Testing limactl command with escaped characters"
+limactl shell "$NAME" bash -c "$(echo -e '\n\techo foo\n\techo bar')"
+
+INFO "Testing limactl command with quotes"
+limactl shell "$NAME" bash -c "echo 'foo \"bar\"'"
+
 if [[ -n ${CHECKS["systemd"]} ]]; then
 	set -x
 	if ! limactl shell "$NAME" systemctl is-system-running --wait; then


### PR DESCRIPTION
Addresses https://github.com/lima-vm/lima/issues/632.

I haven't tested very thoroughly, and may be making some incorrect assumptions about how shellescape works, but I can confirm that this at least fixes the `lima bash -c "$(echo -e '\n\techo balls\n')"` example for me.