### PR TITLE
CI: fix 'fatal: unsafe repository ('/Users/runner/work/lima/lima/vde_vmnet' is owned by someone else)'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,9 +88,11 @@ jobs:
       run: |
         (
           brew install autoconf automake
+          cd ~
           git clone https://github.com/lima-vm/vde_vmnet
           cd vde_vmnet
           git checkout $VDE_VMNET_VERSION
+          sudo git config --global --add safe.directory /Users/runner/vde_vmnet
           sudo make PREFIX=/opt/vde install
         )
         (


### PR DESCRIPTION
CI was failing due to the recent breaking change of git: https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9

> Cloning into 'vde_vmnet'...
> HEAD is now at a4b489e Merge pull request #40 from AkihiroSuda/dev
> git submodule update --init
> fatal: unsafe repository ('/Users/runner/work/lima/lima/vde_vmnet' is owned by someone else)
> To add an exception for this directory, call:
>
> 	git config --global --add safe.directory /Users/runner/work/lima/lima/vde_vmnet
> make: *** [install.vde-2] Error 128
