### PR TITLE
improve vm disk performance with VZDiskImageSynchronizationModeFsync

### DIFF
--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -278,7 +278,7 @@ func attachDisks(driver *driver.BaseDriver, vmConfig *vz.VirtualMachineConfigura
 	if err = validateDiskFormat(diffDiskPath); err != nil {
 		return err
 	}
-	diffDiskAttachment, err := vz.NewDiskImageStorageDeviceAttachment(diffDiskPath, false)
+	diffDiskAttachment, err := vz.NewDiskImageStorageDeviceAttachmentWithCacheAndSync(diffDiskPath, false, vz.DiskImageCachingModeAutomatic, vz.DiskImageSynchronizationModeFsync)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Reason**
The default disk attachment has a very poor disk performance (mainly when accessed via mmap).

From macOS 12 we have option to set cache and sync mode. Using VZDiskImageSynchronizationModeFsync provides a better performance and best-effort consistency as well.
https://developer.apple.com/documentation/virtualization/vzdiskimagesynchronizationmode/vzdiskimagesynchronizationmodefsync?language=objc

**Some results**
Commands
```
#for mmap test
fio --filename=PATH_TO_FILE --direct=1 --rw=randrw --bs=32k --ioengine=mmap --iodepth=256 --runtime=120 --numjobs=4 --time_based --group_reporting --name=iops-test-job --eta-newline=1 --size=1G

#for sync test
fio --filename=PATH_TO_FILE --direct=1 --rw=randrw --bs=32k --ioengine=sync --iodepth=256 --runtime=120 --numjobs=4 --time_based --group_reporting --name=iops-test-job --eta-newline=1 --size=1G
```
Results
Old
mmap - Read & Write IOPS ~52
sync - Read & write IOPS ~5200

With this PR
mmap - Read & Write IOPS ~3900
sync - Read & write IOPS ~5400