### PR TITLE
Only use cpuType=host for OS with accel available

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -105,7 +105,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		RISCV64: "rv64", // FIXME: what is the right choice for riscv64?
 	}
 	for arch := range cpuType {
-		if IsNativeArch(arch) {
+		if IsNativeArch(arch) && IsAccelOS() {
 			cpuType[arch] = "host"
 		}
 	}
@@ -610,6 +610,16 @@ func ResolveArch(s *string) Arch {
 		return NewArch(runtime.GOARCH)
 	}
 	return *s
+}
+
+func IsAccelOS() bool {
+	switch runtime.GOOS {
+	case "darwin", "linux", "netbsd", "windows":
+		// Accelerator
+		return true
+	}
+	// Using TCG
+	return false
 }
 
 func IsNativeArch(arch Arch) bool {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -83,7 +83,9 @@ func TestFillDefault(t *testing.T) {
 			RemoveDefaults: pointer.Bool(false),
 		},
 	}
-	builtin.CPUType[arch] = "host"
+	if IsAccelOS() {
+		builtin.CPUType[arch] = "host"
+	}
 
 	defaultPortForward := PortForward{
 		GuestIP:        api.IPv4loopback1,


### PR DESCRIPTION
This should be matching the qemu getAccel() values

Specifically, no acceleration on FreeBSD right now

Issue #892