### PR TITLE
Install epel-release for EL distros

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -67,7 +67,7 @@ elif command -v dnf >/dev/null 2>&1; then
 			dnf_install_flags="${dnf_install_flags} --repo ol8_baseos_latest --repo ol8_codeready_builder"
 		elif grep -q "release 8" /etc/system-release; then
 			dnf_install_flags="${dnf_install_flags} --enablerepo powertools"
-		else
+		elif grep -q 'ID_LIKE=".*rhel.*"' /etc/os-release; then
 			# Workaround for disappeared sshfs in Base repos
 			# shellcheck disable=SC2086
 			dnf install ${dnf_install_flags} epel-release

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -67,6 +67,11 @@ elif command -v dnf >/dev/null 2>&1; then
 			dnf_install_flags="${dnf_install_flags} --repo ol8_baseos_latest --repo ol8_codeready_builder"
 		elif grep -q "release 8" /etc/system-release; then
 			dnf_install_flags="${dnf_install_flags} --enablerepo powertools"
+		else
+			# Workaround for disappeared sshfs in Base repos
+			# shellcheck disable=SC2086
+			dnf install ${dnf_install_flags} epel-release
+			dnf_install_flags="${dnf_install_flags} --enablerepo epel"
 		fi
 		# shellcheck disable=SC2086
 		dnf install ${dnf_install_flags} ${pkgs}


### PR DESCRIPTION
https://github.com/lima-vm/lima/issues/342#issuecomment-1124750969

I guess EL repos are putting sshfs into epel-release thus there is no sshfs in Base repos. So we should install epel-release first to support EL 9 or maybe later releases.