### PR TITLE
Add feature to install kubernetes worker nodes

### DIFF
--- a/examples/k3s.yaml
+++ b/examples/k3s.yaml
@@ -42,6 +42,8 @@ provision:
     #!/bin/sh
     # To install a worker node, fill in and uncomment this line:
     #export K3S_URL=https://lima-k3s:6443 K3S_TOKEN=xxx
+    # To get the token to use for the variable, run this command:
+    # $ limactl shell k3s sudo cat /var/lib/rancher/k3s/server/node-token
     curl -sfL https://get.k3s.io | sh -
 
 probes:

--- a/examples/k3s.yaml
+++ b/examples/k3s.yaml
@@ -12,6 +12,8 @@
 # lima-k3s   Ready    control-plane,master   69s   v1.21.1+k3s1
 #
 # This example requires Lima v0.7.0 or later.
+# To be able to join worker nodes, an extra network needs to be set up.
+# The default network is only visible from the host, not other guests.
 
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.

--- a/examples/k3s.yaml
+++ b/examples/k3s.yaml
@@ -40,6 +40,8 @@ provision:
 - mode: system
   script: |
     #!/bin/sh
+    # To install a worker node, fill in and uncomment this line:
+    #export K3S_URL=https://lima-k3s:6443 K3S_TOKEN=xxx
     curl -sfL https://get.k3s.io | sh -
 
 probes:

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -1,7 +1,7 @@
 # Deploy kubernetes via kubeadm.
 # $ limactl start ./k8s.yaml
 # $ limactl shell k8s sudo kubectl
-
+#
 # It can be accessed from the host by exporting the kubeconfig file;
 # the ports are already forwarded automatically by lima:
 #
@@ -10,8 +10,9 @@
 # $ kubectl get no
 # NAME       STATUS   ROLES                  AGE   VERSION
 # lima-k8s   Ready    control-plane,master   44s   v1.22.3
-
+#
 # This example requires Lima v0.7.0 or later.
+
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
 - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20221201/ubuntu-22.04-server-cloudimg-amd64.img"
@@ -29,9 +30,11 @@ images:
 
 # Mounts are disabled in this example, but can be enabled optionally.
 mounts: []
+
 containerd:
   system: true
   user: false
+
 provision:
 # See <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/>
 - mode: system
@@ -138,6 +141,7 @@ provision:
     kubectl taint nodes --all node-role.kubernetes.io/control-plane-
     sed -e "s/${LIMA_CIDATA_SLIRP_IP_ADDRESS:-192.168.5.15}/127.0.0.1/" -i $KUBECONFIG
     mkdir -p ${HOME:-/root}/.kube && cp -f $KUBECONFIG ${HOME:-/root}/.kube/config
+
 probes:
 - description: "kubeadm to be installed"
   script: |

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -98,6 +98,8 @@ provision:
     set -eux -o pipefail
     # To install a worker node, fill in and uncomment this line:
     #export K8S_URL=https://lima-k8s:6443 K8S_TOKEN=xxx K8S_HASH=yyy
+    # To get the token/hash to use for the variables, run this command:
+    # $ limactl shell k8s sudo kubeadm token create --print-join-command
     if [ -n "${K8S_TOKEN:-}" ]; then
       # WORKER NODE
       test -e /etc/kubernetes/kubelet.conf && exit 0

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -12,6 +12,8 @@
 # lima-k8s   Ready    control-plane,master   44s   v1.22.3
 #
 # This example requires Lima v0.7.0 or later.
+# To be able to join worker nodes, an extra network needs to be set up.
+# The default network is only visible from the host, not other guests.
 
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -96,6 +96,16 @@ provision:
   script: |
     #!/bin/bash
     set -eux -o pipefail
+    # To install a worker node, fill in and uncomment this line:
+    #export K8S_URL=https://lima-k8s:6443 K8S_TOKEN=xxx K8S_HASH=yyy
+    if [ -n "${K8S_TOKEN:-}" ]; then
+      # WORKER NODE
+      test -e /etc/kubernetes/kubelet.conf && exit 0
+      kubeadm join "${K8S_URL##https://}" --token "${K8S_TOKEN}" \
+             --discovery-token-ca-cert-hash "${K8S_HASH}"
+      exit 0
+    fi
+    # CONTROL PLANE NODE
     test -e /etc/kubernetes/admin.conf && exit 0
     export KUBECONFIG=/etc/kubernetes/admin.conf
     kubeadm config images list


### PR DESCRIPTION
If your instances are connected through a proper network,
then it is possible to join additional workers to the control plane.

Beyond the URL of the apiserver (running on port 6443),
you will also need the secret "token" emitted by the initial installation.

---

The two (or more) Kubernetes nodes will need to be able reach eachother, though.

The default network ("user") will **not** allow this, but it is possible to use "socket":

* https://github.com/lima-vm/lima/issues/682

Probably still need the original NAT network to pull images, so needs eth0/eth1 ?

This is the setup done in minikube, originally by using the VirtualBox networks...

* https://github.com/kubernetes/minikube/issues/4938