### PR TITLE
Suggest creating and using new docker context for each vm

### DIFF
--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -80,7 +80,7 @@ portForwards:
 message: |
   To run `docker` on the host (assumes docker-cli is installed), run the following commands:
   ------
-  docker context create lima --docker "host=unix://{{.Dir}}/sock/docker.sock"
-  docker context use lima
+  docker context create lima-{{.Name}} --docker "host=unix://{{.Dir}}/sock/docker.sock"
+  docker context use lima-{{.Name}}
   docker run hello-world
   ------


### PR DESCRIPTION
The docker template suggests creating and using a context called "lima" each time a new VM is created. This, however, ends up with the following issue:

```bash
docker context create lima --docker "host=unix:///Users/jkremser/.lima/kep/sock/docker.sock"
context "lima" already exists
```

Instead, it would be nice to incorporate the name of the VM into the name of the context so that there is 1:1 relation and the previously mentioned issue is fixed. The output of the suggested commands looks like:

```
To run `docker` on the host (assumes docker-cli is installed), run the following commands:
------
docker context create lima-kep --docker "host=unix:///Users/ab017z6/.lima/kep/sock/docker.sock"
docker context use lima-kep
docker run hello-world
------
```

If the `"name"` argument is not provided to `limactl`, it defaults to `"docker"` so the output looks like this:


```
To run `docker` on the host (assumes docker-cli is installed), run the following commands:
------
docker context create lima-docker --docker "host=unix:///Users/ab017z6/.lima/docker/sock/docker.sock"
docker context use lima-docker
docker run hello-world
------
```

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>