### PR TITLE
limactl: build in experimental/deprecated templates

### DIFF
--- a/cmd/limactl/info.go
+++ b/cmd/limactl/info.go
@@ -21,8 +21,10 @@ func newInfoCommand() *cobra.Command {
 }
 
 type TemplateYAML struct {
-	Name     string `json:"name"`
-	Location string `json:"location"`
+	Name         string `json:"name"`
+	Location     string `json:"location"`
+	Experimental bool   `json:"experimental,omitempty"`
+	Deprecated   bool   `json:"deprecated,omitempty"`
 }
 
 type Info struct {


### PR DESCRIPTION
The template name does not contain '/'.
e.g., `limactl start template://9p`, not `limactl start template://experimental/9p`.

Fix #785
