### PR TITLE
regard linux default shell

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -108,7 +108,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	}
 	logrus.Debugf("changeDirCmd=%q", changeDirCmd)
 
-	script := fmt.Sprintf("%s ; exec bash --login", changeDirCmd)
+	script := fmt.Sprintf("%s ; exec $SHELL --login", changeDirCmd)
 	if len(args) > 1 {
 		script += fmt.Sprintf(
 			" -c %s",


### PR DESCRIPTION
This PR let lima uses the default shell set in Linux.

By using

```bash
chsh -s $(which zsh) $USER
```

The user can set default shell to zsh, and with this PR, lima will regard this setting and use the default shell by reading `/etc/passwd`.