### PR TITLE
Add singularity and run-singularity wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,9 @@ diagrams: docs/lima-sequence-diagram.png
 docs/lima-sequence-diagram.png: docs/images/lima-sequence-diagram.puml
 	$(PLANTUML) ./docs/images/lima-sequence-diagram.puml
 
+# Simple wrapper for 'apptainer run' (.sif)
+RUN_SINGULARITY=./cmd/run-singularity.lima
+
 .PHONY: install
 install: uninstall
 	mkdir -p "$(DEST)"
@@ -131,6 +134,8 @@ install: uninstall
 	( cd _output && tar c * | tar Cxv "$(DEST)" )
 	if [ "$(shell uname -s )" != "Linux" -a ! -e "$(DEST)/bin/nerdctl" ]; then ln -sf nerdctl.lima "$(DEST)/bin/nerdctl"; fi
 	if [ "$(shell uname -s )" != "Linux" -a ! -e "$(DEST)/bin/apptainer" ]; then ln -sf apptainer.lima "$(DEST)/bin/apptainer"; fi
+	if [ "$(shell uname -s )" != "Linux" -a ! -e "$(DEST)/bin/singularity" ]; then ln -sf apptainer.lima "$(DEST)/bin/singularity"; fi
+	if [ "$(shell uname -s )" != "Linux" -a ! -e "$(DEST)/bin/run-singularity" ]; then cp -a $(RUN_SINGULARITY) "$(DEST)/bin/run-singularity"; fi
 
 .PHONY: uninstall
 uninstall:
@@ -149,6 +154,8 @@ uninstall:
 		"$(DEST)/share/lima" "$(DEST)/share/doc/lima"
 	if [ "$$(readlink "$(DEST)/bin/nerdctl")" = "nerdctl.lima" ]; then rm "$(DEST)/bin/nerdctl"; fi
 	if [ "$$(readlink "$(DEST)/bin/apptainer")" = "apptainer.lima" ]; then rm "$(DEST)/bin/apptainer"; fi
+	if [ "$$(readlink "$(DEST)/bin/singularity")" = "apptainer.lima" ]; then rm "$(DEST)/bin/singularity"; fi
+	if grep -q apptainer.lima "$(DEST)/bin/run-singularity"; then rm "$(DEST)/bin/run-singularity"; fi
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,8 @@ diagrams: docs/lima-sequence-diagram.png
 docs/lima-sequence-diagram.png: docs/images/lima-sequence-diagram.puml
 	$(PLANTUML) ./docs/images/lima-sequence-diagram.puml
 
-# Simple wrapper for 'apptainer run' (.sif)
-RUN_SINGULARITY=./cmd/run-singularity.lima
+# Simple wrapper for 'singularity run' (.sif)
+RUN_SINGULARITY=./cmd/run-singularity.sh
 
 .PHONY: install
 install: uninstall
@@ -155,7 +155,7 @@ uninstall:
 	if [ "$$(readlink "$(DEST)/bin/nerdctl")" = "nerdctl.lima" ]; then rm "$(DEST)/bin/nerdctl"; fi
 	if [ "$$(readlink "$(DEST)/bin/apptainer")" = "apptainer.lima" ]; then rm "$(DEST)/bin/apptainer"; fi
 	if [ "$$(readlink "$(DEST)/bin/singularity")" = "apptainer.lima" ]; then rm "$(DEST)/bin/singularity"; fi
-	if grep -q apptainer.lima "$(DEST)/bin/run-singularity"; then rm "$(DEST)/bin/run-singularity"; fi
+	if grep -q "lima apptainer" "$(DEST)/bin/run-singularity"; then rm "$(DEST)/bin/run-singularity"; fi
 
 .PHONY: lint
 lint:

--- a/cmd/run-singularity.lima
+++ b/cmd/run-singularity.lima
@@ -1,3 +1,0 @@
-#!/bin/sh
-set -eu
-exec apptainer.lima --quiet run "$@"

--- a/cmd/run-singularity.lima
+++ b/cmd/run-singularity.lima
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+exec apptainer.lima --quiet run "$@"

--- a/cmd/run-singularity.sh
+++ b/cmd/run-singularity.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+# Simple wrapper for 'lima apptainer run'
+exec singularity --quiet run "$@"


### PR DESCRIPTION
This is for compatibility with older versions of apptainer when it was called still singularity, and to support the .sif file format.

These self-contained (pun intended) files are supposed to be executable, so that you can "run" them by just executing them:

```console
$ apptainer build /tmp/lima/debian.sif docker://debian
INFO:    Starting build...
Getting image source signatures
Copying blob f606d8928ed3 skipped: already exists  
Copying config 0311b76201 done  
Writing manifest to image destination
Storing signatures
2022/10/18 19:53:52  info unpack layer: sha256:f606d8928ed378229f2460b94b504cca239fb906efc57acbdf9340bd298d5ddf
INFO:    Creating SIF file...
INFO:    Build complete: /tmp/lima/debian.sif
$ singularity sif list /tmp/lima/debian.sif
------------------------------------------------------------------------------
ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
------------------------------------------------------------------------------
1    |1       |NONE    |32176-32208               |Def.FILE
2    |1       |NONE    |32208-36135               |JSON.Generic
3    |1       |NONE    |36135-36227               |JSON.Generic
4    |1       |NONE    |36864-51163136            |FS (Squashfs/*System/amd64)
$ file /tmp/lima/debian.sif 
/tmp/lima/debian.sif: a /usr/bin/env run-singularity script executable (binary data)
$ /tmp/lima/debian.sif
Apptainer> 
```

All three programs are included in the apptainer rpm:

```console
[anders@lima-apptainer lima]$ rpm -ql apptainer | grep /usr/bin
/usr/bin/apptainer
/usr/bin/run-singularity
/usr/bin/singularity
```

So make them (all three) available, also on the Mac ?