### PR TITLE
Improve Linux distribution detection

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/27-discover-distribution.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/27-discover-distribution.sh
@@ -1,0 +1,318 @@
+#!/bin/sh
+#    Salt Bootstrap - Generic Salt Bootstrap Script
+
+#    Copyright 2012-2021 SaltStack (saltproject.io)
+
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+set -eux
+echo "#########DISCOVER###########"
+
+DISTRO_NAME=""
+DISTRO_VERSION=""
+#---  FUNCTION  -------------------------------------------------------------------------------------------------------
+#          NAME:  __gather_os_info
+#   DESCRIPTION:  Discover operating system information
+#----------------------------------------------------------------------------------------------------------------------
+__gather_os_info() {
+    OS_NAME=$(uname -s 2>/dev/null)
+    OS_NAME_L=$( echo "$OS_NAME" | tr '[:upper:]' '[:lower:]' )
+    OS_VERSION=$(uname -r)
+    # shellcheck disable=SC2034
+    OS_VERSION_L=$( echo "$OS_VERSION" | tr '[:upper:]' '[:lower:]' )
+}
+__gather_os_info
+
+
+#---  FUNCTION  -------------------------------------------------------------------------------------------------------
+#          NAME:  __parse_version_string
+#   DESCRIPTION:  Parse version strings ignoring the revision.
+#                 MAJOR.MINOR.REVISION becomes MAJOR.MINOR
+#----------------------------------------------------------------------------------------------------------------------
+__parse_version_string() {
+    VERSION_STRING="$1"
+    PARSED_VERSION=$(
+        echo "$VERSION_STRING" |
+        sed -e 's/^/#/' \
+            -e 's/^#[^0-9]*\([0-9][0-9]*\.[0-9][0-9]*\)\(\.[0-9][0-9]*\).*$/\1/' \
+            -e 's/^#[^0-9]*\([0-9][0-9]*\.[0-9][0-9]*\).*$/\1/' \
+            -e 's/^#[^0-9]*\([0-9][0-9]*\).*$/\1/' \
+            -e 's/^#.*$//'
+    )
+    echo "$PARSED_VERSION"
+}
+#---  FUNCTION  -------------------------------------------------------------------------------------------------------
+#          NAME:  __derive_debian_numeric_version
+#   DESCRIPTION:  Derive the numeric version from a Debian version string.
+#----------------------------------------------------------------------------------------------------------------------
+__derive_debian_numeric_version() {
+    NUMERIC_VERSION=""
+    INPUT_VERSION="$1"
+    if echo "$INPUT_VERSION" | grep -q '^[0-9]'; then
+        NUMERIC_VERSION="$INPUT_VERSION"
+    elif [ -z "$INPUT_VERSION" ] && [ -f "/etc/debian_version" ]; then
+        INPUT_VERSION="$(cat /etc/debian_version)"
+    fi
+    if [ -z "$NUMERIC_VERSION" ]; then
+        if [ "$INPUT_VERSION" = "wheezy/sid" ]; then
+            # I've found an EC2 wheezy image which did not tell its version
+            NUMERIC_VERSION=$(__parse_version_string "7.0")
+        elif [ "$INPUT_VERSION" = "jessie/sid" ]; then
+            NUMERIC_VERSION=$(__parse_version_string "8.0")
+        elif [ "$INPUT_VERSION" = "stretch/sid" ]; then
+            NUMERIC_VERSION=$(__parse_version_string "9.0")
+        elif [ "$INPUT_VERSION" = "buster/sid" ]; then
+            NUMERIC_VERSION=$(__parse_version_string "10.0")
+        elif [ "$INPUT_VERSION" = "bullseye/sid" ]; then
+            NUMERIC_VERSION=$(__parse_version_string "11.0")
+        else
+            echowarn "Unable to parse the Debian Version (codename: '$INPUT_VERSION')"
+        fi
+    fi
+    echo "$NUMERIC_VERSION"
+}
+#---  FUNCTION  -------------------------------------------------------------------------------------------------------
+#          NAME:  __unquote_string
+#   DESCRIPTION:  Strip single or double quotes from the provided string.
+#----------------------------------------------------------------------------------------------------------------------
+__unquote_string() {
+    # shellcheck disable=SC1117
+    echo "$*" | sed -e "s/^\([\"\']\)\(.*\)\1\$/\2/g"
+}
+
+#---  FUNCTION  -------------------------------------------------------------------------------------------------------
+#          NAME:  __camelcase_split
+#   DESCRIPTION:  Convert 'CamelCased' strings to 'Camel Cased'
+#----------------------------------------------------------------------------------------------------------------------
+__camelcase_split() {
+    echo "$*" | sed -e 's/\([^[:upper:][:punct:]]\)\([[:upper:]]\)/\1 \2/g'
+}
+
+#---  FUNCTION  -------------------------------------------------------------------------------------------------------
+#          NAME:  __strip_duplicates
+#   DESCRIPTION:  Strip duplicate strings
+#----------------------------------------------------------------------------------------------------------------------
+__strip_duplicates() {
+    echo "$*" | tr -s '[:space:]' '\n' | awk '!x[$0]++'
+}
+#---  FUNCTION  -------------------------------------------------------------------------------------------------------
+#          NAME:  __sort_release_files
+#   DESCRIPTION:  Custom sort function. Alphabetical or numerical sort is not
+#                 enough.
+#----------------------------------------------------------------------------------------------------------------------
+__sort_release_files() {
+    KNOWN_RELEASE_FILES=$(echo "(arch|alpine|centos|debian|ubuntu|fedora|redhat|suse|\
+        mandrake|mandriva|gentoo|slackware|turbolinux|unitedlinux|void|lsb|system|\
+        oracle|os|almalinux|rocky)(-|_)(release|version)" | sed -E 's:[[:space:]]::g')
+    primary_release_files=""
+    secondary_release_files=""
+    # Sort know VS un-known files first
+    for release_file in $(echo "${@}" | sed -E 's:[[:space:]]:\n:g' | sort -f | uniq); do
+        match=$(echo "$release_file" | grep -E -i "${KNOWN_RELEASE_FILES}")
+        if [ "${match}" != "" ]; then
+            primary_release_files="${primary_release_files} ${release_file}"
+        else
+            secondary_release_files="${secondary_release_files} ${release_file}"
+        fi
+    done
+
+    # Now let's sort by know files importance, max important goes last in the max_prio list
+    max_prio="redhat-release centos-release oracle-release fedora-release almalinux-release rocky-release"
+    for entry in $max_prio; do
+        if [ "$(echo "${primary_release_files}" | grep "$entry")" != "" ]; then
+            primary_release_files=$(echo "${primary_release_files}" | sed -e "s:\\(.*\\)\\($entry\\)\\(.*\\):\\2 \\1 \\3:g")
+        fi
+    done
+    # Now, least important goes last in the min_prio list
+    min_prio="lsb-release"
+    for entry in $min_prio; do
+        if [ "$(echo "${primary_release_files}" | grep "$entry")" != "" ]; then
+            primary_release_files=$(echo "${primary_release_files}" | sed -e "s:\\(.*\\)\\($entry\\)\\(.*\\):\\1 \\3 \\2:g")
+        fi
+    done
+
+    # Echo the results collapsing multiple white-space into a single white-space
+    echo "${primary_release_files} ${secondary_release_files}" | sed -E 's:[[:space:]]+:\n:g'
+}
+
+#---  FUNCTION  -------------------------------------------------------------------------------------------------------
+#          NAME:  __gather_linux_system_info
+#   DESCRIPTION:  Discover Linux system information
+#----------------------------------------------------------------------------------------------------------------------
+__gather_linux_system_info() {
+    DISTRO_NAME=""
+    DISTRO_VERSION=""
+
+    # Let's test if the lsb_release binary is available
+    rv=$(lsb_release >/dev/null 2>&1)
+
+    # shellcheck disable=SC2181
+    if [ $? -eq 0 ]; then
+        DISTRO_NAME=$(lsb_release -si)
+        if [ "${DISTRO_NAME}" = "Scientific" ]; then
+            DISTRO_NAME="Scientific Linux"
+        elif [ "$(echo "$DISTRO_NAME" | grep ^CloudLinux)" != "" ]; then
+            DISTRO_NAME="Cloud Linux"
+        elif [ "$(echo "$DISTRO_NAME" | grep ^RedHat)" != "" ]; then
+            # Let's convert 'CamelCased' to 'Camel Cased'
+            n=$(__camelcase_split "$DISTRO_NAME")
+            # Skip setting DISTRO_NAME this time, splitting CamelCase has failed.
+            # See https://github.com/saltstack/salt-bootstrap/issues/918
+            [ "$n" = "$DISTRO_NAME" ] && DISTRO_NAME="" || DISTRO_NAME="$n"
+        elif [ "$( echo "${DISTRO_NAME}" | grep openSUSE )" != "" ]; then
+            # lsb_release -si returns "openSUSE Tumbleweed" on openSUSE tumbleweed
+            # lsb_release -si returns "openSUSE project" on openSUSE 12.3
+            # lsb_release -si returns "openSUSE" on openSUSE 15.n
+            DISTRO_NAME="opensuse"
+        elif [ "${DISTRO_NAME}" = "SUSE LINUX" ]; then
+            if [ "$(lsb_release -sd | grep -i opensuse)" != "" ]; then
+                # openSUSE 12.2 reports SUSE LINUX on lsb_release -si
+                DISTRO_NAME="opensuse"
+            else
+                # lsb_release -si returns "SUSE LINUX" on SLES 11 SP3
+                DISTRO_NAME="suse"
+            fi
+        elif [ "${DISTRO_NAME}" = "EnterpriseEnterpriseServer" ]; then
+            # This the Oracle Linux Enterprise ID before ORACLE LINUX 5 UPDATE 3
+            DISTRO_NAME="Oracle Linux"
+        elif [ "${DISTRO_NAME}" = "OracleServer" ]; then
+            # This the Oracle Linux Server 6.5
+            DISTRO_NAME="Oracle Linux"
+        elif [ "${DISTRO_NAME}" = "AmazonAMI" ] || [ "${DISTRO_NAME}" = "Amazon" ]; then
+            DISTRO_NAME="Amazon Linux AMI"
+        elif [ "${DISTRO_NAME}" = "ManjaroLinux" ]; then
+            DISTRO_NAME="Arch Linux"
+        elif [ "${DISTRO_NAME}" = "Arch" ]; then
+            DISTRO_NAME="Arch Linux"
+            return
+        elif [ "${DISTRO_NAME}" = "Rocky" ]; then
+            DISTRO_NAME="Rocky Linux"
+        fi
+        rv=$(lsb_release -sr)
+        [ "${rv}" != "" ] && DISTRO_VERSION=$(__parse_version_string "$rv")
+    elif [ -f /etc/lsb-release ]; then
+        # We don't have the lsb_release binary, though, we do have the file it parses
+        DISTRO_NAME=$(grep DISTRIB_ID /etc/lsb-release | sed -e 's/.*=//')
+        rv=$(grep DISTRIB_RELEASE /etc/lsb-release | sed -e 's/.*=//')
+        [ "${rv}" != "" ] && DISTRO_VERSION=$(__parse_version_string "$rv")
+    fi
+
+    if [ "$DISTRO_NAME" != "" ] && [ "$DISTRO_VERSION" != "" ]; then
+        # We already have the distribution name and version
+        return
+    fi
+    # shellcheck disable=SC2035,SC2086
+    for rsource in $(__sort_release_files "$(
+            cd /etc && /bin/ls *[_-]release *[_-]version 2>/dev/null | env -i sort | \
+            sed -e '/^redhat-release$/d' -e '/^lsb-release$/d'; \
+            echo redhat-release lsb-release
+            )"); do
+
+        [ ! -f "/etc/${rsource}" ] && continue      # Does not exist
+
+        n=$(echo "${rsource}" | sed -e 's/[_-]release$//' -e 's/[_-]version$//')
+        shortname=$(echo "${n}" | tr '[:upper:]' '[:lower:]')
+        if [ "$shortname" = "debian" ]; then
+            rv=$(__derive_debian_numeric_version "$(cat /etc/${rsource})")
+        else
+            rv=$( (grep VERSION "/etc/${rsource}"; cat "/etc/${rsource}") | grep '[0-9]' | sed -e 'q' )
+        fi
+        [ "${rv}" = "" ] && [ "$shortname" != "arch" ] && continue  # There's no version information. Continue to next rsource
+        v=$(__parse_version_string "$rv")
+        case $shortname in
+            redhat             )
+                if [ "$(grep -E 'CentOS' /etc/${rsource})" != "" ]; then
+                    n="CentOS"
+                elif [ "$(grep -E 'Scientific' /etc/${rsource})" != "" ]; then
+                    n="Scientific Linux"
+                elif [ "$(grep -E 'Red Hat Enterprise Linux' /etc/${rsource})" != "" ]; then
+                    n="<R>ed <H>at <E>nterprise <L>inux"
+                else
+                    n="<R>ed <H>at <L>inux"
+                fi
+                ;;
+            arch               ) n="Arch Linux"     ;;
+            alpine             ) n="Alpine Linux"   ;;
+            centos             ) n="CentOS"         ;;
+            debian             ) n="Debian"         ;;
+            ubuntu             ) n="Ubuntu"         ;;
+            fedora             ) n="Fedora"         ;;
+            suse|opensuse      ) n="SUSE"           ;;
+            mandrake*|mandriva ) n="Mandriva"       ;;
+            gentoo             ) n="Gentoo"         ;;
+            slackware          ) n="Slackware"      ;;
+            turbolinux         ) n="TurboLinux"     ;;
+            unitedlinux        ) n="UnitedLinux"    ;;
+            void               ) n="VoidLinux"      ;;
+            oracle             ) n="Oracle Linux"   ;;
+            almalinux          ) n="AlmaLinux"      ;;
+            rocky              ) n="Rocky Linux"    ;;
+            system             )
+                while read -r line; do
+                    [ "${n}x" != "systemx" ] && break
+                    case "$line" in
+                        *Amazon*Linux*AMI*)
+                            n="Amazon Linux AMI"
+                            break
+                    esac
+                done < "/etc/${rsource}"
+                ;;
+            os                 )
+                nn="$(__unquote_string "$(grep '^ID=' /etc/os-release | sed -e 's/^ID=\(.*\)$/\1/g')")"
+                rv="$(__unquote_string "$(grep '^VERSION_ID=' /etc/os-release | sed -e 's/^VERSION_ID=\(.*\)$/\1/g')")"
+                [ "${rv}" != "" ] && v=$(__parse_version_string "$rv") || v=""
+                case $(echo "${nn}" | tr '[:upper:]' '[:lower:]') in
+                    alpine      )
+                        n="Alpine Linux"
+                        v="${rv}"
+                        ;;
+                    amzn        )
+                        # Amazon AMI's after 2014.09 match here
+                        n="Amazon Linux AMI"
+                        ;;
+                    arch        )
+                        n="Arch Linux"
+                        v=""  # Arch Linux does not provide a version.
+                        ;;
+                    cloudlinux  )
+                        n="Cloud Linux"
+                        ;;
+                    debian      )
+                        n="Debian"
+                        v=$(__derive_debian_numeric_version "$v")
+                        ;;
+                    sles  )
+                        n="SUSE"
+                        v="${rv}"
+                        ;;
+                    opensuse-* )
+                        n="opensuse"
+                        v="${rv}"
+                        ;;
+                    *           )
+                        n=${nn}
+                        ;;
+                esac
+                ;;
+            *                  ) n="${n}"           ;
+        esac
+        DISTRO_NAME=$n
+        DISTRO_VERSION=$v
+        break
+    done
+}
+
+__gather_linux_system_info
+echo $DISTRO_VERSION
+echo $DISTRO_NAME
+

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eux
 
