### PR TITLE
Ubuntu: skip kernel 5.13.0-35.40 (5.4.0-103.117 for 20.04 LTS)

### DIFF
--- a/examples/buildkit.yaml
+++ b/examples/buildkit.yaml
@@ -11,9 +11,19 @@ message: |
  buildctl debug workers
  -------
 images:
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+# ⚠️ release-20220309 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-arm64.img"
+  digest: "sha256:73fe1785c60edeb506f191affff0440abcc2de02420bb70865d51d0ff9b28223"
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-arm64.img"
+  arch: "aarch64"
+  digest: "sha256:1b5b3fe616e1eea4176049d434a360344a7d471f799e151190f21b0a27f0b424"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release/ubuntu-21.10-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release/ubuntu-21.10-server-cloudimg-arm64.img"
   arch: "aarch64"
 
 containerd:

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -13,17 +13,19 @@ arch: null
 # 🟢 Builtin default: null (must be specified)
 # 🔵 This file: Ubuntu 21.10 Impish Indri images
 images:
-# Try to use a local image first.
-- location: "~/Downloads/impish-server-cloudimg-amd64.img"
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+# ⚠️ release-20220309 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "~/Downloads/impish-server-cloudimg-arm64.img"
+  digest: "sha256:73fe1785c60edeb506f191affff0440abcc2de02420bb70865d51d0ff9b28223"
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-arm64.img"
   arch: "aarch64"
-
-# Download the file from the internet when the local file is missing.
-# Hint: run `limactl prune` to invalidate the "current" cache
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"
+  digest: "sha256:1b5b3fe616e1eea4176049d434a360344a7d471f799e151190f21b0a27f0b424"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-arm64.img"
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release/ubuntu-21.10-server-cloudimg-arm64.img"
   arch: "aarch64"
 
 # CPUs: if you see performance issues, try limiting cpus to 1.

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -8,11 +8,21 @@
 
 # This example requires Lima v0.8.0 or later
 images:
-# Hint: run `limactl prune` to invalidate the "current" cache
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+# ⚠️ release-20220309 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-arm64.img"
+  digest: "sha256:73fe1785c60edeb506f191affff0440abcc2de02420bb70865d51d0ff9b28223"
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-arm64.img"
   arch: "aarch64"
+  digest: "sha256:1b5b3fe616e1eea4176049d434a360344a7d471f799e151190f21b0a27f0b424"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release/ubuntu-21.10-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release/ubuntu-21.10-server-cloudimg-arm64.img"
+  arch: "aarch64"
+
 mounts:
 - location: "~"
 - location: "/tmp/lima"

--- a/examples/faasd.yaml
+++ b/examples/faasd.yaml
@@ -17,11 +17,21 @@
 #
 # This example requires Lima v0.7.0 or later.
 
-images:
 # Image is set to focal (20.04 LTS) for long-term stability
-- location: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
+images:
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+# ⚠️ release-20220308 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-arm64.img"
+  digest: "sha256:243157ea0390890d6e60ce5e08e0249b16e23b6b313b63aed50f39f92b020afe"
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-arm64.img"
+  arch: "aarch64"
+  digest: "sha256:fb2b4efdbf0011bd2a9fd49e9d31efdd252966c889f07b5d246351ec5734a329"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-arm64.img"
   arch: "aarch64"
 
 # Mounts are disabled in this example, but can be enabled optionally.

--- a/examples/k3s.yaml
+++ b/examples/k3s.yaml
@@ -14,10 +14,19 @@
 # This example requires Lima v0.7.0 or later.
 
 images:
-# Hint: run `limactl prune` to invalidate the "current" cache
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+# ⚠️ release-20220309 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-arm64.img"
+  digest: "sha256:73fe1785c60edeb506f191affff0440abcc2de02420bb70865d51d0ff9b28223"
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-arm64.img"
+  arch: "aarch64"
+  digest: "sha256:1b5b3fe616e1eea4176049d434a360344a7d471f799e151190f21b0a27f0b424"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release/ubuntu-21.10-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release/ubuntu-21.10-server-cloudimg-arm64.img"
   arch: "aarch64"
 
 # Mounts are disabled in this example, but can be enabled optionally.

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -12,13 +12,24 @@
 # lima-k8s   Ready    control-plane,master   44s   v1.22.3
 
 # This example requires Lima v0.7.0 or later.
