### PR TITLE
nerdctl: update to v0.22.2 ; templates: update archlinux, alpine-lima

### DIFF
--- a/examples/alpine.yaml
+++ b/examples/alpine.yaml
@@ -1,11 +1,11 @@
 # This example requires Lima v0.7.0 or later.
 images:
-- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.18/alpine-lima-std-3.16.0-x86_64.iso"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.20/alpine-lima-std-3.16.0-x86_64.iso"
   arch: "x86_64"
-  digest: "sha512:234e407867a8955b9835b08e605b38583815dbd63c5690b558fbbd7b519af115c53694ddc3ff498cddb112f113e350c9f8b2a3351be038aa443399a39eff6007"
-- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.18/alpine-lima-std-3.16.0-aarch64.iso"
+  digest: "sha512:13568f84cd5b2d9988ff16c2b5a6bfd86ae0d0ac7ec4a4b9903e4b0c46e88dd39a7446d5e9d26037884204567c1f7b6924288786929e8639aae82a43c08261ef"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.20/alpine-lima-std-3.16.0-aarch64.iso"
   arch: "aarch64"
-  digest: "sha512:4e2cb238c78910384f30fb2aba02892d5b5092d50dfb0e345de71f7f194d24b890c81d2d502a0910d150de023ae77a3dbcda76cd6b71df2dd43e4dbccfc85170"
+  digest: "sha512:675df49ff142304fe33e2f93d827e925cdb2de00834360c62f05088d2a0006a3d7a6fc737b39b92ad85f04d0d3635d1f0e30d9657660ab6281666a5b0672c9a7"
 
 mounts:
 - location: "~"

--- a/examples/archlinux.yaml
+++ b/examples/archlinux.yaml
@@ -1,9 +1,9 @@
 # This example requires Lima v0.7.0 or later
 images:
 # Try to use yyyyMMdd.REV image if available. Note that yyyyMMdd.REV will be removed after several months.
-- location: "https://geo.mirror.pkgbuild.com/images/v20220715.68480/Arch-Linux-x86_64-cloudimg-20220715.68480.qcow2"
+- location: "https://geo.mirror.pkgbuild.com/images/v20220801.71902/Arch-Linux-x86_64-cloudimg-20220801.71902.qcow2"
   arch: "x86_64"
-  digest: "sha256:59c15b0c624bd9301e2b85f775dd14f634f8e2bc1ea99065d3f2609e5b6f9916"
+  digest: "sha256:cf814e457e516556172cdd5b921ce79cd7c1a97d685c85ce96070687ff7de992"
 - location: "https://github.com/mcginty/arch-boxes/releases/download/v20220323/Arch-Linux-aarch64-cloudimg-20220323.0.qcow2"
   arch: "aarch64"
   digest: "sha512:27524910bf41cb9b3223c8749c6e67fd2f2fdb8b70d40648708e64d6b03c0b4a01b3c5e72d51fefd3e0c3f58487dbb400a79ca378cde2da341a3a19873612be8"

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -29,7 +29,7 @@ const (
 )
 
 func defaultContainerdArchives() []File {
-	const nerdctlVersion = "0.22.0"
+	const nerdctlVersion = "0.22.2"
 	location := func(goarch string) string {
 		return "https://github.com/containerd/nerdctl/releases/download/v" + nerdctlVersion + "/nerdctl-full-" + nerdctlVersion + "-linux-" + goarch + ".tar.gz"
 	}
@@ -37,12 +37,12 @@ func defaultContainerdArchives() []File {
 		{
 			Location: location("amd64"),
 			Arch:     X8664,
-			Digest:   "sha256:2c891984eae000e76e47ae1e6be82c7c2732202bbfe9e1f9f66ceff44f4ec257",
+			Digest:   "sha256:2b4a099fbc30bd9959b0034f3c3e73a011ea8c76aa7e20139862313aef576e61",
 		},
 		{
 			Location: location("arm64"),
 			Arch:     AARCH64,
-			Digest:   "sha256:939e438a29eee11ff85a808b1f504e8875d1fe9aa2174cff761fc5bfdd461194",
+			Digest:   "sha256:73ecaa66e9d2debbe6a1c47a3ca0bbc14d3e6f9e99f2f5a5a28129c2d745f0ba",
 		},
 		// No riscv64
 	}


### PR DESCRIPTION
https://github.com/containerd/nerdctl/releases/tag/v0.22.1
https://github.com/containerd/nerdctl/releases/tag/v0.22.2