### PR TITLE
[alpine] Persist /root on data volume at /mnt/data/root

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-persistent-data-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-persistent-data-volume.sh
@@ -7,7 +7,7 @@ set -eux -o pipefail
 test -f /etc/alpine-release || exit 0
 
 # Data directories that should be persisted across reboots
-DATADIRS="/etc /home /tmp /usr/local /var/lib"
+DATADIRS="/etc /home /root /tmp /usr/local /var/lib"
 
 # When running from RAM try to move persistent data to data-volume
 # FIXME: the test for tmpfs mounts is probably Alpine-specific


### PR DESCRIPTION
Conceptually `/root` is just `/home/root`, and we already persist `/home`, so wiping `/root` on each reboot doesn't make sense, as it can store config data from rootful nerdctl etc (and the shell history of the root user).
