### PR TITLE
pkg/networks: wait for daemon to stop after killing

### DIFF
--- a/pkg/networks/reconcile/reconcile.go
+++ b/pkg/networks/reconcile/reconcile.go
@@ -226,19 +226,18 @@ func stopNetwork(config *networks.YAML, name string) error {
 				return err
 			}
 		}
-		// wait for VMNet to terminate (up to 5s) before stopping Switch, otherwise the socket may not get deleted
-		if daemon == networks.VDEVMNet {
-			startWaiting := time.Now()
-			for {
-				if pid, _ := store.ReadPIDFile(config.PIDFile(name, daemon)); pid == 0 {
-					break
-				}
-				if time.Since(startWaiting) > 5*time.Second {
-					logrus.Infof("%q daemon for %q network still running after 5 seconds", daemon, name)
-					break
-				}
-				time.Sleep(500 * time.Millisecond)
+		// wait for daemons to terminate (up to 5s) before stopping, otherwise the sockets may not get deleted which
+		// will cause subsequent start commands to fail.
+		startWaiting := time.Now()
+		for {
+			if pid, _ := store.ReadPIDFile(config.PIDFile(name, daemon)); pid == 0 {
+				break
 			}
+			if time.Since(startWaiting) > 5*time.Second {
+				logrus.Infof("%q daemon for %q network still running after 5 seconds", daemon, name)
+				break
+			}
+			time.Sleep(500 * time.Millisecond)
 		}
 	}
 	return nil


### PR DESCRIPTION
Currently, when running an instance with a `socket_vmnet` network configured, if you try the following:

```
limactl stop default && limactl start default
```

you may notice that the `limactl start default` command consistently fails. In my testing, this is because the `pkill` command is issued, but the `socket_vmnet` process hasn't actually stoped yet.

This is what the hostagent logs look like on my system:

```
{"level":"fatal","msg":"template: :1:21: executing \"\" at \u003cfd_connect \"/private/var/run/$NETWORK_NAME/socket_vmnet.$NETWORK_NAME\"\u003e: error calling fd_connect: fd_connect: dial unix /private/var/run/$NETWORK_NAME/socket_vmnet.$NETWORK_NAME: connect: connection refused","time":"2022-10-31T18:31:21-04:00"}
```

Either waiting a few seconds between the stop and start command, or removing this conditional check seems to resolve the issue, but adding another check (like `if daemon == networks.VDEVMNet || daemon == networks.SocketVMNet`) also works, I just wan't sure which one to go with.