-source /etc/os-release
+. /etc/os-release
 SETUP_DNS=0
 DISTRIBUTION=""
 INSTALL_IPTABLES=0
@@ -28,7 +28,7 @@ determine_distribution() {
 		DISTRIBUTION="arch_like"
 	elif command -v zypper >/dev/null 2>&1 && [ "$ID_LIKE" = "opensuse suse" ]; then
 		DISTRIBUTION="suse_like"
-	elif command -v apk >/dev/null 2>&1 && [ "ID" = "alpine" ]; then
+	elif command -v apk >/dev/null 2>&1 && [ "$ID" = "alpine" ]; then
 		DISTRIBUTION="alpine_like"
 	else
 		guess_distribution_based_on_package_manager

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -20,17 +20,17 @@ main() {
 }
 
 determine_distribution() {
-	if command -v apt-get >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : "debian") ]; then
+	if command -v apt-get >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : ".*debian") -gt 0 ]; then
 		DISTRIBUTION="debian_like"
-	elif command -v dnf >/dev/null 2>&1 && [ $(expr "$ID" : "fedora") ]; then
+	elif command -v dnf >/dev/null 2>&1 && [ $(expr "$ID" : ".*fedora") -gt 0 ]; then
 		DISTRIBUTION="redhat_like"
-	elif command -v yum >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : "centos") ]; then
+	elif command -v yum >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : "centos") -gt 0 ]; then
 		DISTRIBUTION="centos_like"
