### PR TITLE
`nvmm` is tested and works fine

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -606,7 +606,7 @@ func getAccel(arch limayaml.Arch) string {
 		case "linux":
 			return "kvm"
 		case "netbsd":
-			return "nvmm" // untested
+			return "nvmm"
 		case "windows":
 			return "whpx" // untested
 		}


### PR DESCRIPTION
At least on NetBSD/amd64 -current(-ish) it works well.
