### PR TITLE
Use short path for LIMA_HOME on windows

### DIFF
--- a/pkg/store/dirnames/shortname_others.go
+++ b/pkg/store/dirnames/shortname_others.go
@@ -1,0 +1,9 @@
+//go:build !windows
+// +build !windows
+
+package dirnames
+
+// ShortPathName just returns the provided path.
+func ShortPathName(path string) (string, error) {
+	return path, nil
+}

--- a/pkg/store/dirnames/shortname_test.go
+++ b/pkg/store/dirnames/shortname_test.go
@@ -1,0 +1,37 @@
+package dirnames
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// Note: can't use t.TempDir(), because it is _always_ long... <sigh>
+//       instead use os.TempDir(), something like `C:\users\anders\Temp`
+
+func TestShortPathNameShort(t *testing.T) {
+	d := os.TempDir()
+	l := filepath.Join(d, "foo")
+	err := os.Mkdir(l, 0755)
+	assert.NilError(t, err)
+	s, err := ShortPathName(l)
+	assert.NilError(t, err)
+	t.Logf("%s => %s", l, s)
+	os.RemoveAll(l)
+}
+
+func TestShortPathNameLong(t *testing.T) {
+	d := os.TempDir()
+	l := filepath.Join(d, "baaaaaaaaaar")
+	err := os.Mkdir(l, 0755)
+	assert.NilError(t, err)
+	s, err := ShortPathName(l)
+	assert.NilError(t, err)
+	t.Logf("%s => %s", l, s)
+	fi, err := os.Stat(s)
+	assert.NilError(t, err)
+	assert.Assert(t, fi.Mode().IsDir())
+	os.RemoveAll(l)
+}

--- a/pkg/store/dirnames/shortname_windows.go
+++ b/pkg/store/dirnames/shortname_windows.go
@@ -1,0 +1,23 @@
+package dirnames
+
+import (
+	"syscall"
+)
+
+// ShortPathName return the short path name, when given a long path.
+func ShortPathName(path string) (string, error) {
+	p := syscall.StringToUTF16(path)
+	b := p // GetShortPathName says we can reuse buffer
+	n, err := syscall.GetShortPathName(&p[0], &b[0], uint32(len(b)))
+	if err != nil {
+		return "", err
+	}
+	if n > uint32(len(b)) {
+		b = make([]uint16, n)
+		n, err = syscall.GetShortPathName(&p[0], &b[0], uint32(len(b)))
+		if err != nil {
+			return "", err
+		}
+	}
+	return syscall.UTF16ToString(b), nil
+}


### PR DESCRIPTION
Other commands such as `qemu-system-x86_64.exe` don't work with
`C:\Users\AndersBjörklund`, they need to use `C:\Users\ANDERS~1`

In theory they _could_ have supported using UNC paths such as
`\\?\C:\Users\AndersBjörklund`, but in practice they do not...

https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getshortpathnamew

> A long file name is considered to be any file name that exceeds the short MS-DOS (also called 8.3) style naming convention.

### GOOS=linux (host)

```
=== RUN   TestShortNameShort
    shortname_test.go:20: /tmp/foo => /tmp/foo
--- PASS: TestShortNameShort (0.00s)
=== RUN   TestShortNameLong
    shortname_test.go:31: /tmp/baaaaaaaaaar => /tmp/baaaaaaaaaar
--- PASS: TestShortNameLong (0.00s)
PASS
```

### GOOS=windows (wine)

```
=== RUN   TestShortNameShort
    shortname_test.go:20: C:\users\anders\Temp\foo => C:\users\anders\Temp\foo
--- PASS: TestShortNameShort (0.00s)
=== RUN   TestShortNameLong
    shortname_test.go:31: C:\users\anders\Temp\baaaaaaaaaar => C:\users\anders\Temp\BAAA~MWI
--- PASS: TestShortNameLong (0.00s)
PASS
```