### PR TITLE
Need squashfs kernel module installed for singularity

### DIFF
--- a/examples/singularity.yaml
+++ b/examples/singularity.yaml
@@ -23,6 +23,12 @@ provision:
   script: |
     #!/bin/bash
     set -eux -o pipefail
+    modprobe squashfs >/dev/null 2>&1 && exit 0
+    dnf install -y kernel-modules-$(uname -r)
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
     command -v singularity >/dev/null 2>&1 && exit 0
     dnf install -y singularity
 probes:


### PR DESCRIPTION
The example doesn't work anymore, since kernel modules are not installed by default in new fedora (36):

`FATAL:   container creation failed: mount /proc/self/fd/3->/var/singularity/mnt/session/rootfs error: while mounting image /proc/self/fd/3: squashfs filesystem seems not enabled and/or supported by your kernel`

Make sure to install the kernel-modules version of the _current_ kernel-core, not for the latest available kernel.

----

```console
[anders@lima-singularity lima]$ sudo modprobe -v squashfs
insmod /lib/modules/5.17.5-300.fc36.x86_64/kernel/fs/squashfs/squashfs.ko.xz 
[anders@lima-singularity lima]$ singularity run docker://alpine
INFO:    Using cached SIF image
Singularity> 
```