### PR TITLE
templates: update Arch Linux to 20220615.61815 ; nerdctl: update to v0.21.0

### DIFF
--- a/examples/alpine.yaml
+++ b/examples/alpine.yaml
@@ -1,11 +1,11 @@
 # This example requires Lima v0.7.0 or later.
 images:
-- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.13/alpine-lima-std-3.15.4-x86_64.iso"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.17/alpine-lima-std-3.16.0-x86_64.iso"
   arch: "x86_64"
-  digest: "sha512:1da1067355e4db7efb5ae6f827f6555480c1510f764f133c795e736a1fea020091d8bf6ad3cffd7f209c2987dfe41ba490f4796c5ea0be1052d8ac99b81d9bef"
-- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.13/alpine-lima-std-3.15.4-aarch64.iso"
+  digest: "sha512:54fea93f797b0f7eabccf8722433bc34d7379930bb740275269191b094dedaa45a27795d3456016377cea8d6750b4d68faeac429fe8ce742a781eb0a45e40936"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.17/alpine-lima-std-3.16.0-aarch64.iso"
   arch: "aarch64"
-  digest: "sha512:68fab773f96cc21ae2422ddcdade51392f4fd99ff8e1906c4912ac77945c58c022109098f25f5f3c11a94351b62419193cae04fc645fe35bf2eefb4bc51bb769"
+  digest: "sha512:c301ac360dab4d5e3ad4be930b3427d30142163a96b4db47dd1365cbc17015a1c01dc494e24c2dd5c72235be5f4c8c44554029cf05a954110e9fe94748d4bd05"
 
 mounts:
 - location: "~"

--- a/examples/archlinux.yaml
+++ b/examples/archlinux.yaml
@@ -1,9 +1,9 @@
 # This example requires Lima v0.7.0 or later
 images:
 # Try to use yyyyMMdd.REV image if available. Note that yyyyMMdd.REV will be removed after several months.
-- location: "https://geo.mirror.pkgbuild.com/images/v20220515.56564/Arch-Linux-x86_64-cloudimg-20220515.56564.qcow2"
+- location: "https://geo.mirror.pkgbuild.com/images/v20220615.61815/Arch-Linux-x86_64-cloudimg-20220615.61815.qcow2"
   arch: "x86_64"
-  digest: "sha256:e7ef924f6c56642e2c3a4be7c74fad4c38a8113c8d527a835b2f51dcb1977394"
+  digest: "sha256:9959c6c9df0f84c1a6892bbe3f47a8545438d83053f762fc5c969ac13c18a3a8"
 - location: "https://github.com/mcginty/arch-boxes/releases/download/v20220323/Arch-Linux-aarch64-cloudimg-20220323.0.qcow2"
   arch: "aarch64"
   digest: "sha512:27524910bf41cb9b3223c8749c6e67fd2f2fdb8b70d40648708e64d6b03c0b4a01b3c5e72d51fefd3e0c3f58487dbb400a79ca378cde2da341a3a19873612be8"

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -30,7 +30,7 @@ const (
 )
 
 func defaultContainerdArchives() []File {
-	const nerdctlVersion = "0.20.0"
+	const nerdctlVersion = "0.21.0"
 	location := func(goarch string) string {
 		return "https://github.com/containerd/nerdctl/releases/download/v" + nerdctlVersion + "/nerdctl-full-" + nerdctlVersion + "-linux-" + goarch + ".tar.gz"
 	}
@@ -38,12 +38,12 @@ func defaultContainerdArchives() []File {
 		{
 			Location: location("amd64"),
 			Arch:     X8664,
-			Digest:   "sha256:2aa63b0487c2a500bdf4fc555b51cd7e2128608a8339f02d89810f9e364f86aa",
+			Digest:   "sha256:728f9b543374b1b1733f759608e156dbe578d7b140a081084a1f4bfb4f2b3fbf",
 		},
 		{
 			Location: location("arm64"),
 			Arch:     AARCH64,
-			Digest:   "sha256:eff8546e289ed20e64d17e4d4a50b99cafc0136745ede795d0c9828b8ca50645",
+			Digest:   "sha256:1d0c822f7571042e71ef0b2f8d092f99b0034061726385ca90deaf0b3d2ce3d9",
 		},
 		// No riscv64
 	}


### PR DESCRIPTION
https://github.com/containerd/nerdctl/releases/tag/v0.21.0

TODO
- https://github.com/lima-vm/alpine-lima/pull/70