### PR TITLE
iptables rule without an ip range applies to all interfaces

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ task:
   - cat /proc/cpuinfo
   install_deps_script:
   - apt-get update
-  - apt-get install -y --no-install-recommends ca-certificates curl git golang openssh-client make netcat ovmf sudo qemu-system-x86 qemu-utils
+  - apt-get install -y --no-install-recommends ca-certificates curl git golang jq openssh-client make netcat ovmf sudo qemu-system-x86 qemu-utils
   go_cache:
     fingerprint_script: uname -s ; cat go.sum
     folder: $GOPATH/pkg/mod

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,9 @@ jobs:
       # QEMU:      required by Lima itself
       # bash:      required by test-example.sh (OS version of bash is too old)
       # coreutils: required by test-example.sh for the "timeout" command
+      # These would need to be added to run the alpine.yaml config on the macOS runner:
+      # curl:      required by test-example.sh to download nerdctl for alpine
+      # jq:        required by test-example.sh to determine download URL for nerdctl
       run: |
         set -x
         # Github runners seem to symlink to python2.7 version of 2to3,

--- a/hack/test-port-forwarding.pl
+++ b/hack/test-port-forwarding.pl
@@ -304,3 +304,10 @@ portForwards:
   # forward: ::             4041 → 127.0.0.1 4041
   # ignore:  127.0.0.1      4043 → 127.0.0.1 4043
   # ignore:  192.168.5.15   4044 → 127.0.0.1 4044
+
+# This rule exist to test `nerdctl run` binding to 0.0.0.0 by default,
+# and making sure it gets forwarded to the external host IP.
+# The actual test code is in test-example.sh in the "port-forwarding" block.
+- guestIPMustBeZero: true
+  guestPort: 8888
+  hostIP: 0.0.0.0

--- a/pkg/guestagent/iptables/iptables.go
+++ b/pkg/guestagent/iptables/iptables.go
@@ -75,12 +75,10 @@ func parsePortsFromRules(rules []string) ([]Entry, error) {
 					istcp = true
 				}
 
-				// if the IP is blank the port forwarding the portforwarding,
-				// which gets information from this, will skip it. When no IP
-				// is present localhost will work.
+				// When no IP is present the rule applies to all interfaces.
 				ip := found[1]
 				if ip == "" {
-					ip = "127.0.0.1"
+					ip = "0.0.0.0"
 				}
 				ent := Entry{
 					IP:   net.ParseIP(ip),

--- a/pkg/guestagent/iptables/iptables_test.go
+++ b/pkg/guestagent/iptables/iptables_test.go
@@ -84,8 +84,8 @@ func TestParsePortsFromRules(t *testing.T) {
 		t.Fatalf("expected 2 ports parsed from iptables but parsed %d", l)
 	}
 
-	if res[0].IP.String() != "127.0.0.1" || res[0].Port != 8082 || res[0].TCP != true {
-		t.Errorf("expected port 8082 on IP 127.0.0.1 with TCP true but go port %d on IP %s with TCP %t", res[0].Port, res[0].IP.String(), res[0].TCP)
+	if res[0].IP.String() != "0.0.0.0" || res[0].Port != 8082 || res[0].TCP != true {
+		t.Errorf("expected port 8082 on IP 0.0.0.0 with TCP true but got port %d on IP %s with TCP %t", res[0].Port, res[0].IP.String(), res[0].TCP)
 	}
 	if res[1].IP.String() != "127.0.0.1" || res[1].Port != 8081 || res[1].TCP != true {
 		t.Errorf("expected port 8081 on IP 127.0.0.1 with TCP true but go port %d on IP %s with TCP %t", res[1].Port, res[1].IP.String(), res[1].TCP)


### PR DESCRIPTION
The current logic pretends it only applies to `127.0.0.1`, which means the new `guestIPMustBeZero` rule does not detect it properly.

This is a problem with `nerdctl` and `containerd` on Alpine. It works "by accident" on Ubuntu because the port was also bound to `[::]`, which had an entry in `/proc/net/tcp6`.

This issue does not affect moby because moby doesn't rely on `iptables` rules but has proper entries in `/proc/net/tcp`.
