### PR TITLE
Use APPTAINER_BINDPATH instead of APPTAINER_HOME

### DIFF
--- a/cmd/apptainer.lima
+++ b/cmd/apptainer.lima
@@ -1,10 +1,15 @@
 #!/bin/sh
 set -eu
 : "${LIMA_INSTANCE:=apptainer}"
+: "${APPTAINER_BINDPATH:=}"
 
 if [ "$(limactl ls -q "$LIMA_INSTANCE" 2>/dev/null)" != "$LIMA_INSTANCE" ]; then
   echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl create --name=$LIMA_INSTANCE template://apptainer\` to create a new instance" >&2
   exit 1
 fi
 export LIMA_INSTANCE
-exec lima APPTAINER_HOME="$HOME" apptainer "$@"
+if [ -n "$APPTAINER_BINDPATH" ]; then
+  APPTAINER_BINDPATH="$APPTAINER_BINDPATH,"
+fi
+APPTAINER_BINDPATH="$APPTAINER_BINDPATH$HOME"
+exec lima APPTAINER_BINDPATH="$APPTAINER_BINDPATH" apptainer "$@"


### PR DESCRIPTION
Not all software was happy with a read-only $HOME directory.

Using APPTAINER_HOME changed the $HOME in the container.

----

So use the regular VM $HOME, but do bind-mount host $HOME.

Using APPTAINER_BINDPATH is the same as using the `-B` flag.