### PR TITLE
Add examples for CentOS Linux and CentOS Stream both

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,8 @@ Distro:
 - [`almalinux.yaml`](./almalinux.yaml): AlmaLinux
 - [`alpine.yaml`](./alpine.yaml): ⭐Alpine Linux
 - [`archlinux.yaml`](./archlinux.yaml): ⭐Arch Linux
+- centos.yaml: ~~CentOS Linux 8~~ ([EOL](https://www.centos.org/centos-linux-eol/))
+- [`centos-stream.yaml`](./centos-stream.yaml): CentOS Stream 8
 - [`debian.yaml`](./debian.yaml): ⭐Debian GNU/Linux
 - [`fedora.yaml`](./fedora.yaml): ⭐Fedora
 - [`opensuse.yaml`](./opensuse.yaml): ⭐openSUSE Leap
@@ -33,7 +35,8 @@ Container orchestration:
 
 Others:
 - [`vmnet.yaml`](./vmnet.yaml): ⭐enable [`vmnet.framework`](../docs/network.md)
-- [`deprecated/centos-7.yaml`](./deprecated/centos-7.yaml): [deprecated] CentOS 7
+- [`deprecated/centos-7.yaml`](./deprecated/centos-7.yaml): [deprecated] CentOS Linux 7
+- [`experimental/centos-stream-9.yaml`](experimental/centos-stream-9.yaml): [experimental] CentOS Stream 9
 - [`experimental/9p.yaml`](experimental/9p.yaml): [experimental] use 9p mount type
 - [`experimental/riscv64.yaml`](experimental/riscv64.yaml): [experimental] RISC-V
 - [`experimental/apptainer.yaml`](./experimental/apptainer.yaml): [experimental] [Apptainer](https://apptainer.org/)

--- a/examples/centos-stream.yaml
+++ b/examples/centos-stream.yaml
@@ -1,0 +1,19 @@
+# This example requires Lima v0.8.3 or later.
+
+images:
+- location: "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20220125.1.x86_64.qcow2"
+  arch: "x86_64"
+  digest: "sha256:a25560ab39e10594ee7a4a1dadcba7bf303b7c3c41559b4a7fc3c522540a6672"
+- location: "https://cloud.centos.org/centos/8-stream/aarch64/images/CentOS-Stream-GenericCloud-8-20220125.1.aarch64.qcow2"
+  arch: "aarch64"
+  digest: "sha256:d973991085db0ca8373e1d9948440213cdc76b6acf8f17aa2aed2163c1347cbc"
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+firmware:
+  legacyBIOS: true
+cpuType:
+  # Workaround for "vmx_write_mem: mmu_gva_to_gpa XXXXXXXXXXXXXXXX failed" on Intel Mac
+  # https://bugs.launchpad.net/qemu/+bug/1838390
+  x86_64: "Haswell-v4"

--- a/examples/experimental/centos-stream-9.yaml
+++ b/examples/experimental/centos-stream-9.yaml
@@ -1,0 +1,19 @@
+# This example requires Lima v0.8.3 or later.
+
+images:
+- location: "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220606.0.x86_64.qcow2"
+  arch: "x86_64"
+  digest: "sha256:41c8cce7b5ed9ba70f7f103f058bd6320e3462f2dc2c97db84ad7f1c6918a525"
+- location: "https://cloud.centos.org/centos/9-stream/aarch64/images/CentOS-Stream-GenericCloud-9-20220606.0.aarch64.qcow2"
+  arch: "aarch64"
+  digest: "sha256:55ef64861d7f9cf5d1407af708fba8ad6015b54bfda81913cc942785091912b0"
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+firmware:
+  legacyBIOS: true
+cpuType:
+  # Workaround for "vmx_write_mem: mmu_gva_to_gpa XXXXXXXXXXXXXXXX failed" on Intel Mac
+  # https://bugs.launchpad.net/qemu/+bug/1838390
+  x86_64: "Haswell-v4"

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -67,6 +67,11 @@ elif command -v dnf >/dev/null 2>&1; then
 			dnf_install_flags="${dnf_install_flags} --repo ol8_baseos_latest --repo ol8_codeready_builder"
 		elif grep -q "release 8" /etc/system-release; then
 			dnf_install_flags="${dnf_install_flags} --enablerepo powertools"
+		elif grep -q "release 9" /etc/system-release; then
+			# shellcheck disable=SC2086
+			dnf install ${dnf_install_flags} epel-release
+			dnf config-manager --disable epel >/dev/null 2>&1
+			dnf_install_flags="${dnf_install_flags} --enablerepo epel"
 		fi
 		# shellcheck disable=SC2086
 		dnf install ${dnf_install_flags} ${pkgs}


### PR DESCRIPTION
CentOS (Linux), downstream of RHEL:
https://centos.org/centos-linux/

CentOS Stream, upstream of RHEL:
https://centos.org/centos-stream/

---

This is a more tested variant of PR #856

* #856

Adressing some comments from Issue #342

* #342

Both distributions have the same CentOS identifier:

```
NAME="CentOS Linux"
VERSION="8"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="8"
PLATFORM_ID="platform:el8"
PRETTY_NAME="CentOS Linux 8"
```

```
VERSION="8"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="8"
PLATFORM_ID="platform:el8"
PRETTY_NAME="CentOS Stream 8"
```

But Stream is always testing the _next_ Linux version.