-	elif command -v pacman >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : "arch") ]; then
+	elif command -v pacman >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : "arch") -gt 0 ]; then
 		DISTRIBUTION="arch_like"
-	elif command -v zypper >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : "suse") ]; then
+	elif command -v zypper >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : "suse") -gt 0 ]; then
 		DISTRIBUTION="suse_like"
-	elif command -v apk >/dev/null 2>&1 && [ $(expr "$ID" : "alpine") ]; then
+	elif command -v apk >/dev/null 2>&1 && [ $(expr "$ID" : "alpine") -gt 0 ]; then
 		DISTRIBUTION="alpine_like"
 	else
 		guess_distribution_based_on_package_manager

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -24,13 +24,13 @@ determine_distribution() {
 		DISTRIBUTION="debian_like"
 	elif command -v dnf >/dev/null 2>&1 && [ $(expr "$ID" : ".*fedora") -gt 0 ]; then
 		DISTRIBUTION="redhat_like"
-	elif command -v yum >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : "centos") -gt 0 ]; then
+	elif command -v yum >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : ".*centos") -gt 0 ]; then
 		DISTRIBUTION="centos_like"
-	elif command -v pacman >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : "arch") -gt 0 ]; then
+	elif command -v pacman >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : ".*arch") -gt 0 ]; then
 		DISTRIBUTION="arch_like"
