### PR TITLE
examples: use the geo.mirror.pkgbuild.com mirror for Arch Linux

### DIFF
--- a/examples/archlinux.yaml
+++ b/examples/archlinux.yaml
@@ -1,7 +1,7 @@
 # This example requires Lima v0.7.0 or later
 images:
 # Try to use yyyyMMdd.REV image if available. Note that yyyyMMdd.REV will be removed after several months.
-- location: "https://mirror.pkgbuild.com/images/v20220515.56564/Arch-Linux-x86_64-cloudimg-20220515.56564.qcow2"
+- location: "https://geo.mirror.pkgbuild.com/images/v20220515.56564/Arch-Linux-x86_64-cloudimg-20220515.56564.qcow2"
   arch: "x86_64"
   digest: "sha256:e7ef924f6c56642e2c3a4be7c74fad4c38a8113c8d527a835b2f51dcb1977394"
 - location: "https://github.com/mcginty/arch-boxes/releases/download/v20220323/Arch-Linux-aarch64-cloudimg-20220323.0.qcow2"
@@ -9,7 +9,7 @@ images:
   digest: "sha512:27524910bf41cb9b3223c8749c6e67fd2f2fdb8b70d40648708e64d6b03c0b4a01b3c5e72d51fefd3e0c3f58487dbb400a79ca378cde2da341a3a19873612be8"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
-- location: "https://mirror.pkgbuild.com/images/latest/Arch-Linux-x86_64-cloudimg.qcow2"
+- location: "https://geo.mirror.pkgbuild.com/images/latest/Arch-Linux-x86_64-cloudimg.qcow2"
   arch: "x86_64"
 
 mounts:


### PR DESCRIPTION
geo.mirror.pkgbuild.com is a GeoDNS mirror that points to sponsored mirrors.

This avoids the usage of Arch's infrastructure (mirror.pkgbuild.com) for large downloads.
See https://gitlab.archlinux.org/archlinux/infrastructure/-/merge_requests/522 for details.
