### PR TITLE
Support configuring mount locations within guests

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -44,6 +44,9 @@ disk: null
 # 🔵 This file: Mount the home as read-only, /tmp/lima as writable
 mounts:
 - location: "~"
+  # Configure the mountPoint inside the guest.
+  # 🟢 Builtin default: value of location
+  mountPoint: null
   # CAUTION: `writable` SHOULD be false for the home directory.
   # Setting `writable` to true is possible, but untested and dangerous.
   # 🟢 Builtin default: false

--- a/pkg/cidata/cidata.TEMPLATE.d/lima.env
+++ b/pkg/cidata/cidata.TEMPLATE.d/lima.env
@@ -3,7 +3,7 @@ LIMA_CIDATA_USER={{ .User }}
 LIMA_CIDATA_UID={{ .UID }}
 LIMA_CIDATA_MOUNTS={{ len .Mounts }}
 {{- range $i, $val := .Mounts}}
-LIMA_CIDATA_MOUNTS_{{$i}}_MOUNTPOINT={{$val.Target}}
+LIMA_CIDATA_MOUNTS_{{$i}}_MOUNTPOINT={{$val.MountPoint}}
 {{- end}}
 LIMA_CIDATA_MOUNTTYPE={{ .MountType }}
 {{- if .Containerd.User}}

--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -9,7 +9,7 @@ growpart:
 {{- if .Mounts }}
 mounts:
   {{- range $m := $.Mounts}}
-- [{{$m.Tag}}, {{$m.Target}}, {{$m.Type}}, "{{$m.Options}}", "0", "0"]
+- [{{$m.Tag}}, {{$m.MountPoint}}, {{$m.Type}}, "{{$m.Options}}", "0", "0"]
   {{- end }}
 {{- end }}
 {{- end }}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -130,7 +130,11 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 	}
 	for i, f := range y.Mounts {
 		tag := fmt.Sprintf("mount%d", i)
-		expanded, err := localpathutil.Expand(f.Location)
+		location, err := localpathutil.Expand(f.Location)
+		if err != nil {
+			return err
+		}
+		mountPoint, err := localpathutil.Expand(f.MountPoint)
 		if err != nil {
 			return err
 		}
@@ -144,14 +148,14 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 			options += fmt.Sprintf(",version=%s", *f.NineP.ProtocolVersion)
 			msize, err := units.RAMInBytes(*f.NineP.Msize)
 			if err != nil {
-				return fmt.Errorf("failed to parse msize for %q: %w", expanded, err)
+				return fmt.Errorf("failed to parse msize for %q: %w", location, err)
 			}
 			options += fmt.Sprintf(",msize=%d", msize)
 			options += fmt.Sprintf(",cache=%s", *f.NineP.Cache)
 			// don't fail the boot, if virtfs is not available
 			options += ",nofail"
 		}
