### PR TITLE
templates: update apptainer to 1.1.0

### DIFF
--- a/examples/experimental/apptainer.yaml
+++ b/examples/experimental/apptainer.yaml
@@ -8,6 +8,9 @@ images:
 - location: "https://dl.rockylinux.org/pub/rocky/8.6/images/Rocky-8-GenericCloud-8.6.20220702.0.x86_64.qcow2"
   arch: "x86_64"
   digest: "sha256:7b786a39eeb96e22dd85386377ff186737f6c1b9a5faa105b0a0a7a4895c29d0"
+- location: "https://dl.rockylinux.org/pub/rocky/8.6/images/Rocky-8-GenericCloud-8.6.20220702.0.aarch64.qcow2"
+  arch: "aarch64"
+  digest: "sha256:42da3cc0c10677d37e43f862c4a8f3ab3b72bcccc91ce0c0ef9f4100f4b950b4"
 mounts:
 - location: "~"
 - location: "/tmp/lima"
@@ -30,8 +33,7 @@ provision:
     dnf install -y yum-utils epel-release
     dnf install -y squashfuse fakeroot
     yum-config-manager --disable epel*
-    dnf install -y https://github.com/apptainer/apptainer/releases/download/v1.1.0/apptainer-1.1.0-1.x86_64.rpm \
-                   https://github.com/apptainer/apptainer/releases/download/v1.1.0/apptainer-suid-1.1.0-1.x86_64.rpm
+    dnf install --enablerepo=epel-testing -y apptainer apptainer-suid
 probes:
 - script: |
     #!/bin/bash

--- a/examples/experimental/apptainer.yaml
+++ b/examples/experimental/apptainer.yaml
@@ -27,7 +27,11 @@ provision:
     #!/bin/bash
     set -eux -o pipefail
     command -v apptainer >/dev/null 2>&1 && exit 0
-    dnf install -y https://github.com/apptainer/apptainer/releases/download/v1.0.3/apptainer-1.0.3-1.x86_64.rpm
+    dnf install -y yum-utils epel-release
+    dnf install -y squashfuse fakeroot
+    yum-config-manager --disable epel*
+    dnf install -y https://github.com/apptainer/apptainer/releases/download/v1.1.0/apptainer-1.1.0-1.x86_64.rpm \
+                   https://github.com/apptainer/apptainer/releases/download/v1.1.0/apptainer-suid-1.1.0-1.x86_64.rpm
 probes:
 - script: |
     #!/bin/bash


### PR DESCRIPTION
Now has support for rootless containers (user namespaces)

https://github.com/apptainer/apptainer/releases/tag/v1.1.0

Add support for aarch64

Currently only from EPEL