### PR TITLE
Avoid translating paths in MSYS2 shell wrapper

### DIFF
--- a/cmd/lima
+++ b/cmd/lima
@@ -30,4 +30,7 @@ fi
 if [ -n "${LIMA_WORKDIR}" ]; then
   set - --workdir "$LIMA_WORKDIR" "$@"
 fi
+# Avoid converting paths with MSYS2
+MSYS2_ARG_CONV_EXCL="*"
+export MSYS2_ARG_CONV_EXCL
 exec "$LIMACTL" shell "$@"


### PR DESCRIPTION
The paths in the command are for the Linux virtual machine,
so we want remote unix paths instead of local windows paths.

Otherwise you get strange results from `lima`, such as:
`cat: 'C:/msys64/etc/os-release': No such file or directory`

----

See https://www.msys2.org/docs/filesystem-paths/#automatic-unix-windows-path-conversion