### PR TITLE
Add VNC video display including password

### DIFF
--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -5,3 +5,4 @@ The following features are experimental and subject to change:
 - `mountType: 9p`
 - `vmType: vz` and relevant configurations (`mountType: virtiofs`, `rosetta`, `[]networks.vzNAT`)
 - `arch: riscv64`
+- `video.display: vnc` and relevant configuration (`video.vnc.display`)

--- a/docs/internal.md
+++ b/docs/internal.md
@@ -56,6 +56,10 @@ SSH:
 - `ssh.sock`: SSH control master socket
 - `ssh.config`: SSH config file for `ssh -F`. Not consumed by Lima itself.
 
+VNC:
+- `vncdisplay`: VNC display host/port
+- `vncpassword`: VNC display password
+
 Guest agent:
 - `ga.sock`: Forwarded to `/run/lima-guestagent.sock` in the guest, via SSH
 

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -245,13 +245,21 @@ firmware:
   legacyBIOS: null
 
 video:
-  # QEMU display, e.g., "none", "cocoa", "sdl", "gtk", "default".
+  # QEMU display, e.g., "none", "cocoa", "sdl", "gtk", "vnc", "default".
   # Choosing "none" will hide the video output, and not show any window.
+  # Choosing "vnc" will use a network server, and not show any window.
   # Choosing "default" will pick the first available of: gtk, sdl, cocoa.
-  # As of QEMU v6.2, enabling this is known to have negative impact
+  # As of QEMU v6.2, enabling anything but none or vnc is known to have negative impact
   # on performance on macOS hosts: https://gitlab.com/qemu-project/qemu/-/issues/334
   # 🟢 Builtin default: "none"
   display: null
+  # VNC (Virtual Network Computing) is a platform-independent graphical
+  # desktop-sharing system that uses the Remote Frame Buffer protocol (RFB)
+  vnc:
+    # VNC display, e.g.,"to=L", "host:d", "unix:path", "none"
+    # By convention the TCP port is 5900+d, connections from any host.
+    # 🟢 Builtin default: "127.0.0.1:0,to=9"
+    display: null
 
 # The instance can get routable IP addresses from the vmnet framework using
 # https://github.com/lima-vm/socket_vmnet.

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/norouter/norouter v0.6.3
 	github.com/nxadm/tail v1.4.8
 	github.com/opencontainers/go-digest v1.0.0