-	elif command -v zypper >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : "suse") -gt 0 ]; then
+	elif command -v zypper >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : ".*suse") -gt 0 ]; then
 		DISTRIBUTION="suse_like"
-	elif command -v apk >/dev/null 2>&1 && [ $(expr "$ID" : "alpine") -gt 0 ]; then
+	elif command -v apk >/dev/null 2>&1 && [ $(expr "$ID" : ".*alpine") -gt 0 ]; then
 		DISTRIBUTION="alpine_like"
 	else
 		guess_distribution_based_on_package_manager

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 set -eux
 
-. /etc/os-release
 SETUP_DNS=0
 DISTRIBUTION=""
 INSTALL_IPTABLES=0
+ID_LIKE=""
+ID=""
+[ -f /etc/os-release ] && . /etc/os-release
 
 
 main() {

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -15,8 +15,8 @@ main() {
 	install_minimal_dependencies
 	setup_dns
 	# update_fuse_conf has to be called after installing all the packages,
-	# otherwise apt-get fails with conflict	
-	update_fuse_conf	
+	# otherwise apt-get fails with conflict
+	update_fuse_conf
 }
 
 determine_distribution() {

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -20,17 +20,17 @@ main() {
 }
 
 determine_distribution() {
-	if command -v apt-get >/dev/null 2>&1 && [ "$ID_LIKE" = "debian" ]; then
+	if command -v apt-get >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : "debian") ]; then
 		DISTRIBUTION="debian_like"
-	elif command -v dnf >/dev/null 2>&1 && [ "$ID" = "fedora" ]; then
+	elif command -v dnf >/dev/null 2>&1 && [ $(expr "$ID" : "fedora") ]; then
 		DISTRIBUTION="redhat_like"
-	elif command -v yum >/dev/null 2>&1 && [ "$ID_LIKE" = "centos" ]; then
+	elif command -v yum >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : "centos") ]; then
 		DISTRIBUTION="centos_like"
