### PR TITLE
Use Fedora 36 to get podman 4

### DIFF
--- a/examples/podman.yaml
+++ b/examples/podman.yaml
@@ -12,19 +12,12 @@
 
 # This example requires Lima v0.8.0 or later
 images:
-# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220420/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2"
   arch: "x86_64"
-  digest: "sha256:de5e632e17b8965f2baf4ea6d2b824788e154d9a65df4fd419ec4019898e15cd"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220420/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:ca9e514cc2f4a7a0188e7c68af60eb4e573d2e6850cc65b464697223f46b4605"
+- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/aarch64/images/Fedora-Cloud-Base-36-1.5.aarch64.qcow2"
   arch: "aarch64"
-  digest: "sha256:66224c7fed99ff5a5539eda406c87bbfefe8af6ff6b47d92df3187832b5b5d4f"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
+  digest: "sha256:5c0e7e99b0c542cb2155cd3b52bbf51a42a65917e52d37df457d1e9759b37512"
 
 mounts:
 - location: "~"
@@ -39,9 +32,7 @@ provision:
     #!/bin/bash
     set -eux -o pipefail
     command -v podman >/dev/null 2>&1 && exit 0
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get update
-    apt-get install -y podman crun
+    dnf -y install podman
 - mode: user
   script: |
     #!/bin/bash
@@ -55,7 +46,7 @@ probes:
       echo >&2 "podman is not installed yet"
       exit 1
     fi
-  hint: See "/var/log/cloud-init-output.log". in the guest
+  hint: See "/var/log/cloud-init-output.log" in the guest
 portForwards:
 - guestSocket: "/run/user/{{.UID}}/podman/podman.sock"
   hostSocket: "{{.Dir}}/sock/podman.sock"


### PR DESCRIPTION
Ubuntu 22.04 provides podman 3.4.4 which is not compatible with podman 4 client that is provided by brew on macOS.