### PR TITLE
podman: Use different connections for different instances

### DIFF
--- a/examples/podman.yaml
+++ b/examples/podman.yaml
@@ -53,7 +53,7 @@ portForwards:
 message: |
   To run `podman` on the host (assumes podman-remote is installed), run the following commands:
   ------
-  podman system connection add lima "unix://{{.Dir}}/sock/podman.sock"
-  podman system connection default lima
+  podman system connection add lima-{{.Name}} "unix://{{.Dir}}/sock/podman.sock"
+  podman system connection default lima-{{.Name}}
   podman{{if eq .HostOS "linux"}} --remote{{end}} run quay.io/podman/hello
   ------


### PR DESCRIPTION
Allows having more than one instance using podman.

Similar to change applied for the docker context.

Compare:

* https://github.com/lima-vm/lima/pull/935

Trying to keep docker and podman reasonably similar...