+	github.com/sethvargo/go-password v0.2.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/xorcare/pointer v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -496,6 +496,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
+github.com/sethvargo/go-password v0.2.0 h1:BTDl4CC/gjf/axHMaDQtw507ogrXLci6XRiLc7i/UHI=
+github.com/sethvargo/go-password v0.2.0/go.mod h1:Ym4Mr9JXLBycr02MFuVQ/0JHidNetSgbzutTr3zsYXE=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -15,6 +15,10 @@ type Driver interface {
 	Start(_ context.Context) (chan error, error)
 
 	Stop(_ context.Context) error
+
+	ChangeDisplayPassword(_ context.Context, password string) error
+
+	GetDisplayConnection(_ context.Context) (string, error)
 }
 
 type BaseDriver struct {
@@ -38,4 +42,12 @@ func (d *BaseDriver) Start(_ context.Context) (chan error, error) {
 
 func (d *BaseDriver) Stop(_ context.Context) error {
 	return nil
+}
+
+func (d *BaseDriver) ChangeDisplayPassword(_ context.Context, password string) error {
+	return nil
+}
+
+func (d *BaseDriver) GetDisplayConnection(_ context.Context) (string, error) {
+	return "", nil
 }

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net"
 	"os"
 	"os/exec"
@@ -33,6 +32,7 @@ import (
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/lima-vm/sshocker/pkg/ssh"
+	"github.com/sethvargo/go-password/password"
 	"github.com/sirupsen/logrus"
 )
 
@@ -253,12 +253,8 @@ func (a *HostAgent) emitEvent(_ context.Context, ev events.Event) {
 }
 
 func generatePassword(length int) (string, error) {
-	passwd := ""
-	rand.Seed(time.Now().UnixNano())
-	for i := 0; i < length; i++ {
-		passwd += strconv.Itoa(rand.Intn(10))
-	}
-	return passwd, nil
+	// avoid any special symbols, to make it easier to copy/paste
+	return password.Generate(length, length/4, 0, false, false)
 }
 
 func (a *HostAgent) Run(ctx context.Context) error {

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -329,10 +329,10 @@ func (a *HostAgent) Run(ctx context.Context) error {
 		if err := os.WriteFile(vncfile, []byte(vncdisplay), 0600); err != nil {
 			return err
 		}
-		vncurl := "vnc://:" + vncpasswd + "@" + net.JoinHostPort(vnchost, vncport)
-		logrus.Infof("VNC server running at <%s>", vncurl)
-		logrus.Infof("VNC Display: \"%s\" `%s`", vncdisplay, vncfile)
-		logrus.Infof("VNC Password: \"%s\" `%s`", vncpasswd, vncpwdfile)
+		vncurl := "vnc://" + net.JoinHostPort(vnchost, vncport)
+		logrus.Infof("VNC server running at %s <%s>", vncdisplay, vncurl)
+		logrus.Infof("VNC Display: `%s`", vncfile)
+		logrus.Infof("VNC Password: `%s`", vncpwdfile)
 	}
 
 	stBase := events.Status{

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -186,6 +186,16 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.Video.Display = pointer.String("none")
 	}
 
+	if y.Video.VNC.Display == nil {
+		y.Video.VNC.Display = d.Video.VNC.Display
+	}
+	if o.Video.VNC.Display != nil {
+		y.Video.VNC.Display = o.Video.VNC.Display
+	}
+	if y.Video.VNC.Display == nil || *y.Video.VNC.Display == "" {
+		y.Video.VNC.Display = pointer.String("127.0.0.1:0,to=9")
+	}
+
 	if y.Firmware.LegacyBIOS == nil {
 		y.Firmware.LegacyBIOS = d.Firmware.LegacyBIOS
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -72,6 +72,9 @@ func TestFillDefault(t *testing.T) {
 		},
 		Video: Video{
 			Display: pointer.String("none"),
+			VNC: VNCOptions{
+				Display: pointer.String("127.0.0.1:0,to=9"),
+			},
 		},
 		HostResolver: HostResolver{
 			Enabled: pointer.Bool(true),
@@ -262,6 +265,9 @@ func TestFillDefault(t *testing.T) {
 		},
 		Video: Video{
 			Display: pointer.String("cocoa"),
+			VNC: VNCOptions{
+				Display: pointer.String("none"),
+			},
 		},
 		HostResolver: HostResolver{
 			Enabled: pointer.Bool(false),
@@ -418,6 +424,9 @@ func TestFillDefault(t *testing.T) {
 		},
 		Video: Video{
 			Display: pointer.String("cocoa"),
+			VNC: VNCOptions{
+				Display: pointer.String("none"),
+			},
 		},
 		HostResolver: HostResolver{
 			Enabled: pointer.Bool(false),

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -122,9 +122,14 @@ type Firmware struct {
 	LegacyBIOS *bool `yaml:"legacyBIOS,omitempty" json:"legacyBIOS,omitempty"`
 }
 
+type VNCOptions struct {
+	Display *string `yaml:"display,omitempty" json:"display,omitempty"`
+}
+
 type Video struct {
 	// Display is a QEMU display string
-	Display *string `yaml:"display,omitempty" json:"display,omitempty"`
+	Display *string    `yaml:"display,omitempty" json:"display,omitempty"`
+	VNC     VNCOptions `yaml:"vnc" json:"vnc"`
 }
 
 type ProvisionMode = string

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -549,7 +549,12 @@ func Cmdline(cfg Config) (string, []string, error) {
 
 	// Graphics
 	if *y.Video.Display != "" {
-		args = appendArgsIfNoConflict(args, "-display", *y.Video.Display)
+		display := *y.Video.Display
+		if display == "vnc" {
+			display += "=" + *y.Video.VNC.Display
+			display += ",password=on"
+		}
+		args = appendArgsIfNoConflict(args, "-display", display)
 	}
 	switch *y.Arch {
 	case limayaml.X8664, limayaml.RISCV64:

--- a/pkg/store/filenames/filenames.go
+++ b/pkg/store/filenames/filenames.go
@@ -38,6 +38,8 @@ const (
 	SerialSock         = "serial.sock"
 	SSHSock            = "ssh.sock"
 	SSHConfig          = "ssh.config"
+	VNCDisplayFile     = "vncdisplay"
+	VNCPasswordFile    = "vncpassword"
 	GuestAgentSock     = "ga.sock"
 	HostAgentPID       = "ha.pid"
 	HostAgentSock      = "ha.sock"


### PR DESCRIPTION
The other display options open a window always, while the
vnc is more "on demand" by using a separate vnc viewer.
    
Add localhost and password support for some minimal security.
The password is generated, and is stored as an instance file.


Closes #1003 