### PR TITLE
Expand tilde using the current home path

### DIFF
--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -134,11 +134,11 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 	}
 	for i, f := range y.Mounts {
 		tag := fmt.Sprintf("mount%d", i)
-		location, err := localpathutil.Expand(f.Location)
+		location, err := localpathutil.ExpandHome(f.Location, hostHome)
 		if err != nil {
 			return err
 		}
-		mountPoint, err := localpathutil.Expand(f.MountPoint)
+		mountPoint, err := localpathutil.ExpandHome(f.MountPoint, u.HomeDir)
 		if err != nil {
 			return err
 		}

--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/localpathutil"
+	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/sshocker/pkg/reversesshfs"
 	"github.com/sirupsen/logrus"
 )
@@ -39,7 +40,11 @@ func (a *HostAgent) setupMount(ctx context.Context, m limayaml.Mount) (*mount, e
 		return nil, err
 	}
 
-	mountPoint, err := localpathutil.Expand(m.MountPoint)
+	u, err := osutil.LimaUser(false)
+	if err != nil {
+		return nil, err
+	}
+	mountPoint, err := localpathutil.ExpandHome(m.MountPoint, u.HomeDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/localpathutil/localpathutil.go
+++ b/pkg/localpathutil/localpathutil.go
@@ -12,14 +12,10 @@ import (
 // Paths like "~foo/bar" are unsupported.
 //
 // FIXME: is there an existing library for this?
-func Expand(orig string) (string, error) {
+func ExpandHome(orig string, homeDir string) (string, error) {
 	s := orig
 	if s == "" {
 		return "", errors.New("empty path")
-	}
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
 	}
 
 	if strings.HasPrefix(s, "~") {
@@ -29,6 +25,19 @@ func Expand(orig string) (string, error) {
 			// Paths like "~foo/bar" are unsupported.
 			return "", fmt.Errorf("unexpandable path %q", orig)
 		}
+	}
+	return s, nil
+}
+
+// Expand expands a path like "~", "~/", "~/foo", on the host.
+func Expand(orig string) (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	s, err := ExpandHome(orig, homeDir)
+	if err != nil {
+		return "", err
 	}
 	return filepath.Abs(s)
 }

--- a/pkg/localpathutil/localpathutil_test.go
+++ b/pkg/localpathutil/localpathutil_test.go
@@ -1,0 +1,29 @@
+package localpathutil
+
+import (
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestExpandTilde(t *testing.T) {
+	_, err := Expand("~")
+	assert.NilError(t, err)
+}
+
+func TestExpandDir(t *testing.T) {
+	h, err := Expand("~")
+	assert.NilError(t, err)
+	d, err := Expand("~/foo")
+	assert.NilError(t, err)
+	// make sure this uses the local filepath
+	assert.Equal(t, d, filepath.Join(h, "foo"))
+}
+
+func TestExpandHome(t *testing.T) {
+	p, err := ExpandHome("~/bar", "/home/user")
+	assert.NilError(t, err)
+	// make sure this uses the unix path
+	assert.Equal(t, p, "/home/user/bar")
+}


### PR DESCRIPTION
For instance it might be `C:\Users\anders` on the host,
but translated to `/c/Users/anders` path in the guest.