### PR TITLE
Convert built-in hosts to unambiguous domain names

### DIFF
--- a/pkg/hostagent/dns/dns.go
+++ b/pkg/hostagent/dns/dns.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/miekg/dns"
 	"github.com/sirupsen/logrus"
 )
@@ -132,10 +131,11 @@ func NewHandler(opts HandlerOptions) (dns.Handler, error) {
 		hostToIP:     make(map[string]net.IP),
 	}
 	for host, address := range opts.StaticHosts {
+		cname := dns.CanonicalName(host)
 		if ip := net.ParseIP(address); ip != nil {
-			h.hostToIP[host] = ip
+			h.hostToIP[cname] = ip
 		} else {
-			h.cnameToHost[host] = limayaml.Cname(address)
+			h.cnameToHost[cname] = dns.CanonicalName(address)
 		}
 	}
 	return h, nil

--- a/pkg/hostagent/dns/dns_test.go
+++ b/pkg/hostagent/dns/dns_test.go
@@ -19,16 +19,7 @@ var (
 	dnsResult *dns.Msg
 )
 
-func TestTXTRecords(t *testing.T) {
-	testDomains := make([]string, 3)
-	testDomains[0] = "onerecord.com"
-	testDomains[1] = "multistringrecord.com"
-	testDomains[2] = "multiplerecords.com"
-
-	expectedResults := make([]string, 3)
-	expectedResults[0] = `onerecord.com.\s+5\s+IN\s+TXT\s+"My txt record"`
-	expectedResults[1] = `multistringrecord.com.\s+5\s+IN\s+TXT\s+"123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345" "67890123456789012345678901234567890"`
-	expectedResults[2] = `multiplerecords.com.\s+5\s+IN\s+TXT\s+"record 1"\nmultiplerecords.com.\s*5\s*IN\s*TXT\s*"record 2"`
+func TestDNSRecords(t *testing.T) {
 
 	srv, _ := mockdns.NewServerWithLogger(map[string]mockdns.Zone{
 		"onerecord.com.": {
@@ -52,33 +43,42 @@ func TestTXTRecords(t *testing.T) {
 	}
 	srv.PatchNet(net.DefaultResolver)
 	defer mockdns.UnpatchNet(net.DefaultResolver)
+	w := new(TestResponseWriter)
+	options := HandlerOptions{
+		IPv6: true,
+		StaticHosts: map[string]string{
+			"MY.Host": "host.lima.internal",
+		},
+	}
 
-	t.Run("test TXT records", func(t *testing.T) {
-		w := new(TestResponseWriter)
-		options := HandlerOptions{
-			IPv6: true,
-			StaticHosts: map[string]string{
-				"MY.Host": "host.lima.internal",
-			},
-		}
-		h, err := NewHandler(options)
-		if err == nil {
-			for i := 0; i < len(testDomains); i++ {
-				req := new(dns.Msg)
-				req.SetQuestion(dns.Fqdn(testDomains[i]), dns.TypeTXT)
-				h.ServeDNS(w, req)
-				regexMatch := func(value string, pattern string) cmp.Comparison {
-					return func() cmp.Result {
-						re := regexp.MustCompile(pattern)
-						if re.MatchString(value) {
-							return cmp.ResultSuccess
-						}
-						return cmp.ResultFailure(
-							fmt.Sprintf("%q did not match pattern %q", value, pattern))
-					}
-				}
-				assert.Assert(t, regexMatch(dnsResult.String(), expectedResults[i]))
+	h, err := NewHandler(options)
+	assert.NilError(t, err)
+
+	regexMatch := func(value string, pattern string) cmp.Comparison {
+		return func() cmp.Result {
+			re := regexp.MustCompile(pattern)
+			if re.MatchString(value) {
+				return cmp.ResultSuccess
 			}
+			return cmp.ResultFailure(
+				fmt.Sprintf("%q did not match pattern %q", value, pattern))
+		}
+	}
+	t.Run("test TXT records", func(t *testing.T) {
+		tests := []struct {
+			testDomain        string
+			expectedTXTRecord string
+		}{
+			{testDomain: "onerecord.com", expectedTXTRecord: `onerecord.com.\s+5\s+IN\s+TXT\s+"My txt record"`},
+			{testDomain: "multistringrecord.com", expectedTXTRecord: `multistringrecord.com.\s+5\s+IN\s+TXT\s+"123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345" "67890123456789012345678901234567890"`},
+			{testDomain: "multiplerecords.com", expectedTXTRecord: `multiplerecords.com.\s+5\s+IN\s+TXT\s+"record 1"\nmultiplerecords.com.\s*5\s*IN\s*TXT\s*"record 2"`},
+		}
+
+		for _, tc := range tests {
+			req := new(dns.Msg)
+			req.SetQuestion(dns.Fqdn(tc.testDomain), dns.TypeTXT)
+			h.ServeDNS(w, req)
+			assert.Assert(t, regexMatch(dnsResult.String(), tc.expectedTXTRecord))
 		}
 	})
 }

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -307,8 +307,8 @@ func (a *HostAgent) Run(ctx context.Context) error {
 
 	if *a.y.HostResolver.Enabled {
 		hosts := a.y.HostResolver.Hosts
-		hosts["host.lima.internal."] = qemuconst.SlirpGateway
-		hosts[fmt.Sprintf("lima-%s.", a.instName)] = qemuconst.SlirpIPAddress
+		hosts["host.lima.internal"] = qemuconst.SlirpGateway
+		hosts[fmt.Sprintf("lima-%s", a.instName)] = qemuconst.SlirpIPAddress
 		srvOpts := dns.ServerOptions{
 			UDPPort: a.udpDNSLocalPort,
 			TCPPort: a.tcpDNSLocalPort,

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"strings"
 	"text/template"
 
 	"github.com/lima-vm/lima/pkg/guestagent/api"
@@ -233,13 +232,13 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 	hosts := make(map[string]string)
 	// Values can be either names or IP addresses. Name values are canonicalized in the hostResolver.
 	for k, v := range d.HostResolver.Hosts {
-		hosts[Cname(k)] = v
+		hosts[k] = v
 	}
 	for k, v := range y.HostResolver.Hosts {
-		hosts[Cname(k)] = v
+		hosts[k] = v
 	}
 	for k, v := range o.HostResolver.Hosts {
-		hosts[Cname(k)] = v
+		hosts[k] = v
 	}
 	y.HostResolver.Hosts = hosts
 
@@ -665,14 +664,6 @@ func IsNativeArch(arch Arch) bool {
 	nativeAARCH64 := arch == AARCH64 && runtime.GOARCH == "arm64"
 	nativeRISCV64 := arch == RISCV64 && runtime.GOARCH == "riscv64"
 	return nativeX8664 || nativeAARCH64 || nativeRISCV64
-}
-
-func Cname(host string) string {
-	host = strings.ToLower(host)
-	if !strings.HasSuffix(host, ".") {
-		host += "."
-	}
-	return host
 }
 
 func unique(s []string) []string {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -149,7 +149,7 @@ func TestFillDefault(t *testing.T) {
 
 	expect := builtin
 	expect.HostResolver.Hosts = map[string]string{
-		"my.host.": "host.lima.internal",
+		"MY.Host": "host.lima.internal",
 	}
 
 	expect.Mounts = y.Mounts
@@ -319,7 +319,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Mounts[0].NineP.Msize = pointer.String(Default9pMsize)
 	expect.Mounts[0].NineP.Cache = pointer.String(Default9pCacheForRO)
 	expect.HostResolver.Hosts = map[string]string{
-		"default.": d.HostResolver.Hosts["default"],
+		"default": d.HostResolver.Hosts["default"],
 	}
 	expect.MountType = pointer.String(REVSSHFS)
 	expect.CACertificates.RemoveDefaults = pointer.Bool(true)
@@ -348,7 +348,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Mounts = append(d.Mounts, y.Mounts...)
 	expect.Networks = append(d.Networks, y.Networks...)
 
-	expect.HostResolver.Hosts["default."] = d.HostResolver.Hosts["default"]
+	expect.HostResolver.Hosts["default"] = d.HostResolver.Hosts["default"]
 
 	// d.DNS will be ignored, and not appended to y.DNS
 
@@ -474,8 +474,8 @@ func TestFillDefault(t *testing.T) {
 	expect.PortForwards = append(append(o.PortForwards, y.PortForwards...), d.PortForwards...)
 	expect.Containerd.Archives = append(append(o.Containerd.Archives, y.Containerd.Archives...), d.Containerd.Archives...)
 
-	expect.HostResolver.Hosts["default."] = d.HostResolver.Hosts["default"]
-	expect.HostResolver.Hosts["my.host."] = d.HostResolver.Hosts["host.lima.internal"]
+	expect.HostResolver.Hosts["default"] = d.HostResolver.Hosts["default"]
+	expect.HostResolver.Hosts["MY.Host"] = d.HostResolver.Hosts["host.lima.internal"]
 
 	// o.Mounts just makes d.Mounts[0] writable because the Location matches
 	expect.Mounts = append(d.Mounts, y.Mounts...)


### PR DESCRIPTION
This change ensures that user-defined host names are converted correctly to unambiguous domain names. Regardless if the user declares them as fully qualified or not we always convert them to fully qualified. 

Addresses: https://github.com/rancher-sandbox/rancher-desktop/issues/3163

Signed-off-by: Nino Kodabande <nkodabande@suse.com>