### PR TITLE
Fallbacks to `-cpu max` on native arch platforms that have an accelerator but do not support `-cpu host`

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -108,6 +108,8 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		if IsNativeArch(arch) && IsAccelOS() {
 			if HasHostCPU() {
 				cpuType[arch] = "host"
+			} else {
+				cpuType[arch] = "max"
 			}
 		}
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -86,6 +86,8 @@ func TestFillDefault(t *testing.T) {
 	if IsAccelOS() {
 		if HasHostCPU() {
 			builtin.CPUType[arch] = "host"
+		} else {
+			builtin.CPUType[arch] = "max"
 		}
 	}
 


### PR DESCRIPTION
On platforms that have an accelerator but `-cpu host` is not available fallbacks to `-cpu max` that enables all features supported by the accelerator in the current host.

This was noticed on NetBSD. What actually happened is that in `qemu.Cmdline()` if nothing adjust the CPU we will ends up with:

https://github.com/lima-vm/lima/blob/64106744775bf0e321e6a301f38c829ea5002557/pkg/qemu/qemu.go#L372

where `-accel` is currently hardcoded to `tcg` later in:

https://github.com/lima-vm/lima/blob/64106744775bf0e321e6a301f38c829ea5002557/pkg/qemu/qemu.go#L379.

And so no host accelerator is used in such case.
