### PR TITLE
pkg/limayaml: remove deprecated `network` and `useHostResolver`

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -309,18 +309,6 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		// After defaults processing the singular HostPort and GuestPort values should not be used again.
 	}
 
-	// If both `useHostResolved` and `HostResolver.Enabled` are defined in the same config,
-	// then the deprecated `useHostResolved` setting is silently ignored.
-	if y.HostResolver.Enabled == nil {
-		y.HostResolver.Enabled = y.UseHostResolver
-	}
-	if d.HostResolver.Enabled == nil {
-		d.HostResolver.Enabled = d.UseHostResolver
-	}
-	if o.HostResolver.Enabled == nil {
-		o.HostResolver.Enabled = o.UseHostResolver
-	}
-
 	if y.HostResolver.Enabled == nil {
 		y.HostResolver.Enabled = d.HostResolver.Enabled
 	}
@@ -349,19 +337,6 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 	}
 	if y.PropagateProxyEnv == nil {
 		y.PropagateProxyEnv = pointer.Bool(true)
-	}
-
-	if len(y.Network.VDEDeprecated) > 0 && len(y.Networks) == 0 {
-		for _, vde := range y.Network.VDEDeprecated {
-			network := Network{
-				Interface:            vde.Name,
-				MACAddress:           vde.MACAddress,
-				SwitchPortDeprecated: vde.SwitchPort,
-				VNLDeprecated:        vde.VNL,
-			}
-			y.Networks = append(y.Networks, network)
-		}
-		y.Network.migrated = true
 	}
 
 	networks := make([]Network, 0, len(d.Networks)+len(y.Networks)+len(o.Networks))

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -22,8 +22,6 @@ func TestFillDefault(t *testing.T) {
 	var d, y, o LimaYAML
 
 	opts := []cmp.Option{
-		// Ignore internal NetworkDeprecated.migrated field
-		cmpopts.IgnoreUnexported(NetworkDeprecated{}),
 		// Consider nil slices and empty slices to be identical
 		cmpopts.EquateEmpty(),
 	}

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -7,32 +7,32 @@ import (
 )
 
 type LimaYAML struct {
-	VMType            *VMType           `yaml:"vmType,omitempty" json:"vmType,omitempty"`
-	Arch              *Arch             `yaml:"arch,omitempty" json:"arch,omitempty"`
-	Images            []Image           `yaml:"images" json:"images"` // REQUIRED
-	CPUType           map[Arch]string   `yaml:"cpuType,omitempty" json:"cpuType,omitempty"`
-	CPUs              *int              `yaml:"cpus,omitempty" json:"cpus,omitempty"`
-	Memory            *string           `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
-	Disk              *string           `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes
-	AdditionalDisks   []Disk            `yaml:"additionalDisks,omitempty" json:"additionalDisks,omitempty"`
-	Mounts            []Mount           `yaml:"mounts,omitempty" json:"mounts,omitempty"`
-	MountType         *MountType        `yaml:"mountType,omitempty" json:"mountType,omitempty"`
-	SSH               SSH               `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
-	Firmware          Firmware          `yaml:"firmware,omitempty" json:"firmware,omitempty"`
-	Video             Video             `yaml:"video,omitempty" json:"video,omitempty"`
-	Provision         []Provision       `yaml:"provision,omitempty" json:"provision,omitempty"`
-	Containerd        Containerd        `yaml:"containerd,omitempty" json:"containerd,omitempty"`
-	Probes            []Probe           `yaml:"probes,omitempty" json:"probes,omitempty"`
-	PortForwards      []PortForward     `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
-	Message           string            `yaml:"message,omitempty" json:"message,omitempty"`
-	Networks          []Network         `yaml:"networks,omitempty" json:"networks,omitempty"`
-	Network           NetworkDeprecated `yaml:"network,omitempty" json:"network,omitempty"` // DEPRECATED, use `networks` instead
-	Env               map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
-	DNS               []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`
-	HostResolver      HostResolver      `yaml:"hostResolver,omitempty" json:"hostResolver,omitempty"`
-	UseHostResolver   *bool             `yaml:"useHostResolver,omitempty" json:"useHostResolver,omitempty"` // DEPRECATED, use `HostResolver.Enabled` instead
-	PropagateProxyEnv *bool             `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty"`
-	CACertificates    CACertificates    `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
+	VMType          *VMType         `yaml:"vmType,omitempty" json:"vmType,omitempty"`
+	Arch            *Arch           `yaml:"arch,omitempty" json:"arch,omitempty"`
+	Images          []Image         `yaml:"images" json:"images"` // REQUIRED
+	CPUType         map[Arch]string `yaml:"cpuType,omitempty" json:"cpuType,omitempty"`
+	CPUs            *int            `yaml:"cpus,omitempty" json:"cpus,omitempty"`
+	Memory          *string         `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
+	Disk            *string         `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes
+	AdditionalDisks []Disk          `yaml:"additionalDisks,omitempty" json:"additionalDisks,omitempty"`
+	Mounts          []Mount         `yaml:"mounts,omitempty" json:"mounts,omitempty"`
+	MountType       *MountType      `yaml:"mountType,omitempty" json:"mountType,omitempty"`
+	SSH             SSH             `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
+	Firmware        Firmware        `yaml:"firmware,omitempty" json:"firmware,omitempty"`
+	Video           Video           `yaml:"video,omitempty" json:"video,omitempty"`
+	Provision       []Provision     `yaml:"provision,omitempty" json:"provision,omitempty"`
+	Containerd      Containerd      `yaml:"containerd,omitempty" json:"containerd,omitempty"`
+	Probes          []Probe         `yaml:"probes,omitempty" json:"probes,omitempty"`
+	PortForwards    []PortForward   `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
+	Message         string          `yaml:"message,omitempty" json:"message,omitempty"`
+	Networks        []Network       `yaml:"networks,omitempty" json:"networks,omitempty"`
+	// `network` was deprecated in Lima v0.7.0, removed in Lima v0.14.0. Use `networks` instead.
+	Env          map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+	DNS          []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`
+	HostResolver HostResolver      `yaml:"hostResolver,omitempty" json:"hostResolver,omitempty"`
+	// `useHostResolver` was deprecated in Lima v0.8.1, removed in Lima v0.14.0. Use `hostResolver.enabled` instead.
+	PropagateProxyEnv *bool          `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty"`
+	CACertificates    CACertificates `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
 }
 
 type Arch = string
@@ -203,12 +203,6 @@ type CACertificates struct {
 
 // Types have been renamed to turn all references to the old names into compiler errors,
 // and to avoid accidental usage in new code.
-
-type NetworkDeprecated struct {
-	VDEDeprecated []VDEDeprecated `yaml:"vde,omitempty" json:"vde,omitempty"`
-	// migrate will be true when `network.VDE` has been copied to `networks` by FillDefaults()
-	migrated bool
-}
 
 type VDEDeprecated struct {
 	VNL        string `yaml:"vnl,omitempty" json:"vnl,omitempty"`

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -261,15 +261,6 @@ func Validate(y LimaYAML, warn bool) error {
 }
 
 func validateNetwork(y LimaYAML, warn bool) error {
-	if len(y.Network.VDEDeprecated) > 0 {
-		if y.Network.migrated {
-			if warn {
-				logrus.Warnf("field `network.VDE` is deprecated; please use `networks` instead")
-			}
-		} else {
-			return fmt.Errorf("you cannot use deprecated field `network.VDE` together with replacement field `networks`")
-		}
-	}
 	interfaceName := make(map[string]int)
 	for i, nw := range y.Networks {
 		field := fmt.Sprintf("networks[%d]", i)


### PR DESCRIPTION
- `network`: deprecated in Lima v0.7.0 (Oct 2021), in favor of `networks`: https://github.com/lima-vm/lima/commit/07e68230e70b21108d2db3ca5e0efd0e43842fbd
- `useHostResolver`: deprecated in Lima v0.8.1 (Jan 2022), in favor of `hostResolver.enabled`: https://github.com/lima-vm/lima/commit/eaeee31b0496174363c55da732c855ae21e9ad97

The deprecated support for VDE is not removed in this commit.

- - -

Split from https://github.com/lima-vm/lima/pull/1069/commits