### PR TITLE
Don't read resolvconf in windows 2/5

### DIFF
--- a/cmd/limactl/debug.go
+++ b/cmd/limactl/debug.go
@@ -47,7 +47,15 @@ func debugDNSAction(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	srv, err := dns.Start(udpLocalPort, tcpLocalPort, ipv6, map[string]string{})
+	srvOpts := dns.ServerOptions{
+		UDPPort: udpLocalPort,
+		TCPPort: tcpLocalPort,
+		HandlerOptions: dns.HandlerOptions{
+			IPv6:        ipv6,
+			StaticHosts: map[string]string{},
+		},
+	}
+	srv, err := dns.Start(srvOpts)
 	if err != nil {
 		return err
 	}

--- a/pkg/hostagent/dns/dns_test.go
+++ b/pkg/hostagent/dns/dns_test.go
@@ -48,9 +48,13 @@ func TestTXTRecords(t *testing.T) {
 
 	t.Run("test TXT records", func(t *testing.T) {
 		w := new(TestResponseWriter)
-		h, err := newHandler(true, map[string]string{
-			"MY.Host": "host.lima.internal",
-		})
+		options := HandlerOptions{
+			IPv6: true,
+			StaticHosts: map[string]string{
+				"MY.Host": "host.lima.internal",
+			},
+		}
+		h, err := NewHandler(options)
 		if err == nil {
 			for i := 0; i < len(testDomains); i++ {
 				req := new(dns.Msg)

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -255,7 +255,15 @@ func (a *HostAgent) Run(ctx context.Context) error {
 		hosts := a.y.HostResolver.Hosts
 		hosts["host.lima.internal."] = qemuconst.SlirpGateway
 		hosts[fmt.Sprintf("lima-%s.", a.instName)] = qemuconst.SlirpIPAddress
-		dnsServer, err := dns.Start(a.udpDNSLocalPort, a.tcpDNSLocalPort, *a.y.HostResolver.IPv6, hosts)
+		srvOpts := dns.ServerOptions{
+			UDPPort: a.udpDNSLocalPort,
+			TCPPort: a.tcpDNSLocalPort,
+			HandlerOptions: dns.HandlerOptions{
+				IPv6:        *a.y.HostResolver.IPv6,
+				StaticHosts: hosts,
+			},
+		}
+		dnsServer, err := dns.Start(srvOpts)
 		if err != nil {
 			return fmt.Errorf("cannot start DNS server: %w", err)
 		}


### PR DESCRIPTION
We are using `dns.go` as a library in Rancher Desktop's [host-resolver](https://github.com/rancher-sandbox/rancher-desktop-host-resolver) and one of our target platform is Windows. This change prevents `dns.go` to look for Client configuration in `/etc/resolv.conf` 