### PR TITLE
9p: change the default `securityModel` from `mapped-xattr` to `none`

### DIFF
--- a/docs/mount.md
+++ b/docs/mount.md
@@ -59,7 +59,8 @@ mounts:
 - location: "~"
   9p:
     # Supported security models are "passthrough", "mapped-xattr", "mapped-file" and "none".
-    # 🟢 Builtin default: "mapped-xattr"
+    # "mapped-xattr" and "mapped-file" are useful for persistent chown but incompatible with symlinks.
+    # 🟢 Builtin default: "none" (since Lima v0.13)
     securityModel: null
     # Select 9P protocol version. Valid options are: "9p2000" (legacy), "9p2000.u", "9p2000.L".
     # 🟢 Builtin default: "9p2000.L"

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -69,7 +69,8 @@ mounts:
     sftpDriver: null
   9p:
     # Supported security models are "passthrough", "mapped-xattr", "mapped-file" and "none".
-    # 🟢 Builtin default: "mapped-xattr"
+    # "mapped-xattr" and "mapped-file" are useful for persistent chown but incompatible with symlinks.
+    # 🟢 Builtin default: "none" (since Lima v0.13)
     securityModel: null
     # Select 9P protocol version. Valid options are: "9p2000" (legacy), "9p2000.u", "9p2000.L".
     # 🟢 Builtin default: "9p2000.L"

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -20,7 +20,9 @@ import (
 )
 
 const (
-	Default9pSecurityModel   string = "mapped-xattr"
+	// Default9pSecurityModel is "none" for supporting symlinks
+	// https://gitlab.com/qemu-project/qemu/-/issues/173
+	Default9pSecurityModel   string = "none"
 	Default9pProtocolVersion string = "9p2000.L"
 	Default9pMsize           string = "128KiB"
 	Default9pCacheForRO      string = "fscache"


### PR DESCRIPTION
The `mapped-xattr` model is known to be incompatible with symlinks: https://gitlab.com/qemu-project/qemu/-/issues/173

The `none` model is obviously incompatible with chown, but this is fine, as the reverse-sshfs does not support chown either.

See issue #971
