### PR TITLE
Add option to force tcg accelerator

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -347,6 +347,10 @@ hostResolver:
 # - 1.1.1.1
 # - 1.0.0.1
 
+# Use Accel: "true", "false". Uses hvf, kvm, nvmm, whpx if true or tcg if false.
+# Builtin default: true
+useAccel: null
+
 # ===================================================================== #
 # GLOBAL DEFAULTS AND OVERRIDES
 # ===================================================================== #

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -75,6 +75,16 @@ func MACAddress(uniqueID string) string {
 // - DNS are picked from the highest priority where DNS is not empty.
 // - CACertificates Files and Certs are uniquely appended
 func FillDefault(y, d, o *LimaYAML, filePath string) {
+	if y.UseAccel == nil {
+		y.UseAccel = d.UseAccel
+	}
+	if o.UseAccel != nil {
+		y.UseAccel = o.UseAccel
+	}
+	if y.UseAccel == nil {
+		y.UseAccel = pointer.Bool(true)
+	}
+
 	if y.Arch == nil {
 		y.Arch = d.Arch
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -82,6 +82,7 @@ func TestFillDefault(t *testing.T) {
 		CACertificates: CACertificates{
 			RemoveDefaults: pointer.Bool(false),
 		},
+		UseAccel: pointer.Bool(true),
 	}
 	if IsAccelOS() {
 		if HasHostCPU() {
@@ -305,6 +306,7 @@ func TestFillDefault(t *testing.T) {
 				"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT\n-----END CERTIFICATE-----\n",
 			},
 		},
+		UseAccel: pointer.Bool(false),
 	}
 
 	expect = d
@@ -463,6 +465,7 @@ func TestFillDefault(t *testing.T) {
 		CACertificates: CACertificates{
 			RemoveDefaults: pointer.Bool(true),
 		},
+		UseAccel: pointer.Bool(false),
 	}
 
 	y = filledDefaults

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -29,6 +29,7 @@ type LimaYAML struct {
 	DNS               []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`
 	HostResolver      HostResolver      `yaml:"hostResolver,omitempty" json:"hostResolver,omitempty"`
 	UseHostResolver   *bool             `yaml:"useHostResolver,omitempty" json:"useHostResolver,omitempty"` // DEPRECATED, use `HostResolver.Enabled` instead
+	UseAccel          *bool             `yaml:"useAccel,omitempty" json:"useAccel,omitempty"`
 	PropagateProxyEnv *bool             `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty"`
 	CACertificates    CACertificates    `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
 }

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -350,7 +350,7 @@ func Cmdline(cfg Config) (string, []string, error) {
 	}
 
 	// Architecture
-	accel := getAccel(*y.Arch)
+	accel := getAccel(*y.Arch, *y.UseAccel)
 	if !strings.Contains(string(features.AccelHelp), accel) {
 		return "", nil, fmt.Errorf("accelerator %q is not supported by %s", accel, exe)
 	}
@@ -602,8 +602,8 @@ func getExe(arch limayaml.Arch) (string, []string, error) {
 	return exe, args, nil
 }
 
-func getAccel(arch limayaml.Arch) string {
-	if limayaml.IsNativeArch(arch) {
+func getAccel(arch limayaml.Arch, useAccel bool) string {
+	if limayaml.IsNativeArch(arch) && useAccel {
 		switch runtime.GOOS {
 		case "darwin":
 			return "hvf"


### PR DESCRIPTION
More a less a different implementation of
https://github.com/lima-vm/lima/pull/951

`useAccel` allow forcing the `tcg` accelerator. This
allows lima to run on AMD based hackintosh machines and other macos
machines that does not support hvf.

Right now it is only possible with `cpu.x86_64:qemu64` which seems to bee a little convoluted