### PR TITLE
Add partial support for cygwin terminal on windows

### DIFF
--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/version"
+	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -57,6 +59,12 @@ func newApp() *cobra.Command {
 		debug, _ := cmd.Flags().GetBool("debug")
 		if debug {
 			logrus.SetLevel(logrus.DebugLevel)
+		}
+		if runtime.GOOS == "windows" && isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+			formatter := new(logrus.TextFormatter)
+			// the default setting does not recognize cygwin on windows
+			formatter.ForceColors = true
+			logrus.StandardLogger().SetFormatter(formatter)
 		}
 		if os.Geteuid() == 0 {
 			return errors.New("must not run as the root")

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -136,7 +136,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	sshArgs := sshutil.SSHArgsFromOpts(sshOpts)
-	if isatty.IsTerminal(os.Stdout.Fd()) {
+	if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
 		// required for showing the shell prompt: https://stackoverflow.com/a/626574
 		sshArgs = append(sshArgs, "-t")
 	}

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -54,6 +54,7 @@ $ limactl start --name=default https://raw.githubusercontent.com/lima-vm/lima/ma
 		ValidArgsFunction: startBashComplete,
 		RunE:              startAction,
 	}
+	// TODO: "survey" does not support using cygwin terminal on windows yet
 	startCommand.Flags().Bool("tty", isatty.IsTerminal(os.Stdout.Fd()), "enable TUI interactions such as opening an editor, defaults to true when stdout is a terminal")
 	startCommand.Flags().String("name", "", "override the instance name")
 	startCommand.Flags().Bool("list-templates", false, "list available templates and exit")

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -292,7 +292,7 @@ func createBar(size int64) (*pb.ProgressBar, error) {
 	bar := pb.New64(size)
 
 	bar.Set(pb.Bytes, true)
-	if isatty.IsTerminal(os.Stdout.Fd()) {
+	if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
 		bar.SetTemplateString(`{{counters . }} {{bar . | green }} {{percent .}} {{speed . "%s/s"}}`)
 		bar.SetRefreshRate(200 * time.Millisecond)
 	} else {


### PR DESCRIPTION
This enables terminal in shell and colored logs/download.
The interactive template selection is not implemented yet.

Issue #936