### PR TITLE
Sync the containerd files for Kubernetes

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -54,10 +54,46 @@ provision:
     apt-get install -y cri-tools
     cat  <<EOF | sudo tee /etc/crictl.yaml
     runtime-endpoint: unix:///run/containerd/containerd.sock
-    image-endpoint: unix:///run/containerd/containerd.sock
     EOF
     # cni-plugins
     apt-get install -y kubernetes-cni
+    mkdir -p /etc/cni/net.d
+    cat << EOF | tee /etc/cni/net.d/10-containerd-net.conflist
+    {
+      "cniVersion": "0.4.0",
+      "name": "containerd-net",
+      "plugins": [
+        {
+          "type": "bridge",
+          "bridge": "cni0",
+          "isGateway": true,
+          "ipMasq": true,
+          "promiscMode": true,
+          "ipam": {
+            "type": "host-local",
+            "ranges": [
+              [{
+                "subnet": "10.88.0.0/16"
+              }],
+              [{
+                "subnet": "2001:4860:4860::/64"
+              }]
+            ],
+            "routes": [
+              { "dst": "0.0.0.0/0" },
+              { "dst": "::/0" }
+            ]
+          }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {"portMappings": true}
+        }
+      ]
+    }
+    EOF
+    # To use flannel, delete the default CNI network
+    # To use containerd-net, comment this and below
     rm -f /etc/cni/net.d/*.conf*
     apt-get install -y kubelet kubeadm kubectl && apt-mark hold kubelet kubeadm kubectl
     systemctl enable --now kubelet


### PR DESCRIPTION
Comparing with:
~~https://github.com/containerd/containerd/blob/main/docs/cri/installation.md~~

Unfortunately the upstream documentation has been deprecated,
and no longer includes the configuration needed for CRI and CNI.

It is also no longer available from the kubernetes [documentation](https://kubernetes.io/docs/setup/production-environment/container-runtimes/#containerd),
so it is up to the user to figure out /etc/crictl.yaml and /etc/cni/net.d

https://github.com/containerd/containerd/blob/main/script/setup/install-critools

https://github.com/containerd/containerd/blob/main/script/setup/install-cni

Upstream includes configuration for CRI and CNI,
so make sure that is added to the nerdctl install.
Currently using "[flannel](https://github.com/flannel-io/flannel)" for multi-node and VXLAN,
but template can be edited to use "containerd-net".

The image endpoint defaults to the runtime endpoint,
so use the same configuration file as upstream has.
Currently we use `kubernetes-cni` which is a slightly
older version so don't bump the `cniVersion` (yet).

----

Reviewer note: this is basically a no-op, unless edited

We create the default file, and then we delete it again