### PR TITLE
templates: update alpine, archlinux, almalinux (but skip updating rocky)

### DIFF
--- a/examples/almalinux.yaml
+++ b/examples/almalinux.yaml
@@ -1,12 +1,12 @@
 # This example requires Lima v0.8.3 or later.
 
 images:
-- location: "http://repo.almalinux.org/almalinux/8.5/cloud/x86_64/images/AlmaLinux-8-GenericCloud-latest.x86_64.qcow2"
+- location: "http://repo.almalinux.org/almalinux/8.6/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.6-20220513.x86_64.qcow2"
   arch: "x86_64"
-  digest: "sha512:19623e60216800fb3cd9f564c6d20415adc6d990ba4924fef2a2056035049d2ac2c749c8b71843f62af2955e8b505f4705daacb16c13d3079366b007ad846491"
-- location: "http://repo.almalinux.org/almalinux/8.5/cloud/aarch64/images/AlmaLinux-8-GenericCloud-latest.aarch64.qcow2"
+  digest: "sha256:1563c0b09d98e7a606e1e737f1c810830aeb0cbe37ac5585f3696be62f0a32b4"
+- location: "http://repo.almalinux.org/almalinux/8.6/cloud/aarch64/images/AlmaLinux-8-GenericCloud-8.6-20220513.aarch64.qcow2"
   arch: "aarch64"
-  digest: "sha512:bf8c0afaa8aaced047977de73455f09d2867907efece91cbad16dbd3ab454328b432eadccc62cdfc6e529f5147e564c9d97405a2598efde6758151c6fda758d4"
+  digest: "sha256:d00960b398f257d83ade160eea954caf95a060ad5d74f3af9feeb17e0aa0b6e2"
 mounts:
 - location: "~"
 - location: "/tmp/lima"

--- a/examples/alpine.yaml
+++ b/examples/alpine.yaml
@@ -1,11 +1,11 @@
 # This example requires Lima v0.7.0 or later.
 images:
-- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.11/alpine-lima-std-3.15.4-x86_64.iso"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.13/alpine-lima-std-3.15.4-x86_64.iso"
   arch: "x86_64"
-  digest: "sha512:58b0003400aa5e54c54970a1a4d2376b3d3d6b48fffa5e21ea5b814f398920d6d38957f2a603520c03bdca178046915e198039243f296adf75ea380e02154aa5"
-- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.11/alpine-lima-std-3.15.4-aarch64.iso"
+  digest: "sha512:1da1067355e4db7efb5ae6f827f6555480c1510f764f133c795e736a1fea020091d8bf6ad3cffd7f209c2987dfe41ba490f4796c5ea0be1052d8ac99b81d9bef"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.13/alpine-lima-std-3.15.4-aarch64.iso"
   arch: "aarch64"
-  digest: "sha512:3449965ae57cef13e9af7797c064431bfee1a5132f5f4c181ff72ab19bacdc870d66dda44511a8214ba17e1d1f554bb34ebeb55da923290cf6598980c4077941"
+  digest: "sha512:68fab773f96cc21ae2422ddcdade51392f4fd99ff8e1906c4912ac77945c58c022109098f25f5f3c11a94351b62419193cae04fc645fe35bf2eefb4bc51bb769"
 
 mounts:
 - location: "~"

--- a/examples/archlinux.yaml
+++ b/examples/archlinux.yaml
@@ -1,9 +1,9 @@
 # This example requires Lima v0.7.0 or later
 images:
 # Try to use yyyyMMdd.REV image if available. Note that yyyyMMdd.REV will be removed after several months.
-- location: "https://mirror.pkgbuild.com/images/v20220415.53207/Arch-Linux-x86_64-cloudimg-20220415.53207.qcow2"
+- location: "https://mirror.pkgbuild.com/images/v20220515.56564/Arch-Linux-x86_64-cloudimg-20220515.56564.qcow2"
   arch: "x86_64"
-  digest: "sha256:04db7dddfec7cff457c3d76f5cd4724725233129fc0fc1b6c0198f3bb728e116"
+  digest: "sha256:e7ef924f6c56642e2c3a4be7c74fad4c38a8113c8d527a835b2f51dcb1977394"
 - location: "https://github.com/mcginty/arch-boxes/releases/download/v20220323/Arch-Linux-aarch64-cloudimg-20220323.0.qcow2"
   arch: "aarch64"
   digest: "sha512:27524910bf41cb9b3223c8749c6e67fd2f2fdb8b70d40648708e64d6b03c0b4a01b3c5e72d51fefd3e0c3f58487dbb400a79ca378cde2da341a3a19873612be8"

--- a/examples/rocky.yaml
+++ b/examples/rocky.yaml
@@ -1,5 +1,6 @@
 # This example requires Lima v0.8.3 or later.
 
+# NOTE: skip 8.6-20220515, as it seems broken (lacks sudo): https://bugs.rockylinux.org/view.php?id=102
 images:
 - location: "https://dl.rockylinux.org/pub/rocky/8.5/images/Rocky-8-GenericCloud-8.5-20211114.2.x86_64.qcow2"
   arch: "x86_64"


### PR DESCRIPTION
AlmaLinux 8.6 works well but Rocky Linux 8.6 (20220515) seems broken (https://bugs.rockylinux.org/view.php?id=102). Even lacks sudo.

Oracle Linux 8.6 images are not available yet: https://yum.oracle.com/oracle-linux-templates.html