### PR TITLE
Add option to add a data disk to an instance

### DIFF
--- a/docs/internal.md
+++ b/docs/internal.md
@@ -35,6 +35,7 @@ cloud-init:
 disk:
 - `basedisk`: the base image
 - `diffdisk`: the diff image (QCOW2)
+- `datadisk`: the data image (QCOW2), optional
 
 QEMU:
 - `qemu.pid`: QEMU PID

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -39,6 +39,10 @@ memory: null
 # 🟢 Builtin default: "100GiB"
 disk: null
 
+# Data size
+# 🟢 Builtin default: "0"
+data: null
+
 # Expose host directories to the guest, the mount point might be accessible from all UIDs in the guest
 # 🟢 Builtin default: null (Mount nothing)
 # 🔵 This file: Mount the home as read-only, /tmp/lima as writable

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -139,6 +139,16 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.Disk = pointer.String("100GiB")
 	}
 
+	if y.Data == nil {
+		y.Data = d.Data
+	}
+	if o.Data != nil {
+		y.Data = o.Data
+	}
+	if y.Data == nil || *y.Data == "" {
+		y.Data = pointer.String("0")
+	}
+
 	if y.Video.Display == nil {
 		y.Video.Display = d.Video.Display
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -55,6 +55,7 @@ func TestFillDefault(t *testing.T) {
 		CPUs:   pointer.Int(4),
 		Memory: pointer.String("4GiB"),
 		Disk:   pointer.String("100GiB"),
+		Data:   pointer.String("0"),
 		Containerd: Containerd{
 			System:   pointer.Bool(false),
 			User:     pointer.Bool(true),
@@ -190,6 +191,7 @@ func TestFillDefault(t *testing.T) {
 		CPUs:   pointer.Int(7),
 		Memory: pointer.String("5GiB"),
 		Disk:   pointer.String("105GiB"),
+		Data:   pointer.String("10GiB"),
 		Containerd: Containerd{
 			System: pointer.Bool(true),
 			User:   pointer.Bool(false),
@@ -314,6 +316,7 @@ func TestFillDefault(t *testing.T) {
 		CPUs:   pointer.Int(12),
 		Memory: pointer.String("7GiB"),
 		Disk:   pointer.String("117GiB"),
+		Data:   pointer.String("17GiB"),
 		Containerd: Containerd{
 			System: pointer.Bool(true),
 			User:   pointer.Bool(false),

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -13,6 +13,7 @@ type LimaYAML struct {
 	CPUs              *int              `yaml:"cpus,omitempty" json:"cpus,omitempty"`
 	Memory            *string           `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
 	Disk              *string           `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes
+	Data              *string           `yaml:"data,omitempty" json:"data,omitempty"`     // go-units.RAMInBytes
 	Mounts            []Mount           `yaml:"mounts,omitempty" json:"mounts,omitempty"`
 	SSH               SSH               `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
 	Firmware          Firmware          `yaml:"firmware,omitempty" json:"firmware,omitempty"`

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -71,6 +71,12 @@ func Validate(y LimaYAML, warn bool) error {
 		return fmt.Errorf("field `memory` has an invalid value: %w", err)
 	}
 
+	if y.Data != nil {
+		if _, err := units.RAMInBytes(*y.Data); err != nil {
+			return fmt.Errorf("field `data` has an invalid value: %w", err)
+		}
+	}
+
 	u, err := osutil.LimaUser(false)
 	if err != nil {
 		return fmt.Errorf("internal error (not an error of YAML): %w", err)

--- a/pkg/store/filenames/filenames.go
+++ b/pkg/store/filenames/filenames.go
@@ -29,6 +29,7 @@ const (
 	CIDataISO          = "cidata.iso"
 	BaseDisk           = "basedisk"
 	DiffDisk           = "diffdisk"
+	DataDisk           = "datadisk"
 	QemuPID            = "qemu.pid"
 	QMPSock            = "qmp.sock"
 	SerialLog          = "serial.log"

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -37,6 +37,7 @@ type Instance struct {
 	CPUs         int                `json:"cpus,omitempty"`
 	Memory       int64              `json:"memory,omitempty"` // bytes
 	Disk         int64              `json:"disk,omitempty"`   // bytes
+	Data         int64              `json:"data,omitempty"`   // bytes
 	Message      string             `json:"message,omitempty"`
 	Networks     []limayaml.Network `json:"network,omitempty"`
 	SSHLocalPort int                `json:"sshLocalPort,omitempty"`
@@ -86,6 +87,10 @@ func Inspect(instName string) (*Instance, error) {
 	disk, err := units.RAMInBytes(*y.Disk)
 	if err == nil {
 		inst.Disk = disk
+	}
+	data, err := units.RAMInBytes(*y.Data)
+	if err == nil {
+		inst.Data = data
 	}
 	inst.Message = y.Message
 	inst.Networks = y.Networks


### PR DESCRIPTION
The data disk will show up after the root disk

Typically as /dev/vdb, when running with virtio

Closes #722

User needs to partition, format and mount the disk...

----

```yaml
# Disk size
# 🟢 Builtin default: "100GiB"
disk: null

# Data size
# 🟢 Builtin default: "0"
data: "10GiB"
```

```
Disk /dev/vda: 100 GiB, 107374182400 bytes, 209715200 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes

Disk /dev/vdb: 10 GiB, 10737418240 bytes, 20971520 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
```