### PR TITLE
Return error when template expansion fails

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -290,7 +290,7 @@ func (a *qArgTemplateApplier) applyTemplate(qArg string) (string, error) {
 	}
 	var b bytes.Buffer
 	if err := tmpl.Execute(&b, nil); err != nil {
-		return "", nil
+		return "", err
 	}
 	return b.String(), nil
 }


### PR DESCRIPTION
Unfortunately I could not determine what triggered this error, but I've run into it while testing Rancher Desktop with socket_vmnet, and qemu failed because it had a `-netdev` option without `id` in the value (there was no value at all).

I've not been able to reproduce it again since I fixed the error reporting.