### PR TITLE
vz: support "lima: shared" networking using VZNATNetworkDeviceAttachment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,6 @@ jobs:
       run: make
     - name: Install
       run: sudo make install
-    - name: Validate examples (except vmnet.yaml)
-      run: find examples -name '*.yaml' | grep -v 'vmnet.yaml' | xargs limactl validate
     - name: Uninstall
       run: sudo make uninstall
 
@@ -89,6 +87,8 @@ jobs:
       run: make
     - name: Install
       run: make install
+    - name: Validate examples
+      run: find examples -name '*.yaml' | xargs limactl validate
     - name: Install test dependencies
       # QEMU:      required by Lima itself
       # bash:      required by test-example.sh (OS version of bash is too old)

--- a/docs/network.md
+++ b/docs/network.md
@@ -44,12 +44,17 @@ If `useHostResolver` is false, then DNS servers can be configured manually in `l
 
 ## Managed VMNet networks (192.168.105.0/24)
 
+### QEMU
 Either [`socket_vmnet`](https://github.com/lima-vm/socket_vmnet) (since Lima v0.12) or [`vde_vmnet`](https://github.com/lima-vm/vde_vmnet) (Deprecated)
 is required for adding another guest IP that is accessible from the host and other guests.
 
 Starting with version v0.7.0 lima can manage the networking daemons automatically. Networks are defined in
 `$LIMA_HOME/_config/networks.yaml`. If this file doesn't already exist, it will be created with these default
 settings:
+
+<details>
+<summary>Default</summary>
+<p>
 
 ```yaml
 # Path to socket_vmnet executable. Because socket_vmnet is invoked via sudo it should be
@@ -92,6 +97,9 @@ networks:
     netmask: 255.255.255.0
 ```
 
+</p>
+</details>
+
 Instances can then reference these networks from their `lima.yaml` file:
 
 ```yaml
@@ -120,7 +128,18 @@ be done via:
 limactl sudoers | sudo tee /etc/sudoers.d/lima
 ```
 
+### VZ
+The `shared` network supports VZ, but no support for custom IP ranges.
+
+```yaml
+networks:
+- lima: shared
+```
+
+The `socket_vmnet` daemon and the `sudoers` file are NOT needed for VZ instances.
+
 ## Unmanaged VMNet networks
+### QEMU
 For Lima >= 0.12:
 ```yaml
 networks:
@@ -132,6 +151,9 @@ networks:
 ```
 
 For older Lima releases:
+<details>
+<p>
+
 ```yaml
 networks:
   # vnl (virtual network locator) points to the vde_switch socket directory,
@@ -147,3 +169,9 @@ networks:
   #   # Interface name, defaults to "lima0", "lima1", etc.
   #   interface: ""
 ```
+
+</p>
+</details>
+
+### VZ
+Not supported.

--- a/examples/experimental/vz.yaml
+++ b/examples/experimental/vz.yaml
@@ -16,3 +16,6 @@ mounts:
 - location: "/tmp/lima"
   writable: true
 mountType: "virtiofs"
+
+networks:
+- lima: shared

--- a/examples/vmnet.yaml
+++ b/examples/vmnet.yaml
@@ -1,6 +1,12 @@
-# Example to enable vmnet.framework
+# Example to enable vmnet.framework to assign the "real" IP address that is reachable from the host.
+# See also https://github.com/lima-vm/lima/blob/master/docs/network.md
+
+# Requirements for QEMU (not needed for VZ):
+# * Install /opt/socket_vmnet/bin/socket_vmnet from https://github.com/lima-vm/socket_vmnet
+# * Run `limactl sudoers | sudo tee /etc/sudoers.d/lima`
+
 # This example requires Lima v0.7.0 or later.
-# Older versions of Lima were using a different syntax for supporting vmnet.framework.
+
 images:
 - location: "https://cloud-images.ubuntu.com/releases/22.10/release-20221022/ubuntu-22.10-server-cloudimg-amd64.img"
   arch: "x86_64"
@@ -20,15 +26,10 @@ mounts:
 - location: "/tmp/lima"
   writable: true
 networks:
-# The instance can get routable IP addresses from the vmnet framework using
-# https://github.com/lima-vm/socket_vmnet (since Lima v0.12) or
-# https://github.com/lima-vm/vde_vmnet (deprecated) .
-#
-# Available networks are defined in
-# $LIMA_HOME/_config/networks.yaml. Supported network types are "host",
-# "shared", or "bridged".
-#
+
+# Available networks are defined in $LIMA_HOME/_config/networks.yaml.
 # Interface "lima0": shared mode  (IP is assigned by macOS's bootpd)
 - lima: shared
 # Interface "lima1": bridged mode (IP is assigned by a DHCP server on the physical network)
+# Not supported for VZ.
 # - lima: bridged

--- a/pkg/networks/networks.go
+++ b/pkg/networks/networks.go
@@ -3,6 +3,7 @@ package networks
 import "net"
 
 type YAML struct {
+	// Paths and Group are ignored for vz
 	Paths    Paths              `yaml:"paths"`
 	Group    string             `yaml:"group,omitempty"` // default: "everyone"
 	Networks map[string]Network `yaml:"networks"`

--- a/pkg/networks/networks.yaml
+++ b/pkg/networks/networks.yaml
@@ -1,3 +1,9 @@
+# Network definitions for Lima.
+#
+# This configuration file is recognized for both QEMU and VZ instances.
+# However, most properties are ignored by VZ.
+
+# [Only for QEMU]
 # Path to socket_vmnet executable. Because socket_vmnet is invoked via sudo it should be
 # installed where only root can modify/replace it. This means also none of the
 # parent directories should be writable by the user.
@@ -19,18 +25,22 @@ paths:
   varRun: /private/var/run/lima
   sudoers: /private/etc/sudoers.d/lima
 
+# [Only for QEMU]
 group: everyone
 
 networks:
+  # "shared" is recognized by both QEMU and VZ, but the IP address range is ignored by VZ
   shared:
     mode: shared
     gateway: 192.168.105.1
     dhcpEnd: 192.168.105.254
     netmask: 255.255.255.0
+  # [Only for QEMU]
   bridged:
     mode: bridged
     interface: en0
     # bridged mode doesn't have a gateway; dhcp is managed by outside network
+  # [Only for QEMU]
   host:
     mode: host
     gateway: 192.168.106.1

--- a/pkg/networks/reconcile/reconcile.go
+++ b/pkg/networks/reconcile/reconcile.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/store"
@@ -35,6 +36,9 @@ func Reconcile(ctx context.Context, newInst string) error {
 		instance, err := store.Inspect(instName)
 		if err != nil {
 			return err
+		}
+		if instance.VMType == limayaml.VZ {
+			continue
 		}
 		// newInst is about to be started, so its networks should be running
 		if instance.Status != store.StatusRunning && instName != newInst {


### PR DESCRIPTION
See `examples/experimental/vz.yaml` .

Unlike QEMU, VZ does not need sudoers for enabling vmnet.

Fix #1161 

- - -
No support for `bridged` mode, as `VZBridgedNetworkDeviceAttachment` requires the `com.apple.vm.networking`entitlement which needs to contact an Apple representative.
 - https://developer.apple.com/documentation/virtualization/vzbridgednetworkdeviceattachment?language=objc
 - https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_vm_networking?language=objc

Probably we need to use `socket_vmnet` too for supporting `bridged` mode with VZ.
(The socket protocol is different, so we need to modify `socket_vmnet`)
