### PR TITLE
For apptainer, move TMPDIR away from tmpfs

### DIFF
--- a/examples/apptainer-rootful.yaml
+++ b/examples/apptainer-rootful.yaml
@@ -31,6 +31,9 @@ provision:
     set -eux -o pipefail
     command -v apptainer >/dev/null 2>&1 && exit 0
     dnf -y install apptainer apptainer-suid
+    # See https://fedoraproject.org/wiki/Features/tmp-on-tmpfs
+    echo "APPTAINER_TMPDIR=/var/tmp" > /etc/profile.d/apptainer.sh
+    echo "export APPTAINER_TMPDIR" >> /etc/profile.d/apptainer.sh
 probes:
 - script: |
     #!/bin/bash

--- a/examples/apptainer.yaml
+++ b/examples/apptainer.yaml
@@ -25,6 +25,9 @@ provision:
     set -eux -o pipefail
     command -v apptainer >/dev/null 2>&1 && exit 0
     dnf -y install apptainer
+    # See https://fedoraproject.org/wiki/Features/tmp-on-tmpfs
+    echo "APPTAINER_TMPDIR=/var/tmp" > /etc/profile.d/apptainer.sh
+    echo "export APPTAINER_TMPDIR" >> /etc/profile.d/apptainer.sh
 probes:
 - script: |
     #!/bin/bash


### PR DESCRIPTION
It has some issues with it being mounted as "nodev", so revert to using a normal file system for $TMPDIR.

```console
$ limactl shell singularity singularity run -u -B $HOME:$HOME docker://alpine
INFO:    Converting OCI blobs to SIF format
WARNING: 'nodev' mount option set on /tmp, it could be a source of failure during build process
INFO:    Starting build...
Getting image source signatures
Copying blob 213ec9aee27d done  
Copying config 29f453b10b done  
Writing manifest to image destination
Storing signatures
2022/10/02 07:18:41  info unpack layer: sha256:213ec9aee27d8be045c6a92b7eac22c9a64b44558193775a1a7f626352392b49
2022/10/02 07:18:41  warn xattr{etc/shadow} ignoring ENOTSUP on setxattr "user.rootlesscontainers"
2022/10/02 07:18:41  warn xattr{/tmp/build-temp-98011911/rootfs/etc/shadow} destination filesystem does not support xattrs, further warnings will be suppressed
INFO:    Creating SIF file...
INFO:    Converting SIF file to temporary sandbox...
Apptainer> 
```

Using /var/tmp is the recommended revert, from the Fedora instructions regarding the change (in fc18):

https://fedoraproject.org/wiki/Features/tmp-on-tmpfs

```console
[anders@lima-singularity lima]$ df -h /var /tmp
Filesystem      Size  Used Avail Use% Mounted on
/dev/vda5        99G  708M   98G   1% /
tmpfs           2.0G     0  2.0G   0% /tmp
[anders@lima-singularity lima]$ findmnt /
TARGET SOURCE           FSTYPE OPTIONS
/      /dev/vda5[/root] btrfs  rw,relatime,seclabel,compress=zstd:1,space_cache=v2,subvolid=256,subvol=/root
[anders@lima-singularity lima]$ findmnt /tmp
TARGET SOURCE FSTYPE OPTIONS
/tmp   tmpfs  tmpfs  rw,nosuid,nodev,seclabel,nr_inodes=1048576,inode64
```
