### PR TITLE
Enable reverse forwarding of portForwards

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -266,8 +266,10 @@ networks:
 #
 # - guestSocket: "/run/user/{{.UID}}/my.sock"
 #   hostSocket: mysocket
+# # default: reverse: false
 # # "guestSocket" can include these template variables: {{.Home}}, {{.UID}}, and {{.User}}.
 # # "hostSocket" can include {{.Home}}, {{.Dir}}, {{.Name}}, {{.UID}}, and {{.User}}.
+# # "reverse" can only be used for unix sockets right now, not for tcp sockets.
 # # Put sockets into "{{.Dir}}/sock" to avoid collision with Lima internal sockets!
 # # Sockets can also be forwarded to ports and vice versa, but not to/from a range of ports.
 # # Forwarding requires the lima user to have rw access to the "guestsocket",

--- a/pkg/hostagent/port_others.go
+++ b/pkg/hostagent/port_others.go
@@ -10,5 +10,5 @@ import (
 )
 
 func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote string, verb string) error {
-	return forwardSSH(ctx, sshConfig, port, local, remote, verb)
+	return forwardSSH(ctx, sshConfig, port, local, remote, verb, false)
 }

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -88,6 +88,7 @@ func TestFillDefault(t *testing.T) {
 		HostIP:         api.IPv4loopback1,
 		HostPortRange:  [2]int{1, 65535},
 		Proto:          TCP,
+		Reverse:        false,
 	}
 
 	// ------------------------------------------------------------------------------------

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -144,6 +144,7 @@ type PortForward struct {
 	HostPortRange     [2]int `yaml:"hostPortRange,omitempty" json:"hostPortRange,omitempty"`
 	HostSocket        string `yaml:"hostSocket,omitempty" json:"hostSocket,omitempty"`
 	Proto             Proto  `yaml:"proto,omitempty" json:"proto,omitempty"`
+	Reverse           bool   `yaml:"reverse,omitempty" json:"reverse,omitempty"`
 	Ignore            bool   `yaml:"ignore,omitempty" json:"ignore,omitempty"`
 }
 

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -212,6 +212,12 @@ func Validate(y LimaYAML, warn bool) error {
 		if rule.Proto != TCP {
 			return fmt.Errorf("field `%s.proto` must be %q", field, TCP)
 		}
+		if rule.Reverse && rule.GuestSocket == "" {
+			return fmt.Errorf("field `%s.reverse` must be %t", field, false)
+		}
+		if rule.Reverse && rule.HostSocket == "" {
+			return fmt.Errorf("field `%s.reverse` must be %t", field, false)
+		}
 		// Not validating that the various GuestPortRanges and HostPortRanges are not overlapping. Rules will be
 		// processed sequentially and the first matching rule for a guest port determines forwarding behavior.
 	}


### PR DESCRIPTION
By default, the portForwards will be forwarded
from local (host) to remote (guest). Flag: `-L`

With reverse, the portForwards will be forwarded
from remote (guest) to local (host). Flag: `-R`

Only implemented for unix sockets at the moment.

I kept the confusing wording, of the logging entries.

Issue #834

Tested by forwarding a memcached socket from the host.

`memcached -s mc.sock`

```yaml
portForwards:
 - guestSocket: "/tmp/mc.sock"
   hostSocket: "{{.Home}}/mc.sock"
   reverse: true
```

`lima sudo apt install -y libmemcached-tools`
`lima MEMCACHED_SERVERS=/tmp/mc.sock memcping`

----

ssh says:

`-L local_socket:remote_socket`
Specifies that connections to the given TCP port or Unix socket on the local (client) host are to be forwarded to the given host and port, or Unix socket, on the remote side.
i.e. from host, to guest
`-R remote_socket:local_socket`
Specifies that connections to the given TCP port or Unix socket on the remote (server) host are to be forwarded to the local side.
i.e. from guest, to host

lima says:

reverse: false
`logrus.Infof("Forwarding %q (guest) to %q (host)", remote, local)`
reverse: true
`logrus.Infof("Forwarding %q (host) to %q (guest)", local, remote)`

