### PR TITLE
Add github test for windows using wine

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,27 @@ jobs:
     - name: Uninstall
       run: sudo make uninstall
 
+  cross-windows:
+    name: "Windows tests (cross)"
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    steps:
+    - uses: actions/setup-go@v3
+      with:
+        go-version: 1.18.x
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+    - name: Install wine
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y wine-binfmt wine64
+        sudo apt-get remove -y mono-runtime || true
+    - name: Unit tests
+      run: GOOS=windows GOARCH=amd64 go test -v ./...
+    - name: Make
+      run: make GOOS=windows GOARCH=amd64
+
   integration:
     name: Integration tests
     runs-on: macos-11


### PR DESCRIPTION
This will only run the unit tests, not any integration tests.

For that, a real Windows machine (with Hyper-V) is needed...
