### PR TITLE
podman: use connection instead of CONTAINER_HOST

### DIFF
--- a/examples/podman.yaml
+++ b/examples/podman.yaml
@@ -51,6 +51,9 @@ portForwards:
 - guestSocket: "/run/user/{{.UID}}/podman/podman.sock"
   hostSocket: "{{.Dir}}/sock/podman.sock"
 message: |
-  To run `podman` on the host (assumes podman-remote is installed):
-  $ export CONTAINER_HOST=unix://{{.Dir}}/sock/podman.sock
-  $ podman{{if eq .HostOS "linux"}} --remote{{end}} ...
+  To run `podman` on the host (assumes podman-remote is installed), run the following commands:
+  ------
+  podman system connection add lima "unix://{{.Dir}}/sock/podman.sock"
+  podman system connection default lima
+  podman{{if eq .HostOS "linux"}} --remote{{end}} run quay.io/podman/hello
+  ------


### PR DESCRIPTION
Sync the podman example, with the docker example.

Copy the example changes that were sneaked into:

* #595

commit 1e45f784168ec9615f195bb57a1213065d47aeff

Note: using the environment variables still _works_ just fine, so they are left in the comments.

Also using the new podman example, instead of running a docker example which was confusing.

https://en.wikipedia.org/wiki/Let%27s_Call_the_Whole_Thing_Off

🎶 "You like crun, I like runc. You say buildah, I say builder. ..." 

----

### Docker

```
To run `docker` on the host (assumes docker-cli is installed), run the following commands:
------
docker context create lima --docker "host=unix:///home/anders/.lima/docker/sock/docker.sock"
docker context use lima
docker run hello-world
------
```

```console
$ docker context list
NAME      DESCRIPTION                               DOCKER ENDPOINT                                     KUBERNETES ENDPOINT   ORCHESTRATOR
default   Current DOCKER_HOST based configuration   unix:///var/run/docker.sock                                               swarm
lima *                                              unix:///home/anders/.lima/docker/sock/docker.sock                         
```

### Podman

```
To run `podman` on the host (assumes podman-remote is installed), run the following commands:
------
podman system connection add lima "unix:///home/anders/.lima/podman/sock/podman.sock"
podman system connection default lima
podman --remote run quay.io/podman/hello
------
```

```console
$ podman system connection list
Name                         Identity                                  URI
lima*                                                                  unix:///home/anders/.lima/podman/sock/podman.sock
podman-machine-default       /home/anders/.ssh/podman-machine-default  ssh://core@localhost:45615/run/user/1000/podman/podman.sock
podman-machine-default-root  /home/anders/.ssh/podman-machine-default  ssh://root@localhost:45615/run/podman/podman.sock
```