### PR TITLE
Add no arch option

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -602,6 +602,8 @@ func NewArch(arch string) Arch {
 		return AARCH64
 	case "riscv64":
 		return RISCV64
+	case "noarch":
+		return NOARCH
 	default:
 		logrus.Warnf("Unknown arch: %s", arch)
 		return arch
@@ -646,6 +648,10 @@ func IsNativeArch(arch Arch) bool {
 	nativeAARCH64 := arch == AARCH64 && runtime.GOARCH == "arm64"
 	nativeRISCV64 := arch == RISCV64 && runtime.GOARCH == "riscv64"
 	return nativeX8664 || nativeAARCH64 || nativeRISCV64
+}
+
+func NoArch(arch Arch) bool {
+	return arch == NOARCH
 }
 
 func Cname(host string) string {

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -40,6 +40,7 @@ const (
 	X8664   Arch = "x86_64"
 	AARCH64 Arch = "aarch64"
 	RISCV64 Arch = "riscv64"
+	NOARCH  Arch = "noarch"
 
 	REVSSHFS MountType = "reverse-sshfs"
 	NINEP    MountType = "9p"

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -603,7 +603,7 @@ func getExe(arch limayaml.Arch) (string, []string, error) {
 }
 
 func getAccel(arch limayaml.Arch) string {
-	if limayaml.IsNativeArch(arch) {
+	if limayaml.IsNativeArch(arch) && !limayaml.NoArch(arch) {
 		switch runtime.GOOS {
 		case "darwin":
 			return "hvf"


### PR DESCRIPTION
Adding a no arch option allow forcing the `tcg` accelerator. This
allows lima to run on AMD based hackintosh machines and other macos
machines that does not support hvf.