### PR TITLE
login with default shell

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -108,7 +108,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	}
 	logrus.Debugf("changeDirCmd=%q", changeDirCmd)
 
-	script := fmt.Sprintf("%s ; exec bash --login", changeDirCmd)
+	script := fmt.Sprintf("%s ; exec $SHELL --login", changeDirCmd)
 	if len(args) > 1 {
 		script += fmt.Sprintf(
 			" -c %s",


### PR DESCRIPTION
<img width="458" alt="image" src="https://user-images.githubusercontent.com/3659110/161427464-27119938-67a1-4a8a-b631-d5141ffb15ce.png">

I am used to using the fish shell and I would like to be able to use the current user's default shell in lima vm as well.