### PR TITLE
Add more fallbacks for LimaUser uid/gid/home

### DIFF
--- a/pkg/osutil/user_test.go
+++ b/pkg/osutil/user_test.go
@@ -1,0 +1,48 @@
+package osutil
+
+import (
+	"path"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestLimaUserWarn(t *testing.T) {
+	_, err := LimaUser(true)
+	assert.NilError(t, err)
+}
+
+func validUsername(username string) bool {
+	validName := "^[a-z_][a-z0-9_-]*$"
+	return regexp.MustCompile(validName).Match([]byte(username))
+}
+
+func TestLimaUsername(t *testing.T) {
+	user, err := LimaUser(false)
+	assert.NilError(t, err)
+	// check for reasonable unix user name
+	assert.Assert(t, validUsername(user.Username), user.Username)
+}
+
+func TestLimaUserUid(t *testing.T) {
+	user, err := LimaUser(false)
+	assert.NilError(t, err)
+	_, err = strconv.Atoi(user.Uid)
+	assert.NilError(t, err)
+}
+
+func TestLimaUserGid(t *testing.T) {
+	user, err := LimaUser(false)
+	assert.NilError(t, err)
+	_, err = strconv.Atoi(user.Gid)
+	assert.NilError(t, err)
+}
+
+func TestLimaHomeDir(t *testing.T) {
+	user, err := LimaUser(false)
+	assert.NilError(t, err)
+	// check for absolute unix path (/home)
+	assert.Assert(t, path.IsAbs(user.HomeDir), user.HomeDir)
+}


### PR DESCRIPTION
Here is what it looks like with Wine, added a unit test:

```
time="2022-06-26T22:55:19+02:00" level=warning msg="local user \"UBUNTU\\\\anders\" is not a valid Linux username (must match \"^[a-z_][a-z0-9_-]*$\"); using \"lima\" username instead"
time="2022-06-26T22:55:19+02:00" level=warning msg="local uid \"S-1-5-21-0-0-0-1000\" is not a valid Linux uid (must be integer); using 4266656744 uid instead"
time="2022-06-26T22:55:19+02:00" level=warning msg="local gid \"S-1-5-21-0-0-0-513\" is not a valid Linux gid (must be integer); using 4266656257 gid instead"
time="2022-06-26T22:55:19+02:00" level=warning msg="local home \"C:\\\\users\\\\anders\" is not a valid Linux path (must match \"^[/a-zA-Z0-9_-]+$\"); using \"/c/users/anders\" home instead"
```

Closes #928

* #928