### PR TITLE
templates: update Ubuntu, Arch, Debian; update nerdctl to v1.0.0

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,8 +1,8 @@
-This is an *informal* translation of [`README.md` (revision 725d7dca, 2022-Oct-8)](https://github.com/lima-vm/lima/blob/725d7dcac3e641905a444777bce8a65190db1692/README.md) in Japanese.
+This is an *informal* translation of [`README.md` (revision b65049d4, 2022-Oct-23)](https://github.com/lima-vm/lima/blob/b65049d4b89421fca5c73f494bb35e23b3c576c0/README.md) in Japanese.
 This translation might be out of sync with the English version.
 Please refer to the [English `README.md`](README.md) for the latest information.
 
-[`README.md` (リビジョン 725d7dca, 2022年10月8日)](https://github.com/lima-vm/lima/blob/725d7dcac3e641905a444777bce8a65190db1692/README.md)の *非正式* な日本語訳です。
+[`README.md` (リビジョン b65049d4, 2022年10月23日)](https://github.com/lima-vm/lima/blob/b65049d4b89421fca5c73f494bb35e23b3c576c0/README.md)の *非正式* な日本語訳です。
 英語版からの翻訳が遅れていることがあります。
 最新の情報については[英語版 `README.md`](README.md)をご覧ください。
 
@@ -253,7 +253,7 @@ Limaにはデータの喪失を引き起こすバグが含まれているかも�
 [`./examples/default.yaml`](./examples/default.yaml)を見てください。
 
 現在のデフォルト構成:
-- OS: Ubuntu 22.04 (Jammy Jellyfish)
+- OS: Ubuntu 22.10 (Kinetic Kudu)
 - CPU: 4 コア
 - メモリ: 4 GiB
 - ストレージ: 100 GiB

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Especially, the following data might be easily lost:
 See [`./examples/default.yaml`](./examples/default.yaml).
 
 The current default spec:
-- OS: Ubuntu 22.04 (Jammy Jellyfish)
+- OS: Ubuntu 22.10 (Kinetic Kudu)
 - CPU: 4 cores
 - Memory: 4 GiB
 - Disk: 100 GiB

--- a/examples/archlinux.yaml
+++ b/examples/archlinux.yaml
@@ -1,9 +1,9 @@
 # This example requires Lima v0.7.0 or later
 images:
 # Try to use yyyyMMdd.REV image if available. Note that yyyyMMdd.REV will be removed after several months.
-- location: "https://geo.mirror.pkgbuild.com/images/v20220901.79699/Arch-Linux-x86_64-cloudimg-20220901.79699.qcow2"
+- location: "https://geo.mirror.pkgbuild.com/images/v20221015.94571/Arch-Linux-x86_64-cloudimg-20221015.94571.qcow2"
   arch: "x86_64"
-  digest: "sha256:41d4456a23bff524a2343417d3712ee3e60797cb17b51986f85a598ac0bc4bff"
+  digest: "sha256:9b28e98d7ab81716c77472d3428acf1c81bb3d280b25879880b39f95fb02aa37"
 - location: "https://github.com/mcginty/arch-boxes/releases/download/v20220323/Arch-Linux-aarch64-cloudimg-20220323.0.qcow2"
   arch: "aarch64"
   digest: "sha512:27524910bf41cb9b3223c8749c6e67fd2f2fdb8b70d40648708e64d6b03c0b4a01b3c5e72d51fefd3e0c3f58487dbb400a79ca378cde2da341a3a19873612be8"

--- a/examples/buildkit.yaml
+++ b/examples/buildkit.yaml
@@ -12,12 +12,12 @@ message: |
  -------
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:c777670007cc5f132417b9e0bc01367ccfc2a989951ffa225bb1952917c3aa81"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:9620f479bd5a6cbf1e805654d41b27f4fc56ef20f916c8331558241734de81ae"
+  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"

--- a/examples/buildkit.yaml
+++ b/examples/buildkit.yaml
@@ -12,17 +12,17 @@ message: |
  -------
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20221022/ubuntu-22.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:8dc6cbae004d61dcd6098a93eeddebc3ddc7221df6688d1cbbbf0d86909aecf4"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20221022/ubuntu-22.10-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
+  digest: "sha256:9a95b52bc68639f3c60109d25d99fe0b3127d21632da437f00cb18e32bc528c4"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
   arch: "aarch64"
 
 containerd:

--- a/examples/debian.yaml
+++ b/examples/debian.yaml
@@ -1,11 +1,11 @@
 # This example requires Lima v0.7.0 or later
 images:
-- location: "https://cloud.debian.org/images/cloud/bullseye/20220816-1109/debian-11-generic-amd64-20220816-1109.qcow2"
+- location: "https://cloud.debian.org/images/cloud/bullseye/20221020-1174/debian-11-generic-amd64-20221020-1174.qcow2"
   arch: "x86_64"
-  digest: "sha512:934e1a177ad92ce5171b6d4d90796541ccad1bbdaf26a310065bbb00374e82d8d8b44e95f574dbd54e90c9edbeb735d4b5922aba6107fc821718dedbc0183961"
-- location: "https://cloud.debian.org/images/cloud/bullseye/20220816-1109/debian-11-generic-arm64-20220816-1109.qcow2"
+  digest: "sha512:334bd66215a8ebf98009fc5d1198aa3c99ec1a71d0cd55befb9e5413d016f8b43eeaf141af7f5ae82b6c32a02ad68a0418e1be623df6f62ccf782c31e29af429"
+- location: "https://cloud.debian.org/images/cloud/bullseye/20221020-1174/debian-11-generic-arm64-20221020-1174.qcow2"
   arch: "aarch64"
-  digest: "sha512:4ba22e50d2603e113a045583f2e7d31cf4db1a1c246a1a62703b4f16892e479d9bf8eb8e82499c1e78455735e4ef6cdf0dc20513c279115c1e80f8a9c3f516b2"
+  digest: "sha512:bd1e3b95e589df3ec8f869a9e7d14bbd2f64f479e52c0e93c7c3e6576177a0796c17c5b4775086215163b5427c2a77bf7816ffad012aeab11bfdb813f11ed467"
 mounts:
 - location: "~"
 - location: "/tmp/lima"

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -11,20 +11,20 @@ arch: null
 
 # OpenStack-compatible disk image.
 # 🟢 Builtin default: null (must be specified)
-# 🔵 This file: Ubuntu 22.04 Jammy Jellyfish images
+# 🔵 This file: Ubuntu 22.10 Kinetic Kudu images
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20221022/ubuntu-22.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:8dc6cbae004d61dcd6098a93eeddebc3ddc7221df6688d1cbbbf0d86909aecf4"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20221022/ubuntu-22.10-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
+  digest: "sha256:9a95b52bc68639f3c60109d25d99fe0b3127d21632da437f00cb18e32bc528c4"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
   arch: "aarch64"
 
 # CPUs: if you see performance issues, try limiting cpus to 1.

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -14,12 +14,12 @@ arch: null
 # 🔵 This file: Ubuntu 22.04 Jammy Jellyfish images
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:c777670007cc5f132417b9e0bc01367ccfc2a989951ffa225bb1952917c3aa81"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:9620f479bd5a6cbf1e805654d41b27f4fc56ef20f916c8331558241734de81ae"
+  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"

--- a/examples/docker-rootful.yaml
+++ b/examples/docker-rootful.yaml
@@ -9,12 +9,12 @@
 # This example requires Lima v0.8.0 or later
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:c777670007cc5f132417b9e0bc01367ccfc2a989951ffa225bb1952917c3aa81"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:9620f479bd5a6cbf1e805654d41b27f4fc56ef20f916c8331558241734de81ae"
+  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -9,12 +9,12 @@
 # This example requires Lima v0.8.0 or later
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:c777670007cc5f132417b9e0bc01367ccfc2a989951ffa225bb1952917c3aa81"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:9620f479bd5a6cbf1e805654d41b27f4fc56ef20f916c8331558241734de81ae"
+  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"

--- a/examples/experimental/9p.yaml
+++ b/examples/experimental/9p.yaml
@@ -3,12 +3,12 @@
 # This example is planned to be merged to default.yaml in Lima v1.0 (ETA: 2022 Q2).
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:c777670007cc5f132417b9e0bc01367ccfc2a989951ffa225bb1952917c3aa81"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:9620f479bd5a6cbf1e805654d41b27f4fc56ef20f916c8331558241734de81ae"
+  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"

--- a/examples/experimental/9p.yaml
+++ b/examples/experimental/9p.yaml
@@ -3,17 +3,17 @@
 # This example is planned to be merged to default.yaml in Lima v1.0 (ETA: 2022 Q2).
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20221022/ubuntu-22.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:8dc6cbae004d61dcd6098a93eeddebc3ddc7221df6688d1cbbbf0d86909aecf4"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20221022/ubuntu-22.10-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
+  digest: "sha256:9a95b52bc68639f3c60109d25d99fe0b3127d21632da437f00cb18e32bc528c4"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
   arch: "aarch64"
 
 mounts:

--- a/examples/experimental/riscv64.yaml
+++ b/examples/experimental/riscv64.yaml
@@ -2,7 +2,7 @@
 
 arch: "riscv64"
 images:
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-riscv64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-riscv64.img"
   digest: "sha256:c9c436b7734a53a7d4edb3ff9ccecd60c8484675302d1a4903775152a44170bd"
   kernel:
     # Extracted from http://http.us.debian.org/debian/pool/main/u/u-boot/u-boot-qemu_2022.04+dfsg-2_all.deb (GPL-2.0)

--- a/examples/experimental/riscv64.yaml
+++ b/examples/experimental/riscv64.yaml
@@ -2,15 +2,15 @@
 
 arch: "riscv64"
 images:
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-riscv64.img"
-  digest: "sha256:c9c436b7734a53a7d4edb3ff9ccecd60c8484675302d1a4903775152a44170bd"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20221022/ubuntu-22.10-server-cloudimg-riscv64.img"
+  digest: "sha256:548075df0138acdfd276ad2c4c09f348e8ecac5739a99284251fdf2052769e28"
   kernel:
     # Extracted from http://http.us.debian.org/debian/pool/main/u/u-boot/u-boot-qemu_2022.04+dfsg-2_all.deb (GPL-2.0)
     location: "https://github.com/lima-vm/u-boot-qemu-mirror/releases/download/2022.04%2Bdfsg-2/qemu-riscv64_smode_uboot.elf"
     digest: "sha256:d250ede9b4d0ea1871714395edd38a7eb2bc8425b697673cfd15e62e7ee4529c"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-riscv64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-riscv64.img"
   kernel:
     # Extracted from http://http.us.debian.org/debian/pool/main/u/u-boot/u-boot-qemu_2022.04+dfsg-2_all.deb (GPL-2.0)
     location: "https://github.com/lima-vm/u-boot-qemu-mirror/releases/download/2022.04%2Bdfsg-2/qemu-riscv64_smode_uboot.elf"

--- a/examples/faasd.yaml
+++ b/examples/faasd.yaml
@@ -27,12 +27,12 @@ message: |
 # Image is set to jammy (22.04 LTS) for long-term stability
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:c777670007cc5f132417b9e0bc01367ccfc2a989951ffa225bb1952917c3aa81"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:9620f479bd5a6cbf1e805654d41b27f4fc56ef20f916c8331558241734de81ae"
+  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"

--- a/examples/k3s.yaml
+++ b/examples/k3s.yaml
@@ -15,12 +15,12 @@
 
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:c777670007cc5f132417b9e0bc01367ccfc2a989951ffa225bb1952917c3aa81"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:9620f479bd5a6cbf1e805654d41b27f4fc56ef20f916c8331558241734de81ae"
+  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -14,12 +14,12 @@
 # This example requires Lima v0.7.0 or later.
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:c777670007cc5f132417b9e0bc01367ccfc2a989951ffa225bb1952917c3aa81"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:9620f479bd5a6cbf1e805654d41b27f4fc56ef20f916c8331558241734de81ae"
+  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"

--- a/examples/ubuntu-lts.yaml
+++ b/examples/ubuntu-lts.yaml
@@ -1,1 +1,20 @@
-ubuntu.yaml
+# This example requires Lima v0.7.0 or later.
+images:
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
+  arch: "x86_64"
+  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
+  arch: "aarch64"
+  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+  arch: "aarch64"
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true

--- a/examples/ubuntu.yaml
+++ b/examples/ubuntu.yaml
@@ -1,12 +1,12 @@
 # This example requires Lima v0.7.0 or later.
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:c777670007cc5f132417b9e0bc01367ccfc2a989951ffa225bb1952917c3aa81"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:9620f479bd5a6cbf1e805654d41b27f4fc56ef20f916c8331558241734de81ae"
+  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"

--- a/examples/ubuntu.yaml
+++ b/examples/ubuntu.yaml
@@ -1,17 +1,17 @@
 # This example requires Lima v0.7.0 or later.
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20221022/ubuntu-22.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:8dc6cbae004d61dcd6098a93eeddebc3ddc7221df6688d1cbbbf0d86909aecf4"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20221022/ubuntu-22.10-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
+  digest: "sha256:9a95b52bc68639f3c60109d25d99fe0b3127d21632da437f00cb18e32bc528c4"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
   arch: "aarch64"
 
 mounts:

--- a/examples/vmnet.yaml
+++ b/examples/vmnet.yaml
@@ -2,12 +2,12 @@
 # This example requires Lima v0.7.0 or later.
 # Older versions of Lima were using a different syntax for supporting vmnet.framework.
 images:
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:c777670007cc5f132417b9e0bc01367ccfc2a989951ffa225bb1952917c3aa81"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:9620f479bd5a6cbf1e805654d41b27f4fc56ef20f916c8331558241734de81ae"
+  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"

--- a/examples/vmnet.yaml
+++ b/examples/vmnet.yaml
@@ -2,17 +2,17 @@
 # This example requires Lima v0.7.0 or later.
 # Older versions of Lima were using a different syntax for supporting vmnet.framework.
 images:
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20221022/ubuntu-22.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221018/ubuntu-22.04-server-cloudimg-arm64.img"
+  digest: "sha256:8dc6cbae004d61dcd6098a93eeddebc3ddc7221df6688d1cbbbf0d86909aecf4"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20221022/ubuntu-22.10-server-cloudimg-arm64.img"
   arch: "aarch64"
-  digest: "sha256:f753d6f9cea84e4f35160b77189c422578fbb007e789b7e66d96edd6d8a3fa34"
+  digest: "sha256:9a95b52bc68639f3c60109d25d99fe0b3127d21632da437f00cb18e32bc528c4"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
   arch: "aarch64"
 
 mounts:

--- a/hack/test-example.sh
+++ b/hack/test-example.sh
@@ -230,7 +230,7 @@ if [[ -n ${CHECKS["vmnet"]} ]]; then
 	set +x
 	INFO "Benchmarking with iperf3"
 	set -x
-	limactl shell "$NAME" sudo apt-get install -y iperf3
+	limactl shell "$NAME" sudo DEBIAN_FRONTEND=noninteractive apt-get install -y iperf3
 	limactl shell "$NAME" iperf3 -s -1 -D
 	iperf3 -c "$guestip"
 	set +x

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -30,7 +30,7 @@ const (
 )
 
 func defaultContainerdArchives() []File {
-	const nerdctlVersion = "0.23.0"
+	const nerdctlVersion = "1.0.0"
 	location := func(goarch string) string {
 		return "https://github.com/containerd/nerdctl/releases/download/v" + nerdctlVersion + "/nerdctl-full-" + nerdctlVersion + "-linux-" + goarch + ".tar.gz"
 	}
@@ -38,12 +38,12 @@ func defaultContainerdArchives() []File {
 		{
 			Location: location("amd64"),
 			Arch:     X8664,
-			Digest:   "sha256:2097ffb95c6ce3d847ca4882867297b5ab80e3daea6f967e96ce00cc636981b6",
+			Digest:   "sha256:b7f76a3bf1b8161eb94ebe885945feb2887dfc0d274f9da908a17bc0ef853eb9",
 		},
 		{
 			Location: location("arm64"),
 			Arch:     AARCH64,
-			Digest:   "sha256:d25171f8b6fe778b77ff0830a8e17bd61c68af69bd734fb9d7f4490e069a7816",
+			Digest:   "sha256:e4c9b9434c88847f4d18f8b84c0d073555e4c949546cfa8a21e719de67afdf70",
 		},
 		// No riscv64
 	}


### PR DESCRIPTION
Docker is still pinned to 22.04, as 22.10 is missing in https://download.docker.com/linux/ubuntu/dists/


- - -

nerdctl v1.0.0: https://github.com/containerd/nerdctl/releases/tag/v1.0.0