### PR TITLE
add usb hub to each vm

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -517,6 +517,7 @@ func Cmdline(cfg Config) (string, []string, error) {
 		args = append(args, "-device", "virtio-vga")
 		args = append(args, "-device", "virtio-keyboard-pci")
 		args = append(args, "-device", "virtio-mouse-pci")
+		args = append(args, "-device", "qemu-xhci,id=usb-bus")
 	default:
 		// QEMU does not seem to support virtio-vga for aarch64
 		args = append(args, "-vga", "none", "-device", "ramfb")


### PR DESCRIPTION
I am working on a project where we need to forward devices into the qemu guest OS. ARM guests already get a USB hub, unfortunately, x86 doesn't. It would be great to add to each x86 vm an xhci usb hub as well. (All other usb related work can then happen through qmp/hmp (at some point it might be cool to have an easy way to find the path of the colima qmp socket, but for now we can just build the path on our own).