### PR TITLE
Allow adding static names to hostresolver

### DIFF
--- a/cmd/limactl/debug.go
+++ b/cmd/limactl/debug.go
@@ -47,7 +47,7 @@ func debugDNSAction(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	srv, err := dns.Start(udpLocalPort, tcpLocalPort, ipv6)
+	srv, err := dns.Start(udpLocalPort, tcpLocalPort, ipv6, map[string]string{})
 	if err != nil {
 		return err
 	}

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -23,6 +23,10 @@ containerd:
   user: false
 provision:
 - mode: system
+  # This script defines the host.docker.internal hostname when hostResolver is disabled.
+  # It is also needed for lima 0.8.2 and earlier, which does not support hostResolver.hosts.
+  # Names defined in /etc/hosts inside the VM are not resolved inside containers when
+  # using the hostResolver; use hostResolver.hosts instead (requires lima 0.8.3 or later).
   script: |
     #!/bin/sh
     sed -i 's/host.lima.internal.*/host.lima.internal host.docker.internal/' /etc/hosts
@@ -56,6 +60,11 @@ probes:
       exit 1
     fi
   hint: See "/var/log/cloud-init-output.log". in the guest
+hostResolver:
+  # hostResolver.hosts requires lima 0.8.3 or later. Names defined here will also
+  # resolve inside containers, and not just inside the VM itself.
+  hosts:
+    host.docker.internal: host.lima.internal
 portForwards:
 - guestSocket: "/run/user/{{.UID}}/docker.sock"
   hostSocket: "{{.Dir}}/sock/docker.sock"

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/06-etc-hosts.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/06-etc-hosts.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -eux -o pipefail
 
+# Define host.lima.internal in case the hostResolver is disabled. When using
+# the hostResolver, the name is provided by the lima resolver itself because
+# it doesn't have access to /etc/hosts inside the VM.
 sed -i '/host.lima.internal/d' /etc/hosts
 echo -e "${LIMA_CIDATA_SLIRP_GATEWAY}\thost.lima.internal" >>/etc/hosts

--- a/pkg/hostagent/dns/dns.go
+++ b/pkg/hostagent/dns/dns.go
@@ -82,6 +82,7 @@ func (h *Handler) handleQuery(w dns.ResponseWriter, req *dns.Msg) {
 		switch q.Qtype {
 		case dns.TypeAAAA:
 			if !h.IPv6 {
+				handled = true
 				break
 			}
 			fallthrough

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -27,6 +27,7 @@ import (
 	"github.com/lima-vm/lima/pkg/hostagent/events"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/qemu"
+	qemuconst "github.com/lima-vm/lima/pkg/qemu/const"
 	"github.com/lima-vm/lima/pkg/sshutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
@@ -249,7 +250,9 @@ func (a *HostAgent) Run(ctx context.Context) error {
 	}()
 
 	if *a.y.HostResolver.Enabled {
-		dnsServer, err := dns.Start(a.udpDNSLocalPort, a.tcpDNSLocalPort, *a.y.HostResolver.IPv6)
+		hosts := a.y.HostResolver.Hosts
+		hosts["host.lima.internal."] = qemuconst.SlirpGateway
+		dnsServer, err := dns.Start(a.udpDNSLocalPort, a.tcpDNSLocalPort, *a.y.HostResolver.IPv6, hosts)
 		if err != nil {
 			return fmt.Errorf("cannot start DNS server: %w", err)
 		}

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -41,6 +41,7 @@ type HostAgent struct {
 	udpDNSLocalPort int
 	tcpDNSLocalPort int
 	instDir         string
+	instName        string
 	sshConfig       *ssh.SSHConfig
 	portForwarder   *portForwarder
 	onClose         []func() error // LIFO
@@ -146,6 +147,7 @@ func New(instName string, stdout io.Writer, sigintCh chan os.Signal, opts ...Opt
 		udpDNSLocalPort: udpDNSLocalPort,
 		tcpDNSLocalPort: tcpDNSLocalPort,
 		instDir:         inst.Dir,
+		instName:        instName,
 		sshConfig:       sshConfig,
 		portForwarder:   newPortForwarder(sshConfig, sshLocalPort, rules),
 		qExe:            qExe,
@@ -252,6 +254,7 @@ func (a *HostAgent) Run(ctx context.Context) error {
 	if *a.y.HostResolver.Enabled {
 		hosts := a.y.HostResolver.Hosts
 		hosts["host.lima.internal."] = qemuconst.SlirpGateway
+		hosts[fmt.Sprintf("lima-%s.", a.instName)] = qemuconst.SlirpIPAddress
 		dnsServer, err := dns.Start(a.udpDNSLocalPort, a.tcpDNSLocalPort, *a.y.HostResolver.IPv6, hosts)
 		if err != nil {
 			return fmt.Errorf("cannot start DNS server: %w", err)

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -256,6 +256,12 @@ hostResolver:
   enabled: null
   # Default: false
   ipv6: null
+  # Static names can be defined here as an alternative to adding them to the hosts /etc/hosts.
+  # Values can be either other hostnames, or IP addresses. The host.lima.internal name is
+  # predefined to specify the gateway address to the host.
+  hosts:
+    # guest.name: 127.1.1.1
+    # host.name: host.lima.internal
 
 # If useHostResolver is false, then the following rules apply for configuring dns:
 # Explicitly set DNS addresses for qemu user-mode networking. By default qemu picks *one*

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -89,6 +89,11 @@ func TestFillDefault(t *testing.T) {
 	// All these slices and maps are empty in "builtin". Add minimal entries here to see that
 	// their values are retained and defaults for their fields are applied correctly.
 	y = LimaYAML{
+		HostResolver: HostResolver{
+			Hosts: map[string]string{
+				"MY.Host": "host.lima.internal",
+			},
+		},
 		Mounts: []Mount{
 			{Location: "/tmp"},
 		},
@@ -119,6 +124,10 @@ func TestFillDefault(t *testing.T) {
 	}
 
 	expect := builtin
+	expect.HostResolver.Hosts = map[string]string{
+		"my.host.": "host.lima.internal",
+	}
+
 	expect.Mounts = y.Mounts
 	expect.Mounts[0].Writable = pointer.Bool(false)
 	expect.Mounts[0].SSHFS.Cache = pointer.Bool(true)
@@ -195,6 +204,9 @@ func TestFillDefault(t *testing.T) {
 		HostResolver: HostResolver{
 			Enabled: pointer.Bool(false),
 			IPv6:    pointer.Bool(true),
+			Hosts: map[string]string{
+				"default": "localhost",
+			},
 		},
 		PropagateProxyEnv: pointer.Bool(false),
 
@@ -248,6 +260,9 @@ func TestFillDefault(t *testing.T) {
 	expect.Containerd.Archives[0].Arch = *d.Arch
 	expect.Mounts[0].SSHFS.Cache = pointer.Bool(true)
 	expect.Mounts[0].SSHFS.FollowSymlinks = pointer.Bool(false)
+	expect.HostResolver.Hosts = map[string]string{
+		"default.": d.HostResolver.Hosts["default"],
+	}
 
 	y = LimaYAML{}
 	FillDefault(&y, &d, &LimaYAML{}, filePath)
@@ -269,6 +284,8 @@ func TestFillDefault(t *testing.T) {
 	// Mounts and Networks start with lowest priority first, so higher priority entries can overwrite
 	expect.Mounts = append(d.Mounts, y.Mounts...)
 	expect.Networks = append(d.Networks, y.Networks...)
+
+	expect.HostResolver.Hosts["default."] = d.HostResolver.Hosts["default"]
 
 	// d.DNS will be ignored, and not appended to y.DNS
 
@@ -312,6 +329,9 @@ func TestFillDefault(t *testing.T) {
 		HostResolver: HostResolver{
 			Enabled: pointer.Bool(false),
 			IPv6:    pointer.Bool(false),
+			Hosts: map[string]string{
+				"override.": "underflow",
+			},
 		},
 		PropagateProxyEnv: pointer.Bool(false),
 
@@ -375,6 +395,9 @@ func TestFillDefault(t *testing.T) {
 	expect.Probes = append(append(o.Probes, y.Probes...), d.Probes...)
 	expect.PortForwards = append(append(o.PortForwards, y.PortForwards...), d.PortForwards...)
 	expect.Containerd.Archives = append(append(o.Containerd.Archives, y.Containerd.Archives...), d.Containerd.Archives...)
+
+	expect.HostResolver.Hosts["default."] = d.HostResolver.Hosts["default"]
+	expect.HostResolver.Hosts["my.host."] = d.HostResolver.Hosts["host.lima.internal"]
 
 	// o.Mounts just makes d.Mounts[0] writable because the Location matches
 	expect.Mounts = append(d.Mounts, y.Mounts...)

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -136,8 +136,9 @@ type Network struct {
 }
 
 type HostResolver struct {
-	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
-	IPv6    *bool `yaml:"ipv6,omitempty" json:"ipv6,omitempty"`
+	Enabled *bool             `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	IPv6    *bool             `yaml:"ipv6,omitempty" json:"ipv6,omitempty"`
+	Hosts   map[string]string `yaml:"hosts,omitempty" json:"hosts,omitempty"`
 }
 
 // DEPRECATED types below


### PR DESCRIPTION
This is an alternative to adding static names to `/etc/hosts` on the **host**, to make them available inside containers running in the guest. In addition this change allows creating aliases to `host.lima.internal` to point to the host gateway from inside the guest.

Manual testing with `examples/docker.yaml` with these changes:

```yaml
hostResolver:
  hosts:
    host.docker.internal: host.lima.internal
    cname.docker.internal: host.docker.internal
    guest.internal: 127.1.1.1
```

Testing inside an Alpine container running on Docker:

```console
$ docker context create lima --docker "host=unix:///Users/jan/.lima/docker/sock/docker.sock"
$ docker context use lima
$ docker run -it --rm alpine
/ # nslookup host.docker.internal
Server:		10.0.2.3
Address:	10.0.2.3:53

Non-authoritative answer:

Non-authoritative answer:
host.docker.internal	canonical name = host.lima.internal
Name:	host.lima.internal
Address: 192.168.5.2

/ # nslookup cname.docker.internal
Server:		10.0.2.3
Address:	10.0.2.3:53

Non-authoritative answer:

Non-authoritative answer:
cname.docker.internal	canonical name = host.lima.internal
Name:	host.lima.internal
Address: 192.168.5.2

/ # nslookup guest.internal
Server:		10.0.2.3
Address:	10.0.2.3:53

Non-authoritative answer:
Name:	guest.internal
Address: 127.1.1.1

Non-authoritative answer:
```

In addition this PR contains a bugfix for the `hostResolver.ipv6: false` configuration: instead of forwarding `AAAA` queries to the default resolvers, we now return an empty reply to avoid returning `NXDOMAIN`. During testing I found that that was causing names to resolve correctly on Alpine even when `dig` and `nslookup` seemed to show proper DNS information. It might be a bug in the musl resolver.

Finally this PR also adds the current hostname with the slirp IP address to the host resolver. This is done automatically by systemd-resolved, but necessary for e.g. Alpine.

Fixes #622