### PR TITLE
Make cpuType a map instead of a single value

### DIFF
--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -27,12 +27,6 @@ images:
 - location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-arm64.img"
   arch: "aarch64"
 
-# Specify QEMU CPU emulation, e.g., "host", "qemu64", "Haswell".
-# You can see what options are available for host emulation with: `qemu-system-$(arch) -cpu help`.
-# Setting of instructions is supported like this: "qemu64,+ssse3".
-# Default: "host" (native arch), "qemu64" (Intel on ARM), or "cortex-a72" (ARM on Intel)
-cpuType: null
-
 # CPUs: if you see performance issues, try limiting cpus to 1.
 # Default: 4
 cpus: null
@@ -140,6 +134,15 @@ containerd:
 # ===================================================================== #
 # FURTHER ADVANCED CONFIGURATION
 # ===================================================================== #
+
+# Specify desired QEMU CPU type for each arch.
+# You can see what options are available for host emulation with: `qemu-system-$(arch) -cpu help`.
+# Setting of instructions is supported like this: "qemu64,+ssse3".
+cpuType:
+  # Default: "cortex-a72" (or "host" when running on arm64)
+  aarch64: null
+  # Default: "qemu64" (or "host" when running on amd64)
+  x86_64: null
 
 firmware:
   # Use legacy BIOS instead of UEFI.

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -81,24 +81,32 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		}
 	}
 
