### PR TITLE
Not all OS with -accel has -cpu host option

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -106,7 +106,9 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 	}
 	for arch := range cpuType {
 		if IsNativeArch(arch) && IsAccelOS() {
-			cpuType[arch] = "host"
+			if HasHostCPU() {
+				cpuType[arch] = "host"
+			}
 		}
 	}
 	for k, v := range d.CPUType {
@@ -619,6 +621,17 @@ func IsAccelOS() bool {
 		return true
 	}
 	// Using TCG
+	return false
+}
+
+func HasHostCPU() bool {
+	switch runtime.GOOS {
+	case "darwin", "linux":
+		return true
+	case "netbsd", "windows":
+		return false
+	}
+	// Not reached
 	return false
 }
 

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -84,7 +84,9 @@ func TestFillDefault(t *testing.T) {
 		},
 	}
 	if IsAccelOS() {
-		builtin.CPUType[arch] = "host"
+		if HasHostCPU() {
+			builtin.CPUType[arch] = "host"
+		}
 	}
 
 	defaultPortForward := PortForward{


### PR DESCRIPTION
Instead use -cpu max, for everything available.

Affects NetBSD (NVMM) and Windows (WHPX)

Follow-up from #894