### PR TITLE
vz: support `.[]networks.vzNAT` networking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,6 @@ jobs:
       run: make
     - name: Install
       run: sudo make install
-    - name: Validate examples (except vmnet.yaml)
-      run: find examples -name '*.yaml' | grep -v 'vmnet.yaml' | xargs limactl validate
     - name: Uninstall
       run: sudo make uninstall
 
@@ -89,6 +87,8 @@ jobs:
       run: make
     - name: Install
       run: make install
+    - name: Validate examples
+      run: find examples -name '*.yaml' | xargs limactl validate
     - name: Install test dependencies
       # QEMU:      required by Lima itself
       # bash:      required by test-example.sh (OS version of bash is too old)

--- a/docs/network.md
+++ b/docs/network.md
@@ -42,7 +42,16 @@ During initial cloud-init bootstrap, `iptables` may not yet be installed. In tha
 
 If `useHostResolver` is false, then DNS servers can be configured manually in `lima.yaml` via the `dns` setting. If that list is empty, then Lima will either use the slirp DNS (on Linux), or the nameservers from the first host interface in service order that has an assigned IPv4 address (on macOS).
 
-## Managed VMNet networks (192.168.105.0/24)
+## VMNet networks
+
+VMNet assigns a "real" IP address that is reachable from the host.
+
+The configuration steps are different across QEMU and VZ:
+- [QEMU](#qemu)
+- [VZ](#vz)
+
+### QEMU
+#### Managed (192.168.105.0/24)
 
 Either [`socket_vmnet`](https://github.com/lima-vm/socket_vmnet) (since Lima v0.12) or [`vde_vmnet`](https://github.com/lima-vm/vde_vmnet) (Deprecated)
 is required for adding another guest IP that is accessible from the host and other guests.
@@ -50,6 +59,11 @@ is required for adding another guest IP that is accessible from the host and oth
 Starting with version v0.7.0 lima can manage the networking daemons automatically. Networks are defined in
 `$LIMA_HOME/_config/networks.yaml`. If this file doesn't already exist, it will be created with these default
 settings:
+
+<details>
+<summary>Default</summary>
+
+<p>
 
 ```yaml
 # Path to socket_vmnet executable. Because socket_vmnet is invoked via sudo it should be
@@ -92,6 +106,10 @@ networks:
     netmask: 255.255.255.0
 ```
 
+</p>
+
+</details>
+
 Instances can then reference these networks from their `lima.yaml` file:
 
 ```yaml
@@ -120,7 +138,7 @@ be done via:
 limactl sudoers | sudo tee /etc/sudoers.d/lima
 ```
 
-## Unmanaged VMNet networks
+#### Unmanaged
 For Lima >= 0.12:
 ```yaml
 networks:
@@ -131,7 +149,11 @@ networks:
   # - socket: "/var/run/socket_vmnet"
 ```
 
-For older Lima releases:
+<details>
+<summary>For older Lima releases</summary>
+
+<p>
+
 ```yaml
 networks:
   # vnl (virtual network locator) points to the vde_switch socket directory,
@@ -147,3 +169,18 @@ networks:
   #   # Interface name, defaults to "lima0", "lima1", etc.
   #   interface: ""
 ```
+</p>
+
+</details>
+
+### VZ
+
+For VZ instances, the "vzNAT" network can be configured as follows:
+```yaml
+networks:
+- vzNAT: true
+```
+
+The range of the IP address is not specifiable.
+
+The "vzNAT" network does not need the `socket_vmnet` binary and the `sudoers` file.

--- a/docs/vmtype.md
+++ b/docs/vmtype.md
@@ -37,5 +37,4 @@ mountType: "virtiofs"
 
 ### Known Issues
 - "vz" doesn't support `legacyBoot: true` option, so guest machine like centos-stream, archlinux, oraclelinux will not work
-- Host to guest networking (`networks` section in lima yaml) is not supported
 - When running lima using "vz", `${LIMA_HOME}/<INSTANCE>/serial.log` will not contain kernel boot logs

--- a/examples/experimental/vz.yaml
+++ b/examples/experimental/vz.yaml
@@ -16,3 +16,6 @@ mounts:
 - location: "/tmp/lima"
   writable: true
 mountType: "virtiofs"
+
+networks:
+- vzNAT: true

--- a/examples/vmnet.yaml
+++ b/examples/vmnet.yaml
@@ -1,4 +1,6 @@
-# Example to enable vmnet.framework
+# Example to enable vmnet.framework for QEMU.
+# VZ users should refer to experimental/vz.yaml
+
 # This example requires Lima v0.7.0 or later.
 # Older versions of Lima were using a different syntax for supporting vmnet.framework.
 images:

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -184,6 +184,9 @@ type Network struct {
 	Lima string `yaml:"lima,omitempty" json:"lima,omitempty"`
 	// Socket is a QEMU-compatible socket
 	Socket string `yaml:"socket,omitempty" json:"socket,omitempty"`
+	// VZNAT uses VZNATNetworkDeviceAttachment. Needs VZ. No root privilege is required.
+	VZNAT *bool `yaml:"vzNAT,omitempty" json:"vzNAT,omitempty"`
+
 	// VNLDeprecated is a Virtual Network Locator (https://github.com/rd235/vdeplug4/commit/089984200f447abb0e825eb45548b781ba1ebccd).
 	// On macOS, only VDE2-compatible form (optionally with vde:// prefix) is supported.
 	// VNLDeprecated is deprecated. Use Socket.

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -271,6 +271,9 @@ func validateNetwork(y LimaYAML, warn bool) error {
 			if nw.Socket != "" {
 				return fmt.Errorf("field `%s.lima` and field `%s.socket` are mutually exclusive", field, field)
 			}
+			if nw.VZNAT != nil && *nw.VZNAT {
+				return fmt.Errorf("field `%s.lima` and field `%s.vzNAT` are mutually exclusive", field, field)
+			}
 			if nw.VNLDeprecated != "" {
 				return fmt.Errorf("field `%s.lima` and field `%s.vnl` are mutually exclusive", field, field)
 			}
@@ -285,6 +288,9 @@ func validateNetwork(y LimaYAML, warn bool) error {
 				return fmt.Errorf("field `%s.lima` references network %q which is not defined in networks.yaml", field, nw.Lima)
 			}
 		} else if nw.Socket != "" {
+			if nw.VZNAT != nil && *nw.VZNAT {
+				return fmt.Errorf("field `%s.socket` and field `%s.vzNAT` are mutually exclusive", field, field)
+			}
 			if nw.VNLDeprecated != "" {
 				return fmt.Errorf("field `%s.socket` and field `%s.vnl` are mutually exclusive", field, field)
 			}
@@ -295,6 +301,22 @@ func validateNetwork(y LimaYAML, warn bool) error {
 				return err
 			} else if err == nil && fi.Mode()&os.ModeSocket == 0 {
 				return fmt.Errorf("field `%s.socket` %q points to a non-socket file", field, nw.Socket)
+			}
+		} else if nw.VZNAT != nil && *nw.VZNAT {
+			if y.VMType == nil || *y.VMType != VZ {
+				return fmt.Errorf("field `%s.vzNAT` requires `vmType` to be %q", field, VZ)
+			}
+			if nw.Lima != "" {
+				return fmt.Errorf("field `%s.vzNAT` and field `%s.lima` are mutually exclusive", field, field)
+			}
+			if nw.Socket != "" {
+				return fmt.Errorf("field `%s.vzNAT` and field `%s.socket` are mutually exclusive", field, field)
+			}
+			if nw.VNLDeprecated != "" {
+				return fmt.Errorf("field `%s.vzNAT` and field `%s.vnl` are mutually exclusive", field, field)
+			}
+			if nw.SwitchPortDeprecated != 0 {
+				return fmt.Errorf("field `%s.switchPort` cannot be used with field `%s.vzNAT`", field, field)
 			}
 		} else {
 			if nw.VNLDeprecated == "" {

--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -191,6 +191,23 @@ func attachSerialPort(driver *driver.BaseDriver, config *vz.VirtualMachineConfig
 	return err
 }
 
+func newVirtioNetworkDeviceConfiguration(attachment vz.NetworkDeviceAttachment, macStr string) (*vz.VirtioNetworkDeviceConfiguration, error) {
+	networkConfig, err := vz.NewVirtioNetworkDeviceConfiguration(attachment)
+	if err != nil {
+		return nil, err
+	}
+	mac, err := net.ParseMAC(macStr)
+	if err != nil {
+		return nil, err
+	}
+	address, err := vz.NewMACAddress(mac)
+	if err != nil {
+		return nil, err
+	}
+	networkConfig.SetMACAddress(address)
+	return networkConfig, nil
+}
+
 func attachNetwork(driver *driver.BaseDriver, vmConfig *vz.VirtualMachineConfiguration, networkConn *os.File) error {
 	//slirp network using gvisor netstack
 	fileAttachment, err := vz.NewFileHandleNetworkDeviceAttachment(networkConn)
@@ -201,22 +218,25 @@ func attachNetwork(driver *driver.BaseDriver, vmConfig *vz.VirtualMachineConfigu
 	if err != nil {
 		return err
 	}
-	networkConfig, err := vz.NewVirtioNetworkDeviceConfiguration(fileAttachment)
+	networkConfig, err := newVirtioNetworkDeviceConfiguration(fileAttachment, limayaml.MACAddress(driver.Instance.Dir))
 	if err != nil {
 		return err
 	}
-	mac, err := net.ParseMAC(limayaml.MACAddress(driver.Instance.Dir))
-	if err != nil {
-		return err
-	}
-	address, err := vz.NewMACAddress(mac)
-	if err != nil {
-		return err
-	}
-	networkConfig.SetMACAddress(address)
-
 	configurations := []*vz.VirtioNetworkDeviceConfiguration{
 		networkConfig,
+	}
+	for _, nw := range driver.Instance.Networks {
+		if nw.VZNAT != nil && *nw.VZNAT {
+			attachment, err := vz.NewNATNetworkDeviceAttachment()
+			if err != nil {
+				return err
+			}
+			networkConfig, err = newVirtioNetworkDeviceConfiguration(attachment, nw.MACAddress)
+			if err != nil {
+				return err
+			}
+			configurations = append(configurations, networkConfig)
+		}
 	}
 	vmConfig.SetNetworkDevicesVirtualMachineConfiguration(configurations)
 	return nil


### PR DESCRIPTION
Introduces a new YAML property `.[]networks.vzNAT` for enabling `VZNATNetworkDeviceAttachment`. No root privilege is needed.

`.[]networks.lima` is reserved for future support of `socket_vmnet` for VZ.

Fix #1161
Replaces #1206