-	if y.CPUType == nil {
-		y.CPUType = d.CPUType
+	cpuType := map[Arch]string{
+		AARCH64: "cortex-a72",
+		// Since https://github.com/lima-vm/lima/pull/494, we use qemu64 cpu for better emulation of x86_64.
+		X8664: "qemu64",
 	}
-	if o.CPUType != nil {
-		y.CPUType = o.CPUType
-	}
-	if y.CPUType == nil || *y.CPUType == "" {
-		if IsNativeArch(*y.Arch) {
-			y.CPUType = pointer.String("host")
-		} else if *y.Arch == X8664 {
-			// Intel on ARM
-			// Since https://github.com/lima-vm/lima/pull/494, we use qemu64 cpu for better emulation of x86_64.
-			y.CPUType = pointer.String("qemu64")
-		} else {
-			// ARM on Intel
-			y.CPUType = pointer.String("cortex-a72")
+	for arch := range cpuType {
+		if IsNativeArch(arch) {
+			cpuType[arch] = "host"
 		}
 	}
+	for k, v := range d.CPUType {
+		if len(v) > 0 {
+			cpuType[k] = v
+		}
+	}
+	for k, v := range y.CPUType {
+		if len(v) > 0 {
+			cpuType[k] = v
+		}
+	}
+	for k, v := range o.CPUType {
+		if len(v) > 0 {
+			cpuType[k] = v
+		}
+	}
+	y.CPUType = cpuType
 
 	if y.CPUs == nil {
 		y.CPUs = d.CPUs

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -47,11 +47,14 @@ func TestFillDefault(t *testing.T) {
 
 	// Builtin default values
 	builtin := LimaYAML{
-		Arch:    pointer.String(arch),
-		CPUType: pointer.String("host"),
-		CPUs:    pointer.Int(4),
-		Memory:  pointer.String("4GiB"),
-		Disk:    pointer.String("100GiB"),
+		Arch: pointer.String(arch),
+		CPUType: map[Arch]string{
+			AARCH64: "cortex-a72",
+			X8664:   "qemu64",
+		},
+		CPUs:   pointer.Int(4),
+		Memory: pointer.String("4GiB"),
+		Disk:   pointer.String("100GiB"),
 		Containerd: Containerd{
 			System:   pointer.Bool(false),
 			User:     pointer.Bool(true),
@@ -74,6 +77,7 @@ func TestFillDefault(t *testing.T) {
 		},
 		PropagateProxyEnv: pointer.Bool(true),
 	}
+	builtin.CPUType[arch] = "host"
 
 	defaultPortForward := PortForward{
 		GuestIP:        api.IPv4loopback1,
@@ -169,11 +173,14 @@ func TestFillDefault(t *testing.T) {
 
 	// Choose values that are different from the "builtin" defaults
 	d = LimaYAML{
-		Arch:    pointer.String("unknown"),
-		CPUType: pointer.String("host"),
-		CPUs:    pointer.Int(7),
-		Memory:  pointer.String("5GiB"),
-		Disk:    pointer.String("105GiB"),
+		Arch: pointer.String("unknown"),
+		CPUType: map[Arch]string{
+			AARCH64: "arm64",
+			X8664:   "amd64",
+		},
+		CPUs:   pointer.Int(7),
+		Memory: pointer.String("5GiB"),
+		Disk:   pointer.String("105GiB"),
 		Containerd: Containerd{
 			System: pointer.Bool(true),
 			User:   pointer.Bool(false),
@@ -282,11 +289,14 @@ func TestFillDefault(t *testing.T) {
 	// User-provided overrides should override user-provided config settings
 
 	o = LimaYAML{
-		Arch:    pointer.String(arch),
-		CPUType: pointer.String("host"),
-		CPUs:    pointer.Int(12),
-		Memory:  pointer.String("7GiB"),
-		Disk:    pointer.String("117GiB"),
+		Arch: pointer.String(arch),
+		CPUType: map[Arch]string{
+			AARCH64: "uber-arm",
+			X8664:   "pentium",
+		},
+		CPUs:   pointer.Int(12),
+		Memory: pointer.String("7GiB"),
+		Disk:   pointer.String("117GiB"),
 		Containerd: Containerd{
 			System: pointer.Bool(true),
 			User:   pointer.Bool(false),

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -9,7 +9,7 @@ import (
 type LimaYAML struct {
 	Arch              *Arch             `yaml:"arch,omitempty" json:"arch,omitempty"`
 	Images            []File            `yaml:"images" json:"images"` // REQUIRED
-	CPUType           *string           `yaml:"cpuType,omitempty" json:"cpuType,omitempty"`
+	CPUType           map[Arch]string   `yaml:"cpuType,omitempty" json:"cpuType,omitempty"`
 	CPUs              *int              `yaml:"cpus,omitempty" json:"cpus,omitempty"`
 	Memory            *string           `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
 	Disk              *string           `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -50,8 +50,13 @@ func Validate(y LimaYAML, warn bool) error {
 		}
 	}
 
-	if *y.CPUType == "" {
-		return fmt.Errorf("field `cpuType` must be set")
+	for arch := range y.CPUType {
+		switch arch {
+		case AARCH64, X8664:
+			// these are the only supported architectures
+		default:
+			return fmt.Errorf("field `cpuType` uses unsupported arch %q", arch)
+		}
 	}
 
 	if *y.CPUs == 0 {

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -207,7 +207,7 @@ func Cmdline(cfg Config) (string, []string, error) {
 		return "", nil, errors.New(errStr)
 	}
 
-	cpu := *y.CPUType
+	cpu := y.CPUType[*y.Arch]
 	args = appendArgsIfNoConflict(args, "-cpu", cpu)
 	switch *y.Arch {
 	case limayaml.X8664:

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -76,7 +76,8 @@ func Inspect(instName string) (*Instance, error) {
 	}
 	inst.Dir = instDir
 	inst.Arch = *y.Arch
-	inst.CPUType = *y.CPUType
+	inst.CPUType = y.CPUType[*y.Arch]
+
 	inst.CPUs = *y.CPUs
 	memory, err := units.RAMInBytes(*y.Memory)
 	if err == nil {


### PR DESCRIPTION
That way a template lima.yaml can specify alternate cpu types for multiple archs. Also makes it possible to specify defaults and overrides for cpu type globally.

Fixes #647 