### PR TITLE
Set required Containerd env vars in model zshrc - fixes #862

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/20-rootless-base.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/20-rootless-base.sh
@@ -5,7 +5,7 @@ set -eux
 command -v systemctl >/dev/null 2>&1 || exit 0
 
 # Set up env
-for f in .profile .bashrc; do
+for f in .profile .bashrc .zshrc; do
 	if ! grep -q "# Lima BEGIN" "/home/${LIMA_CIDATA_USER}.linux/$f"; then
 		cat >>"/home/${LIMA_CIDATA_USER}.linux/$f" <<EOF
 # Lima BEGIN


### PR DESCRIPTION
I've added .zshrc to the list of shell rc files where the default `CONTAINERD_SNAPSHOTTER` gets set. I've tested this and it fixes #862. This is my first PR in the project, so apologies if I've missed any steps.