### PR TITLE
generate qemu vm uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/elastic/go-libaudit/v2 v2.2.0
 	github.com/google/go-cmp v0.5.7
+	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/lima-vm/sshocker v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -528,6 +528,7 @@ github.com/google/subcommands v1.0.2-0.20190508160503-636abe8753b8/go.mod h1:Zjh
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -22,6 +22,8 @@ import (
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/mattn/go-shellwords"
 	"github.com/sirupsen/logrus"
+
+	"github.com/google/uuid"
 )
 
 type Config struct {
@@ -425,6 +427,7 @@ func Cmdline(cfg Config) (string, []string, error) {
 
 	// QEMU process
 	args = append(args, "-name", "lima-"+cfg.Name)
+	args = append(args, "-uuid", uuid.NewMD5(uuid.NameSpaceOID, []byte(cfg.Name)).String() )
 	args = append(args, "-pidfile", filepath.Join(cfg.InstanceDir, filenames.QemuPID))
 
 	return exe, args, nil


### PR DESCRIPTION
# Background

Some application may requires the `product_uuid` from sysfs, OR it will be broken, eg.

- https://github.com/nestybox/sysbox/issues/439
- https://bugs.launchpad.net/ubuntu/+source/qemu-kvm/+bug/959308

The patch will generate a UUID, based of the MD5 sum of the VM name, and append as qemu `--uuid` parameter.
It should be safe and no impact to others usecase.
