### PR TITLE
Disable starting an instance with default yaml if existing-instance f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ To see the template list:
 $ limactl start --list-templates
 ```
 
+To specify using an existing instance
+```console
+$ limactl start <INSTANCE> --existing-instance
+```
+
 To create an instance "default" from a local file:
 ```console
 $ limactl start --name=default /usr/local/share/lima/examples/fedora.yaml

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -58,6 +58,7 @@ $ limactl start --name=default https://raw.githubusercontent.com/lima-vm/lima/ma
 	startCommand.Flags().Bool("tty", isatty.IsTerminal(os.Stdout.Fd()), "enable TUI interactions such as opening an editor, defaults to true when stdout is a terminal")
 	startCommand.Flags().String("name", "", "override the instance name")
 	startCommand.Flags().Bool("list-templates", false, "list available templates and exit")
+	startCommand.Flags().Bool("existing-instance", false, "specify whether to start an existed instance")
 	return startCommand
 }
 
@@ -180,6 +181,13 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string) (*store.Instance, e
 		} else {
 			if !errors.Is(err, os.ErrNotExist) {
 				return nil, err
+			}
+			existingInstance, err := cmd.Flags().GetBool("existing-instance")
+			if err != nil {
+				return nil, err
+			}
+			if existingInstance {
+				return nil, errors.New("virtual machine instance does not exist. Set existing-instance to false to create an instance")
 			}
 			if arg != "" && arg != DefaultInstanceName {
 				logrus.Infof("Creating an instance %q from template://default (Not from template://%s)", st.instName, st.instName)


### PR DESCRIPTION
Hi. Today if we start a VM with limactl in a workflow with tty=false without specifing template or yaml, it will create a new instance with default yaml if we start an instance that doesn't exist. For example "limactl start newInstance --tty=false" will create a new instance with name "newInstance" from default.yaml file. We want to provide a way for users to start only existing instances without creating a new instance from default.yaml file unintentionlly. For backward capability, we added new flag --existing-instance to start command so that when user specifies the flag to be true, lima will throw an error instead of creating a new instance if the instance doesn't exist.