### PR TITLE
add "boot" provisioning script mode

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -171,6 +171,12 @@ containerd:
 #     cat <<EOF > ~/.vimrc
 #     set number
 #     EOF
+# # `boot` is executed directly by /bin/sh as part of cloud-init-local.service's early boot process,
+# # which is why there is no hash-bang specified in the example
+# # See cloud-init docs for more info https://cloudinit.readthedocs.io/en/latest/topics/examples.html#run-commands-on-first-boot
+# - mode: boot
+#   script: |
+#     systemctl disable NetworkManager-wait-online.service
 
 # Probe scripts to check readiness.
 # 🟢 Builtin default: null

--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -64,3 +64,13 @@ ca-certs:
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{- if .BootCmds }}
+bootcmd:
+  {{- range $cmd := $.BootCmds }}
+- |
+    {{- range $line := $cmd.Lines }}
+  {{ $line }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -42,6 +42,9 @@ type Mount struct {
 	Type       string
 	Options    string
 }
+type BootCmds struct {
+	Lines []string
+}
 type TemplateArgs struct {
 	Name               string // instance name
 	IID                string // instance id
@@ -62,6 +65,7 @@ type TemplateArgs struct {
 	DNSAddresses       []string
 	CACerts            CACerts
 	HostHomeMountPoint string
+	BootCmds           []BootCmds
 }
 
 func ValidateTemplateArgs(args TemplateArgs) error {

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -116,6 +116,7 @@ type ProvisionMode = string
 const (
 	ProvisionModeSystem ProvisionMode = "system"
 	ProvisionModeUser   ProvisionMode = "user"
+	ProvisionModeBoot   ProvisionMode = "boot"
 )
 
 type Provision struct {

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -153,10 +153,10 @@ func Validate(y LimaYAML, warn bool) error {
 
 	for i, p := range y.Provision {
 		switch p.Mode {
-		case ProvisionModeSystem, ProvisionModeUser:
+		case ProvisionModeSystem, ProvisionModeUser, ProvisionModeBoot:
 		default:
-			return fmt.Errorf("field `provision[%d].mode` must be either %q or %q",
-				i, ProvisionModeSystem, ProvisionModeUser)
+			return fmt.Errorf("field `provision[%d].mode` must be either %q, %q, or %q",
+				i, ProvisionModeSystem, ProvisionModeUser, ProvisionModeBoot)
 		}
 	}
 	needsContainerdArchives := (y.Containerd.User != nil && *y.Containerd.User) || (y.Containerd.System != nil && *y.Containerd.System)


### PR DESCRIPTION
Allows users to customize their early boot workflow by specifying `bootCmds`. These commands are run by `cloud-init-local.service`, which runs before `cloud-init.service` (which only starts after the network is up), and allow users to disable services (as in the example) or run other commands early on in the boot process. [More info here](https://cloudinit.readthedocs.io/en/latest/topics/examples.html#run-commands-on-first-boot).

Resolves one of the proposals in #1093 