### PR TITLE
Fassd template fix

### DIFF
--- a/examples/faasd.yaml
+++ b/examples/faasd.yaml
@@ -1,21 +1,28 @@
 # Deploy faasd (which installs a bundled containerd).
 #
 # It can be accessed from the host by authenticating with faas-cli;
-# the ports are already forwarded automatically by lima:
-#
-# Get the faas-cli:
-# $ curl -sLS https://cli.openfaas.com | sh
-#
-# You can now log into your gateway:
-# $ export OPENFAAS_URL=http://localhost:8080
-# $ limactl shell faasd sudo cat /var/lib/faasd/secrets/basic-auth-password | faas-cli login -u admin --password-stdin
-# $
-# $ faas-cli store deploy NodeInfo
-#
-# Deployed. 200 OK.
-# URL: http://localhost:8080/function/nodeinfo
+# the ports are already forwarded automatically by lima.
 #
 # This example requires Lima v0.7.0 or later.
+
+message: |
+  # Get the faas-cli from one of following sources:
+  # package manager:
+  brew install faas-cli
+  #
+  # script:
+  curl -sLS https://cli.openfaas.com | sh
+  #
+  # You can now log into your gateway:
+  ------
+  export OPENFAAS_URL=http://localhost:8080
+  limactl shell faasd sudo cat /var/lib/faasd/secrets/basic-auth-password | faas-cli login -u admin --password-stdin
+  ------
+  #
+  # Once logged in, you can deploy your first function
+  ------
+  faas-cli store deploy NodeInfo
+  ------
 
 # Image is set to jammy (22.04 LTS) for long-term stability
 images:
@@ -42,7 +49,7 @@ containerd:
   user: false
 
 provision:
-- mode: system
+- mode: user
   script: |
     #!/bin/sh
     curl -sfL https://raw.githubusercontent.com/openfaas/faasd/master/hack/install.sh | bash -s -


### PR DESCRIPTION
Fixes #880

# What does it solves
Currently, the `faasd` template gets stuck while trying to run the `provision` script. This PR solves this issue by changing the `provision` mode from `system` to `user`.

# Additional changes
The current script has an explanation on the usage in the header, as comments. I added a message at the end, based on those header comments.

Tested locally:
```
limactl start faasd.yaml
? Creating an instance "faasd" Proceed with the current configuration
INFO[0001] Attempting to download the image from "https://cloud-images.ubuntu.com/releases/22.04/release-20220420/ubuntu-22.04-server-cloudimg-amd64.img"  digest="sha256:de5e632e17b8965f2baf4ea6d2b824788e154d9a65df4fd419ec4019898e15cd"
INFO[0003] Using cache "/Users/corsair/Library/Caches/lima/download/by-url-sha256/62c871f6f494814b9c6555e6ac74e1e81c35ba6f12beec1a0d74c7bee5c8a41d/data"
INFO[0004] [hostagent] Starting QEMU (hint: to watch the boot progress, see "/Users/corsair/.lima/faasd/serial.log")
INFO[0004] SSH Local Port: 58204
INFO[0004] [hostagent] Waiting for the essential requirement 1 of 3: "ssh"
INFO[0056] [hostagent] Waiting for the essential requirement 1 of 3: "ssh"
INFO[0060] [hostagent] The essential requirement 1 of 3 is satisfied
INFO[0060] [hostagent] Waiting for the essential requirement 2 of 3: "user session is ready for ssh"
INFO[0075] [hostagent] Waiting for the essential requirement 2 of 3: "user session is ready for ssh"
INFO[0075] [hostagent] The essential requirement 2 of 3 is satisfied
INFO[0075] [hostagent] Waiting for the essential requirement 3 of 3: "the guest agent to be running"
INFO[0075] [hostagent] The essential requirement 3 of 3 is satisfied
INFO[0075] [hostagent] Waiting for the optional requirement 1 of 1: "user probe 1/1"
INFO[0075] [hostagent] Forwarding "/run/lima-guestagent.sock" (guest) to "/Users/corsair/.lima/faasd/ga.sock" (host)
INFO[0075] [hostagent] Not forwarding TCP 0.0.0.0:22
INFO[0075] [hostagent] Not forwarding TCP 127.0.0.53:53
INFO[0075] [hostagent] Not forwarding TCP [::]:22
INFO[0116] [hostagent] Waiting for the optional requirement 1 of 1: "user probe 1/1"
INFO[0153] [hostagent] Forwarding TCP from 127.0.0.1:43601 to 127.0.0.1:43601
INFO[0155] [hostagent] Waiting for the optional requirement 1 of 1: "user probe 1/1"
INFO[0168] [hostagent] Forwarding TCP from [::]:8081 to 127.0.0.1:8081
INFO[0196] [hostagent] Waiting for the optional requirement 1 of 1: "user probe 1/1"
INFO[0211] [hostagent] The optional requirement 1 of 1 is satisfied
INFO[0211] [hostagent] Waiting for the final requirement 1 of 1: "boot scripts must have finished"
INFO[0211] [hostagent] The final requirement 1 of 1 is satisfied
INFO[0211] READY. Run `limactl shell faasd` to open the shell.
INFO[0211] Message from the instance "faasd":
# You can now log into your gateway:
------
export OPENFAAS_URL=http://localhost:8080
limactl shell faasd sudo cat /var/lib/faasd/secrets/basic-auth-password | faas-cli login -u admin --password-stdin
------

# Once logged in, you can deploy your first function
------
faas-cli store deploy NodeInfo
------
```