### PR TITLE
Closes the responseWriter after serving the Answer

### DIFF
--- a/pkg/hostagent/dns/dns.go
+++ b/pkg/hostagent/dns/dns.go
@@ -150,6 +150,7 @@ func (h *Handler) handleQuery(w dns.ResponseWriter, req *dns.Msg) {
 		reply   dns.Msg
 		handled bool
 	)
+	defer w.Close()
 	reply.SetReply(req)
 	logrus.Debugf("handleQuery received DNS query: %v", req)
 	for _, q := range req.Question {


### PR DESCRIPTION
Currently, we are leaving the response writer open for both connected sockets (TCP) and non-connected sockets (UPD), this change closes the response writer accordingly.

This change is meant to address the user-reported issue on Lima: https://github.com/lima-vm/lima/issues/1285

Signed-off-by: Nino Kodabande <nkodabande@suse.com>