### PR TITLE
templates: Update docker.yaml to use official Docker repository

### DIFF
--- a/examples/docker-rootful.yaml
+++ b/examples/docker-rootful.yaml
@@ -54,6 +54,20 @@ provision:
     fi
     export DEBIAN_FRONTEND=noninteractive
     curl -fsSL https://get.docker.com | sh
+
+    # DOCKER_INSTALL_START
+    # From official Docker Engine installation guide: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
+    apt-get update
+    apt-get -y install ca-certificates curl gnupg lsb-release
+
+    mkdir -p /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+    apt-get update
+    apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    # DOCKER_INSTALL_END
 probes:
 - script: |
     #!/bin/bash

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -45,7 +45,21 @@ provision:
     set -eux -o pipefail
     command -v docker >/dev/null 2>&1 && exit 0
     export DEBIAN_FRONTEND=noninteractive
-    curl -fsSL https://get.docker.com | sh
+
+    # DOCKER_INSTALL_START
+    # From official Docker Engine installation guide: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
+    apt-get update
+    apt-get -y install ca-certificates curl gnupg lsb-release
+
+    mkdir -p /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+    apt-get update
+    apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-ce-rootless-extras
+    # DOCKER_INSTALL_END
+
     # NOTE: you may remove the lines below, if you prefer to use rootful docker, not rootless
     systemctl disable --now docker
     apt-get install -y uidmap dbus-user-session


### PR DESCRIPTION
# Background
According to the [official installation guide for Ubuntu](https://docs.docker.com/engine/install/ubuntu/#install-using-the-convenience-script), using [get.docker.com](get.docker.com) script is not recommanded for production environment.

> Docker provides a convenience script at [get.docker.com](https://get.docker.com/) to install Docker into development environments quickly and non-interactively. The convenience script is **not recommended for production environments**, but can be used as an example to create a provisioning script that is tailored to your needs.

So I made changes to ```examples/docker.yaml``` according to the [official Docker Engine installation guide](https://docs.docker.com/engine/install/ubuntu/#set-up-the-repository) and replaced convenience-script with apt-get using official Docker repository.

This might not be relevant since lima-vm is still in beta state(assuming it hasn't reached to v1), I thought this might be a good idea for future production-ready lima-vm.

# Notes
I purposfully did not update ```examples/docker-rootful.yaml``` since rootful environment should be used for test/local development environment only.