### PR TITLE
vmnet: Support socket_vmnet; deprecate vde_vmnet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,22 +105,6 @@ jobs:
         time brew update
         time brew install qemu bash coreutils curl jq
         time brew upgrade
-    - name: Install vde_switch and vde_vmnet
-      env:
-        VDE_VMNET_VERSION: v0.6.0
-      run: |
-        (
-          brew install autoconf automake
-          cd ~
-          git clone https://github.com/lima-vm/vde_vmnet
-          cd vde_vmnet
-          git checkout $VDE_VMNET_VERSION
-          sudo git config --global --add safe.directory /Users/runner/vde_vmnet
-          sudo make PREFIX=/opt/vde install
-        )
-        (
-          limactl sudoers | sudo tee /etc/sudoers.d/lima
-        )
     - name: Cache ~/Library/Caches/lima/download
       uses: actions/cache@v3
       with:
@@ -147,15 +131,78 @@ jobs:
         retry_on: error
         max_attempts: 3
         command: ./hack/test-example.sh examples/experimental/9p.yaml
-    - name: "Test vmnet.yaml"
+    # GHA macOS is slow and flaky, so we only test a few YAMLS here.
+    # Other yamls are tested on Linux instances of Cirrus.
+
+  vmnet:
+    name: "VMNet test"
+    runs-on: macos-11
+    timeout-minutes: 120
+    steps:
+    - uses: actions/setup-go@v3
+      with:
+        go-version: 1.19.x
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+    - name: Make
+      run: make
+    - name: Install
+      run: make install
+    - name: Install test dependencies
+      run: brew install qemu bash coreutils iperf3
+    - name: Cache ~/Library/Caches/lima/download
+      uses: actions/cache@v3
+      with:
+        path: ~/Library/Caches/lima/download
+        key: ${{ runner.os }}-vmnet
+    - name: Install vde_switch and vde_vmnet (Deprecated)
+      env:
+        VDE_VMNET_VERSION: v0.6.0
+      run: |
+        (
+          brew install autoconf automake
+          cd ~
+          git clone https://github.com/lima-vm/vde_vmnet
+          cd vde_vmnet
+          git checkout $VDE_VMNET_VERSION
+          sudo git config --global --add safe.directory /Users/runner/vde_vmnet
+          sudo make PREFIX=/opt/vde install
+        )
+        limactl sudoers | sudo tee /etc/sudoers.d/lima
+    - name: Unit test (pkg/networks) with vde_vmnet (Deprecated)
+      # Set -count=1 to disable cache
+      run: go test -v -count=1 ./pkg/networks/...
+    - name: Test vde_vmnet (Deprecated)
       uses: nick-invision/retry@v2
       with:
         timeout_minutes: 30
         retry_on: error
         max_attempts: 3
         command: ./hack/test-example.sh examples/vmnet.yaml
-    # GHA macOS is slow and flaky, so we only test a few YAMLS here.
-    # Other yamls are tested on Linux instances of Cirrus.
+    - name: Install socket_vmnet
+      env:
+        SOCKET_VMNET_VERSION: v1.0.0-alpha.0
+      run: |
+        (
+          cd ~
+          git clone https://github.com/lima-vm/socket_vmnet
+          cd socket_vmnet
+          git checkout $SOCKET_VMNET_VERSION
+          sudo git config --global --add safe.directory /Users/runner/socket_vmnet
+          sudo make PREFIX=/opt/socket_vmnet install
+        )
+        limactl sudoers | sudo tee /etc/sudoers.d/lima
+    - name: Unit test (pkg/networks) with socket_vmnet
+      # Set -count=1 to disable cache
+      run: go test -v -count=1 ./pkg/networks/...
+    - name: Test socket_vmnet
+      uses: nick-invision/retry@v2
+      with:
+        timeout_minutes: 30
+        retry_on: error
+        max_attempts: 3
+        command: ./hack/test-example.sh examples/vmnet.yaml
 
   upgrade:
     name: "Upgrade test"

--- a/README.md
+++ b/README.md
@@ -435,7 +435,8 @@ The `copy` command only works for instances that have been created by lima 0.5.0
 
 The default guest IP 192.168.5.15 is not accessible from the host and other guests.
 
