### PR TITLE
CI: upgrading test: set the old ver to 0.10.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,7 +140,7 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
-        oldver: ["v0.8.0"]
+        oldver: ["v0.10.0"]
     steps:
     - uses: actions/setup-go@v3
       with:


### PR DESCRIPTION
Lima v0.8.0 no longer starts up with the default template as Ubuntu 21.10 reached EOL

Fix #991
