### PR TITLE
Allow forwarding X11 to VM

### DIFF
--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -108,7 +108,7 @@ func copyAction(cmd *cobra.Command, args []string) error {
 		// arguments such as ControlPath.  This is preferred as we can multiplex
 		// sessions without re-authenticating (MaxSessions permitting).
 		for _, instDir := range instDirs {
-			sshOpts, err = sshutil.SSHOpts(instDir, false, false)
+			sshOpts, err = sshutil.SSHOpts(instDir, false, false, false, false)
 			if err != nil {
 				return err
 			}

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -131,7 +131,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	sshOpts, err := sshutil.SSHOpts(inst.Dir, *y.SSH.LoadDotSSHPubKeys, *y.SSH.ForwardAgent)
+	sshOpts, err := sshutil.SSHOpts(inst.Dir, *y.SSH.LoadDotSSHPubKeys, *y.SSH.ForwardAgent, *y.SSH.ForwardX11, *y.SSH.ForwardX11Trusted)
 	if err != nil {
 		return err
 	}

--- a/cmd/limactl/show_ssh.go
+++ b/cmd/limactl/show_ssh.go
@@ -87,7 +87,7 @@ func showSSHAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	opts, err := sshutil.SSHOpts(inst.Dir, *y.SSH.LoadDotSSHPubKeys, *y.SSH.ForwardAgent)
+	opts, err := sshutil.SSHOpts(inst.Dir, *y.SSH.LoadDotSSHPubKeys, *y.SSH.ForwardAgent, *y.SSH.ForwardX11, *y.SSH.ForwardX11Trusted)
 	if err != nil {
 		return err
 	}

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -106,6 +106,12 @@ ssh:
   # Forward ssh agent into the instance.
   # 🟢 Builtin default: false
   forwardAgent: null
+  # Forward X11 into the instance
+  # 🟢 Builtin default: false
+  forwardX11: null
+  # Trust forwarded X11 clients
+  # 🟢 Builtin default: false
+  forwardX11Trusted: null
 
 # ===================================================================== #
 # ADVANCED CONFIGURATION

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -120,7 +120,7 @@ func New(instName string, stdout io.Writer, sigintCh chan os.Signal, opts ...Opt
 		return nil, err
 	}
 
-	sshOpts, err := sshutil.SSHOpts(inst.Dir, *y.SSH.LoadDotSSHPubKeys, *y.SSH.ForwardAgent)
+	sshOpts, err := sshutil.SSHOpts(inst.Dir, *y.SSH.LoadDotSSHPubKeys, *y.SSH.ForwardAgent, *y.SSH.ForwardX11, *y.SSH.ForwardX11Trusted)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -206,6 +206,26 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.SSH.ForwardAgent = pointer.Bool(false)
 	}
 
+	if y.SSH.ForwardX11 == nil {
+		y.SSH.ForwardX11 = d.SSH.ForwardX11
+	}
+	if o.SSH.ForwardX11 != nil {
+		y.SSH.ForwardX11 = o.SSH.ForwardX11
+	}
+	if y.SSH.ForwardX11 == nil {
+		y.SSH.ForwardX11 = pointer.Bool(false)
+	}
+
+	if y.SSH.ForwardX11Trusted == nil {
+		y.SSH.ForwardX11Trusted = d.SSH.ForwardX11Trusted
+	}
+	if o.SSH.ForwardX11Trusted != nil {
+		y.SSH.ForwardX11Trusted = o.SSH.ForwardX11Trusted
+	}
+	if y.SSH.ForwardX11Trusted == nil {
+		y.SSH.ForwardX11Trusted = pointer.Bool(false)
+	}
+
 	hosts := make(map[string]string)
 	// Values can be either names or IP addresses. Name values are canonicalized in the hostResolver.
 	for k, v := range d.HostResolver.Hosts {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -65,6 +65,8 @@ func TestFillDefault(t *testing.T) {
 			LocalPort:         pointer.Int(0),
 			LoadDotSSHPubKeys: pointer.Bool(true),
 			ForwardAgent:      pointer.Bool(false),
+			ForwardX11:        pointer.Bool(false),
+			ForwardX11Trusted: pointer.Bool(false),
 		},
 		Firmware: Firmware{
 			LegacyBIOS: pointer.Bool(false),
@@ -230,6 +232,8 @@ func TestFillDefault(t *testing.T) {
 			LocalPort:         pointer.Int(888),
 			LoadDotSSHPubKeys: pointer.Bool(false),
 			ForwardAgent:      pointer.Bool(true),
+			ForwardX11:        pointer.Bool(false),
+			ForwardX11Trusted: pointer.Bool(false),
 		},
 		Firmware: Firmware{
 			LegacyBIOS: pointer.Bool(true),
@@ -376,6 +380,8 @@ func TestFillDefault(t *testing.T) {
 			LocalPort:         pointer.Int(4433),
 			LoadDotSSHPubKeys: pointer.Bool(true),
 			ForwardAgent:      pointer.Bool(true),
+			ForwardX11:        pointer.Bool(false),
+			ForwardX11Trusted: pointer.Bool(false),
 		},
 		Firmware: Firmware{
 			LegacyBIOS: pointer.Bool(true),

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -96,6 +96,8 @@ type SSH struct {
 	// LoadDotSSHPubKeys loads ~/.ssh/*.pub in addition to $LIMA_HOME/_config/user.pub .
 	LoadDotSSHPubKeys *bool `yaml:"loadDotSSHPubKeys,omitempty" json:"loadDotSSHPubKeys,omitempty"` // default: true
 	ForwardAgent      *bool `yaml:"forwardAgent,omitempty" json:"forwardAgent,omitempty"`           // default: false
+	ForwardX11        *bool `yaml:"forwardX11,omitempty" json:"forwardX11,omitempty"`               // default: false
+	ForwardX11Trusted *bool `yaml:"forwardX11Trusted,omitempty" json:"forwardX11Trusted,omitempty"` // default: false
 }
 
 type Firmware struct {

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -201,7 +201,7 @@ func CommonOpts(useDotSSH bool) ([]string, error) {
 }
 
 // SSHOpts adds the following options to CommonOptions: User, ControlMaster, ControlPath, ControlPersist
-func SSHOpts(instDir string, useDotSSH, forwardAgent bool) ([]string, error) {
+func SSHOpts(instDir string, useDotSSH, forwardAgent bool, forwardX11 bool, forwardX11Trusted bool) ([]string, error) {
 	controlSock := filepath.Join(instDir, filenames.SSHSock)
 	if len(controlSock) >= osutil.UnixPathMax {
 		return nil, fmt.Errorf("socket path %q is too long: >= UNIX_PATH_MAX=%d", controlSock, osutil.UnixPathMax)
@@ -222,6 +222,12 @@ func SSHOpts(instDir string, useDotSSH, forwardAgent bool) ([]string, error) {
 	)
 	if forwardAgent {
 		opts = append(opts, "ForwardAgent=yes")
+	}
+	if forwardX11 {
+		opts = append(opts, "ForwardX11=yes")
+	}
+	if forwardX11Trusted {
+		opts = append(opts, "ForwardX11Trusted=yes")
 	}
 	return opts, nil
 }


### PR DESCRIPTION
This allows people who have XQuartz installed to easily install and run X11 applications inside lima.

This is a nicer replacement for https://github.com/lima-vm/lima/pull/875 - it adds two new settings to the `ssh` section of the template - `forwardX11` and `forwardX11Trusted` correspond to the similarly-named ssh options, like `forwardAgent` does.