-To add another IP address that is accessible from the host and other virtual machines, enable [`vde_vmnet`](https://github.com/lima-vm/vde_vmnet).
+To add another IP address that is accessible from the host and other virtual machines, enable [`socket_vmnet`](https://github.com/lima-vm/socket_vmnet) (since Lima v0.12)
+or [`vde_vmnet`](https://github.com/lima-vm/vde_vmnet) (Deprecated).
 
 See [`./docs/network.md`](./docs/network.md).
 

--- a/docs/network.md
+++ b/docs/network.md
@@ -10,7 +10,7 @@ The guest IP address is set to `192.168.5.15`.
 
 This IP address is not accessible from the host by design.
 
-Use [vde_vmnet](https://github.com/lima-vm/vde_vmnet) to allow accessing the guest IP from the host and other guests.
+Use VMNet (see below) to allow accessing the guest IP from the host and other guests.
 
 ### Host IP (192.168.5.2)
 
@@ -42,50 +42,32 @@ During initial cloud-init bootstrap, `iptables` may not yet be installed. In tha
 
 If `useHostResolver` is false, then DNS servers can be configured manually in `lima.yaml` via the `dns` setting. If that list is empty, then Lima will either use the slirp DNS (on Linux), or the nameservers from the first host interface in service order that has an assigned IPv4 address (on macOS).
 
-## `vde_vmnet` (192.168.105.0/24)
+## Managed VMNet networks (192.168.105.0/24)
 
-[`vde_vmnet`](https://github.com/lima-vm/vde_vmnet) is required for adding another guest IP that is accessible from
-the host and other guests.
-
-To enable `vde_vmnet` (in addition the user-mode network), add the following lines to the YAML after installing `vde_vmnet`.
-
-```yaml
-networks:
-  # vnl (virtual network locator) points to the vde_switch socket directory,
-  # optionally with vde:// prefix
-  # - vnl: "vde:///var/run/vde.ctl"
-  #   # VDE Switch port number (not TCP/UDP port number). Set to 65535 for PTP mode.
-  #   # Default: 0
-  #   switchPort: 0
-  #   # MAC address of the instance; lima will pick one based on the instance name,
-  #   # so DHCP assigned ip addresses should remain constant over instance restarts.
-  #   macAddress: ""
-  #   # Interface name, defaults to "lima0", "lima1", etc.
-  #   interface: ""
-```
-
-The IP address range is typically `192.168.105.0/24`, but depends on the configuration of `vde_vmnet`.
-See [the documentation of `vde_vmnet`](https://github.com/lima-vm/vde_vmnet) for further information.
-
-## Managed VMNet networks (via vde_vmnet)
+Either [`socket_vmnet`](https://github.com/lima-vm/socket_vmnet) (since Lima v0.12) or [`vde_vmnet`](https://github.com/lima-vm/vde_vmnet) (Deprecated)
+is required for adding another guest IP that is accessible from the host and other guests.
 
 Starting with version v0.7.0 lima can manage the networking daemons automatically. Networks are defined in
 `$LIMA_HOME/_config/networks.yaml`. If this file doesn't already exist, it will be created with these default
 settings:
 
 ```yaml
-# Paths to vde executables. Because vde_vmnet is invoked via sudo it should be
+# Path to socket_vmnet executable. Because socket_vmnet is invoked via sudo it should be
 # installed where only root can modify/replace it. This means also none of the
 # parent directories should be writable by the user.
 #
 # The varRun directory also must not be writable by the user because it will
-# include the vde_vmnet pid files. Those will be terminated via sudo, so replacing
-# the pid files would allow killing of arbitrary privileged processes. varRun
+# include the socket_vmnet pid file. Those will be terminated via sudo, so replacing
+# the pid file would allow killing of arbitrary privileged processes. varRun
 # however MUST be writable by the daemon user.
 #
 # None of the paths segments may be symlinks, why it has to be /private/var
 # instead of /var etc.
 paths:
+# socketVMNet requires Lima >= 0.12 .
+# socketVMNet has precedence over vdeVMNet.
+  socketVMNet: /opt/socket_vmnet/bin/socket_vmnet
+# vdeSwitch and vdeVMNet are DEPRECATED.
   vdeSwitch: /opt/vde/bin/vde_switch
   vdeVMNet: /opt/vde/bin/vde_vmnet
   varRun: /private/var/run/lima
@@ -115,8 +97,9 @@ Instances can then reference these networks from their `lima.yaml` file:
 ```yaml
 networks:
   # Lima can manage daemons for networks defined in $LIMA_HOME/_config/networks.yaml
-  # automatically. Both vde_switch and vde_vmnet binaries must be installed into
+  # automatically. The socket_vmnet must be installed into
   # secure locations only alterable by the "root" user.
+  # The same applies to vde_switch and vde_vmnet for the deprecated VDE mode.
   # - lima: shared
   #   # MAC address of the instance; lima will pick one based on the instance name,
   #   # so DHCP assigned ip addresses should remain constant over instance restarts.
@@ -129,10 +112,38 @@ The network daemons are started automatically when the first instance referencin
 and will stop automatically once the last instance has stopped. Daemon logs will be stored in the
 `$LIMA_HOME/_networks` directory.
 
-Since the commands to start and stop the `vde_vmnet` daemon requires root, the user either must
+Since the commands to start and stop the `socket_vmnet` daemon (or the `vde_vmnet` daemon) requires root, the user either must
 have password-less `sudo` enabled, or add the required commands to a `sudoers` file. This can
 be done via:
 
 ```shell
 limactl sudoers | sudo tee /etc/sudoers.d/lima
+```
+
+## Unmanaged VMNet networks
+For Lima >= 0.12:
+```yaml
+networks:
+  # Lima can also connect to "unmanaged" networks addressed by "socket". This
+  # means that the daemons will not be controlled by Lima, but must be started
+  # before the instance.  The interface type (host, shared, or bridged) is
+  # configured in socket_vmnet and not in lima.
+  # - socket: "/var/run/socket_vmnet"
+```
+
+For older Lima releases:
+```yaml
+networks:
+  # vnl (virtual network locator) points to the vde_switch socket directory,
+  # optionally with vde:// prefix
+  # ⚠️  vnl is deprecated, use socket.
+  # - vnl: "vde:///var/run/vde.ctl"
+  #   # VDE Switch port number (not TCP/UDP port number). Set to 65535 for PTP mode.
+  #   # Builtin default: 0
+  #   switchPort: 0
+  #   # MAC address of the instance; lima will pick one based on the instance name,
+  #   # so DHCP assigned ip addresses should remain constant over instance restarts.
+  #   macAddress: ""
+  #   # Interface name, defaults to "lima0", "lima1", etc.
+  #   interface: ""
 ```

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -217,12 +217,13 @@ video:
   display: null
 
 # The instance can get routable IP addresses from the vmnet framework using
-# https://github.com/lima-vm/vde_vmnet.
+# https://github.com/lima-vm/socket_vmnet.
 # 🟢 Builtin default: null
 networks:
 # Lima can manage daemons for networks defined in $LIMA_HOME/_config/networks.yaml
-# automatically. Both vde_switch and vde_vmnet binaries must be installed into
+# automatically. The socket_vmnet binary must be installed into
 # secure locations only alterable by the "root" user.
+# The same applies to vde_switch and vde_vmnet for the deprecated VDE mode.
 # - lima: shared
 #   # MAC address of the instance; lima will pick one based on the instance name,
 #   # so DHCP assigned ip addresses should remain constant over instance restarts.
@@ -230,12 +231,15 @@ networks:
 #   # Interface name, defaults to "lima0", "lima1", etc.
 #   interface: ""
 #
-# Lima can also connect to "unmanaged" vde networks addressed by "vnl". This
+# Lima can also connect to "unmanaged" networks addressed by "socket". This
 # means that the daemons will not be controlled by Lima, but must be started
 # before the instance.  The interface type (host, shared, or bridged) is
-# configured in vde_vmnet and not in lima.
+# configured in socket_vmnet and not in lima.
+# - socket: "/var/run/socket_vmnet"
+
 # vnl (virtual network locator) points to the vde_switch socket directory,
 # optionally with vde:// prefix
+# ⚠️  vnl is deprecated, use socket.
 # - vnl: "vde:///var/run/vde.ctl"
 #   # VDE Switch port number (not TCP/UDP port number). Set to 65535 for PTP mode.
 #   # Builtin default: 0

--- a/examples/vmnet.yaml
+++ b/examples/vmnet.yaml
@@ -21,7 +21,14 @@ mounts:
   writable: true
 networks:
 # The instance can get routable IP addresses from the vmnet framework using
-# https://github.com/lima-vm/vde_vmnet. Available networks are defined in
+# https://github.com/lima-vm/socket_vmnet (since Lima v0.12) or
+# https://github.com/lima-vm/vde_vmnet (deprecated) .
+#
+# Available networks are defined in
 # $LIMA_HOME/_config/networks.yaml. Supported network types are "host",
 # "shared", or "bridged".
+#
+# Interface "lima0": shared mode  (IP is assigned by macOS's bootpd)
 - lima: shared
+# Interface "lima1": bridged mode (IP is assigned by a DHCP server on the physical network)
+# - lima: bridged

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -277,10 +277,10 @@ func TestFillDefault(t *testing.T) {
 		},
 		Networks: []Network{
 			{
-				VNL:        "/tmp/vde.ctl",
-				SwitchPort: 65535,
-				MACAddress: "11:22:33:44:55:66",
-				Interface:  "def0",
+				VNLDeprecated:        "/tmp/vde.ctl",
+				SwitchPortDeprecated: 65535,
+				MACAddress:           "11:22:33:44:55:66",
+				Interface:            "def0",
 			},
 		},
 		DNS: []net.IP{
@@ -492,8 +492,8 @@ func TestFillDefault(t *testing.T) {
 	// o.Networks[1] is overriding the d.Networks[0].Lima entry for the "def0" interface
 	expect.Networks = append(append(d.Networks, y.Networks...), o.Networks[0])
 	expect.Networks[0].Lima = o.Networks[1].Lima
-	expect.Networks[0].VNL = ""
-	expect.Networks[0].SwitchPort = 0
+	expect.Networks[0].VNLDeprecated = ""
+	expect.Networks[0].SwitchPortDeprecated = 0
 
 	// Only highest prio DNS are retained
 	expect.DNS = o.DNS

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -164,14 +164,17 @@ type PortForward struct {
 }
 
 type Network struct {
-	// `Lima` and `VNL` are mutually exclusive; exactly one is required
+	// `Lima`, `Socket`, and `VNL` are mutually exclusive; exactly one is required
 	Lima string `yaml:"lima,omitempty" json:"lima,omitempty"`
-	// VNL is a Virtual Network Locator (https://github.com/rd235/vdeplug4/commit/089984200f447abb0e825eb45548b781ba1ebccd).
+	// Socket is a QEMU-compatible socket
+	Socket string `yaml:"socket,omitempty" json:"socket,omitempty"`
+	// VNLDeprecated is a Virtual Network Locator (https://github.com/rd235/vdeplug4/commit/089984200f447abb0e825eb45548b781ba1ebccd).
 	// On macOS, only VDE2-compatible form (optionally with vde:// prefix) is supported.
-	VNL        string `yaml:"vnl,omitempty" json:"vnl,omitempty"`
-	SwitchPort uint16 `yaml:"switchPort,omitempty" json:"switchPort,omitempty"` // VDE Switch port, not TCP/UDP port (only used by VDE networking)
-	MACAddress string `yaml:"macAddress,omitempty" json:"macAddress,omitempty"`
-	Interface  string `yaml:"interface,omitempty" json:"interface,omitempty"`
+	// VNLDeprecated is deprecated. Use Socket.
+	VNLDeprecated        string `yaml:"vnl,omitempty" json:"vnl,omitempty"`
+	SwitchPortDeprecated uint16 `yaml:"switchPort,omitempty" json:"switchPort,omitempty"` // VDE Switch port, not TCP/UDP port (only used by VDE networking)
+	MACAddress           string `yaml:"macAddress,omitempty" json:"macAddress,omitempty"`
+	Interface            string `yaml:"interface,omitempty" json:"interface,omitempty"`
 }
 
 type HostResolver struct {

--- a/pkg/networks/commands.go
+++ b/pkg/networks/commands.go
@@ -1,16 +1,21 @@
 package networks
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 )
 
 const (
-	Switch = "switch"
-	VMNet  = "vmnet"
+	VDESwitch   = "vde_switch" // Deprecated
+	VDEVMNet    = "vde_vmnet"  // Deprecated
+	SocketVMNet = "socket_vmnet"
 )
 
 // Commands in `sudoers` cannot use quotes, so all arguments are printed via "%s"
@@ -23,22 +28,68 @@ func (config *NetworksConfig) Check(name string) error {
 	return fmt.Errorf("network %q is not defined", name)
 }
 
+// DaemonPath returns the daemon path.
+func (config *NetworksConfig) DaemonPath(daemon string) (string, error) {
+	switch daemon {
+	case VDESwitch:
+		return config.Paths.VDESwitch, nil
+	case VDEVMNet:
+		return config.Paths.VDEVMNet, nil
+	case SocketVMNet:
+		return config.Paths.SocketVMNet, nil
+	default:
+		return "", fmt.Errorf("unknown daemon type %q", daemon)
+	}
+}
+
+// IsDaemonInstalled checks whether the daemon is installed.
+func (config *NetworksConfig) IsDaemonInstalled(daemon string) (bool, error) {
+	p, err := config.DaemonPath(daemon)
+	if err != nil {
+		return false, err
+	}
+	if p == "" {
+		return false, nil
+	}
+	if _, err := exec.LookPath(p); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// Sock returns a socket_vmnet socket.
+func (config *NetworksConfig) Sock(name string) string {
+	return filepath.Join(config.Paths.VarRun, fmt.Sprintf("socket_vmnet.%s", name))
+}
+
+// VDESock returns a vde socket.
+//
+// Deprecated. Use Sock.
 func (config *NetworksConfig) VDESock(name string) string {
 	return filepath.Join(config.Paths.VarRun, fmt.Sprintf("%s.ctl", name))
 }
 
 func (config *NetworksConfig) PIDFile(name, daemon string) string {
-	return filepath.Join(config.Paths.VarRun, fmt.Sprintf("%s_%s.pid", name, daemon))
+	daemonTrimmed := strings.TrimPrefix(daemon, "vde_") // for compatibility
+	return filepath.Join(config.Paths.VarRun, fmt.Sprintf("%s_%s.pid", name, daemonTrimmed))
 }
 
 func (config *NetworksConfig) LogFile(name, daemon, stream string) string {
 	networksDir, _ := dirnames.LimaNetworksDir()
-	return filepath.Join(networksDir, fmt.Sprintf("%s_%s.%s.log", name, daemon, stream))
+	daemonTrimmed := strings.TrimPrefix(daemon, "vde_") // for compatibility
+	return filepath.Join(networksDir, fmt.Sprintf("%s_%s.%s.log", name, daemonTrimmed, stream))
 }
 
 func (config *NetworksConfig) User(daemon string) (osutil.User, error) {
+	if ok, _ := config.IsDaemonInstalled(daemon); !ok {
+		daemonPath, _ := config.DaemonPath(daemon)
+		return osutil.User{}, fmt.Errorf("daemon %q (path=%q) is not available", daemon, daemonPath)
+	}
 	switch daemon {
-	case Switch:
+	case VDESwitch:
 		user, err := osutil.LookupUser("daemon")
 		if err != nil {
 			return user, err
@@ -47,7 +98,7 @@ func (config *NetworksConfig) User(daemon string) (osutil.User, error) {
 		user.Group = group.Name
 		user.Gid = group.Gid
 		return user, err
-	case VMNet:
+	case VDEVMNet, SocketVMNet:
 		return osutil.LookupUser("root")
 	}
 	return osutil.User{}, fmt.Errorf("daemon %q not defined", daemon)
@@ -58,15 +109,24 @@ func (config *NetworksConfig) MkdirCmd() string {
 }
 
 func (config *NetworksConfig) StartCmd(name, daemon string) string {
+	if ok, _ := config.IsDaemonInstalled(daemon); !ok {
+		panic(fmt.Errorf("daemon %q is not available", daemon))
+	}
 	var cmd string
 	switch daemon {
-	case Switch:
+	case VDESwitch:
+		if config.Paths.VDESwitch == "" {
+			panic("config.Paths.VDESwitch is empty")
+		}
 		cmd = fmt.Sprintf("%s --pidfile=%s --sock=%s --group=%s --dirmode=0770 --nostdin",
-			config.Paths.VDESwitch, config.PIDFile(name, Switch), config.VDESock(name), config.Group)
-	case VMNet:
+			config.Paths.VDESwitch, config.PIDFile(name, VDESwitch), config.VDESock(name), config.Group)
+	case VDEVMNet:
 		nw := config.Networks[name]
+		if config.Paths.VDEVMNet == "" {
+			panic("config.Paths.VDEVMNet is empty")
+		}
 		cmd = fmt.Sprintf("%s --pidfile=%s --vde-group=%s --vmnet-mode=%s",
-			config.Paths.VDEVMNet, config.PIDFile(name, VMNet), config.Group, nw.Mode)
+			config.Paths.VDEVMNet, config.PIDFile(name, VDEVMNet), config.Group, nw.Mode)
 		switch nw.Mode {
 		case ModeBridged:
 			cmd += fmt.Sprintf(" --vmnet-interface=%s", nw.Interface)
@@ -75,6 +135,21 @@ func (config *NetworksConfig) StartCmd(name, daemon string) string {
 				nw.Gateway, nw.DHCPEnd, nw.NetMask)
 		}
 		cmd += " " + config.VDESock(name)
+	case SocketVMNet:
+		nw := config.Networks[name]
+		if config.Paths.SocketVMNet == "" {
+			panic("config.Paths.SocketVMNet is empty")
+		}
+		cmd = fmt.Sprintf("%s --pidfile=%s --socket-group=%s --vmnet-mode=%s",
+			config.Paths.SocketVMNet, config.PIDFile(name, SocketVMNet), config.Group, nw.Mode)
+		switch nw.Mode {
+		case ModeBridged:
+			cmd += fmt.Sprintf(" --vmnet-interface=%s", nw.Interface)
+		case ModeHost, ModeShared:
+			cmd += fmt.Sprintf(" --vmnet-gateway=%s --vmnet-dhcp-end=%s --vmnet-mask=%s",
+				nw.Gateway, nw.DHCPEnd, nw.NetMask)
+		}
+		cmd += " " + config.Sock(name)
 	}
 	return cmd
 }

--- a/pkg/networks/commands_darwin_test.go
+++ b/pkg/networks/commands_darwin_test.go
@@ -6,6 +6,14 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+func TestSock(t *testing.T) {
+	config, err := DefaultConfig()
+	assert.NilError(t, err)
+
+	sock := config.Sock("foo")
+	assert.Equal(t, sock, "/private/var/run/lima/socket_vmnet.foo")
+}
+
 func TestVDESock(t *testing.T) {
 	config, err := DefaultConfig()
 	assert.NilError(t, err)

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -82,6 +82,24 @@ func Config() (NetworksConfig, error) {
 	return cache.config, cache.err
 }
 
+// Sock returns a socket_vmnet socket.
+func Sock(name string) (string, error) {
+	loadCache()
+	if cache.err != nil {
+		return "", cache.err
+	}
+	if err := cache.config.Check(name); err != nil {
+		return "", err
+	}
+	if cache.config.Paths.SocketVMNet == "" {
+		return "", errors.New("socketVMNet is not set")
+	}
+	return cache.config.Sock(name), nil
+}
+
+// VDESock returns a vde socket.
+//
+// Deprecated. Use Sock.
 func VDESock(name string) (string, error) {
 	loadCache()
 	if cache.err != nil {
@@ -89,6 +107,9 @@ func VDESock(name string) (string, error) {
 	}
 	if err := cache.config.Check(name); err != nil {
 		return "", err
+	}
+	if cache.config.Paths.VDEVMNet == "" {
+		return "", errors.New("vdeVMnet is not set")
 	}
 	return cache.config.VDESock(name), nil
 }

--- a/pkg/networks/networks.go
+++ b/pkg/networks/networks.go
@@ -9,10 +9,11 @@ type NetworksConfig struct {
 }
 
 type Paths struct {
-	VDESwitch string `yaml:"vdeSwitch"`
-	VDEVMNet  string `yaml:"vdeVMNet"`
-	VarRun    string `yaml:"varRun"`
-	Sudoers   string `yaml:"sudoers,omitempty"`
+	SocketVMNet string `yaml:"socketVMNet"`
+	VDESwitch   string `yaml:"vdeSwitch"` // Deprecated
+	VDEVMNet    string `yaml:"vdeVMNet"`  // Deprecated
+	VarRun      string `yaml:"varRun"`
+	Sudoers     string `yaml:"sudoers,omitempty"`
 }
 
 const (

--- a/pkg/networks/networks.yaml
+++ b/pkg/networks/networks.yaml
@@ -1,15 +1,19 @@
-# Paths to vde executables. Because vde_vmnet is invoked via sudo it should be
+# Path to socket_vmnet executable. Because socket_vmnet is invoked via sudo it should be
 # installed where only root can modify/replace it. This means also none of the
 # parent directories should be writable by the user.
 #
 # The varRun directory also must not be writable by the user because it will
-# include the vde_vmnet pid files. Those will be terminated via sudo, so replacing
-# the pid files would allow killing of arbitrary privileged processes. varRun
+# include the socket_vmnet pid file. Those will be terminated via sudo, so replacing
+# the pid file would allow killing of arbitrary privileged processes. varRun
 # however MUST be writable by the daemon user.
 #
 # None of the paths segments may be symlinks, why it has to be /private/var
 # instead of /var etc.
 paths:
+# socketVMNet requires Lima >= 0.12 .
+# socketVMNet has precedence over vdeVMNet.
+  socketVMNet: /opt/socket_vmnet/bin/socket_vmnet
+# vdeSwitch and vdeVMNet are DEPRECATED.
   vdeSwitch: /opt/vde/bin/vde_switch
   vdeVMNet: /opt/vde/bin/vde_vmnet
   varRun: /private/var/run/lima

--- a/pkg/networks/sudoers.go
+++ b/pkg/networks/sudoers.go
@@ -30,7 +30,12 @@ func Sudoers() (string, error) {
 	for _, name := range names {
 		sb.WriteRune('\n')
 		sb.WriteString(fmt.Sprintf("# Manage %q network daemons\n", name))
-		for _, daemon := range []string{Switch, VMNet} {
+		for _, daemon := range []string{VDESwitch, VDEVMNet, SocketVMNet} {
+			if ok, err := config.IsDaemonInstalled(daemon); err != nil {
+				return "", err
+			} else if !ok {
+				continue
+			}
 			user, err := config.User(daemon)
 			if err != nil {
 				return "", err
@@ -53,7 +58,12 @@ func (config *NetworksConfig) passwordLessSudo() error {
 	}
 	// Verify that user/groups for both daemons work without a password, e.g.
 	// %admin ALL = (ALL:ALL) NOPASSWD: ALL
-	for _, daemon := range []string{Switch, VMNet} {
+	for _, daemon := range []string{VDESwitch, VDEVMNet, SocketVMNet} {
+		if ok, err := config.IsDaemonInstalled(daemon); err != nil {
+			return err
+		} else if !ok {
+			continue
+		}
 		user, err := config.User(daemon)
 		if err != nil {
 			return err


### PR DESCRIPTION
socket_vmnet is similar to vde_vmnet but does not depend on VDE.

https://github.com/lima-vm/socket_vmnet


See `docs/network.md` for how to create `networks.yaml` with `socketVMNet`.
When both `socketVMNet` and `vdeVMNet` (deprecated) are present in the YAML, `socketVMNet` is chosen.


- - -
## iperf3 benchmark (host -> guest)

Mode                 | Shared (NAT) | Bridged
---------------|--------------|----------
socket_vmnet | 0.66 Gbps      | 1.23 Gbps
vde_vmnet      | 0.27 Gbps      | 0.31 Gbps

Tested on MacBook Pro 2020 (Intel), macOS 12
Lima commit 8db31e8087272da1c848d5d6d23f680004ad7d45 , socket_vmnet v1.0.0-alpha.0, vde_vmnet v0.6.0

Known issue: the throughput of the Shared (NAT) interface can be slower when both the Shared (NAT) and the Bridged interfaces are configured

