### PR TITLE
Use the latest and greatest flannel CNI for k8s

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -116,7 +116,7 @@ provision:
     EOF
     kubeadm init --config kubeadm-config.yaml
     # Installing a Pod network add-on
-    kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/v0.14.0/Documentation/kube-flannel.yml
+    kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/v0.19.1-1-gab7a3945/Documentation/kube-flannel.yml
     # Control plane node isolation
     kubectl taint nodes --all node-role.kubernetes.io/control-plane-
     sed -e "s/${LIMA_CIDATA_SLIRP_IP_ADDRESS:-192.168.5.15}/127.0.0.1/" -i $KUBECONFIG


### PR DESCRIPTION
The manifest for 0.19 was broken again, wrong images.

~~Might as well use the latest, same as with kubeadm ?~~

Closes #1034 

EDIT: Using specified version again, instead of "master"