### PR TITLE
Enable trimming QEMU disks

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -433,9 +433,9 @@ func Cmdline(cfg Config) (string, []string, error) {
 		args = appendArgsIfNoConflict(args, "-boot", "order=c,splash-time=0,menu=on")
 	}
 	if diskSize, _ := units.RAMInBytes(*cfg.LimaYAML.Disk); diskSize > 0 {
-		args = append(args, "-drive", fmt.Sprintf("file=%s,if=virtio", diffDisk))
+		args = append(args, "-drive", fmt.Sprintf("file=%s,if=virtio,discard=on", diffDisk))
 	} else if !isBaseDiskCDROM {
-		args = append(args, "-drive", fmt.Sprintf("file=%s,if=virtio", baseDisk))
+		args = append(args, "-drive", fmt.Sprintf("file=%s,if=virtio,discard=on", baseDisk))
 	}
 	// cloud-init
 	switch *y.Arch {


### PR DESCRIPTION
This would enable trimming of QEMU virtual disks, by adding the `discard=on` argument to `-drive` flag for `basedisk` or `diffdisk`. As a result, running `fstrim -a` in the guest would reduce the disk space consumed by QEMU disks (`basedisk` or `diffdisk`), and reduce the disk usage of Lima guests.

Current behavior: there's no easy way to reduce the disk usage of `diffdisk`, and running `fstrim -a` in the guest has no effect.

Resolves #356