### PR TITLE
Add --shell option to limactl shell

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -36,6 +36,7 @@ func newShellCommand() *cobra.Command {
 
 	shellCmd.Flags().SetInterspersed(false)
 
+	shellCmd.Flags().String("shell", "", "shell interpreter, e.g. /bin/bash")
 	shellCmd.Flags().String("workdir", "", "working directory")
 	return shellCmd
 }
@@ -108,7 +109,16 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	}
 	logrus.Debugf("changeDirCmd=%q", changeDirCmd)
 
-	script := fmt.Sprintf("%s ; exec $SHELL --login", changeDirCmd)
+	shell, err := cmd.Flags().GetString("shell")
+	if err != nil {
+		return err
+	}
+	if shell == "" {
+		shell = `"$SHELL"`
+	} else {
+		shell = shellescape.Quote(shell)
+	}
+	script := fmt.Sprintf("%s ; exec %s --login", changeDirCmd, shell)
 	if len(args) > 1 {
 		script += fmt.Sprintf(
 			" -c %s",

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -84,19 +84,19 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if workDir != "" {
-		changeDirCmd = fmt.Sprintf("cd %q || exit 1", workDir)
+		changeDirCmd = fmt.Sprintf("cd %s || exit 1", shellescape.Quote(workDir))
 		// FIXME: check whether y.Mounts contains the home, not just len > 0
 	} else if len(y.Mounts) > 0 {
 		hostCurrentDir, err := os.Getwd()
 		if err == nil {
-			changeDirCmd = fmt.Sprintf("cd %q", hostCurrentDir)
+			changeDirCmd = fmt.Sprintf("cd %s", shellescape.Quote(hostCurrentDir))
 		} else {
 			changeDirCmd = "false"
 			logrus.WithError(err).Warn("failed to get the current directory")
 		}
 		hostHomeDir, err := os.UserHomeDir()
 		if err == nil {
-			changeDirCmd = fmt.Sprintf("%s || cd %q", changeDirCmd, hostHomeDir)
+			changeDirCmd = fmt.Sprintf("%s || cd %s", changeDirCmd, shellescape.Quote(hostHomeDir))
 		} else {
 			logrus.WithError(err).Warn("failed to get the home directory")
 		}


### PR DESCRIPTION
This allows to use a predictable shell for scripting, and also provides a way to recover an instance when the user shell has
been misconfigured:

```console
$ limactl shell --shell /bin/ash alpine uname -a
Linux lima-alpine 5.10.93-0-virt #1-Alpine SMP Thu, 27 Jan 2022 09:34:38 +0000 x86_64 Linux
```

This is a followup to https://github.com/lima-vm/lima/pull/775#pullrequestreview-932678689

I'm not happy about the repetition of the word "shell" in `limactl shell --shell /bin/sh ...`, but it still seems like the most appropriate name for the option.

<hr>

This part has been split off into #780

Also adds `LIMA_SHELL` support to the `lima` command:

```console
$ export LIMA_INSTANCE=alpine
$ lima sudo apk add fish
[...]
$ export LIMA_SHELL=/usr/bin/fish
$ lima
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
jan@lima-alpine /U/jan>
```