### PR TITLE
Fix the cri-socket in the k8s example

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -78,9 +78,9 @@ provision:
     test -e /etc/kubernetes/admin.conf && exit 0
     export KUBECONFIG=/etc/kubernetes/admin.conf
     kubeadm config images list
-    kubeadm config images pull
+    kubeadm config images pull --cri-socket=unix:///run/containerd/containerd.sock
     # Initializing your control-plane node
-    kubeadm init --cri-socket=/run/containerd/containerd.sock --pod-network-cidr=10.244.0.0/16 --apiserver-cert-extra-sans 127.0.0.1
+    kubeadm init --cri-socket=unix:///run/containerd/containerd.sock --pod-network-cidr=10.244.0.0/16 --apiserver-cert-extra-sans 127.0.0.1
     # Installing a Pod network add-on
     kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/v0.14.0/Documentation/kube-flannel.yml
     # Control plane node isolation


### PR DESCRIPTION
Make sure to pass an explicit cri socket for containerd.

Make sure to add the unix:// schema to the socket path.

Issue #792

By explicitly choosing containerd, it shouldn't try docker.