### PR TITLE
examples: split the examples to "Tier 1" and others

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,8 @@ task:
     DEBIAN_FRONTEND: noninteractive
     # yamllint disable rule:key-duplicates
     matrix:
-      # default.yaml is tested on GHA macOS, so we skip default.yaml here
+      # We only test "Tier 1" yamls. See examples/README.md for the list of the "Tier 1" yamls.
+      # default.yaml and vmnet.yaml are tested on GHA macOS.
       EXAMPLE: alpine.yaml
       EXAMPLE: debian.yaml
       EXAMPLE: fedora.yaml

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,14 +1,16 @@
 # Lima examples
 
-Default: [`default.yaml`](../pkg/limayaml/default.yaml) (Ubuntu, with containerd/nerdctl)
+⭐ = ["Tier 1"](#tier-1)
+
+Default: [`default.yaml`](../pkg/limayaml/default.yaml) (⭐Ubuntu, with containerd/nerdctl)
 
 Distro:
 - [`almalinux.yaml`](./almalinux.yaml): AlmaLinux
-- [`alpine.yaml`](./alpine.yaml): Alpine Linux
-- [`archlinux.yaml`](./archlinux.yaml): Arch Linux
-- [`debian.yaml`](./debian.yaml): Debian GNU/Linux
-- [`fedora.yaml`](./fedora.yaml): Fedora
-- [`opensuse.yaml`](./opensuse.yaml): openSUSE Leap
+- [`alpine.yaml`](./alpine.yaml): ⭐Alpine Linux
+- [`archlinux.yaml`](./archlinux.yaml): ⭐Arch Linux
+- [`debian.yaml`](./debian.yaml): ⭐Debian GNU/Linux
+- [`fedora.yaml`](./fedora.yaml): ⭐Fedora
+- [`opensuse.yaml`](./opensuse.yaml): ⭐openSUSE Leap
 - [`rocky.yaml`](./rocky.yaml): Rocky Linux
 - [`ubuntu.yaml`](./ubuntu.yaml): Ubuntu (same as `default.yaml` but without extra YAML lines)
 - [`ubuntu-lts.yaml`](./ubuntu-lts.yaml): Ubuntu LTS (same as `ubuntu.yaml` but pinned to an LTS version)
@@ -26,7 +28,13 @@ Container orchestration:
 - [`faasd.yaml`](./faasd.yaml): [Faasd](https://docs.openfaas.com/deployment/faasd/)
 
 Others:
-- [`vmnet.yaml`](./vmnet.yaml): enable [`vmnet.framework`](../docs/network.md)
+- [`vmnet.yaml`](./vmnet.yaml): ⭐enable [`vmnet.framework`](../docs/network.md)
+
+## Tier 1
+
+The "Tier 1" yamls (marked with ⭐) are regularly tested on the CI.
+
+Other yamls are tested only occasionally and manually.
 
 ## Usage
 Run `limactl start fedora.yaml` to create a Lima instance named "fedora".


### PR DESCRIPTION
The "Tier 1" yamls are regularly tested on the CI. Other yamls are tested only occasionally and manually.

The following yamls are in the "Tier 1" category:

- default.yaml
- alpine.yaml
- archlinux.yaml
- debian.yaml
- fedora.yaml
- opensuse.yaml
- vmnet.yaml