-	elif command -v pacman >/dev/null 2>&1 && [ "$ID_LIKE" = "arch" ]; then
+	elif command -v pacman >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : "arch") ]; then
 		DISTRIBUTION="arch_like"
-	elif command -v zypper >/dev/null 2>&1 && [ "$ID_LIKE" = "opensuse suse" ]; then
+	elif command -v zypper >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : "suse") ]; then
 		DISTRIBUTION="suse_like"
-	elif command -v apk >/dev/null 2>&1 && [ "$ID" = "alpine" ]; then
+	elif command -v apk >/dev/null 2>&1 && [ $(expr "$ID" : "alpine") ]; then
 		DISTRIBUTION="alpine_like"
 	else
 		guess_distribution_based_on_package_manager

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -1,29 +1,86 @@
 #!/bin/sh
 set -eux
 
-update_fuse_conf() {
-	# Modify /etc/fuse.conf (/etc/fuse3.conf) to allow "-o allow_root"
-	if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ]; then
-		fuse_conf="/etc/fuse.conf"
-		if [ -e /etc/fuse3.conf ]; then
-			fuse_conf="/etc/fuse3.conf"
-		fi
-		if ! grep -q "^user_allow_other" "${fuse_conf}"; then
-			echo "user_allow_other" >>"${fuse_conf}"
-		fi
+source /etc/os-release
+SETUP_DNS=0
+DISTRIBUTION=""
+INSTALL_IPTABLES=0
+
+
+main() {
+	determine_distribution
+	determine_need_for_iptables
+	install_minimal_dependencies
+	setup_dns
+	# update_fuse_conf has to be called after installing all the packages,
+	# otherwise apt-get fails with conflict	
+	update_fuse_conf	
+}
+
+determine_distribution() {
+	if command -v apt-get >/dev/null 2>&1 && [ "$ID_LIKE" = "debian" ]; then
+		DISTRIBUTION="debian_like"
+	elif command -v dnf >/dev/null 2>&1 && [ "$ID" = "fedora" ]; then
+		DISTRIBUTION="redhat_like"
+	elif command -v yum >/dev/null 2>&1 && [ "$ID_LIKE" = "centos" ]; then
+		DISTRIBUTION="centos_like"
+	elif command -v pacman >/dev/null 2>&1 && [ "$ID_LIKE" = "arch" ]; then
+		DISTRIBUTION="arch_like"
+	elif command -v zypper >/dev/null 2>&1 && [ "$ID_LIKE" = "opensuse suse" ]; then
+		DISTRIBUTION="suse_like"
+	elif command -v apk >/dev/null 2>&1 && [ "ID" = "alpine" ]; then
+		DISTRIBUTION="alpine_like"
+	else
+		guess_distribution_based_on_package_manager
 	fi
 }
 
