### PR TITLE
Hide columns in the list command

### DIFF
--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -3,11 +3,14 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
 
+	"github.com/cheggaaa/pb/v3/termutil"
 	"github.com/lima-vm/lima/pkg/store"
+	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -163,6 +166,13 @@ func listAction(cmd *cobra.Command, args []string) error {
 
 	options := store.PrintOptions{AllFields: allFields}
 	out := cmd.OutOrStdout()
+	if out == os.Stdout {
+		if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+			if w, err := termutil.TerminalWidth(); err == nil {
+				options.TerminalWidth = w
+			}
+		}
+	}
 	return store.PrintInstances(out, instances, format, &options)
 }
 

--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -54,6 +54,7 @@ func newListCommand() *cobra.Command {
 	listCommand.Flags().Bool("list-fields", false, "List fields available for format")
 	listCommand.Flags().Bool("json", false, "JSONify output")
 	listCommand.Flags().BoolP("quiet", "q", false, "Only show names")
+	listCommand.Flags().Bool("all-fields", false, "Show all fields")
 
 	return listCommand
 }
@@ -155,7 +156,14 @@ func listAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	return store.PrintInstances(cmd.OutOrStdout(), instances, format)
+	allFields, err := cmd.Flags().GetBool("all-fields")
+	if err != nil {
+		return err
+	}
+
+	options := store.PrintOptions{AllFields: allFields}
+	out := cmd.OutOrStdout()
+	return store.PrintInstances(out, instances, format, &options)
 }
 
 func listBashComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/store/instance_test.go
+++ b/pkg/store/instance_test.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"bytes"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/lima-vm/lima/pkg/limayaml"
+	"gotest.tools/v3/assert"
+)
+
+const separator = string(filepath.Separator)
+
+var vmtype = limayaml.QEMU
+var goarch = limayaml.NewArch(runtime.GOARCH)
+
+var instance = Instance{
+	Name:   "foo",
+	Status: StatusStopped,
+	VMType: vmtype,
+	Arch:   goarch,
+	Dir:    "dir",
+}
+
+var table = "NAME    STATUS     SSH            CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    127.0.0.1:0    0       0B        0B      dir\n"
+
+var tableEmu = "NAME    STATUS     SSH            ARCH       CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    127.0.0.1:0    unknown    0       0B        0B      dir\n"
+
+var tableHome = "NAME    STATUS     SSH            CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    127.0.0.1:0    0       0B        0B      ~" + separator + "dir\n"
+
+var tableAll = "NAME    STATUS     SSH            VMTYPE    ARCH      CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    127.0.0.1:0    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
+
+var tableTwo = "NAME    STATUS     SSH            VMTYPE    ARCH       CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    127.0.0.1:0    qemu      x86_64     0       0B        0B      dir\n" +
+	"bar     Stopped    127.0.0.1:0    vz        aarch64    0       0B        0B      dir\n"
+
+func TestPrintInstanceTable(t *testing.T) {
+	var buf bytes.Buffer
+	instances := []*Instance{&instance}
+	PrintInstances(&buf, instances, "table", nil)
+	assert.Equal(t, table, buf.String())
+}
+
+func TestPrintInstanceTableEmu(t *testing.T) {
+	var buf bytes.Buffer
+	instance1 := instance
+	instance1.Arch = "unknown"
+	instances := []*Instance{&instance1}
+	PrintInstances(&buf, instances, "table", nil)
+	assert.Equal(t, tableEmu, buf.String())
+}
+
+func TestPrintInstanceTableHome(t *testing.T) {
+	var buf bytes.Buffer
+	u, err := user.Current()
+	assert.NilError(t, err)
+	instance1 := instance
+	instance1.Dir = filepath.Join(u.HomeDir, "dir")
+	instances := []*Instance{&instance1}
+	PrintInstances(&buf, instances, "table", nil)
+	assert.Equal(t, tableHome, buf.String())
+}
+
+func TestPrintInstanceTableAll(t *testing.T) {
+	var buf bytes.Buffer
+	instances := []*Instance{&instance}
+	options := PrintOptions{AllFields: true}
+	PrintInstances(&buf, instances, "table", &options)
+	assert.Equal(t, tableAll, buf.String())
+}
+
+func TestPrintInstanceTableTwo(t *testing.T) {
+	var buf bytes.Buffer
+	instance1 := instance
+	instance1.Name = "foo"
+	instance1.VMType = limayaml.QEMU
+	instance1.Arch = limayaml.X8664
+	instance2 := instance
+	instance2.Name = "bar"
+	instance2.VMType = limayaml.VZ
+	instance2.Arch = limayaml.AARCH64
+	instances := []*Instance{&instance1, &instance2}
+	options := PrintOptions{}
+	PrintInstances(&buf, instances, "table", &options)
+	assert.Equal(t, tableTwo, buf.String())
+}


### PR DESCRIPTION
* Hide identical columns in the list command
    
    If all the instances have the same type or arch,
    then don't display the column - unless requested.

* Hide the directory column on narrow terminal
    
    If the terminal width does not fit all the list
    columns, then hide "dir" column - unless requested.



before
```
NAME    STATUS     SSH            VMTYPE    ARCH      CPUS    MEMORY    DISK   
   DIR
k8s     Stopped    127.0.0.1:0    qemu      x86_64    4       4GiB      100GiB  
  ~/.lima/k8s
```

after
```
NAME    STATUS     SSH            CPUS    MEMORY    DISK      DIR
k8s     Stopped    127.0.0.1:0    4       4GiB      100GiB    ~/.lima/k8s
```

```
NAME    STATUS     SSH            VMTYPE    ARCH      CPUS    MEMORY    DISK
k8s     Stopped    127.0.0.1:0    qemu      x86_64    4       4GiB      100GiB
```

One can use the `--all-fields` flag, to get the old behaviour back again.

On a wide enough terminal, the table output is the same as before.

Closes #1204