### PR TITLE
Add possibility to customize accel parameter in qemu

### DIFF
--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -66,7 +66,8 @@ type SSH struct {
 type Firmware struct {
 	// LegacyBIOS disables UEFI if set.
 	// LegacyBIOS is ignored for aarch64.
-	LegacyBIOS *bool `yaml:"legacyBIOS,omitempty" json:"legacyBIOS,omitempty"`
+	LegacyBIOS *bool   `yaml:"legacyBIOS,omitempty" json:"legacyBIOS,omitempty"`
+	Accel      *string `yaml:"accel,omitempty" json:"accel,omitempty"`
 }
 
 type Video struct {

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -255,7 +255,7 @@ func Cmdline(cfg Config) (string, []string, error) {
 	}
 
 	// Architecture
-	accel := getAccel(*y.Arch)
+	accel := getAccel(*y.Arch, y.Firmware.Accel)
 	if !strings.Contains(string(features.AccelHelp), accel) {
 		return "", nil, fmt.Errorf("accelerator %q is not supported by %s", accel, exe)
 	}
@@ -451,7 +451,10 @@ func getExe(arch limayaml.Arch) (string, []string, error) {
 	return exe, args, nil
 }
 
-func getAccel(arch limayaml.Arch) string {
+func getAccel(arch limayaml.Arch, accel *string) string {
+	if accel != nil {
+		return *accel
+	}
 	if limayaml.IsNativeArch(arch) {
 		switch runtime.GOOS {
 		case "darwin":


### PR DESCRIPTION
Some distros, like Rocky/Alma and any RHEL-like version 8, don't support Apple M1 `host` CPU with `hvf` enabled, giving the error:
```
EFI stub: ERROR: This 64 KB granular kernel is not supported by your CPU

  Failed to boot both default and fallback entries
```

I think the problem is the kernel was built with default pagesize equals to 64K and Apple M1 has a cpu pagesize of 16K. So the solution is to get the original qcow2 and recompile the kernel using, for example, a 4K pagesize.

Instead of doing this I'm proposing to allow change the default (hard-coded) `hvf` accelerator and allow to pass other thing, like `tcg`.

YAML:
```yaml
images:
- location: "http://repo.almalinux.org/almalinux/8.5/cloud/aarch64/images/AlmaLinux-8-GenericCloud-latest.aarch64.qcow2"
  arch: "aarch64"
  digest: "sha512:bf8c0afaa8aaced047977de73455f09d2867907efece91cbad16dbd3ab454328b432eadccc62cdfc6e529f5147e564c9d97405a2598efde6758151c6fda758d4"
mounts:
- location: "~"
- location: "/tmp/lima"
  writable: true
firmware:
  accel: tcg
cpuType:
  aarch64: "max"
```

This is slower than using `host` cpu type with `accel=hvf`, but at least you don't need to regenerate an image for your use, and it's faster than emulating x86_64 on M1.

PS: Don't know if under firmware is the best place to put this option.

# References:
https://gitlab.com/qemu-project/qemu/-/issues/444
https://forums.rockylinux.org/t/installation-of-rocky-not-proceeding-in-macbook-pro-m1-silicon-chip/4734/3