### PR TITLE
Add wrapper for running apptainer on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ binaries: clean \
 	_output/bin/lima$(bat) \
 	_output/bin/limactl$(exe) \
 	_output/bin/nerdctl.lima \
+	_output/bin/apptainer.lima \
 	_output/bin/docker.lima \
 	_output/bin/podman.lima \
 	_output/share/lima/lima-guestagent.Linux-x86_64 \
@@ -61,6 +62,10 @@ _output/bin/lima.bat:
 _output/bin/nerdctl.lima:
 	mkdir -p _output/bin
 	cp -a ./cmd/nerdctl.lima $@
+
+_output/bin/apptainer.lima: ./cmd/apptainer.lima
+	@mkdir -p _output/bin
+	cp -a $^ $@
 
 _output/bin/docker.lima: ./cmd/docker.lima
 	@mkdir -p _output/bin
@@ -102,6 +107,7 @@ install: uninstall
 	# Use tar rather than cp, for better symlink handling
 	( cd _output && tar c * | tar Cxv "$(DEST)" )
 	if [ "$(shell uname -s )" != "Linux" -a ! -e "$(DEST)/bin/nerdctl" ]; then ln -sf nerdctl.lima "$(DEST)/bin/nerdctl"; fi
+	if [ "$(shell uname -s )" != "Linux" -a ! -e "$(DEST)/bin/apptainer" ]; then ln -sf apptainer.lima "$(DEST)/bin/apptainer"; fi
 
 .PHONY: uninstall
 uninstall:
@@ -111,10 +117,12 @@ uninstall:
 		"$(DEST)/bin/lima$(bat)" \
 		"$(DEST)/bin/limactl$(exe)" \
 		"$(DEST)/bin/nerdctl.lima" \
+		"$(DEST)/bin/apptainer.lima" \
 		"$(DEST)/bin/docker.lima" \
 		"$(DEST)/bin/podman.lima" \
 		"$(DEST)/share/lima" "$(DEST)/share/doc/lima"
 	if [ "$$(readlink "$(DEST)/bin/nerdctl")" = "nerdctl.lima" ]; then rm "$(DEST)/bin/nerdctl"; fi
+	if [ "$$(readlink "$(DEST)/bin/apptainer")" = "apptainer.lima" ]; then rm "$(DEST)/bin/apptainer"; fi
 
 .PHONY: lint
 lint:

--- a/cmd/apptainer.lima
+++ b/cmd/apptainer.lima
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+: "${LIMA_INSTANCE:=apptainer}"
+
+if [ "$(limactl ls -q "$LIMA_INSTANCE" 2>/dev/null)" != "$LIMA_INSTANCE" ]; then
+  echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl start --name=$LIMA_INSTANCE template://apptainer\` to create a new instance" >&2
+  exit 1
+fi
+export LIMA_INSTANCE
+exec lima APPTAINER_HOME="$HOME" apptainer "$@"


### PR DESCRIPTION

Now that Apptainer has been moved from experimental, and accepted as LF project, it might be time for a wrapper ?

There is no client for `apptainer`, similar to `nerdctl`.

So use a small shell wrapper, to run "lima apptainer".

This is so that the user can follow the documentation, without having to write an extra `lima ` prefix before every command:

https://apptainer.org/docs/user/main/quick_start.html

We might still have to document the read-only home.

```
FATAL:   While performing build: while creating SIF: while creating container: open /home/anders/lima/alpine.sif: read-only file system
```

---

This is different from the situation for docker and podman.

Since they already have client binaries, available for Mac.