### PR TITLE
Remove brew installation of lima

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,10 @@ jobs:
         # breaking upgrades to latest python@3.9
         rm -f /usr/local/bin/2to3
         time brew update
+        # Github runners seem to have lima installed by brew already; we don't want/need it
+        # It also does throw an error during `brew upgrade`.
+        # Needs --ignore-dependencies because it is installed as a prerequisite for colima.
+        time brew uninstall --ignore-dependencies lima
         time brew install qemu bash coreutils curl jq
         time brew upgrade
     - name: Cache ~/Library/Caches/lima/download


### PR DESCRIPTION
It looks like the runners have an older version of lima already installed via brew. We don't want/need that, as it can confuse our testing.

Also it currently seems to break upgrading, which looks like a brew issue:

```
==> Upgrading lima
  0.12.0 -> 0.13.0

==> Pouring lima--0.13.0.monterey.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/apptainer.lima
Target /usr/local/bin/apptainer.lima
already exists. You may want to remove it:
  rm '/usr/local/bin/apptainer.lima'

To force the link and overwrite all conflicting files:
  brew link --overwrite lima

To list all files that would be deleted:
  brew link --overwrite --dry-run lima

Possible conflicting files are:
/usr/local/bin/apptainer.lima
/usr/local/bin/docker.lima
/usr/local/bin/lima
/usr/local/bin/limactl
...
```

Signed-off-by: Jan Dubois <jan.dubois@suse.com>