### PR TITLE
Set the kubelet cgroup driver to systemd (v2)

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -110,6 +110,10 @@ provision:
       - "127.0.0.1"
     networking:
       podSubnet: "10.244.0.0/16" # --pod-network-cidr
+    ---
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
     EOF
     kubeadm init --config kubeadm-config.yaml
     # Installing a Pod network add-on

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -75,6 +75,23 @@ provision:
   script: |
     #!/bin/bash
     set -eux -o pipefail
+    grep SystemdCgroup /etc/containerd/config.toml && exit 0
+    # Configuring a cgroup driver
+    cat <<EOF >>/etc/containerd/config.toml
+      [plugins]
+        [plugins."io.containerd.grpc.v1.cri"]
+          [plugins."io.containerd.grpc.v1.cri".containerd]
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+                runtime_type = "io.containerd.runc.v2"
+                [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+                  SystemdCgroup = true
+    EOF
+    systemctl restart containerd
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
     test -e /etc/kubernetes/admin.conf && exit 0
     export KUBECONFIG=/etc/kubernetes/admin.conf
     kubeadm config images list

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -76,6 +76,7 @@ provision:
     #!/bin/bash
     set -eux -o pipefail
     grep SystemdCgroup /etc/containerd/config.toml && exit 0
+    grep "version = 2" /etc/containerd/config.toml || exit 1
     # Configuring a cgroup driver
     cat <<EOF >>/etc/containerd/config.toml
       [plugins]

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -97,7 +97,21 @@ provision:
     kubeadm config images list
     kubeadm config images pull --cri-socket=unix:///run/containerd/containerd.sock
     # Initializing your control-plane node
-    kubeadm init --cri-socket=unix:///run/containerd/containerd.sock --pod-network-cidr=10.244.0.0/16 --apiserver-cert-extra-sans 127.0.0.1
+    cat <<EOF >kubeadm-config.yaml
+    kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    nodeRegistration:
+      criSocket: unix:///run/containerd/containerd.sock
+    ---
+    kind: ClusterConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    apiServer:
+      certSANs: # --apiserver-cert-extra-sans
+      - "127.0.0.1"
+    networking:
+      podSubnet: "10.244.0.0/16" # --pod-network-cidr
+    EOF
+    kubeadm init --config kubeadm-config.yaml
     # Installing a Pod network add-on
     kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/v0.14.0/Documentation/kube-flannel.yml
     # Control plane node isolation


### PR DESCRIPTION
See https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/

```
NAME       STATUS   ROLES                  AGE     VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE           KERNEL-VERSION      CONTAINER-RUNTIME
lima-k8s   Ready    control-plane,master   2m32s   v1.23.6   192.168.5.15   <none>        Ubuntu 22.04 LTS   5.15.0-25-generic   containerd://1.6.2
```

Closes #817