### PR TITLE
nerdctl: use fuse-overlayfs only when kernel < 5.13

### DIFF
--- a/docs/internal.md
+++ b/docs/internal.md
@@ -92,6 +92,7 @@ The directory contains the following files:
 - `nerdctl-full.tgz`: [`nerdctl-full-<VERSION>-linux-<ARCH>.tar.gz`](https://github.com/containerd/nerdctl/releases)
 - `boot.sh`: Boot script
 - `boot/*`: Boot script modules
+- `util/*`: Utility command scripts, executed in the boot script modules
 - `provision.system/*`: Custom provision scripts (system)
 - `provision.user/*`: Custom provision scripts (user)
 - `etc_environment`: Environment variables to be added to `/etc/environment` (also loaded during `boot.sh`)

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.sh
@@ -25,6 +25,9 @@ while read -r line; do
 	[ -n "$line" ] && export "$line"
 done <"${LIMA_CIDATA_MNT}"/etc_environment
 
+PATH="${LIMA_CIDATA_MNT}"/util:"${PATH}"
+export PATH
+
 CODE=0
 
 # Don't make any changes to /etc or /var/lib until boot/05-persistent-data-volume.sh

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/20-rootless-base.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/20-rootless-base.sh
@@ -11,9 +11,18 @@ for f in .profile .bashrc; do
 # Lima BEGIN
 # Make sure iptables and mount.fuse3 are available
 PATH="\$PATH:/usr/sbin:/sbin"
-# fuse-overlayfs is the most stable snapshotter for rootless
+export PATH
+EOF
+		if compare_version.sh "$(uname -r)" -lt "5.13"; then
+			cat >>"/home/${LIMA_CIDATA_USER}.linux/$f" <<EOF
+# fuse-overlayfs is the most stable snapshotter for rootless, on kernel < 5.13
+# https://github.com/lima-vm/lima/issues/383
+# https://rootlesscontaine.rs/how-it-works/overlayfs/
 CONTAINERD_SNAPSHOTTER="fuse-overlayfs"
-export PATH CONTAINERD_SNAPSHOTTER
+export CONTAINERD_SNAPSHOTTER
+EOF
+		fi
+		cat >>"/home/${LIMA_CIDATA_USER}.linux/$f" <<EOF
 # Lima END
 EOF
 		chown "${LIMA_CIDATA_USER}" "/home/${LIMA_CIDATA_USER}.linux/$f"

--- a/pkg/cidata/cidata.TEMPLATE.d/util/compare_version.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/util/compare_version.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -eu
+
+: "${SELFTEST:=}"
+if [ -n "$SELFTEST" ]; then
+	unset SELFTEST
+	echo >&2 "=== Running positive tests ==="
+	(
+		set -x
+		"$0" 0.1.2 -eq 0.1.2
+		"$0" 0.1.2 -ne 0.1.3
+		"$0" 0.1.2 -ge 0.1.1
+		"$0" 0.1.2 -ge 0.1.2
+		"$0" 0.1.10 -ge 0.1.9
+		"$0" 0.1.2 -gt 0.1.1
+		"$0" 0.1.10 -gt 0.1.9
+		"$0" 0.1.2 -le 0.1.2
+		"$0" 0.1.2 -le 0.1.3
+		"$0" 0.1.2 -le 0.1.10
+		"$0" 0.1.2 -lt 0.1.3
+		"$0" 0.1.2 -lt 0.1.10
+	)
+	echo >&2 "=== Running negative tests ==="
+	(
+		set -x
+		"$0" 0.1.2 -eq 0.1.1 && false
+		"$0" 0.1.2 -ne 0.1.2 && false
+		"$0" 0.1.2 -ge 0.1.3 && false
+		"$0" 0.1.2 -gt 0.1.2 && false
+		"$0" 0.1.2 -le 0.1.1 && false
+		"$0" 0.1.2 -lt 0.1.2 && false
+		true
+	)
+	exit 0
+fi
+
+if [ "$#" -ne 3 ]; then
+	echo >&2 "Usage: $0 VERSION-A OP VERSION-B"
+	echo >&2 "Implemented operators: -eq, -ne, -ge, -gt, -le, -lt"
+	echo >&2 ""
+	echo >&2 "Example: $0 1.2.10 -ge 1.2.9"
+	exit 1
+fi
+
+version_a="$1"
+op="$2"
+version_b="$3"
+
+sorted="$(echo -ne "${version_a}\n${version_b}\n" | sort -V -r | head -n1)"
+case "${op}" in
+-eq)
+	[ "${version_a}" = "${version_b}" ]
+	;;
+-ne)
+	[ "${version_a}" != "${version_b}" ]
+	;;
+-ge)
+	[ "${version_a}" = "${sorted}" ]
+	;;
+-gt)
+	[ "${version_a}" = "${sorted}" ] && [ "${version_a}" != "${version_b}" ]
+	;;
+-le)
+	[ "${version_b}" = "${sorted}" ]
+	;;
+-lt)
+	[ "${version_b}" = "${sorted}" ] && [ "${version_a}" != "${version_b}" ]
+	;;
+*)
+	echo "Unknown operator \"$op\""
+	exit 1
+	;;
+esac


### PR DESCRIPTION
The real overlayfs can be safely used on kernel >= 5.13.

Instances created with older releases of Lima will continue to use fuse-overlayfs.

Fix #383
