### PR TITLE
 simplify `FillDefault()` using reflects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/huandu/go-clone v1.4.0
 	github.com/intel-go/cpuid v0.0.0-20220614022739-219e067757cb
 	github.com/lima-vm/sshocker v0.3.0
 	github.com/mattn/go-isatty v0.0.16

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,10 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
+github.com/huandu/go-assert v1.1.5 h1:fjemmA7sSfYHJD7CUqs9qTwwfdNAx7/j2/ZlHXzNB3c=
+github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
+github.com/huandu/go-clone v1.4.0 h1:NlnghW4lsmMoz+3N4yb4Ouff86ArRYPo/1aCsqQKKF4=
+github.com/huandu/go-clone v1.4.0/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/intel-go/cpuid v0.0.0-20220614022739-219e067757cb h1:Fg0Y/RDZ6UPwl3o7/IzPbneDq8g9+gH6DPs42KFUsy8=

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -299,18 +299,6 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		// After defaults processing the singular HostPort and GuestPort values should not be used again.
 	}
 
-	// If both `useHostResolved` and `HostResolver.Enabled` are defined in the same config,
-	// then the deprecated `useHostResolved` setting is silently ignored.
-	if y.HostResolver.Enabled == nil {
-		y.HostResolver.Enabled = y.UseHostResolver
-	}
-	if d.HostResolver.Enabled == nil {
-		d.HostResolver.Enabled = d.UseHostResolver
-	}
-	if o.HostResolver.Enabled == nil {
-		o.HostResolver.Enabled = o.UseHostResolver
-	}
-
 	if y.HostResolver.Enabled == nil {
 		y.HostResolver.Enabled = d.HostResolver.Enabled
 	}
