### PR TITLE
vmnet: support detecting Homebrew's socket_vmnet path

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -53,11 +53,23 @@ The configuration steps are different across QEMU and VZ:
 ### QEMU
 #### Managed (192.168.105.0/24)
 
-Either [`socket_vmnet`](https://github.com/lima-vm/socket_vmnet) (since Lima v0.12) or [`vde_vmnet`](https://github.com/lima-vm/vde_vmnet) (Deprecated)
-is required for adding another guest IP that is accessible from the host and other guests.
+[`socket_vmnet`](https://github.com/lima-vm/socket_vmnet) is required for adding another guest IP that is accessible from the host and other guests.
 
-Starting with version v0.7.0 lima can manage the networking daemons automatically. Networks are defined in
-`$LIMA_HOME/_config/networks.yaml`. If this file doesn't already exist, it will be created with these default
+```bash
+# Install socket_vmnet
+brew install socket_vmnet
+
+# Set up the sudoers file for launching socket_vmnet from Lima
+limactl sudoers >etc_sudoers.d_lima
+sudo install -o root etc_sudoers.d_lima /etc/sudoers.d/lima
+```
+
+> **Note**
+>
+> Lima before v0.12 used `vde_vmnet` for managing the networks.
+> `vde_vmnet` is still supported but it is deprecated and no longer documented here.
+
+The networks are defined in `$LIMA_HOME/_config/networks.yaml`. If this file doesn't already exist, it will be created with these default
 settings:
 
 <details>
@@ -114,9 +126,8 @@ Instances can then reference these networks from their `lima.yaml` file:
 
 ```yaml
 networks:
-  # Lima can manage daemons for networks defined in $LIMA_HOME/_config/networks.yaml
-  # automatically. The socket_vmnet must be installed into
-  # secure locations only alterable by the "root" user.
+  # Lima can manage the socket_vmnet daemon for networks defined in $LIMA_HOME/_config/networks.yaml automatically.
+  # The socket_vmnet binary must be installed into a secure location only alterable by the admin.
   # The same applies to vde_switch and vde_vmnet for the deprecated VDE mode.
   # - lima: shared
   #   # MAC address of the instance; lima will pick one based on the instance name,
@@ -126,17 +137,9 @@ networks:
   #   interface: ""
 ```
 
-The network daemons are started automatically when the first instance referencing them is started,
+The network daemon is started automatically when the first instance referencing them is started,
 and will stop automatically once the last instance has stopped. Daemon logs will be stored in the
 `$LIMA_HOME/_networks` directory.
-
-Since the commands to start and stop the `socket_vmnet` daemon (or the `vde_vmnet` daemon) requires root, the user either must
-have password-less `sudo` enabled, or add the required commands to a `sudoers` file. This can
-be done via:
-
-```shell
-limactl sudoers | sudo tee /etc/sudoers.d/lima
-```
 
 #### Unmanaged
 For Lima >= 0.12:

--- a/examples/vmnet.yaml
+++ b/examples/vmnet.yaml
@@ -1,6 +1,12 @@
 # Example to enable vmnet.framework for QEMU.
 # VZ users should refer to experimental/vz.yaml
 
+# Usage:
+#   brew install socket_vmnet
+#   limactl sudoers >etc_sudoers.d_lima
+#   sudo install -o root etc_sudoers.d_lima /etc/sudoers.d/lima
+#   limactl start template://vmnet
+
 # This example requires Lima v0.7.0 or later.
 # Older versions of Lima were using a different syntax for supporting vmnet.framework.
 images:

--- a/pkg/networks/networks.TEMPLATE.yaml
+++ b/pkg/networks/networks.TEMPLATE.yaml
@@ -12,7 +12,7 @@
 paths:
 # socketVMNet requires Lima >= 0.12 .
 # socketVMNet has precedence over vdeVMNet.
-  socketVMNet: /opt/socket_vmnet/bin/socket_vmnet
+  socketVMNet: "{{.SocketVMNet}}"
 # vdeSwitch and vdeVMNet are DEPRECATED.
   vdeSwitch: /opt/vde/bin/vde_switch
   vdeVMNet: /opt/vde/bin/vde_vmnet

--- a/pkg/networks/sudoers.go
+++ b/pkg/networks/sudoers.go
@@ -85,6 +85,8 @@ func (config *YAML) VerifySudoAccess(sudoersFile string) error {
 		}
 		return fmt.Errorf("passwordLessSudo error: %w", err)
 	}
+	hint := fmt.Sprintf("run `%s sudoers >etc_sudoers.d_lima && sudo install -o root etc_sudoers.d_lima %q`)",
+		os.Args[0], sudoersFile)
 	b, err := os.ReadFile(sudoersFile)
 	if err != nil {
 		// Default networks.yaml specifies /etc/sudoers.d/lima file. Don't throw an error when the
@@ -97,14 +99,15 @@ func (config *YAML) VerifySudoAccess(sudoersFile string) error {
 			}
 			logrus.Debugf("%q does not exist; passwordLessSudo error: %s", sudoersFile, err)
 		}
-		return fmt.Errorf("can't read %q: %s", sudoersFile, err)
+		return fmt.Errorf("can't read %q: %s (Hint: %s)", sudoersFile, err, hint)
 	}
 	sudoers, err := Sudoers()
 	if err != nil {
 		return err
 	}
 	if string(b) != sudoers {
-		return fmt.Errorf("sudoers file %q is out of sync and must be regenerated", sudoersFile)
+		// Happens on upgrading socket_vmnet with Homebrew
+		return fmt.Errorf("sudoers file %q is out of sync and must be regenerated (Hint: %s)", sudoersFile, hint)
 	}
 	return nil
 }


### PR DESCRIPTION
On Homebrew environments, socket_vmnet is installed on:
- `/usr/local/opt/socket_vmnet/Cellar/<VERSION>/bin/socket_vmnet` (Intel)
- `/opt/homebrew/opt/socket_vmnet/Cellar/<VERSION>/bin/socket_vmnet` (ARM)

The binary is usually owned by a non-root admin user. (i.e., the homebrew user).
The group is typically set to "admin".

https://github.com/Homebrew/homebrew-core/commit/636ac0700e011b23c3e41cc4176b30e01a3af5ae
