### PR TITLE
Add client wrappers for docker and podman, similar to nerdctl wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ binaries: clean \
 	_output/bin/lima \
 	_output/bin/limactl \
 	_output/bin/nerdctl.lima \
+	_output/bin/docker.lima \
+	_output/bin/podman.lima \
 	_output/share/lima/lima-guestagent.Linux-x86_64 \
 	_output/share/lima/lima-guestagent.Linux-aarch64 \
 	_output/share/lima/lima-guestagent.Linux-riscv64
@@ -39,6 +41,14 @@ _output/bin/lima:
 _output/bin/nerdctl.lima:
 	mkdir -p _output/bin
 	cp -a ./cmd/nerdctl.lima $@
+
+_output/bin/docker.lima: ./cmd/docker.lima
+	@mkdir -p _output/bin
+	cp -a $^ $@
+
+_output/bin/podman.lima: ./cmd/podman.lima
+	@mkdir -p _output/bin
+	cp -a $^ $@
 
 .PHONY: _output/bin/limactl
 _output/bin/limactl:

--- a/cmd/docker.lima
+++ b/cmd/docker.lima
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+: "${LIMA_INSTANCE:=docker}"
+: "${DOCKER:=docker}"
+
+if [ "$(limactl ls -q "$LIMA_INSTANCE" 2>/dev/null)" != "$LIMA_INSTANCE" ]; then
+  echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl start --name=$LIMA_INSTANCE template://docker\` to create a new instance" >&2
+  exit 1
+fi
+DOCKER=$(command -v "$DOCKER" || true)
+if [ -n "$DOCKER" ]; then
+  DOCKER_HOST=$(limactl list "$LIMA_INSTANCE" --format 'unix://{{.Dir}}/sock/docker.sock')
+  export DOCKER_HOST
+  exec "$DOCKER" "$@"
+else
+  export LIMA_INSTANCE
+  exec lima docker "$@"
+fi

--- a/cmd/podman.lima
+++ b/cmd/podman.lima
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+: "${LIMA_INSTANCE:=podman}"
+: "${PODMAN:=podman}"
+
+if [ "$(limactl ls -q "$LIMA_INSTANCE" 2>/dev/null)" != "$LIMA_INSTANCE" ]; then
+  echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl start --name=$LIMA_INSTANCE template://podman\` to create a new instance" >&2
+  exit 1
+fi
+PODMAN=$(command -v "$PODMAN" || true)
+if [ -n "$PODMAN" ]; then
+  CONTAINER_HOST=$(limactl list "$LIMA_INSTANCE" --format 'unix://{{.Dir}}/sock/podman.sock')
+  export CONTAINER_HOST
+  exec "$PODMAN" --remote "$@"
+else
+  export LIMA_INSTANCE
+  exec lima podman "$@"
+fi


### PR DESCRIPTION
These will call the clients, without having to clobber the global configuration.

~~You only need to run the **first** command from the "message", not the second:~~

<details>
<pre>
INFO[0128] Message from the instance "docker":          
To run `docker` on the host (assumes docker-cli is installed), run the following commands:
------
docker context create lima --docker "host=unix:///home/anders/.lima/docker/sock/docker.sock"
docker context use lima
docker run hello-world
------
</pre>

<pre>
INFO[0018] Message from the instance "podman":          
To run `podman` on the host (assumes podman-remote is installed), run the following commands:
------
podman system connection add lima "unix:///home/anders/.lima/podman/sock/podman.sock"
podman system connection default lima
podman --remote run quay.io/podman/hello
------
</pre>
</details>

EDIT: Don't have to create the context/connection, using env variables instead.

They were mentioned as comments in the YAML files, if you looked close enough...

Sometimes the commands are missed, then it would be useful to view them:

* #614

Installing the clients _is_ painful, but you can use `brew` and it was scoped out:

* ~#515~

----

~~Only one VM of each kind is supported, since the name "lima" is hardcoded.~~

Note that you need `podman-remote` for [v3](https://github.com/containers/podman/releases/tag/v3.4.4), in order to talk to the podman VM:

```
Error: unable to connect to Podman socket: server API version is too old. Client "4.0.0" server "3.4.4"
```

If the binary clients are _missing_, it will default to SSH - just as for `nerdctl`...

`limactl shell docker docker`

`limactl shell podman podman`
