### PR TITLE
Check for /sbin/openrc-run instead of /sbin/openrc-init

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.sh
@@ -54,7 +54,7 @@ fi
 
 USER_SCRIPT="/home/${LIMA_CIDATA_USER}.linux/.lima-user-script"
 if [ -d "${LIMA_CIDATA_MNT}"/provision.user ]; then
-	if [ ! -f /sbin/openrc-init ]; then
+	if [ ! -f /sbin/openrc-run ]; then
 		until [ -e "/run/user/${LIMA_CIDATA_UID}/systemd/private" ]; do sleep 3; done
 	fi
 	for f in "${LIMA_CIDATA_MNT}"/provision.user/*; do

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/11-colorterm-environment.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/11-colorterm-environment.sh
@@ -7,7 +7,7 @@ fi
 
 # accept any incoming COLORTERM environment variable
 sed -i 's/^AcceptEnv LANG LC_\*$/AcceptEnv COLORTERM LANG LC_*/' /etc/ssh/sshd_config
-if [ -f /sbin/openrc-init ]; then
+if [ -f /sbin/openrc-run ]; then
 	rc-service --ifstarted sshd reload
 elif command -v systemctl >/dev/null 2>&1; then
 	if systemctl -q is-active ssh; then

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
@@ -18,7 +18,7 @@ fi
 install -m 755 "${LIMA_CIDATA_MNT}"/lima-guestagent /usr/local/bin/lima-guestagent
 
 # Launch the guestagent service
-if [ -f /sbin/openrc-init ]; then
+if [ -f /sbin/openrc-run ]; then
 	# Install the openrc lima-guestagent service script
 	cat >/etc/init.d/lima-guestagent <<'EOF'
 #!/sbin/openrc-run


### PR DESCRIPTION
Alpine doesn't use openrc-init (it uses busybox init) and has deleted it from the package in 3.16:

https://gitlab.alpinelinux.org/alpine/aports/-/commit/7a4d6d22cdb4696e93b3a0fce91e851c4db5366e