-INSTALL_IPTABLES=0
-if [ "${LIMA_CIDATA_CONTAINERD_SYSTEM}" = 1 ] || [ "${LIMA_CIDATA_CONTAINERD_USER}" = 1 ]; then
-	INSTALL_IPTABLES=1
-fi
-if [ "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" -ne 0 ] || [ "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" -ne 0 ]; then
-	INSTALL_IPTABLES=1
-fi
+guess_distribution_based_on_package_manager() {
+	if command -v apt-get >/dev/null 2>&1; then
+		DISTRIBUTION="debian_like"
+	elif command -v dnf >/dev/null 2>&1; then
+		DISTRIBUTION="redhat_like"
+	elif command -v yum >/dev/null 2>&1; then
+		DISTRIBUTION="redhat_like"
+	elif command -v pacman >/dev/null 2>&1; then
+		DISTRIBUTION="arch_like"
+	elif command -v zypper >/dev/null 2>&1; then
+		DISTRIBUTION="suse_like"
+	elif command -v apk >/dev/null 2>&1; then
+		DISTRIBUTION="alpine_like"
+	fi
+}
+
+determine_need_for_iptables() {
+	if [ "${LIMA_CIDATA_CONTAINERD_SYSTEM}" = 1 ] || [ "${LIMA_CIDATA_CONTAINERD_USER}" = 1 ]; then
+		INSTALL_IPTABLES=1
+	fi
+	if [ "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" -ne 0 ] || [ "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" -ne 0 ]; then
+		INSTALL_IPTABLES=1
+	fi
+}
+
+install_minimal_dependencies() {
+	case $DISTRIBUTION in
+		"debian_like") install_debian_dependencies
+		;;
+		"redhat_like") install_redhat_dependencies
+		;;
+		"centos_like") install_centos_dependencies
+		;;
+		"arch_like") install_arch_dependencies
+		;;
+		"suse_like") install_suse_dependencies
+		;;
+		"alpine_like") install_alpine_dependencies
+		;;
+		*) echo "Could not determine any suitable actions to provision machine"
+		;;
+	esac
+}
 
 # Install minimum dependencies
-if command -v apt-get >/dev/null 2>&1; then
+install_debian_dependencies() {
 	pkgs=""
 	if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
 		if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ] && ! command -v sshfs >/dev/null 2>&1; then
@@ -43,7 +100,9 @@ if command -v apt-get >/dev/null 2>&1; then
 		# shellcheck disable=SC2086
 		apt-get install -y --no-upgrade --no-install-recommends -q ${pkgs}
 	fi
-elif command -v dnf >/dev/null 2>&1; then
+}
+
+install_redhat_dependencies() {
 	pkgs=""
 	if ! command -v tar >/dev/null 2>&1; then
 		pkgs="${pkgs} tar"
@@ -84,7 +143,9 @@ elif command -v dnf >/dev/null 2>&1; then
 		# Workaround for https://github.com/containerd/stargz-snapshotter/issues/340
 		ln -s fusermount3 /usr/bin/fusermount
 	fi
-elif command -v yum >/dev/null 2>&1; then
+}
+
+install_centos_dependencies() {
 	echo "DEPRECATED: CentOS7 and others RHEL-like version 7 are unsupported and might be removed or stop to work in future lima releases"
 	pkgs=""
 	yum_install_flags="-y"
@@ -113,7 +174,9 @@ elif command -v yum >/dev/null 2>&1; then
 		yum install ${yum_install_flags} ${pkgs}
 		yum-config-manager --disable epel >/dev/null 2>&1
 	fi
-elif command -v pacman >/dev/null 2>&1; then
+}
+
+install_arch_dependencies() {
 	pkgs=""
 	if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
 		if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ] && ! command -v sshfs >/dev/null 2>&1; then
@@ -125,7 +188,9 @@ elif command -v pacman >/dev/null 2>&1; then
 		# shellcheck disable=SC2086
 		pacman -Sy --noconfirm ${pkgs}
 	fi
-elif command -v zypper >/dev/null 2>&1; then
+}
+
+install_suse_dependencies() {
 	pkgs=""
 	if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
 		if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ] && ! command -v sshfs >/dev/null 2>&1; then
@@ -142,7 +207,9 @@ elif command -v zypper >/dev/null 2>&1; then
 		# shellcheck disable=SC2086
 		zypper --non-interactive install -y --no-recommends ${pkgs}
 	fi
