### PR TITLE
cidata: automatically upgrade existing containerd/nerdctl ; nerdctl: update to v0.17.1

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -22,7 +22,7 @@ import (
 )
 
 func defaultContainerdArchives() []File {
-	const nerdctlVersion = "0.17.0"
+	const nerdctlVersion = "0.17.1"
 	location := func(goarch string) string {
 		return "https://github.com/containerd/nerdctl/releases/download/v" + nerdctlVersion + "/nerdctl-full-" + nerdctlVersion + "-linux-" + goarch + ".tar.gz"
 	}
@@ -30,12 +30,12 @@ func defaultContainerdArchives() []File {
 		{
 			Location: location("amd64"),
 			Arch:     X8664,
-			Digest:   "sha256:5eef74d5031b2f014a7f594e1f2ff319161a29f9309a56bee1a44fb90430a28d",
+			Digest:   "sha256:046ac1c3d007b9b64880cb15a78ea1e0be345d31f51ff282be783a9c203f299d",
 		},
 		{
 			Location: location("arm64"),
 			Arch:     AARCH64,
-			Digest:   "sha256:b0ae2fc89d362afa18afcc35798d4da613096613d06cae07181b777cd66002e8",
+			Digest:   "sha256:b773a0db178af9d0963b7c84df88ee434e0c1986fe7491dc1de3231e071e3921",
 		},
 	}
 }


### PR DESCRIPTION
When the timestamp of `/mnt/lima-cidata/nerdctl-full.tgz:bin/nerdctl` is newer than
`/usr/local/bin/nerdctl`, containerd/nerdctl is automatically upgraded.

Drawback: increases boot time by 4-5 seconds.

Fix #303

- - -

Also bumps up the default nerdctl version to 0.17.1: https://github.com/containerd/nerdctl/releases/tag/v0.17.1