### PR TITLE
Bump k8s flannel version from 0.20.0 to 0.20.1

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -121,7 +121,7 @@ provision:
     EOF
     kubeadm init --config kubeadm-config.yaml
     # Installing a Pod network add-on
-    kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/v0.20.0/Documentation/kube-flannel.yml
+    kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/v0.20.1/Documentation/kube-flannel.yml
     # Control plane node isolation
     kubectl taint nodes --all node-role.kubernetes.io/control-plane-
     sed -e "s/${LIMA_CIDATA_SLIRP_IP_ADDRESS:-192.168.5.15}/127.0.0.1/" -i $KUBECONFIG


### PR DESCRIPTION
Kubeadm doesn't really support using flannel anymore, so could still change to a simpler plugin.

* #718

But I don't really want to bother with anything heavy like calico or cilium, for this single-node cluster.
