### PR TITLE
Add template functions for list/inspect message

### DIFF
--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -41,7 +41,8 @@ func newListCommand() *cobra.Command {
 		  --format yaml  - output in yaml format
 		  --format table - output in table format
 		  --format '{{ <go template> }}' - if the format begins and ends with '{{ }}', then it is used as a go template.
-
+` + store.FormatHelp +
+			`
 		The following legacy flags continue to function:
 		  --json - equal to '--format json'
 		`,

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -285,6 +285,7 @@ func PrintInstances(w io.Writer, instances []*Instance, format string) error {
 		if err != nil {
 			return err
 		}
+		data.Message = strings.TrimSuffix(instance.Message, "\n")
 		err = tmpl.Execute(w, data)
 		if err != nil {
 			return err

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -211,6 +211,11 @@ type FormatData struct {
 	IdentityFile string
 }
 
+var FormatHelp = "\n" + textutil.PrefixString("\t\t",
+	"These functions are available to go templates:\n\n"+
+		textutil.IndentString(2,
+			strings.Join(textutil.FuncHelp, "\n")+"\n"))
+
 func AddGlobalFields(inst *Instance) (FormatData, error) {
 	var data FormatData
 	data.Instance = *inst

--- a/pkg/textutil/textutil.go
+++ b/pkg/textutil/textutil.go
@@ -3,6 +3,7 @@ package textutil
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"text/template"
@@ -74,8 +75,46 @@ var TemplateFuncMap = template.FuncMap{
 		}
 		return "---\n" + strings.TrimSuffix(b.String(), "\n")
 	},
-	"indent":  IndentString,
-	"missing": MissingString,
+	"indent": func(a ...interface{}) (string, error) {
+		if len(a) == 0 {
+			return "", errors.New("function takes at at least one string argument")
+		}
+		if len(a) > 2 {
+			return "", errors.New("function takes at most 2 arguments")
+		}
+		var ok bool
+		size := 2
+		if len(a) > 1 {
+			if size, ok = a[0].(int); !ok {
+				return "", errors.New("optional first argument must be an integer")
+			}
+		}
+		text := ""
+		if text, ok = a[len(a)-1].(string); !ok {
+			return "", errors.New("last argument must be a string")
+		}
+		return IndentString(size, text), nil
+	},
+	"missing": func(a ...interface{}) (string, error) {
+		if len(a) == 0 {
+			return "", errors.New("function takes at at least one string argument")
+		}
+		if len(a) > 2 {
+			return "", errors.New("function takes at most 2 arguments")
+		}
+		var ok bool
+		message := "<missing>"
+		if len(a) > 1 {
+			if message, ok = a[0].(string); !ok {
+				return "", errors.New("optional first argument must be a string")
+			}
+		}
+		text := ""
+		if text, ok = a[len(a)-1].(string); !ok {
+			return "", errors.New("last argument must be a string")
+		}
+		return MissingString(message, text), nil
+	},
 }
 
 // TemplateFuncHelp is help for TemplateFuncMap.

--- a/pkg/textutil/textutil.go
+++ b/pkg/textutil/textutil.go
@@ -25,14 +25,15 @@ func ExecuteTemplate(tmpl string, args interface{}) ([]byte, error) {
 
 // PrefixString adds prefix to beginning of each line
 func PrefixString(prefix string, text string) string {
-	result := ""
+	result := []string{}
 	for _, line := range strings.Split(text, "\n") {
 		if line == "" {
+			result = append(result, "")
 			continue
 		}
-		result += prefix + line + "\n"
+		result = append(result, prefix+line)
 	}
-	return result
+	return strings.Join(result, "\n")
 }
 
 // IndentString add spaces to beginning of each line
@@ -74,13 +75,11 @@ var TemplateFuncMap = template.FuncMap{
 		return "---\n" + strings.TrimSuffix(b.String(), "\n")
 	},
 	"indent":  IndentString,
-	"trim":    TrimString,
 	"missing": MissingString,
 }
 
 // TemplateFuncHelp is help for TemplateFuncMap.
 var FuncHelp = []string{
 	"indent <size>: add spaces to beginning of each line",
-	"trim <cutset>: remove characters from beginning and end",
 	"missing <message>: return message if the text is empty",
 }

--- a/pkg/textutil/textutil.go
+++ b/pkg/textutil/textutil.go
@@ -23,6 +23,37 @@ func ExecuteTemplate(tmpl string, args interface{}) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
+// PrefixString adds prefix to beginning of each line
+func PrefixString(prefix string, text string) string {
+	result := ""
+	for _, line := range strings.Split(text, "\n") {
+		if line == "" {
+			continue
+		}
+		result += prefix + line + "\n"
+	}
+	return result
+}
+
+// IndentString add spaces to beginning of each line
+func IndentString(size int, text string) string {
+	prefix := strings.Repeat(" ", size)
+	return PrefixString(prefix, text)
+}
+
+// TrimString removes characters from beginning and end
+func TrimString(cutset string, text string) string {
+	return strings.Trim(text, cutset)
+}
+
+// MissingString returns message if the text is empty
+func MissingString(message string, text string) string {
+	if text == "" {
+		return message
+	}
+	return text
+}
+
 // TemplateFuncMap is a text/template FuncMap.
 var TemplateFuncMap = template.FuncMap{
 	"json": func(v interface{}) string {
@@ -42,4 +73,14 @@ var TemplateFuncMap = template.FuncMap{
 		}
 		return "---\n" + strings.TrimSuffix(b.String(), "\n")
 	},
+	"indent":  IndentString,
+	"trim":    TrimString,
+	"missing": MissingString,
+}
+
+// TemplateFuncHelp is help for TemplateFuncMap.
+var FuncHelp = []string{
+	"indent <size>: add spaces to beginning of each line",
+	"trim <cutset>: remove characters from beginning and end",
+	"missing <message>: return message if the text is empty",
 }

--- a/pkg/textutil/textutil_test.go
+++ b/pkg/textutil/textutil_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestPrefixString(t *testing.T) {
-	assert.Equal(t, "- foo\n", PrefixString("- ", "foo"))
+	assert.Equal(t, "- foo", PrefixString("- ", "foo"))
 	assert.Equal(t, "- foo\n- bar\n", PrefixString("- ", "foo\nbar\n"))
 }
 func TestIndentString(t *testing.T) {
-	assert.Equal(t, "  foo\n", IndentString(2, "foo"))
+	assert.Equal(t, "  foo", IndentString(2, "foo"))
 	assert.Equal(t, "  foo\n  bar\n", IndentString(2, "foo\nbar\n"))
 }
 
@@ -33,18 +33,18 @@ func TestTemplateFuncs(t *testing.T) {
 		Bar     string `json:"bar" yaml:"bar"`
 		Message string `json:"message,omitempty" yaml:"message,omitempty"`
 	}
-	x := X{Foo: 42, Bar: "hello", Message: "One\nTwo\nThree\n"}
+	x := X{Foo: 42, Bar: "hello", Message: "One\nTwo\nThree"}
 
 	testCases := map[string]string{
-		"{{json .}}": `{"foo":42,"bar":"hello","message":"One\nTwo\nThree\n"}`,
+		"{{json .}}": `{"foo":42,"bar":"hello","message":"One\nTwo\nThree"}`,
 		"{{yaml .}}": `---
 foo: 42
 bar: hello
-message: |
+message: |-
   One
   Two
   Three`,
-		`{{.Bar}}{{"\n"}}{{.Message | missing "<no message>" | indent 2 | trim "\n"}}`: "hello\n  One\n  Two\n  Three",
+		`{{.Bar}}{{"\n"}}{{.Message | missing "<no message>" | indent 2}}`: "hello\n  One\n  Two\n  Three",
 	}
 
 	for format, expected := range testCases {

--- a/pkg/textutil/textutil_test.go
+++ b/pkg/textutil/textutil_test.go
@@ -32,8 +32,9 @@ func TestTemplateFuncs(t *testing.T) {
 		Foo     int    `json:"foo" yaml:"foo"`
 		Bar     string `json:"bar" yaml:"bar"`
 		Message string `json:"message,omitempty" yaml:"message,omitempty"`
+		Missing string `json:"missing,omitempty" yaml:"missing,omitempty"`
 	}
-	x := X{Foo: 42, Bar: "hello", Message: "One\nTwo\nThree"}
+	x := X{Foo: 42, Bar: "hello", Message: "One\nTwo\nThree", Missing: ""}
 
 	testCases := map[string]string{
 		"{{json .}}": `{"foo":42,"bar":"hello","message":"One\nTwo\nThree"}`,
@@ -45,6 +46,8 @@ message: |-
   Two
   Three`,
 		`{{.Bar}}{{"\n"}}{{.Message | missing "<no message>" | indent 2}}`: "hello\n  One\n  Two\n  Three",
+		`{{.Message | indent}}`:  "  One\n  Two\n  Three",
+		`{{.Missing | missing}}`: "<missing>",
 	}
 
 	for format, expected := range testCases {

--- a/pkg/textutil/textutil_test.go
+++ b/pkg/textutil/textutil_test.go
@@ -8,18 +8,43 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+func TestPrefixString(t *testing.T) {
+	assert.Equal(t, "- foo\n", PrefixString("- ", "foo"))
+	assert.Equal(t, "- foo\n- bar\n", PrefixString("- ", "foo\nbar\n"))
+}
+func TestIndentString(t *testing.T) {
+	assert.Equal(t, "  foo\n", IndentString(2, "foo"))
+	assert.Equal(t, "  foo\n  bar\n", IndentString(2, "foo\nbar\n"))
+}
+
+func TestTrimString(t *testing.T) {
+	assert.Equal(t, "foo", TrimString("\n", "foo"))
+	assert.Equal(t, "bar", TrimString("\n", "bar\n"))
+}
+
+func TestMissingString(t *testing.T) {
+	assert.Equal(t, "no", MissingString("no", ""))
+	assert.Equal(t, "msg", MissingString("no", "msg"))
+}
+
 func TestTemplateFuncs(t *testing.T) {
 	type X struct {
-		Foo int    `json:"foo" yaml:"foo"`
-		Bar string `json:"bar" yaml:"bar"`
+		Foo     int    `json:"foo" yaml:"foo"`
+		Bar     string `json:"bar" yaml:"bar"`
+		Message string `json:"message,omitempty" yaml:"message,omitempty"`
 	}
-	x := X{Foo: 42, Bar: "hello"}
+	x := X{Foo: 42, Bar: "hello", Message: "One\nTwo\nThree\n"}
 
 	testCases := map[string]string{
-		"{{json .}}": `{"foo":42,"bar":"hello"}`,
+		"{{json .}}": `{"foo":42,"bar":"hello","message":"One\nTwo\nThree\n"}`,
 		"{{yaml .}}": `---
 foo: 42
-bar: hello`,
+bar: hello
+message: |
+  One
+  Two
+  Three`,
+		`{{.Bar}}{{"\n"}}{{.Message | missing "<no message>" | indent 2 | trim "\n"}}`: "hello\n  One\n  Two\n  Three",
 	}
 
 	for format, expected := range testCases {


### PR DESCRIPTION
Makes it possible to show messages using a format string like:

    {{.Name}}{{printf "\n"}}{{.Message | indent 2 | trim "\n"}}

Without having to add a command like `message` or a flag like `--message`.

Sample output:

```console
$ limactl ls -f '{{.Name}}{{printf "\n"}}{{.Message | indent 2 | trim "\n"}}'
k3d
  To run `kubectl` on the host (assumes kubectl is installed), run the following commands:
  ------
  mkdir -p "/home/anders/.lima/k3d/conf"
  export KUBECONFIG="/home/anders/.lima/k3d/conf/kubeconfig.yaml"
  limactl shell k3d sh -c 'cat ~/.kube/config' >$KUBECONFIG
  kubectl ...
  ------
  To run `docker` on the host (assumes docker-cli is installed), run the following commands:
  ------
  export DOCKER_HOST="unix:///home/anders/.lima/k3d/sock/docker.sock"
  docker ...
  ------
kind
  To run `kubectl` on the host (assumes kubectl is installed), run the following commands:
  ------
  mkdir -p "/home/anders/.lima/kind/conf"
  export KUBECONFIG="/home/anders/.lima/kind/conf/kubeconfig.yaml"
  limactl shell kind sh -c 'cat ~/.kube/config' >$KUBECONFIG
  kubectl ...
  ------
  To run `docker` on the host (assumes docker-cli is installed), run the following commands:
  ------
  export DOCKER_HOST="unix:///home/anders/.lima/kind/sock/docker.sock"
  docker ...
  ------
```

Closes #614