### PR TITLE
Recommend QEMU 6.2.0_1 on M1 macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,16 @@ brew install lima
 
 #### Install QEMU
 
-Install recent version of QEMU. v6.2.0 or later is recommended.
+Install recent version of QEMU.
+
+On M1 macOS, [Homebrew's QEMU `6.2.0_1`](https://github.com/Homebrew/homebrew-core/pull/96743) or later is recommended.
+
+If you are not using Homebrew, make sure to include the following commits to boot recent Linux guests:
+- https://github.com/qemu/qemu/commit/ad99f64f `hvf: arm: Use macros for sysreg shift/masking`
+- https://github.com/qemu/qemu/commit/7f6c295c `hvf: arm: Handle unknown ID registers as RES0`
+
+These commits are planned to be included in the upstream QEMU 7.0.0 (ETA: April 2022).
+See https://github.com/Homebrew/homebrew-core/pull/96743 for the further information.
 
 #### Install Lima
 
@@ -402,8 +411,12 @@ On Linux hosts, you might have to set sysctl value `net.ipv4.ip_unprivileged_por
 
 #### stuck on "Waiting for the essential requirement 1 of X: "ssh"
 
-libslirp v4.6.0 used by QEMU is known to be [broken](https://gitlab.freedesktop.org/slirp/libslirp/-/issues/48).
-If you have libslirp v4.6.0 in `/usr/local/Cellar/libslirp`, you have to upgrade it to v4.6.1 or later (`brew upgrade`).
+On M1 macOS, QEMU needs to be [Homebrew's QEMU `6.2.0_1`](https://github.com/Homebrew/homebrew-core/pull/96743) or later to run recent Linux guests.
+Run `brew upgrade` to upgrade QEMU.
+
+If you are not using Homebrew, see the "Manual installation steps" in the [Installation](#installation) section.
+
+See also `serial.log` in `~/.lima/<INSTANCE>` for debugging.
 
 #### "permission denied" for `limactl cp` command
 

--- a/examples/buildkit.yaml
+++ b/examples/buildkit.yaml
@@ -12,7 +12,6 @@ message: |
  -------
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-# ⚠️ release-20220309 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
 - location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:73fe1785c60edeb506f191affff0440abcc2de02420bb70865d51d0ff9b28223"

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -14,7 +14,6 @@ arch: null
 # 🔵 This file: Ubuntu 21.10 Impish Indri images
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-# ⚠️ release-20220309 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
 - location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:73fe1785c60edeb506f191affff0440abcc2de02420bb70865d51d0ff9b28223"

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -9,7 +9,6 @@
 # This example requires Lima v0.8.0 or later
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-# ⚠️ release-20220309 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
 - location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:73fe1785c60edeb506f191affff0440abcc2de02420bb70865d51d0ff9b28223"

--- a/examples/faasd.yaml
+++ b/examples/faasd.yaml
@@ -20,7 +20,6 @@
 # Image is set to focal (20.04 LTS) for long-term stability
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-# ⚠️ release-20220308 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
 - location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:243157ea0390890d6e60ce5e08e0249b16e23b6b313b63aed50f39f92b020afe"

--- a/examples/k3s.yaml
+++ b/examples/k3s.yaml
@@ -15,7 +15,6 @@
 
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-# ⚠️ release-20220309 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
 - location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:73fe1785c60edeb506f191affff0440abcc2de02420bb70865d51d0ff9b28223"

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -16,7 +16,6 @@
 # Image is set to focal (20.04 LTS) for long-term stability
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-# ⚠️ release-20220308 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
 - location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:243157ea0390890d6e60ce5e08e0249b16e23b6b313b63aed50f39f92b020afe"

--- a/examples/nomad.yaml
+++ b/examples/nomad.yaml
@@ -12,7 +12,6 @@
 # Image is set to focal (20.04 LTS) for long-term stability
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-# ⚠️ release-20220308 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
 - location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:243157ea0390890d6e60ce5e08e0249b16e23b6b313b63aed50f39f92b020afe"

--- a/examples/podman.yaml
+++ b/examples/podman.yaml
@@ -13,7 +13,6 @@
 # This example requires Lima v0.8.0 or later
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-# ⚠️ release-20220309 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
 - location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:73fe1785c60edeb506f191affff0440abcc2de02420bb70865d51d0ff9b28223"

--- a/examples/ubuntu-lts.yaml
+++ b/examples/ubuntu-lts.yaml
@@ -3,7 +3,6 @@
 # This example requires Lima v0.7.0 or later.
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-# ⚠️ release-20220308 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
 - location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:243157ea0390890d6e60ce5e08e0249b16e23b6b313b63aed50f39f92b020afe"

--- a/examples/ubuntu.yaml
+++ b/examples/ubuntu.yaml
@@ -1,7 +1,6 @@
 # This example requires Lima v0.7.0 or later.
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-# ⚠️ release-20220309 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
 - location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:73fe1785c60edeb506f191affff0440abcc2de02420bb70865d51d0ff9b28223"

--- a/examples/vmnet.yaml
+++ b/examples/vmnet.yaml
@@ -2,7 +2,6 @@
 # This example requires Lima v0.7.0 or later.
 # Older versions of Lima were using a different syntax for supporting vmnet.framework.
 images:
-# ⚠️ release-20220309 is known to be broken on aarch64: https://github.com/lima-vm/lima/issues/712
 - location: "https://cloud-images.ubuntu.com/releases/21.10/release-20220201/ubuntu-21.10-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:73fe1785c60edeb506f191affff0440abcc2de02420bb70865d51d0ff9b28223"


### PR DESCRIPTION
Homebrew's QEMU 6.2.0_1 contains the following commits to run recent Linux guests:

- qemu/qemu@ad99f64f `hvf: arm: Use macros for sysreg shift/masking`
- qemu/qemu@7f6c295c `hvf: arm: Handle unknown ID registers as RES0`

These commits are planned to be included in the upstream QEMU 7.0.0 (ETA: April 2022).

See Homebrew/homebrew-core#96743 for the further information.
