### PR TITLE
whpx: Don't use -cpu max, add kernel-irqchip=off

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -108,7 +108,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		if IsNativeArch(arch) && IsAccelOS() {
 			if HasHostCPU() {
 				cpuType[arch] = "host"
-			} else {
+			} else if HasMaxCPU() {
 				cpuType[arch] = "max"
 			}
 		}
@@ -635,6 +635,11 @@ func HasHostCPU() bool {
 	}
 	// Not reached
 	return false
+}
+
+func HasMaxCPU() bool {
+	// WHPX: Unexpected VP exit code 4
+	return runtime.GOOS != "windows"
 }
 
 func IsNativeArch(arch Arch) bool {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -86,7 +86,7 @@ func TestFillDefault(t *testing.T) {
 	if IsAccelOS() {
 		if HasHostCPU() {
 			builtin.CPUType[arch] = "host"
-		} else {
+		} else if HasMaxCPU() {
 			builtin.CPUType[arch] = "max"
 		}
 	}


### PR DESCRIPTION
Doesn't work now, after adding 017a56ca10f0a867c73d2b06547302787ffddabc

Also needs to avoid falling back on tcg

----

Tested on Windows 10 (Pro), x64 (Intel)

Using Alpine Linux, and Alpine-Lima