-elif command -v apk >/dev/null 2>&1; then
+}
+
+install_alpine_dependencies() {
 	pkgs=""
 	if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
 		if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ] && ! command -v sshfs >/dev/null 2>&1; then
@@ -157,22 +224,32 @@ elif command -v apk >/dev/null 2>&1; then
 		# shellcheck disable=SC2086
 		apk add ${pkgs}
 	fi
-fi
+}
 
-SETUP_DNS=0
-if [ -n "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" ] && [ "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" -ne 0 ]; then
-	SETUP_DNS=1
-fi
-if [ -n "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" ] && [ "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" -ne 0 ]; then
-	SETUP_DNS=1
-fi
-if [ "${SETUP_DNS}" = 1 ]; then
-	# Try to setup iptables rule again, in case we just installed iptables
-	"${LIMA_CIDATA_MNT}/boot/09-host-dns-setup.sh"
-fi
+setup_dns() {
+	if [ -n "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" ] && [ "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" -ne 0 ]; then
+		SETUP_DNS=1
+	fi
+	if [ -n "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" ] && [ "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" -ne 0 ]; then
+		SETUP_DNS=1
+	fi
+	if [ "${SETUP_DNS}" = 1 ]; then
+		# Try to setup iptables rule again, in case we just installed iptables
+		"${LIMA_CIDATA_MNT}/boot/09-host-dns-setup.sh"
+	fi
+}
 
-# update_fuse_conf has to be called after installing all the packages,
-# otherwise apt-get fails with conflict
-if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
-	update_fuse_conf
-fi
+update_fuse_conf() {
+	# Modify /etc/fuse.conf (/etc/fuse3.conf) to allow "-o allow_root"
+	if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ] && [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
+		fuse_conf="/etc/fuse.conf"
+		if [ -e /etc/fuse3.conf ]; then
+			fuse_conf="/etc/fuse3.conf"
+		fi
+		if ! grep -q "^user_allow_other" "${fuse_conf}"; then
+			echo "user_allow_other" >>"${fuse_conf}"
+		fi
+	fi
+}
+
+main

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -6,6 +6,11 @@ DISTRIBUTION=""
 INSTALL_IPTABLES=0
 ID_LIKE=""
 ID=""
+
+# We check if the file exists or not and we have
+# safeguards in case it sources only empty vars
+# hence we can ignore shellcheck in this instance
+# shellcheck disable=SC1091
 [ -f /etc/os-release ] && . /etc/os-release
 
 
@@ -20,17 +25,17 @@ main() {
 }
 
 determine_distribution() {
-	if command -v apt-get >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : ".*debian") -gt 0 ]; then
+	if command -v apt-get >/dev/null 2>&1 && [ "$(expr "$ID_LIKE" : ".*debian")" -gt 0 ]; then
 		DISTRIBUTION="debian_like"
-	elif command -v dnf >/dev/null 2>&1 && [ $(expr "$ID" : ".*fedora") -gt 0 ]; then
+	elif command -v dnf >/dev/null 2>&1 && [ "$(expr "$ID" : ".*fedora")" -gt 0 ]; then
 		DISTRIBUTION="redhat_like"
-	elif command -v yum >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : ".*centos") -gt 0 ]; then
+	elif command -v yum >/dev/null 2>&1 && [ "$(expr "$ID_LIKE" : ".*centos")" -gt 0 ]; then
 		DISTRIBUTION="centos_like"
-	elif command -v pacman >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : ".*arch") -gt 0 ]; then
+	elif command -v pacman >/dev/null 2>&1 && [ "$(expr "$ID_LIKE" : ".*arch")" -gt 0 ]; then
 		DISTRIBUTION="arch_like"
-	elif command -v zypper >/dev/null 2>&1 && [ $(expr "$ID_LIKE" : ".*suse") -gt 0 ]; then
+	elif command -v zypper >/dev/null 2>&1 && [ "$(expr "$ID_LIKE" : ".*suse")" -gt 0 ]; then
 		DISTRIBUTION="suse_like"
-	elif command -v apk >/dev/null 2>&1 && [ $(expr "$ID" : ".*alpine") -gt 0 ]; then
+	elif command -v apk >/dev/null 2>&1 && [ "$(expr "$ID" : ".*alpine")" -gt 0 ]; then
 		DISTRIBUTION="alpine_like"
 	else
 		guess_distribution_based_on_package_manager

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -2,60 +2,16 @@
 set -eux
 
 SETUP_DNS=0
-DISTRIBUTION=""
 INSTALL_IPTABLES=0
