### PR TITLE
Add VM labels

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -45,6 +45,10 @@ memory: null
 # 🟢 Builtin default: "100GiB"
 disk: null
 
+# List of VM user-defined labels.
+# 🟢 Builtin default: []
+labels: null
+
 # Expose host directories to the guest, the mount point might be accessible from all UIDs in the guest
 # 🟢 Builtin default: null (Mount nothing)
 # 🔵 This file: Mount the home as read-only, /tmp/lima as writable

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -525,6 +525,8 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 
 	caCerts := unique(append(append(d.CACertificates.Certs, y.CACertificates.Certs...), o.CACertificates.Certs...))
 	y.CACertificates.Certs = caCerts
+
+	y.Labels = unique(append(append(o.Labels, y.Labels...), d.Labels...))
 }
 
 func FillPortForwardDefaults(rule *PortForward, instDir string) {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -144,6 +144,9 @@ func TestFillDefault(t *testing.T) {
 				"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT\n-----END CERTIFICATE-----\n",
 			},
 		},
+		Labels: []Label{
+			"label_one",
+		},
 	}
 
 	expect := builtin
@@ -206,6 +209,8 @@ func TestFillDefault(t *testing.T) {
 			"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT\n-----END CERTIFICATE-----\n",
 		},
 	}
+
+	expect.Labels = y.Labels
 
 	FillDefault(&y, &LimaYAML{}, &LimaYAML{}, filePath)
 	assert.DeepEqual(t, &y, &expect, opts...)
@@ -308,6 +313,10 @@ func TestFillDefault(t *testing.T) {
 				"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT\n-----END CERTIFICATE-----\n",
 			},
 		},
+		Labels: []Label{
+			"label_one",
+			"label_two",
+		},
 	}
 
 	expect = d
@@ -359,6 +368,8 @@ func TestFillDefault(t *testing.T) {
 
 	// "TWO" does not exist in filledDefaults.Env, so is set from d.Env
 	expect.Env["TWO"] = d.Env["TWO"]
+
+	expect.Labels = unique(append(y.Labels, d.Labels...))
 
 	FillDefault(&y, &d, &LimaYAML{}, filePath)
 	assert.DeepEqual(t, &y, &expect, opts...)
@@ -472,6 +483,9 @@ func TestFillDefault(t *testing.T) {
 		CACertificates: CACertificates{
 			RemoveDefaults: pointer.Bool(true),
 		},
+		Labels: []Label{
+			"label_three",
+		},
 	}
 
 	y = filledDefaults
@@ -516,6 +530,8 @@ func TestFillDefault(t *testing.T) {
 	expect.CACertificates.Certs = []string{
 		"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT\n-----END CERTIFICATE-----\n",
 	}
+
+	expect.Labels = unique(append(append(o.Labels, y.Labels...), d.Labels...))
 
 	FillDefault(&y, &d, &o, filePath)
 	assert.DeepEqual(t, &y, &expect, opts...)

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -34,6 +34,7 @@ type LimaYAML struct {
 	PropagateProxyEnv *bool          `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty"`
 	CACertificates    CACertificates `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
 	Rosetta           Rosetta        `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
+	Labels            []Label        `yaml:"labels,omitempty" json:"labels,omitempty"`
 }
 
 type Arch = string
@@ -207,6 +208,8 @@ type CACertificates struct {
 	Files          []string `yaml:"files,omitempty" json:"files,omitempty"`
 	Certs          []string `yaml:"certs,omitempty" json:"certs,omitempty"`
 }
+
+type Label = string
 
 // DEPRECATED types below
 

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -46,6 +46,7 @@ type Instance struct {
 	Message         string             `json:"message,omitempty"`
 	AdditionalDisks []limayaml.Disk    `json:"additionalDisks,omitempty"`
 	Networks        []limayaml.Network `json:"network,omitempty"`
+	Labels          []limayaml.Label   `json:"labels,omitempty"`
 	SSHLocalPort    int                `json:"sshLocalPort,omitempty"`
 	HostAgentPID    int                `json:"hostAgentPID,omitempty"`
 	DriverPID       int                `json:"driverPID,omitempty"`
@@ -101,6 +102,7 @@ func Inspect(instName string) (*Instance, error) {
 	inst.AdditionalDisks = y.AdditionalDisks
 	inst.Networks = y.Networks
 	inst.SSHLocalPort = *y.SSH.LocalPort // maybe 0
+	inst.Labels = y.Labels
 
 	inst.HostAgentPID, err = ReadPIDFile(filepath.Join(instDir, filenames.HostAgentPID))
 	if err != nil {


### PR DESCRIPTION
Implement ability to add custom user-defined labels to a VM (by editing the VM's `lima.yaml` at the moment). Labels are only available in `limactl list --format json` currently.

Closes #1304