### PR TITLE
Make sure inst.Dir is set when store.Inspect returns no error

### DIFF
--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -65,6 +65,8 @@ func Inspect(instName string) (*Instance, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Make sure inst.Dir is set, even when YAML validation fails
+	inst.Dir = instDir
 	yamlPath := filepath.Join(instDir, filenames.LimaYAML)
 	y, err := LoadYAMLByFilePath(yamlPath)
 	if err != nil {
@@ -74,7 +76,6 @@ func Inspect(instName string) (*Instance, error) {
 		inst.Errors = append(inst.Errors, err)
 		return inst, nil
 	}
-	inst.Dir = instDir
 	inst.Arch = *y.Arch
 	inst.CPUType = y.CPUType[*y.Arch]
 


### PR DESCRIPTION
This is necessary to be able to delete instances that fail YAML validation (e.g. because they have been created using a different branch).

I ran into this when I created a `riscv64` instance with the PR branch and tried to delete it with the `master` branch version:

```console
$ l --debug delete -f riscv64
DEBU[0000] Mixing "/Users/jan/.lima/_config/default.yaml" into "/Users/jan/.lima/riscv64/lima.yaml"
DEBU[0000] Mixing "/Users/jan/.lima/_config/override.yaml" into "/Users/jan/.lima/riscv64/lima.yaml"
INFO[0000] The QEMU process seems already stopped
INFO[0000] The host agent process seems already stopped
INFO[0000] Removing *.pid *.sock under ""
ERRO[0000] open : no such file or directory
INFO[0000] Deleted "riscv64" ("")
DEBU[0000] Mixing "/Users/jan/.lima/_config/default.yaml" into "/Users/jan/.lima/9p/lima.yaml"
DEBU[0000] Mixing "/Users/jan/.lima/_config/override.yaml" into "/Users/jan/.lima/9p/lima.yaml"
DEBU[0000] Mixing "/Users/jan/.lima/_config/default.yaml" into "/Users/jan/.lima/default/lima.yaml"
DEBU[0000] Mixing "/Users/jan/.lima/_config/override.yaml" into "/Users/jan/.lima/default/lima.yaml"
DEBU[0000] Mixing "/Users/jan/.lima/_config/default.yaml" into "/Users/jan/.lima/riscv64/lima.yaml"
DEBU[0000] Mixing "/Users/jan/.lima/_config/override.yaml" into "/Users/jan/.lima/riscv64/lima.yaml"
DEBU[0000] Make sure "shared" network is stopped
DEBU[0000] Make sure "bridged" network is stopped
DEBU[0000] Make sure "host" network is stopped
```

Thankfully we catch that `""` is not a valid directory and don't proceed to delete all files in the current dir...