### PR TITLE
Forward X11 to VM, if available

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -233,6 +233,10 @@ func SSHArgsFromOpts(opts []string) []string {
 	for _, o := range opts {
 		args = append(args, "-o", o)
 	}
+	if _, present := os.LookupEnv("DISPLAY"); present {
+		// forward X11 to vm, if available
+		args = append(args, "-Y")
+	}
 	return args
 }
 


### PR DESCRIPTION
This allows people who have XQuartz installed to easily install and run X11 applications inside lima