### PR TITLE
fix alpine data-volume issue

### DIFF
--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -240,6 +240,15 @@ func attachDisks(driver *driver.BaseDriver, vmConfig *vz.VirtualMachineConfigura
 		}
 		configurations = append(configurations, baseDisk)
 	}
+	diffDiskAttachment, err := vz.NewDiskImageStorageDeviceAttachment(diffDiskPath, false)
+	if err != nil {
+		return err
+	}
+	diffDisk, err := vz.NewVirtioBlockDeviceConfiguration(diffDiskAttachment)
+	if err != nil {
+		return err
+	}
+	configurations = append(configurations, diffDisk)
 
 	ciDataAttachment, err := vz.NewDiskImageStorageDeviceAttachment(ciDataPath, true)
 	if err != nil {
@@ -250,17 +259,6 @@ func attachDisks(driver *driver.BaseDriver, vmConfig *vz.VirtualMachineConfigura
 		return err
 	}
 	configurations = append(configurations, ciData)
-
-	diffDiskAttachment, err := vz.NewDiskImageStorageDeviceAttachment(diffDiskPath, false)
-	if err != nil {
-		return err
-	}
-
-	diffDisk, err := vz.NewVirtioBlockDeviceConfiguration(diffDiskAttachment)
-	if err != nil {
-		return err
-	}
-	configurations = append(configurations, diffDisk)
 
 	vmConfig.SetStorageDevicesVirtualMachineConfiguration(configurations)
 	return nil


### PR DESCRIPTION
Fixes the issue mentioned here
https://github.com/lima-vm/alpine-lima/issues/94

The reason is, 04-persistent-data-volume.sh bind the first available disk as data volume. Since cidata was first available and it was already mounted. the script was failing. Due to disk name mismatch (lsblk say vda for cidata, but /proc/mounts give disk/by-label/lima-cidata as name)

Keeping cidata as last disk similar to qemu fixes this issue.