-		args.Mounts = append(args.Mounts, Mount{Tag: tag, Target: expanded, Type: fstype, Options: options})
+		args.Mounts = append(args.Mounts, Mount{Tag: tag, MountPoint: mountPoint, Type: fstype, Options: options})
 	}
 
 	switch *y.MountType {

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -37,10 +37,10 @@ type Network struct {
 	Interface  string
 }
 type Mount struct {
-	Tag     string
-	Target  string // abs path, accessible by the User
-	Type    string
-	Options string
+	Tag        string
+	MountPoint string // abs path, accessible by the User
+	Type       string
+	Options    string
 }
 type TemplateArgs struct {
 	Name            string // instance name
@@ -80,7 +80,7 @@ func ValidateTemplateArgs(args TemplateArgs) error {
 		return errors.New("field SSHPubKeys must be set")
 	}
 	for i, m := range args.Mounts {
-		f := m.Target
+		f := m.MountPoint
 		if !filepath.IsAbs(f) {
 			return fmt.Errorf("field mounts[%d] must be absolute, got %q", i, f)
 		}

--- a/pkg/cidata/template_test.go
+++ b/pkg/cidata/template_test.go
@@ -17,8 +17,8 @@ func TestTemplate(t *testing.T) {
 			"ssh-rsa dummy foo@example.com",
 		},
 		Mounts: []Mount{
-			{Target: "/Users/dummy"},
-			{Target: "/Users/dummy/lima"},
+			{MountPoint: "/Users/dummy"},
+			{MountPoint: "/Users/dummy/lima"},
 		},
 		MountType: "reverse-sshfs",
 	}
@@ -45,8 +45,8 @@ func TestTemplate9p(t *testing.T) {
 			"ssh-rsa dummy foo@example.com",
 		},
 		Mounts: []Mount{
-			{Tag: "mount0", Target: "/Users/dummy", Type: "9p", Options: "ro,trans=virtio"},
-			{Tag: "mount1", Target: "/Users/dummy/lima", Type: "9p", Options: "rw,trans=virtio"},
+			{Tag: "mount0", MountPoint: "/Users/dummy", Type: "9p", Options: "ro,trans=virtio"},
+			{Tag: "mount1", MountPoint: "/Users/dummy/lima", Type: "9p", Options: "rw,trans=virtio"},
 		},
 		MountType: "9p",
 	}

--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -34,11 +34,16 @@ func (a *HostAgent) setupMounts(ctx context.Context) ([]*mount, error) {
 }
 
 func (a *HostAgent) setupMount(ctx context.Context, m limayaml.Mount) (*mount, error) {
-	expanded, err := localpathutil.Expand(m.Location)
+	location, err := localpathutil.Expand(m.Location)
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(expanded, 0755); err != nil {
+
+	mountPoint, err := localpathutil.Expand(m.MountPoint)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(location, 0755); err != nil {
 		return nil, err
 	}
 	// NOTE: allow_other requires "user_allow_other" in /etc/fuse.conf
@@ -49,34 +54,35 @@ func (a *HostAgent) setupMount(ctx context.Context, m limayaml.Mount) (*mount, e
 	if *m.SSHFS.FollowSymlinks {
 		sshfsOptions = sshfsOptions + ",follow_symlinks"
 	}
-	logrus.Infof("Mounting %q", expanded)
+	logrus.Infof("Mounting %q on %q", location, mountPoint)
+
 	rsf := &reversesshfs.ReverseSSHFS{
 		Driver:              *m.SSHFS.SFTPDriver,
 		SSHConfig:           a.sshConfig,
-		LocalPath:           expanded,
+		LocalPath:           location,
 		Host:                "127.0.0.1",
 		Port:                a.sshLocalPort,
-		RemotePath:          expanded,
+		RemotePath:          mountPoint,
 		Readonly:            !(*m.Writable),
 		SSHFSAdditionalArgs: []string{"-o", sshfsOptions},
 	}
 	if err := rsf.Prepare(); err != nil {
-		return nil, fmt.Errorf("failed to prepare reverse sshfs for %q: %w", expanded, err)
+		return nil, fmt.Errorf("failed to prepare reverse sshfs for %q on %q: %w", location, mountPoint, err)
 	}
 	if err := rsf.Start(); err != nil {
-		logrus.WithError(err).Warnf("failed to mount reverse sshfs for %q, retrying with `-o nonempty`", expanded)
+		logrus.WithError(err).Warnf("failed to mount reverse sshfs for %q on %q, retrying with `-o nonempty`", location, mountPoint)
 		// NOTE: nonempty is not supported for libfuse3: https://github.com/canonical/multipass/issues/1381
 		rsf.SSHFSAdditionalArgs = []string{"-o", "nonempty"}
 		if err := rsf.Start(); err != nil {
-			return nil, fmt.Errorf("failed to mount reverse sshfs for %q: %w", expanded, err)
+			return nil, fmt.Errorf("failed to mount reverse sshfs for %q on %q: %w", location, mountPoint, err)
 		}
 	}
 
 	res := &mount{
 		close: func() error {
-			logrus.Infof("Unmounting %q", expanded)
+			logrus.Infof("Unmounting %q", location)
 			if closeErr := rsf.Close(); closeErr != nil {
-				return fmt.Errorf("failed to unmount reverse sshfs for %q: %w", expanded, err)
+				return fmt.Errorf("failed to unmount reverse sshfs for %q on %q: %w", location, mountPoint, err)
 			}
 			return nil
 		},

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -402,6 +402,9 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 			if mount.Writable != nil {
 				mounts[i].Writable = mount.Writable
 			}
+			if mount.MountPoint != "" {
+				mounts[i].MountPoint = mount.MountPoint
+			}
 		} else {
 			location[mount.Location] = len(mounts)
 			mounts = append(mounts, mount)
@@ -438,6 +441,9 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 			} else {
 				mounts[i].NineP.Cache = pointer.String(Default9pCacheForRO)
 			}
+		}
+		if mount.MountPoint == "" {
+			mounts[i].MountPoint = mount.Location
 		}
 	}
 

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -145,6 +145,7 @@ func TestFillDefault(t *testing.T) {
 	}
 
 	expect.Mounts = y.Mounts
+	expect.Mounts[0].MountPoint = expect.Mounts[0].Location
 	expect.Mounts[0].Writable = pointer.Bool(false)
 	expect.Mounts[0].SSHFS.Cache = pointer.Bool(true)
 	expect.Mounts[0].SSHFS.FollowSymlinks = pointer.Bool(false)
@@ -299,6 +300,7 @@ func TestFillDefault(t *testing.T) {
 	expect = d
 	// Also verify that archive arch is filled in
 	expect.Containerd.Archives[0].Arch = *d.Arch
+	expect.Mounts[0].MountPoint = expect.Mounts[0].Location
 	expect.Mounts[0].SSHFS.Cache = pointer.Bool(true)
 	expect.Mounts[0].SSHFS.FollowSymlinks = pointer.Bool(false)
 	expect.Mounts[0].SSHFS.SFTPDriver = pointer.String("")

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -63,10 +63,11 @@ type Image struct {
 }
 
 type Mount struct {
-	Location string `yaml:"location" json:"location"` // REQUIRED
-	Writable *bool  `yaml:"writable,omitempty" json:"writable,omitempty"`
-	SSHFS    SSHFS  `yaml:"sshfs,omitempty" json:"sshfs,omitempty"`
-	NineP    NineP  `yaml:"9p,omitempty" json:"9p,omitempty"`
+	Location   string `yaml:"location" json:"location"` // REQUIRED
+	MountPoint string `yaml:"mountPoint,omitempty" json:"mountPoint,omitempty"`
+	Writable   *bool  `yaml:"writable,omitempty" json:"writable,omitempty"`
+	SSHFS      SSHFS  `yaml:"sshfs,omitempty" json:"sshfs,omitempty"`
+	NineP      NineP  `yaml:"9p,omitempty" json:"9p,omitempty"`
 }
 
 type SFTPDriver = string

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -539,16 +539,16 @@ func Cmdline(cfg Config) (string, []string, error) {
 	if *y.MountType == limayaml.NINEP {
 		for i, f := range y.Mounts {
 			tag := fmt.Sprintf("mount%d", i)
-			expanded, err := localpathutil.Expand(f.Location)
+			location, err := localpathutil.Expand(f.Location)
 			if err != nil {
 				return "", nil, err
 			}
-			if err := os.MkdirAll(expanded, 0755); err != nil {
+			if err := os.MkdirAll(location, 0755); err != nil {
 				return "", nil, err
 			}
 			options := "local"
 			options += fmt.Sprintf(",mount_tag=%s", tag)
-			options += fmt.Sprintf(",path=%s", expanded)
+			options += fmt.Sprintf(",path=%s", location)
 			options += fmt.Sprintf(",security_model=%s", *f.NineP.SecurityModel)
 			if !*f.Writable {
 				options += ",readonly"


### PR DESCRIPTION
Closes #659

Tested with both sshfs and 9p and confirmed that the mounts were configured in the location specified by `mounts[*].mountPoint`. 

eg:
```
mounts:
- location: "~/Movies"
  mountPoint: "/movies"
```