@@ -339,19 +327,6 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 	}
 	if y.PropagateProxyEnv == nil {
 		y.PropagateProxyEnv = pointer.Bool(true)
-	}
-
-	if len(y.Network.VDEDeprecated) > 0 && len(y.Networks) == 0 {
-		for _, vde := range y.Network.VDEDeprecated {
-			network := Network{
-				Interface:            vde.Name,
-				MACAddress:           vde.MACAddress,
-				SwitchPortDeprecated: vde.SwitchPort,
-				VNLDeprecated:        vde.VNL,
-			}
-			y.Networks = append(y.Networks, network)
-		}
-		y.Network.migrated = true
 	}
 
 	networks := make([]Network, 0, len(d.Networks)+len(y.Networks)+len(o.Networks))

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -22,8 +22,6 @@ func TestFillDefault(t *testing.T) {
 	var d, y, o LimaYAML
 
 	opts := []cmp.Option{
-		// Ignore internal NetworkDeprecated.migrated field
-		cmpopts.IgnoreUnexported(NetworkDeprecated{}),
 		// Consider nil slices and empty slices to be identical
 		cmpopts.EquateEmpty(),
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -46,10 +46,10 @@ func TestFillDefault(t *testing.T) {
 	// Builtin default values
 	builtin := LimaYAML{
 		Arch: pointer.String(arch),
-		CPUType: map[Arch]string{
-			AARCH64: "cortex-a72",
-			X8664:   "qemu64",
-			RISCV64: "rv64",
+		CPUType: map[Arch]*string{
+			AARCH64: pointer.String("cortex-a72"),
+			X8664:   pointer.String("qemu64"),
+			RISCV64: pointer.String("rv64"),
 		},
 		CPUs:   pointer.Int(4),
 		Memory: pointer.String("4GiB"),
@@ -83,9 +83,9 @@ func TestFillDefault(t *testing.T) {
 	}
 	if IsAccelOS() {
 		if HasHostCPU() {
-			builtin.CPUType[arch] = "host"
+			builtin.CPUType[arch] = pointer.String("host")
 		} else if HasMaxCPU() {
-			builtin.CPUType[arch] = "max"
+			builtin.CPUType[arch] = pointer.String("max")
 		}
 	}
 
@@ -217,10 +217,10 @@ func TestFillDefault(t *testing.T) {
 	// Choose values that are different from the "builtin" defaults
 	d = LimaYAML{
 		Arch: pointer.String("unknown"),
-		CPUType: map[Arch]string{
-			AARCH64: "arm64",
-			X8664:   "amd64",
-			RISCV64: "riscv64",
+		CPUType: map[Arch]*string{
+			AARCH64: pointer.String("arm64"),
+			X8664:   pointer.String("amd64"),
+			RISCV64: pointer.String("riscv64"),
 		},
 		CPUs:   pointer.Int(7),
 		Memory: pointer.String("5GiB"),
@@ -361,10 +361,10 @@ func TestFillDefault(t *testing.T) {
 
 	o = LimaYAML{
 		Arch: pointer.String(arch),
-		CPUType: map[Arch]string{
-			AARCH64: "uber-arm",
-			X8664:   "pentium",
-			RISCV64: "sifive-u54",
+		CPUType: map[Arch]*string{
+			AARCH64: pointer.String("uber-arm"),
+			X8664:   pointer.String("pentium"),
+			RISCV64: pointer.String("sifive-u54"),
 		},
 		CPUs:   pointer.Int(12),
 		Memory: pointer.String("7GiB"),

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -7,30 +7,30 @@ import (
 )
 
 type LimaYAML struct {
-	Arch              *Arch             `yaml:"arch,omitempty" json:"arch,omitempty"`
-	Images            []Image           `yaml:"images" json:"images"` // REQUIRED
-	CPUType           map[Arch]string   `yaml:"cpuType,omitempty" json:"cpuType,omitempty"`
-	CPUs              *int              `yaml:"cpus,omitempty" json:"cpus,omitempty"`
-	Memory            *string           `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
-	Disk              *string           `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes
-	Mounts            []Mount           `yaml:"mounts,omitempty" json:"mounts,omitempty"`
-	MountType         *MountType        `yaml:"mountType,omitempty" json:"mountType,omitempty"`
-	SSH               SSH               `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
-	Firmware          Firmware          `yaml:"firmware,omitempty" json:"firmware,omitempty"`
-	Video             Video             `yaml:"video,omitempty" json:"video,omitempty"`
-	Provision         []Provision       `yaml:"provision,omitempty" json:"provision,omitempty"`
-	Containerd        Containerd        `yaml:"containerd,omitempty" json:"containerd,omitempty"`
-	Probes            []Probe           `yaml:"probes,omitempty" json:"probes,omitempty"`
-	PortForwards      []PortForward     `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
-	Message           string            `yaml:"message,omitempty" json:"message,omitempty"`
-	Networks          []Network         `yaml:"networks,omitempty" json:"networks,omitempty"`
-	Network           NetworkDeprecated `yaml:"network,omitempty" json:"network,omitempty"` // DEPRECATED, use `networks` instead
-	Env               map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
-	DNS               []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`
-	HostResolver      HostResolver      `yaml:"hostResolver,omitempty" json:"hostResolver,omitempty"`
-	UseHostResolver   *bool             `yaml:"useHostResolver,omitempty" json:"useHostResolver,omitempty"` // DEPRECATED, use `HostResolver.Enabled` instead
-	PropagateProxyEnv *bool             `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty"`
-	CACertificates    CACertificates    `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
+	Arch         *Arch           `yaml:"arch,omitempty" json:"arch,omitempty"`
+	Images       []Image         `yaml:"images" json:"images"` // REQUIRED
+	CPUType      map[Arch]string `yaml:"cpuType,omitempty" json:"cpuType,omitempty"`
+	CPUs         *int            `yaml:"cpus,omitempty" json:"cpus,omitempty"`
+	Memory       *string         `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
+	Disk         *string         `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes
+	Mounts       []Mount         `yaml:"mounts,omitempty" json:"mounts,omitempty"`
+	MountType    *MountType      `yaml:"mountType,omitempty" json:"mountType,omitempty"`
+	SSH          SSH             `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
+	Firmware     Firmware        `yaml:"firmware,omitempty" json:"firmware,omitempty"`
+	Video        Video           `yaml:"video,omitempty" json:"video,omitempty"`
+	Provision    []Provision     `yaml:"provision,omitempty" json:"provision,omitempty"`
+	Containerd   Containerd      `yaml:"containerd,omitempty" json:"containerd,omitempty"`
+	Probes       []Probe         `yaml:"probes,omitempty" json:"probes,omitempty"`
+	PortForwards []PortForward   `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
+	Message      string          `yaml:"message,omitempty" json:"message,omitempty"`
+	Networks     []Network       `yaml:"networks,omitempty" json:"networks,omitempty"`
+	// `network` was deprecated in Lima v0.7.0, removed in Lima v1.0.0. Use `networks` instead.
+	Env          map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+	DNS          []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`
+	HostResolver HostResolver      `yaml:"hostResolver,omitempty" json:"hostResolver,omitempty"`
+	// `useHostResolver` was deprecated in Lima v0.8.1, removed in Lima v1.0.0. Use `hostResolver.enabled` instead.
+	PropagateProxyEnv *bool          `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty"`
+	CACertificates    CACertificates `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
 }
 
 type Arch = string
@@ -193,12 +193,6 @@ type CACertificates struct {
 
 // Types have been renamed to turn all references to the old names into compiler errors,
 // and to avoid accidental usage in new code.
-
-type NetworkDeprecated struct {
-	VDEDeprecated []VDEDeprecated `yaml:"vde,omitempty" json:"vde,omitempty"`
-	// migrate will be true when `network.VDE` has been copied to `networks` by FillDefaults()
-	migrated bool
-}
 
 type VDEDeprecated struct {
 	VNL        string `yaml:"vnl,omitempty" json:"vnl,omitempty"`

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -7,23 +7,23 @@ import (
 )
 
 type LimaYAML struct {
-	Arch         *Arch           `yaml:"arch,omitempty" json:"arch,omitempty"`
-	Images       []Image         `yaml:"images" json:"images"` // REQUIRED
-	CPUType      map[Arch]string `yaml:"cpuType,omitempty" json:"cpuType,omitempty"`
-	CPUs         *int            `yaml:"cpus,omitempty" json:"cpus,omitempty"`
-	Memory       *string         `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
-	Disk         *string         `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes
-	Mounts       []Mount         `yaml:"mounts,omitempty" json:"mounts,omitempty"`
-	MountType    *MountType      `yaml:"mountType,omitempty" json:"mountType,omitempty"`
-	SSH          SSH             `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
-	Firmware     Firmware        `yaml:"firmware,omitempty" json:"firmware,omitempty"`
-	Video        Video           `yaml:"video,omitempty" json:"video,omitempty"`
-	Provision    []Provision     `yaml:"provision,omitempty" json:"provision,omitempty"`
-	Containerd   Containerd      `yaml:"containerd,omitempty" json:"containerd,omitempty"`
-	Probes       []Probe         `yaml:"probes,omitempty" json:"probes,omitempty"`
-	PortForwards []PortForward   `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
-	Message      string          `yaml:"message,omitempty" json:"message,omitempty"`
-	Networks     []Network       `yaml:"networks,omitempty" json:"networks,omitempty"`
+	Arch         *Arch            `yaml:"arch,omitempty" json:"arch,omitempty"`
+	Images       []Image          `yaml:"images" json:"images"` // REQUIRED
+	CPUType      map[Arch]*string `yaml:"cpuType,omitempty" json:"cpuType,omitempty"`
+	CPUs         *int             `yaml:"cpus,omitempty" json:"cpus,omitempty"`
+	Memory       *string          `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
+	Disk         *string          `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes
+	Mounts       []Mount          `yaml:"mounts,omitempty" json:"mounts,omitempty"`
+	MountType    *MountType       `yaml:"mountType,omitempty" json:"mountType,omitempty"`
+	SSH          SSH              `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
+	Firmware     Firmware         `yaml:"firmware,omitempty" json:"firmware,omitempty"`
+	Video        Video            `yaml:"video,omitempty" json:"video,omitempty"`
+	Provision    []Provision      `yaml:"provision,omitempty" json:"provision,omitempty"`
+	Containerd   Containerd       `yaml:"containerd,omitempty" json:"containerd,omitempty"`
+	Probes       []Probe          `yaml:"probes,omitempty" json:"probes,omitempty"`
+	PortForwards []PortForward    `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
+	Message      string           `yaml:"message,omitempty" json:"message,omitempty"`
+	Networks     []Network        `yaml:"networks,omitempty" json:"networks,omitempty"`
 	// `network` was deprecated in Lima v0.7.0, removed in Lima v1.0.0. Use `networks` instead.
 	Env          map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 	DNS          []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -262,15 +262,6 @@ func Validate(y LimaYAML, warn bool) error {
 }
 
 func validateNetwork(y LimaYAML, warn bool) error {
-	if len(y.Network.VDEDeprecated) > 0 {
-		if y.Network.migrated {
-			if warn {
-				logrus.Warnf("field `network.VDE` is deprecated; please use `networks` instead")
-			}
-		} else {
-			return fmt.Errorf("you cannot use deprecated field `network.VDE` together with replacement field `networks`")
-		}
-	}
 	interfaceName := make(map[string]int)
 	for i, nw := range y.Networks {
 		field := fmt.Sprintf("networks[%d]", i)

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -365,11 +365,14 @@ func Cmdline(cfg Config) (string, []string, error) {
 	args = appendArgsIfNoConflict(args, "-m", strconv.Itoa(int(memBytes>>20)))
 
 	// CPU
-	cpu := y.CPUType[*y.Arch]
-	args = appendArgsIfNoConflict(args, "-cpu", cpu)
+	cpu, ok := y.CPUType[*y.Arch]
+	if !ok || cpu == nil {
+		return "", nil, fmt.Errorf("no cpu type is defined for arch %q", *y.Arch)
+	}
+	args = appendArgsIfNoConflict(args, "-cpu", *cpu)
 	switch *y.Arch {
 	case limayaml.X8664:
-		if strings.HasPrefix(cpu, "qemu64") && runtime.GOOS != "windows" {
+		if strings.HasPrefix(*cpu, "qemu64") && runtime.GOOS != "windows" {
 			// use q35 machine with vmware io port disabled.
 			args = appendArgsIfNoConflict(args, "-machine", "q35,vmport=off")
 			// use tcg accelerator with multi threading with 512MB translation block size

--- a/pkg/reflectutil/reflectutil.go
+++ b/pkg/reflectutil/reflectutil.go
@@ -1,0 +1,104 @@
+package reflectutil
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+
+	"github.com/huandu/go-clone"
+)
+
+// NonAppendableSliceTypes are non-appendable slice types, such as net.IP .
+var NonAppendableSliceTypes = map[reflect.Type]struct{}{
+	reflect.TypeOf(net.IP{}): {}, // []byte
+}
+
+// MergeMany merges vv and returns the new value.
+// MergeMany does not alter vv.
+//
+// Maps are merged in "vv[0], vv[1], .., vv[N-1]" order.
+// Slices are appended in the "vv[N-1], .., vv[1], vv[0]" order.
+func MergeMany(vv ...interface{}) (interface{}, error) {
+	if l := len(vv); l < 2 {
+		return nil, fmt.Errorf("expected len(vv) >= 2, got %d", l)
+	}
+	x := vv[0]
+	for _, v := range vv[1:] {
+		var err error
+		x, err = Merge(x, v)
+		if err != nil {
+			return x, err
+		}
+	}
+	return x, nil
+}
+
+// Merge merges o (override) into d (default) and returns the new value.
+// Merge does not alter o and d.
+//
+// Maps are merged in the "d, o" order.
+// Slices are appended in the "o, d" order.
+func Merge(d, o interface{}) (interface{}, error) {
+	if o == nil {
+		return d, nil
+	}
+	dVal, oVal := reflect.ValueOf(d), reflect.ValueOf(o)
+	if dVal.Type() != oVal.Type() {
+		return nil, fmt.Errorf("type mismatch: %T vs %T", d, o)
+	}
+	x := clone.Clone(d)
+	xVal := reflect.ValueOf(x)
+	merge(xVal, oVal)
+	return x, nil
+}
+
+func merge(xVal, oVal reflect.Value) {
+	switch k := xVal.Kind(); k {
+	case reflect.Pointer:
+		if !oVal.IsNil() {
+			if xVal.IsNil() {
+				xVal.Set(cloneVal(oVal))
+			} else {
+				merge(xVal.Elem(), oVal.Elem())
+			}
+		}
+	case reflect.Struct:
+		numField := xVal.NumField()
+		for i := 0; i < numField; i++ {
+			merge(xVal.Field(i), oVal.Field(i))
+		}
+	case reflect.Map:
+		if xVal.IsNil() {
+			xVal.Set(reflect.MakeMap(oVal.Type()))
+		}
+		oValIter := oVal.MapRange()
+		for oValIter.Next() {
+			k, v := oValIter.Key(), oValIter.Value()
+			// Ignore nil pointer (but empty value like "" and 0 are not ignored)
+			if v.Kind() == reflect.Pointer && v.IsNil() {
+				continue
+			}
+			xVal.SetMapIndex(cloneVal(k), cloneVal(v))
+		}
+	case reflect.Array:
+		xVal.Set(cloneVal(oVal))
+	case reflect.Slice:
+		if _, ok := NonAppendableSliceTypes[xVal.Type()]; ok {
+			xVal.Set(cloneVal(oVal))
+		} else {
+			// o comes first
+			xVal.Set(reflect.AppendSlice(cloneVal(oVal), xVal))
+		}
+	case reflect.Chan, reflect.Func, reflect.Interface:
+		panic(fmt.Errorf("unexpected kind %+v", k))
+	default:
+		if xVal.CanSet() {
+			// oVal is not a pointer(-ish), so no need to clone oVal
+			xVal.Set(oVal)
+		}
+	}
+}
+
+func cloneVal(v reflect.Value) reflect.Value {
+	return reflect.ValueOf(clone.Clone(v.Interface()))
+}

--- a/pkg/reflectutil/reflectutil_test.go
+++ b/pkg/reflectutil/reflectutil_test.go
@@ -1,0 +1,154 @@
+package reflectutil
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+
+	"github.com/xorcare/pointer"
+	"gotest.tools/v3/assert"
+)
+
+type Foo struct {
+	BoolPtr, BoolPtr2, BoolPtr3, BoolPtr4 *bool
+	IntPtr, IntPtr2, IntPtr3, IntPtr4     *int
+	StrPtr, StrPtr2                       *string
+	StrStrMap, StrStrMap2                 map[string]string
+	StrSlice                              []string
+	StrArray                              [2]string
+	Struct                                FooChild
+}
+
+type FooChild struct {
+	Int, Int2    int
+	Str, Str2    string
+	IP           net.IP
+	IPSlice      []net.IP
+	StrStrPtrMap map[string]*string
+}
+
+func TestMerge(t *testing.T) {
+	d := &Foo{
+		BoolPtr:  pointer.Bool(true),
+		BoolPtr2: pointer.Bool(false),
+		BoolPtr3: nil,
+		BoolPtr4: pointer.Bool(true),
+		IntPtr:   pointer.Int(42),
+		IntPtr2:  pointer.Int(200),
+		IntPtr3:  nil,
+		IntPtr4:  pointer.Int(400),
+		StrPtr:   pointer.String("hello"),
+		StrPtr2:  pointer.String("world"),
+		StrStrMap: map[string]string{
+			"a": "apple",
+			"b": "banana",
+			"c": "cranberry",
+		},
+		StrStrMap2: nil,
+		StrSlice:   []string{"alpha", "beta"},
+		StrArray:   [2]string{"alabama", "alaska"},
+		Struct: FooChild{
+			Int:     -42,
+			Int2:    -100,
+			Str:     "bonjour",
+			Str2:    "le monde",
+			IP:      net.ParseIP("192.168.10.1"),
+			IPSlice: []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.2")},
+			StrStrPtrMap: map[string]*string{
+				"a": pointer.String("appricot"),
+				"b": pointer.String("blueberry"),
+				"c": nil,
+				"d": pointer.String("dragonfruit"),
+			},
+		},
+	}
+
+	o := &Foo{
+		BoolPtr:  pointer.Bool(false),
+		BoolPtr2: pointer.Bool(true),
+		BoolPtr3: pointer.Bool(true),
+		BoolPtr4: nil,
+		IntPtr:   pointer.Int(43),
+		IntPtr2:  nil,
+		IntPtr3:  pointer.Int(300),
+		IntPtr4:  pointer.Int(0),
+		StrPtr:   pointer.String("olleh"),
+		StrPtr2:  nil,
+		StrStrMap: map[string]string{
+			"b": "beer",
+			"c": "",
+			"d": "daiquiri",
+		},
+		StrSlice: []string{"gamma", "delta"},
+		StrStrMap2: map[string]string{
+			"a": "america",
+			"b": "brazil",
+		},
+		StrArray: [2]string{"california", "colorado"},
+		Struct: FooChild{
+			Int:     -43,
+			Str:     "ruojnob",
+			IP:      net.ParseIP("192.168.11.1"),
+			IPSlice: []net.IP{net.ParseIP("10.0.0.3")},
+			StrStrPtrMap: map[string]*string{
+				"a": nil,
+				"b": pointer.String("bacardi"),
+				"c": pointer.String("cinzano"),
+				"d": pointer.String(""),
+			},
+		},
+	}
+
+	expected := &Foo{
+		BoolPtr:  pointer.Bool(false),     // overridden
+		BoolPtr2: pointer.Bool(true),      // overridden
+		BoolPtr3: pointer.Bool(true),      // overridden (d=nil)
+		BoolPtr4: pointer.Bool(true),      // Not overridden (o=nil)
+		IntPtr:   pointer.Int(43),         // overridden
+		IntPtr2:  pointer.Int(200),        // Not overridden (o=nil)
+		IntPtr3:  pointer.Int(300),        // overridden (d=nil)
+		IntPtr4:  pointer.Int(0),          // overridden
+		StrPtr:   pointer.String("olleh"), // overridden
+		StrPtr2:  pointer.String("world"), // Not overridden (o=nil)
+		StrStrMap: map[string]string{ // merged (d, o)
+			"a": "apple",
+			"b": "beer",
+			"c": "",
+			"d": "daiquiri",
+		},
+		StrStrMap2: map[string]string{ // merged (d=nil, o)
+			"a": "america",
+			"b": "brazil",
+		},
+		StrSlice: []string{"gamma", "delta", "alpha", "beta"}, // appended (o, d)
+		StrArray: [2]string{"california", "colorado"},         // overridden
+		Struct: FooChild{
+			Int:     -43,                                                                                 // overridden
+			Int2:    0,                                                                                   // overridden (o=zero)
+			Str:     "ruojnob",                                                                           // overridden
+			Str2:    "",                                                                                  // overridden (o=empty)
+			IP:      net.ParseIP("192.168.11.1"),                                                         // overridden
+			IPSlice: []net.IP{net.ParseIP("10.0.0.3"), net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.2")}, // appended (o, d)
+			StrStrPtrMap: map[string]*string{ // merged (d, o)
+				"a": pointer.String("appricot"),
+				"b": pointer.String("bacardi"),
+				"c": pointer.String("cinzano"),
+				"d": pointer.String(""),
+			},
+		},
+	}
+
+	x, err := Merge(d, o)
+	assert.NilError(t, err)
+	logX(t, d, "d")
+	logX(t, o, "o")
+	logX(t, x, "x")
+	assert.DeepEqual(t, expected, x)
+}
+
+func logX(t testing.TB, x interface{}, format string, args ...interface{}) {
+	// Print in JSON for human readability
+	j, err := json.Marshal(x)
+	assert.NilError(t, err)
+	t.Logf(format+": %s", append(args, string(j))...)
+}

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -78,7 +78,11 @@ func Inspect(instName string) (*Instance, error) {
 		return inst, nil
 	}
 	inst.Arch = *y.Arch
-	inst.CPUType = y.CPUType[*y.Arch]
+	cpuType, ok := y.CPUType[*y.Arch]
+	if !ok || cpuType == nil {
+		return nil, fmt.Errorf("no cpu type is defined for arch %q", *y.Arch)
+	}
+	inst.CPUType = *cpuType
 
 	inst.CPUs = *y.CPUs
 	memory, err := units.RAMInBytes(*y.Memory)


### PR DESCRIPTION

The type of ` CPUType  map[Arch]string` is now changed to `map[Arch]*string`, as `pkg/reflectutil.Merge()` is designed to distinguish "empty" from "nil".
