### PR TITLE
Add portForwards.guestIPMustBeZero property

### DIFF
--- a/hack/test-port-forwarding.pl
+++ b/hack/test-port-forwarding.pl
@@ -292,3 +292,15 @@ portForwards:
   # forward: 0.0.0.0      4033 → ipv4 4033
   # forward: ::           4034 → ipv4 4034
   # forward: ::1          4035 → ipv4 4035
+
+- guestIPMustBeZero: true
+  guestPortRange: [4040, 4049]
+
+- guestIP: "0.0.0.0"
+  guestPortRange: [4040, 4049]
+  ignore: true
+
+  # forward: 0.0.0.0        4040 → 127.0.0.1 4040
+  # forward: ::             4041 → 127.0.0.1 4041
+  # ignore:  127.0.0.1      4043 → 127.0.0.1 4043
+  # ignore:  192.168.5.15   4044 → 127.0.0.1 4044

--- a/pkg/hostagent/port.go
+++ b/pkg/hostagent/port.go
@@ -52,7 +52,9 @@ func (pf *portForwarder) forwardingAddresses(guest api.IPPort) (string, string) 
 		case guest.IP.IsUnspecified():
 		case guest.IP.Equal(rule.GuestIP):
 		case guest.IP.Equal(net.IPv6loopback) && rule.GuestIP.Equal(api.IPv4loopback1):
-		case rule.GuestIP.IsUnspecified():
+		case rule.GuestIP.IsUnspecified() && !rule.GuestIPMustBeZero:
+			// When GuestIPMustBeZero is true, then 0.0.0.0 must be an exact match, which is already
+			// handled above by the guest.IP.IsUnspecified() condition.
 		default:
 			continue
 		}

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -209,6 +209,11 @@ networks:
 # - guestPort: 8888
 #   ignore: true (don't forward this port)
 #
+# - guestPort: 7443
+#   guestIP: "0.0.0.0"       # Will match *any* interface
+#   guestIPMustBeZero: true  # Restrict matching to 0.0.0.0 binds only
+#   hostIP: "0.0.0.0"        # Forwards to 0.0.0.0, exposing it externally
+#
 # - guestSocket: "/run/user/{{.UID}}/my.sock"
 #   hostSocket: mysocket
 # # "guestSocket" can include these template variables: {{.Home}}, {{.UID}}, and {{.User}}.

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -402,7 +402,11 @@ func FillPortForwardDefaults(rule *PortForward, instDir string) {
 		rule.Proto = TCP
 	}
 	if rule.GuestIP == nil {
-		rule.GuestIP = api.IPv4loopback1
+		if rule.GuestIPMustBeZero {
+			rule.GuestIP = net.IPv4zero
+		} else {
+			rule.GuestIP = api.IPv4loopback1
+		}
 	}
 	if rule.HostIP == nil {
 		rule.HostIP = api.IPv4loopback1

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -112,16 +112,17 @@ const (
 )
 
 type PortForward struct {
-	GuestIP        net.IP `yaml:"guestIP,omitempty" json:"guestIP,omitempty"`
-	GuestPort      int    `yaml:"guestPort,omitempty" json:"guestPort,omitempty"`
-	GuestPortRange [2]int `yaml:"guestPortRange,omitempty" json:"guestPortRange,omitempty"`
-	GuestSocket    string `yaml:"guestSocket,omitempty" json:"guestSocket,omitempty"`
-	HostIP         net.IP `yaml:"hostIP,omitempty" json:"hostIP,omitempty"`
-	HostPort       int    `yaml:"hostPort,omitempty" json:"hostPort,omitempty"`
-	HostPortRange  [2]int `yaml:"hostPortRange,omitempty" json:"hostPortRange,omitempty"`
-	HostSocket     string `yaml:"hostSocket,omitempty" json:"hostSocket,omitempty"`
-	Proto          Proto  `yaml:"proto,omitempty" json:"proto,omitempty"`
-	Ignore         bool   `yaml:"ignore,omitempty" json:"ignore,omitempty"`
+	GuestIPMustBeZero bool   `yaml:"guestIPMustBeZero,omitempty" json:"guestIPMustBeZero,omitempty"`
+	GuestIP           net.IP `yaml:"guestIP,omitempty" json:"guestIP,omitempty"`
+	GuestPort         int    `yaml:"guestPort,omitempty" json:"guestPort,omitempty"`
+	GuestPortRange    [2]int `yaml:"guestPortRange,omitempty" json:"guestPortRange,omitempty"`
+	GuestSocket       string `yaml:"guestSocket,omitempty" json:"guestSocket,omitempty"`
+	HostIP            net.IP `yaml:"hostIP,omitempty" json:"hostIP,omitempty"`
+	HostPort          int    `yaml:"hostPort,omitempty" json:"hostPort,omitempty"`
+	HostPortRange     [2]int `yaml:"hostPortRange,omitempty" json:"hostPortRange,omitempty"`
+	HostSocket        string `yaml:"hostSocket,omitempty" json:"hostSocket,omitempty"`
+	Proto             Proto  `yaml:"proto,omitempty" json:"proto,omitempty"`
+	Ignore            bool   `yaml:"ignore,omitempty" json:"ignore,omitempty"`
 }
 
 type Network struct {

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -134,6 +134,9 @@ func Validate(y LimaYAML, warn bool) error {
 	}
 	for i, rule := range y.PortForwards {
 		field := fmt.Sprintf("portForwards[%d]", i)
+		if rule.GuestIPMustBeZero && !rule.GuestIP.Equal(net.IPv4zero) {
+			return fmt.Errorf("field `%s.guestIPMustBeZero` can only be true when field `%s.guestIP` is 0.0.0.0", field, field)
+		}
 		if rule.GuestPort != 0 {
 			if rule.GuestSocket != "" {
 				return fmt.Errorf("field `%s.guestPort` must be 0 when field `%s.guestSocket` is set", field, field)


### PR DESCRIPTION
When `guestIPMustBeZero` is set the rule will only match if the bind is against literal `0.0.0.0` and not any other interface.

To forward any ports bound to `0.0.0.0` in the guest to `0.0.0.0` on the host, but any other ports bound to `127.0.0.1` only to localhost on the host use these rules:

```yaml
portForwards:
- guestPortRange: [1, 65535]
  guestIPMustBeZero: true
  hostIP: "0.0.0.0"
- guestPortRange: [1, 65535]
  guestIP: "127.0.0.1"
  hostIP: "127.0.0.1"
```

Fixes #658