-images:
+
 # Image is set to focal (20.04 LTS) for long-term stability
-# Hint: run `limactl prune` to invalidate the "current" cache
-- location: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
+images:
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+# ⚠️ release-20220308 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-arm64.img"
+  digest: "sha256:243157ea0390890d6e60ce5e08e0249b16e23b6b313b63aed50f39f92b020afe"
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-arm64.img"
   arch: "aarch64"
+  digest: "sha256:fb2b4efdbf0011bd2a9fd49e9d31efdd252966c889f07b5d246351ec5734a329"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-arm64.img"
+  arch: "aarch64"
+
 # Mounts are disabled in this example, but can be enabled optionally.
 mounts: []
 containerd:

--- a/examples/nomad.yaml
+++ b/examples/nomad.yaml
@@ -8,13 +8,24 @@
 # https://github.com/Roblox/nomad-driver-containerd/tree/master/example
 
 # This example requires Lima v0.7.0 or later.
-images:
+
 # Image is set to focal (20.04 LTS) for long-term stability
-# Hint: run `limactl prune` to invalidate the "current" cache
-- location: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
+images:
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+# ⚠️ release-20220308 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-arm64.img"
+  digest: "sha256:243157ea0390890d6e60ce5e08e0249b16e23b6b313b63aed50f39f92b020afe"
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-arm64.img"
   arch: "aarch64"
+  digest: "sha256:fb2b4efdbf0011bd2a9fd49e9d31efdd252966c889f07b5d246351ec5734a329"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-arm64.img"
+  arch: "aarch64"
+
 # Mounts are disabled in this example, but can be enabled optionally.
 mounts: []
 containerd:

--- a/examples/podman.yaml
+++ b/examples/podman.yaml
@@ -12,11 +12,21 @@
 
 # This example requires Lima v0.8.0 or later
 images:
-# Hint: run `limactl prune` to invalidate the "current" cache
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+# ⚠️ release-20220309 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-arm64.img"
+  digest: "sha256:73fe1785c60edeb506f191affff0440abcc2de02420bb70865d51d0ff9b28223"
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-arm64.img"
   arch: "aarch64"
+  digest: "sha256:1b5b3fe616e1eea4176049d434a360344a7d471f799e151190f21b0a27f0b424"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release/ubuntu-21.10-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release/ubuntu-21.10-server-cloudimg-arm64.img"
+  arch: "aarch64"
+
 mounts:
 - location: "~"
 - location: "/tmp/lima"

--- a/examples/ubuntu-lts.yaml
+++ b/examples/ubuntu-lts.yaml
@@ -2,11 +2,21 @@
 
 # This example requires Lima v0.7.0 or later.
 images:
-# Hint: run `limactl prune` to invalidate the "current" cache
-- location: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+# ⚠️ release-20220308 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-arm64.img"
+  digest: "sha256:243157ea0390890d6e60ce5e08e0249b16e23b6b313b63aed50f39f92b020afe"
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-arm64.img"
   arch: "aarch64"
+  digest: "sha256:fb2b4efdbf0011bd2a9fd49e9d31efdd252966c889f07b5d246351ec5734a329"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-arm64.img"
+  arch: "aarch64"
+
 mounts:
 - location: "~"
 - location: "/tmp/lima"

--- a/examples/ubuntu.yaml
+++ b/examples/ubuntu.yaml
@@ -1,10 +1,20 @@
 # This example requires Lima v0.7.0 or later.
 images:
-# Hint: run `limactl prune` to invalidate the "current" cache
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+# ⚠️ release-20220309 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-arm64.img"
+  digest: "sha256:73fe1785c60edeb506f191affff0440abcc2de02420bb70865d51d0ff9b28223"
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-arm64.img"
   arch: "aarch64"
+  digest: "sha256:1b5b3fe616e1eea4176049d434a360344a7d471f799e151190f21b0a27f0b424"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release/ubuntu-21.10-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release/ubuntu-21.10-server-cloudimg-arm64.img"
+  arch: "aarch64"
+
 mounts:
 - location: "~"
 - location: "/tmp/lima"

