### PR TITLE
9p: use `fscache` by default for RO mounts

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -72,7 +72,9 @@ mounts:
     # 🟢 Builtin default: "128KiB"
     msize: null
     # Specifies a caching policy. Valid options are: "none", "loose", "fscache" and "mmap".
-    # 🟢 Builtin default: "mmap"
+    # Try choosing "mmap" or "none" if you see a stability issue with the default "fscache".
+    # See https://www.kernel.org/doc/Documentation/filesystems/9p.txt
+    # 🟢 Builtin default: "fscache" for non-writable mounts, "mmap" for writable mounts
     cache: null
 - location: "/tmp/lima"
   # 🟢 Builtin default: false

--- a/examples/experimental/9p.yaml
+++ b/examples/experimental/9p.yaml
@@ -18,6 +18,12 @@ images:
 
 mounts:
 - location: "~"
+  9p:
+    # Try choosing "mmap" or "none" if you see a stability issue with the default "fscache".
+    cache: "fscache"
 - location: "/tmp/lima"
   writable: true
+  9p:
+    cache: "mmap"
+
 mountType: "9p"

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -25,7 +25,8 @@ const (
 	Default9pSecurityModel   string = "mapped-xattr"
 	Default9pProtocolVersion string = "9p2000.L"
 	Default9pMsize           string = "128KiB"
-	Default9pCache           string = "mmap"
+	Default9pCacheForRO      string = "fscache"
+	Default9pCacheForRW      string = "mmap"
 )
 
 func defaultContainerdArchives() []File {
@@ -413,11 +414,15 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		if mount.NineP.Msize == nil {
 			mounts[i].NineP.Msize = pointer.String(Default9pMsize)
 		}
-		if mount.NineP.Cache == nil {
-			mounts[i].NineP.Cache = pointer.String(Default9pCache)
-		}
 		if mount.Writable == nil {
 			mount.Writable = pointer.Bool(false)
+		}
+		if mount.NineP.Cache == nil {
+			if *mount.Writable {
+				mounts[i].NineP.Cache = pointer.String(Default9pCacheForRW)
+			} else {
+				mounts[i].NineP.Cache = pointer.String(Default9pCacheForRO)
+			}
 		}
 	}
 

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -140,7 +140,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Mounts[0].NineP.SecurityModel = pointer.String(Default9pSecurityModel)
 	expect.Mounts[0].NineP.ProtocolVersion = pointer.String(Default9pProtocolVersion)
 	expect.Mounts[0].NineP.Msize = pointer.String(Default9pMsize)
-	expect.Mounts[0].NineP.Cache = pointer.String(Default9pCache)
+	expect.Mounts[0].NineP.Cache = pointer.String(Default9pCacheForRO)
 	// Only missing Mounts field is Writable, and the default value is also the null value: false
 
 	expect.MountType = pointer.String(NINEP)
@@ -277,7 +277,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Mounts[0].NineP.SecurityModel = pointer.String(Default9pSecurityModel)
 	expect.Mounts[0].NineP.ProtocolVersion = pointer.String(Default9pProtocolVersion)
 	expect.Mounts[0].NineP.Msize = pointer.String(Default9pMsize)
-	expect.Mounts[0].NineP.Cache = pointer.String(Default9pCache)
+	expect.Mounts[0].NineP.Cache = pointer.String(Default9pCacheForRO)
 	expect.HostResolver.Hosts = map[string]string{
 		"default.": d.HostResolver.Hosts["default"],
 	}


### PR DESCRIPTION
Fix #786
