### PR TITLE
Fix `limactl ls` treating files in limadir as instances

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -25,6 +25,9 @@ func Instances() ([]string, error) {
 		if strings.HasPrefix(f.Name(), ".") || strings.HasPrefix(f.Name(), "_") {
 			continue
 		}
+		if !f.IsDir() {
+			continue
+		}
 		names = append(names, f.Name())
 	}
 	return names, nil


### PR DESCRIPTION
## Summary

Only treat directories in limadir as instances.

## Why is this needed?

This is my local limadir, where I stored custom `docker.yaml` and `podman.yaml`:
```bash
$ ls -1 ~/.lima
_config
docker
docker.yaml
podman.yaml
```

Here the `limactl ls` command behaves unexpected and treats these files as instances:

```bash
$ limactl list
WARN[0000] instance "docker.yaml" has errors             errors="[open /Users/jwhb/.lima/docker.yaml/lima.yaml: not a directory]"
WARN[0000] instance "podman.yaml" has errors             errors="[open /Users/jwhb/.lima/podman.yaml/lima.yaml: not a directory]"
NAME           STATUS     SSH                ARCH      CPUS    MEMORY    DISK      DIR
docker         Running    127.0.0.1:57265    x86_64    4       4GiB      100GiB    /Users/jwhb/.lima/docker
docker.yaml               127.0.0.1:0                  0       0B        0B        
podman.yaml               127.0.0.1:0                  0       0B        0B        
```

## Proposed solution

With the proposed change in this commit the output of `limactl ls` is as expected:

```bash
$ _output/bin/limactl ls
NAME      STATUS     SSH                ARCH      CPUS    MEMORY    DISK      DIR
docker    Running    127.0.0.1:57265    x86_64    4       4GiB      100GiB    /Users/jwhb/.lima/docker
```

I am assuming that only directories in limadir are to be considered instances.