### PR TITLE
Force sync after moving persistent directories to data volume

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-persistent-data-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-persistent-data-volume.sh
@@ -43,6 +43,8 @@ if [ "$(awk '$2 == "/" {print $3}' /proc/mounts)" == "tmpfs" ]; then
 					mkdir -p "${DIR}" "${DEST}"
 					mv "${DIR}" "${DEST}"
 				done
+				# Make sure all data moved to the persistent volume has been committed to disk
+				sync
 				break
 			fi
 		done


### PR DESCRIPTION
Otherwise the data configured by cloud-init/lima-init may get lost if the instance is forcibly stopped (e.g. via `limactl stop -f`).

Example: `$HOME/.ssh/authorized_hosts` is lost (size 0):

Even though cloud-init/lima-init will re-create the file on next boot, the new version will be shadowed by the `/mnt/data/home/$USER.linux/.ssh` directory that will be mounted on top and the instance will remain
inaccessible.