--- a/examples/vmnet.yaml
+++ b/examples/vmnet.yaml
@@ -2,11 +2,20 @@
 # This example requires Lima v0.7.0 or later.
 # Older versions of Lima were using a different syntax for supporting vmnet.framework.
 images:
-# Hint: run `limactl prune` to invalidate the "current" cache
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"
+# ⚠️ release-20220309 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-arm64.img"
+  digest: "sha256:73fe1785c60edeb506f191affff0440abcc2de02420bb70865d51d0ff9b28223"
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-arm64.img"
   arch: "aarch64"
+  digest: "sha256:1b5b3fe616e1eea4176049d434a360344a7d471f799e151190f21b0a27f0b424"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release/ubuntu-21.10-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/releases/21.10/release/ubuntu-21.10-server-cloudimg-arm64.img"
+  arch: "aarch64"
+
 mounts:
 - location: "~"
 - location: "/tmp/lima"

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"text/template"
 	"time"
 
@@ -148,6 +150,8 @@ func Start(ctx context.Context, inst *store.Instance) error {
 		return err
 	}
 
+	showUbuntuMarch2022Warning(inst) // remove when Ubuntu fixes https://github.com/lima-vm/lima/issues/712
+
 	watchErrCh := make(chan error)
 	go func() {
 		watchErrCh <- watchHostAgentEvents(ctx, inst, haStdoutPath, haStderrPath, begin)
@@ -270,4 +274,61 @@ func ShowMessage(inst *store.Instance) error {
 		return err
 	}
 	return nil
+}
+
+// showUbuntuMarch2022Warning shows warning for https://github.com/lima-vm/lima/issues/712
+func showUbuntuMarch2022Warning(inst *store.Instance) {
+	if runtime.GOARCH != "arm64" {
+		return
+	}
+	if unlikelyUbuntu(inst.Name) {
+		return
+	}
+	display := "sdl"
+	if runtime.GOOS == "darwin" {
+		display = "cocoa"
+	}
+	s := fmt.Sprintf(`
+============ ⚠️  March 2022 update of Ubuntu does not work on ARM ⚠️  ============
+Ubuntu kernel 5.13.0-35.40 (5.4.0-103.117 for 20.04 LTS) released in March 2022
+is not bootable on ARM hosts.
+(EFI stub: ERROR: FIRMWARE BUG: kernel image not aligned on 64k boundary
+
+Until the issue gets resolved, it is HIGHLY RECOMMENDED to run the following
+command in the Ubuntu shell (NOT the host shell) to avoid upgrading the kernel:
+
+------------------------------------------------------------
+sudo apt-mark hold linux-image-$(uname -r)
+------------------------------------------------------------
+
+If your kernel was already upgraded and the VM does not boot, try running Lima
+with the following environment variable to show the QEMU video display:
+
+------------------------------------------------------------
+export QEMU_SYSTEM_AARCH64="qemu-system-aarch64 -display %s"
+------------------------------------------------------------
+
+After the display is shown, press the Esc key several times to show the GRUB
+prompt for choosing an older kernel.
+
+To receive updates about this issue, subscribe to the following issue tickets:
+- https://github.com/lima-vm/lima/issues/712
+- https://bugs.launchpad.net/ubuntu/+source/grub2/+bug/1947046
+
+If you are not using Ubuntu, you can ignore this warning message.
+============ ⚠️  March 2022 update of Ubuntu does not work on ARM ⚠️  ============
+`, display)
+	logrus.Warn(s)
+}
+
+func unlikelyUbuntu(instName string) bool {
+	dict := []string{
+		"alma", "alpine", "archlinux", "centos", "debian", "fedora", "red", "rhel", "suse", "oracle", "rocky",
+	}
+	for _, f := range dict {
+		if strings.Contains(instName, f) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Ubuntu kernel 5.13.0-35.40 (5.4.0-103.117 for 20.04 LTS) is broken for ARM:
`EFI stub: ERROR: FIRMWARE BUG: kernel image not aligned on 64k boundary`

Until the issue gets resolved, it is highly recommended to run
`sudo apt-mark hold linux-image-$(uname -r)` to avoid upgrading the kernel.

See issue #712
