### PR TITLE
Bump lima-alpine to 0.2.22 to include resize2fs

### DIFF
--- a/examples/alpine.yaml
+++ b/examples/alpine.yaml
@@ -1,11 +1,11 @@
 # This example requires Lima v0.7.0 or later.
 images:
-- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.21/alpine-lima-std-3.16.0-x86_64.iso"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.22/alpine-lima-std-3.16.0-x86_64.iso"
   arch: "x86_64"
-  digest: "sha512:1929516c3deb8846b52f2404db1c5ed795a88fa3c7809b07df5365fc4223d83bce34a4bb31315a25325b62e4105433e7cb22327532da7705a807c9747eb427ea"
-- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.21/alpine-lima-std-3.16.0-aarch64.iso"
+  digest: "sha512:b2e7dfd946eea14d52b3958b9a26d69b97f9c03ef4c68666717a75c54e4c192e6fc9a8827683746dd1d6a93160f302d77acf4aa5358b9cd99f6cd9039d55c950"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.22/alpine-lima-std-3.16.0-aarch64.iso"
   arch: "aarch64"
-  digest: "sha512:9cf67ab5e8b0373acc1985048e571efcfa17523b1391cdd24a4adf45ec69b3b51bf7339215b383d64100b5f492bbcf673b0518947e2c2cc4e4e11df4c8946be3"
+  digest: "sha512:5e218e863f1edb8d138d1fa2c63fc470c6c31427f71227fc6a7e6e53c7f06c339112102375e1a2fe7e008129fd4d48f66b9169cd1f60f9ac6a5670f8696fdff6"
 
 mounts:
 - location: "~"


### PR DESCRIPTION
This will be needed to grow the filesystem when the size of the attached data volume is increased. See https://github.com/lima-vm/lima/issues/1103
