### PR TITLE
Arch Linux aarch64 image

### DIFF
--- a/examples/archlinux.yaml
+++ b/examples/archlinux.yaml
@@ -1,6 +1,8 @@
 # This example requires Lima v0.7.0 or later
-arch: "x86_64"
 images:
+- location: "https://github.com/mcginty/arch-boxes/releases/download/v20220323/Arch-Linux-aarch64-cloudimg-20220323.0.qcow2"
+  arch: "aarch64"
+  digest: "sha512:27524910bf41cb9b3223c8749c6e67fd2f2fdb8b70d40648708e64d6b03c0b4a01b3c5e72d51fefd3e0c3f58487dbb400a79ca378cde2da341a3a19873612be8"
 # NOTE: the image is periodically rotated, if you face 404, see https://mirror.pkgbuild.com/images/ to find the latest image.
 - location: "https://mirror.pkgbuild.com/images/v20220301.49177/Arch-Linux-x86_64-cloudimg-20220301.49177.qcow2"
   arch: "x86_64"


### PR DESCRIPTION
I've forked the official [`arch-boxes`](https://gitlab.archlinux.org/archlinux/arch-boxes/) project and modified it to create aarch64-friendly cloud-init images.

The full diff can be found here: https://github.com/mcginty/arch-boxes/compare/bc74609...v20220323

High-level changes:
* Use Arch Linux ARM repo and signing keys
* Add EFI support via `systemd-boot`
* Patch `cloud-init` package to build on Arch Linux ARM

I've tested this by running:

```
limactl start https://raw.githubusercontent.com/mcginty/lima/archlinux-aarch64/examples/archlinux.yaml
```

and the system spins up as expected, `limactl shell` connecting normally.