### PR TITLE
Use the new format of message for easy copy/paste

### DIFF
--- a/examples/k3s.yaml
+++ b/examples/k3s.yaml
@@ -55,8 +55,10 @@ probes:
     Run "limactl shell k3s sudo journalctl -u k3s" to check the log.
     If that is still empty, check the bottom of the log at "/var/log/cloud-init-output.log".
 message: |
-  To run `kubectl` on the host (assumes kubectl is installed):
-  $ mkdir -p "{{.Dir}}/conf"
-  $ export KUBECONFIG="{{.Dir}}/conf/kubeconfig.yaml"
-  $ limactl shell {{.Name}} sudo cat /etc/rancher/k3s/k3s.yaml >$KUBECONFIG
-  $ kubectl ...
+  To run `kubectl` on the host (assumes kubectl is installed), run the following commands:
+  ------
+  mkdir -p "{{.Dir}}/conf"
+  export KUBECONFIG="{{.Dir}}/conf/kubeconfig.yaml"
+  limactl shell {{.Name}} sudo cat /etc/rancher/k3s/k3s.yaml >$KUBECONFIG
+  kubectl ...
+  ------

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -151,8 +151,10 @@ probes:
       exit 1
     fi
 message: |
-  To run `kubectl` on the host (assumes kubectl is installed):
-  $ mkdir -p "{{.Dir}}/conf"
-  $ export KUBECONFIG="{{.Dir}}/conf/kubeconfig.yaml"
-  $ limactl shell {{.Name}} sudo cat /etc/kubernetes/admin.conf >$KUBECONFIG
-  $ kubectl ...
+  To run `kubectl` on the host (assumes kubectl is installed), run the following commands:
+  ------
+  mkdir -p "{{.Dir}}/conf"
+  export KUBECONFIG="{{.Dir}}/conf/kubeconfig.yaml"
+  limactl shell {{.Name}} sudo cat /etc/kubernetes/admin.conf >$KUBECONFIG
+  kubectl ...
+  ------


### PR DESCRIPTION
Easier to select multiple lines, without the "$ " prompt.

Separate the commands by dashes instead, like in docker.

----

Improves the output of PR #838 

```
default
  <no message>
docker
  To run `docker` on the host (assumes docker-cli is installed), run the following commands:
  ------
  docker context create lima --docker "host=unix:///home/anders/.lima/docker/sock/docker.sock"
  docker context use lima
  docker run hello-world
  ------
k8s
  To run `kubectl` on the host (assumes kubectl is installed), run the following commands:
  ------
  mkdir -p "/home/anders/.lima/k8s/conf"
  export KUBECONFIG="/home/anders/.lima/k8s/conf/kubeconfig.yaml"
  limactl shell k8s sudo cat /etc/kubernetes/admin.conf >$KUBECONFIG
  kubectl ...
  ------
```