### PR TITLE
Add LIMA_CIDATA_HOSTHOME_MOUNTPOINT

### DIFF
--- a/docs/internal.md
+++ b/docs/internal.md
@@ -118,6 +118,7 @@ The volume label is "cidata", as defined by [cloud-init NoCloud](https://cloudin
 - `LIMA_CIDATA_MNT`: the mount point of the disk. `/mnt/lima-cidata`.
 - `LIMA_CIDATA_USER`: the user name string
 - `LIMA_CIDATA_UID`: the numeric UID
+- `LIMA_CIDATA_HOSTHOME_MOUNTPOINT`: the mount point of the host home directory, or empty if not mounted
 - `LIMA_CIDATA_MOUNTS`: the number of the Lima mounts
 - `LIMA_CIDATA_MOUNTS_%d_MOUNTPOINT`: the N-th mount point of Lima mounts (N=0, 1, ...)
 - `LIMA_CIDATA_MOUNTTYPE`: the type of the Lima mounts ("reverse-sshfs", "9p", ...)

--- a/pkg/cidata/cidata.TEMPLATE.d/lima.env
+++ b/pkg/cidata/cidata.TEMPLATE.d/lima.env
@@ -1,6 +1,7 @@
 LIMA_CIDATA_NAME={{ .Name }}
 LIMA_CIDATA_USER={{ .User }}
 LIMA_CIDATA_UID={{ .UID }}
+LIMA_CIDATA_HOSTHOME_MOUNTPOINT={{ .HostHomeMountPoint }}
 LIMA_CIDATA_MOUNTS={{ len .Mounts }}
 {{- range $i, $val := .Mounts}}
 LIMA_CIDATA_MOUNTS_{{$i}}_MOUNTPOINT={{$val.MountPoint}}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -128,6 +128,10 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 	case limayaml.NINEP:
 		fstype = "9p"
 	}
+	hostHome, err := localpathutil.Expand("~")
+	if err != nil {
+		return err
+	}
 	for i, f := range y.Mounts {
 		tag := fmt.Sprintf("mount%d", i)
 		location, err := localpathutil.Expand(f.Location)
@@ -156,6 +160,9 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 			options += ",nofail"
 		}
 		args.Mounts = append(args.Mounts, Mount{Tag: tag, MountPoint: mountPoint, Type: fstype, Options: options})
+		if location == hostHome {
+			args.HostHomeMountPoint = mountPoint
+		}
 	}
 
 	switch *y.MountType {

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -43,24 +43,25 @@ type Mount struct {
 	Options    string
 }
 type TemplateArgs struct {
-	Name            string // instance name
-	IID             string // instance id
-	User            string // user name
-	UID             int
-	SSHPubKeys      []string
-	Mounts          []Mount
-	MountType       string
-	Containerd      Containerd
-	Networks        []Network
-	SlirpNICName    string
-	SlirpGateway    string
-	SlirpDNS        string
-	SlirpIPAddress  string
-	UDPDNSLocalPort int
-	TCPDNSLocalPort int
-	Env             map[string]string
-	DNSAddresses    []string
-	CACerts         CACerts
+	Name               string // instance name
+	IID                string // instance id
+	User               string // user name
+	UID                int
+	SSHPubKeys         []string
+	Mounts             []Mount
+	MountType          string
+	Containerd         Containerd
+	Networks           []Network
+	SlirpNICName       string
+	SlirpGateway       string
+	SlirpDNS           string
+	SlirpIPAddress     string
+	UDPDNSLocalPort    int
+	TCPDNSLocalPort    int
+	Env                map[string]string
+	DNSAddresses       []string
+	CACerts            CACerts
+	HostHomeMountPoint string
 }
 
 func ValidateTemplateArgs(args TemplateArgs) error {


### PR DESCRIPTION
This can be used by provisioning scripts to locate the mount point of the user's home directory. We can't just use `/Users/$LIMA_CIDATA_USER` because we don't know if the host is Linux or macOS, so it could be `/home/$LIMA_CIDATA_USER` or something completely custom. Also `$LIMA_CIDATA_USER` is the username inside the guest and might be set to `lima` if the username on the macOS host is not a valid Linux username.

Example usage to configure client certs for the docker daemon:

```shell
ln -s $LIMA_CIDATA_HOME_MOUNTPOINT/.docker/certs.d /etc/docker/certs.d
```
