### PR TITLE
Remove nonexisting err from AES detection warning

### DIFF
--- a/pkg/sshutil/sshutil_others.go
+++ b/pkg/sshutil/sshutil_others.go
@@ -11,6 +11,6 @@ import (
 
 func detectAESAcceleration() bool {
 	const fallback = runtime.GOARCH == "amd64"
-	logrus.WithError(err).Warnf("cannot detect whether AES accelerator is available, assuming %v", fallback)
+	logrus.Warnf("cannot detect whether AES accelerator is available, assuming %v", fallback)
 	return fallback
 }


### PR DESCRIPTION
Fixes build on platforms other than darwin and linux.

For instance: `GOOS=netbsd`, `GOOS=freebsd`

Issue #892 