-ID_LIKE=""
-ID=""
-
-# We check if the file exists or not and we have
-# safeguards in case it sources only empty vars
-# hence we can ignore shellcheck in this instance
-# shellcheck disable=SC1091
-[ -f /etc/os-release ] && . /etc/os-release
-
-
+. "${LIMA_CIDATA_MNT}/boot/27-discover-distribution.sh"
+echo $DISTRO_NAME
 main() {
-	determine_distribution
 	determine_need_for_iptables
 	install_minimal_dependencies
 	setup_dns
 	# update_fuse_conf has to be called after installing all the packages,
 	# otherwise apt-get fails with conflict
 	update_fuse_conf
-}
-
-determine_distribution() {
-	if command -v apt-get >/dev/null 2>&1 && [ "$(expr "$ID_LIKE" : ".*debian")" -gt 0 ]; then
-		DISTRIBUTION="debian_like"
-	elif command -v dnf >/dev/null 2>&1 && [ "$(expr "$ID" : ".*fedora")" -gt 0 ]; then
-		DISTRIBUTION="redhat_like"
-	elif command -v yum >/dev/null 2>&1 && [ "$(expr "$ID_LIKE" : ".*centos")" -gt 0 ]; then
-		DISTRIBUTION="centos_like"
-	elif command -v pacman >/dev/null 2>&1 && [ "$(expr "$ID_LIKE" : ".*arch")" -gt 0 ]; then
-		DISTRIBUTION="arch_like"
-	elif command -v zypper >/dev/null 2>&1 && [ "$(expr "$ID_LIKE" : ".*suse")" -gt 0 ]; then
-		DISTRIBUTION="suse_like"
-	elif command -v apk >/dev/null 2>&1 && [ "$(expr "$ID" : ".*alpine")" -gt 0 ]; then
-		DISTRIBUTION="alpine_like"
-	else
-		guess_distribution_based_on_package_manager
-	fi
-}
-
-guess_distribution_based_on_package_manager() {
-	if command -v apt-get >/dev/null 2>&1; then
-		DISTRIBUTION="debian_like"
-	elif command -v dnf >/dev/null 2>&1; then
-		DISTRIBUTION="redhat_like"
-	elif command -v yum >/dev/null 2>&1; then
-		DISTRIBUTION="redhat_like"
-	elif command -v pacman >/dev/null 2>&1; then
-		DISTRIBUTION="arch_like"
-	elif command -v zypper >/dev/null 2>&1; then
-		DISTRIBUTION="suse_like"
-	elif command -v apk >/dev/null 2>&1; then
-		DISTRIBUTION="alpine_like"
-	fi
 }
 
 determine_need_for_iptables() {
@@ -68,18 +24,39 @@ determine_need_for_iptables() {
 }
 
 install_minimal_dependencies() {
-	case $DISTRIBUTION in
-		"debian_like") install_debian_dependencies
+	echo "##################INSTALL######################"
+	case $DISTRO_NAME in
+		"Arch Linux") install_arch_dependencies
 		;;
-		"redhat_like") install_redhat_dependencies
+		"Alpine Linux") install_alpine_dependencies
 		;;
-		"centos_like") install_centos_dependencies
+		"CentOS") install_centos_dependencies
 		;;
-		"arch_like") install_arch_dependencies
+		"Debian") install_debian_dependencies
 		;;
-		"suse_like") install_suse_dependencies
+		"Ubuntu") install_debian_dependencies
 		;;
-		"alpine_like") install_alpine_dependencies
+		"Fedora") install_redhat_dependencies
+		;;
+		"SUSE") install_suse_dependencies
+		;;
+		"Mandriva")
+		;;
+		"Gentoo")
+		;;
+		"Slackware")
+		;;
+		"TurboLinux")
+		;;
+		"UnitedLinux")
+		;;
+		"VoidLinux")
+		;;
+		"Oracle Linux") install_redhat_dependencies
+		;;
+		"AlmaLinux") install_redhat_dependencies
+		;;
+		"Rocky Linux") install_redhat_dependencies
 		;;
 		*) echo "Could not determine any suitable actions to provision machine"
 		;;


### PR DESCRIPTION
This will close https://github.com/lima-vm/lima/issues/983. I took the liberty to reorder the file a little so one does not need to parse the whole file to understand what will happen. As it is now, this will implement both ways of checking for the distribution as discussed. It will check for the distribution and the package manager. If those checks fail it will try to work with the package manager only on a best effort basis.

Now you only need to parse the main function to understand the intent of the file. Addition of new distributions should hopefully be easier as well since one won't need to parse the long `if elif else` decision tree.

I'd like to simplify the new `install_$DISTRO_dependencies` functions a little more too but I'd need input on if it is the right course to take.