### PR TITLE
Fix test failures on windows, mostly paths

### DIFF
--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"path/filepath"
+	"path"
 
 	"github.com/lima-vm/lima/pkg/iso9660util"
 
@@ -82,7 +82,7 @@ func ValidateTemplateArgs(args TemplateArgs) error {
 	}
 	for i, m := range args.Mounts {
 		f := m.MountPoint
-		if !filepath.IsAbs(f) {
+		if !path.IsAbs(f) {
 			return fmt.Errorf("field mounts[%d] must be absolute, got %q", i, f)
 		}
 	}

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	osuser "os/user"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -569,7 +568,7 @@ func FillPortForwardDefaults(rule *PortForward, instDir string) {
 	if rule.HostSocket != "" {
 		tmpl, err := template.New("").Parse(rule.HostSocket)
 		if err == nil {
-			user, _ := osuser.Current()
+			user, _ := osutil.LimaUser(false)
 			home, _ := os.UserHomeDir()
 			limaHome, _ := dirnames.LimaDir()
 			data := map[string]string{

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -217,7 +218,7 @@ func Validate(y LimaYAML, warn bool) error {
 			return fmt.Errorf("field `%s.hostPortRange` must specify the same number of ports as field `%s.guestPortRange`", field, field)
 		}
 		if rule.GuestSocket != "" {
-			if !filepath.IsAbs(rule.GuestSocket) {
+			if !path.IsAbs(rule.GuestSocket) {
 				return fmt.Errorf("field `%s.guestSocket` must be an absolute path", field)
 			}
 			if rule.HostSocket == "" && rule.HostPortRange[1]-rule.HostPortRange[0] > 0 {

--- a/pkg/networks/commands.go
+++ b/pkg/networks/commands.go
@@ -2,6 +2,7 @@ package networks
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
@@ -23,16 +24,16 @@ func (config *NetworksConfig) Check(name string) error {
 }
 
 func (config *NetworksConfig) VDESock(name string) string {
-	return fmt.Sprintf("%s/%s.ctl", config.Paths.VarRun, name)
+	return filepath.Join(config.Paths.VarRun, fmt.Sprintf("%s.ctl", name))
 }
 
 func (config *NetworksConfig) PIDFile(name, daemon string) string {
-	return fmt.Sprintf("%s/%s_%s.pid", config.Paths.VarRun, name, daemon)
+	return filepath.Join(config.Paths.VarRun, fmt.Sprintf("%s_%s.pid", name, daemon))
 }
 
 func (config *NetworksConfig) LogFile(name, daemon, stream string) string {
 	networksDir, _ := dirnames.LimaNetworksDir()
-	return fmt.Sprintf("%s/%s_%s.%s.log", networksDir, name, daemon, stream)
+	return filepath.Join(networksDir, fmt.Sprintf("%s_%s.%s.log", name, daemon, stream))
 }
 
 func (config *NetworksConfig) User(daemon string) (osutil.User, error) {

--- a/pkg/networks/commands_darwin_test.go
+++ b/pkg/networks/commands_darwin_test.go
@@ -1,7 +1,6 @@
 package networks
 
 import (
-	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -12,8 +11,7 @@ func TestVDESock(t *testing.T) {
 	assert.NilError(t, err)
 
 	vdeSock := config.VDESock("foo")
-	varRunDir := filepath.Join("/", "private", "var", "run", "lima")
-	assert.Equal(t, vdeSock, filepath.Join(varRunDir, "foo.ctl"))
+	assert.Equal(t, vdeSock, "/private/var/run/lima/foo.ctl")
 }
 
 func TestPIDFile(t *testing.T) {
@@ -21,6 +19,5 @@ func TestPIDFile(t *testing.T) {
 	assert.NilError(t, err)
 
 	pidFile := config.PIDFile("name", "daemon")
-	varRunDir := filepath.Join("/", "private", "var", "run", "lima")
-	assert.Equal(t, pidFile, filepath.Join(varRunDir, "name_daemon.pid"))
+	assert.Equal(t, pidFile, "/private/var/run/lima/name_daemon.pid")
 }

--- a/pkg/networks/commands_darwin_test.go
+++ b/pkg/networks/commands_darwin_test.go
@@ -1,0 +1,26 @@
+package networks
+
+import (
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestVDESock(t *testing.T) {
+	config, err := DefaultConfig()
+	assert.NilError(t, err)
+
+	vdeSock := config.VDESock("foo")
+	varRunDir := filepath.Join("/", "private", "var", "run", "lima")
+	assert.Equal(t, vdeSock, filepath.Join(varRunDir, "foo.ctl"))
+}
+
+func TestPIDFile(t *testing.T) {
+	config, err := DefaultConfig()
+	assert.NilError(t, err)
+
+	pidFile := config.PIDFile("name", "daemon")
+	varRunDir := filepath.Join("/", "private", "var", "run", "lima")
+	assert.Equal(t, pidFile, filepath.Join(varRunDir, "name_daemon.pid"))
+}

--- a/pkg/networks/commands_test.go
+++ b/pkg/networks/commands_test.go
@@ -21,24 +21,6 @@ func TestCheck(t *testing.T) {
 	assert.ErrorContains(t, err, "not defined")
 }
 
-func TestVDESock(t *testing.T) {
-	config, err := DefaultConfig()
-	assert.NilError(t, err)
-
-	vdeSock := config.VDESock("foo")
-	varRunDir := filepath.Join("/", "private", "var", "run", "lima")
-	assert.Equal(t, vdeSock, filepath.Join(varRunDir, "foo.ctl"))
-}
-
-func TestPIDFile(t *testing.T) {
-	config, err := DefaultConfig()
-	assert.NilError(t, err)
-
-	pidFile := config.PIDFile("name", "daemon")
-	varRunDir := filepath.Join("/", "private", "var", "run", "lima")
-	assert.Equal(t, pidFile, filepath.Join(varRunDir, "name_daemon.pid"))
-}
-
 func TestLogFile(t *testing.T) {
 	config, err := DefaultConfig()
 	assert.NilError(t, err)


### PR DESCRIPTION
After merging the other code fixes.

Only unit tests, not functional tests...

-----

```
--- FAIL: TestTemplate (0.00s)
    template_test.go:26: assertion failed: error is not nil: field mounts[0] must be absolute, got "/Users/dummy"
--- FAIL: TestTemplate9p (0.00s)
    template_test.go:54: assertion failed: error is not nil: field mounts[0] must be absolute, got "/Users/dummy"
FAIL
FAIL	github.com/lima-vm/lima/pkg/cidata	1.177s
--- FAIL: TestTXTRecords (0.07s)
    --- FAIL: TestTXTRecords/test_TXT_records (0.07s)
        dns_test.go:60: assertion failed: regex_check is false
FAIL
FAIL	github.com/lima-vm/lima/pkg/hostagent/dns	1.229s
--- FAIL: TestFillDefault (0.01s)
    defaults_test.go:212: assertion failed: 
        --- &y
        +++ &expect
          &limayaml.LimaYAML{
          	... // 12 identical fields
          	Containerd: {System: &false, User: &true, Archives: {{Location: "https://github.com/containerd/nerdctl/releases/download/v0.21.0/"..., Arch: "x86_64", Digest: s"sha256:728f9b543374b1b1733f759608e156dbe578d7b140a081084a1f4bfb4"...}, {Location: "https://github.com/containerd/nerdctl/releases/download/v0.21.0/"..., Arch: "aarch64", Digest: s"sha256:1d0c822f7571042e71ef0b2f8d092f99b0034061726385ca90deaf0b3"...}}},
          	Probes:     {{Mode: "readiness", Description: "user probe 1/1", Script: "#!/bin/false"}},
          	PortForwards: []limayaml.PortForward{
          		{GuestIP: s"127.0.0.1", GuestPortRange: {1, 65535}, HostIP: s"127.0.0.1", HostPortRange: {1, 65535}, ...},
          		{GuestIP: s"127.0.0.1", GuestPort: 80, GuestPortRange: {80, 80}, HostIP: s"127.0.0.1", ...},
          		{GuestIP: s"127.0.0.1", GuestPort: 8080, GuestPortRange: {8080, 8080}, HostIP: s"127.0.0.1", ...},
          		{
          			... // 6 identical fields
          			HostPort:      0,
          			HostPortRange: {1, 65535},
          			HostSocket: strings.Join({
          				`C:\users\anders | C:\users\anders\.lima\instance | instance | S-`,
          				"1-5-21-0-0-0-1000 | ",
        - 				`UBUNTU\anders`,
        + 				"lima",
          			}, ""),
          			Proto:   "tcp",
          			Reverse: false,
          			Ignore:  false,
          		},
          	},
          	Message:  "",
          	Networks: {{Lima: "shared", MACAddress: "52:55:55:f0:96:23", Interface: "lima0"}},
          	... // 7 identical fields
          }
        
FAIL
FAIL	github.com/lima-vm/lima/pkg/limayaml	1.270s
--- FAIL: TestLogFile (0.00s)
    commands_test.go:47: assertion failed: C:\users\anders\.lima\_networks/name_daemon.stream.log (logFile string) != C:\users\anders\.lima\_networks\name_daemon.stream.log (string)
--- FAIL: TestUser (0.00s)
    commands_test.go:59: assertion failed: error is not nil: No security ID mapped.
FAIL
FAIL	github.com/lima-vm/lima/pkg/networks	0.880s
```
