### PR TITLE
feat: report error when running under rosetta

### DIFF
--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/version"
 	"github.com/mattn/go-isatty"
@@ -60,6 +61,12 @@ func newApp() *cobra.Command {
 		if debug {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
+
+		if osutil.IsBeingRosettaTranslated() {
+			// running under rosetta would provide inappropriate runtime.GOARCH info, see: https://github.com/lima-vm/lima/issues/543
+			return errors.New("limactl is running under rosetta, please reinstall lima with native arch")
+		}
+
 		if runtime.GOOS == "windows" && isatty.IsCygwinTerminal(os.Stdout.Fd()) {
 			formatter := new(logrus.TextFormatter)
 			// the default setting does not recognize cygwin on windows

--- a/pkg/osutil/rosetta_darwin.go
+++ b/pkg/osutil/rosetta_darwin.go
@@ -1,0 +1,24 @@
+package osutil
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+func IsBeingRosettaTranslated() bool {
+	ret, err := unix.SysctlUint32("sysctl.proc_translated")
+	if err != nil {
+		const fallback = false
+		if err == unix.ENOENT {
+			return false
+		}
+
+		err = fmt.Errorf(`failed to read sysctl "sysctl.proc_translated": %w`, err)
+		logrus.WithError(err).Warnf("failed to detect whether running under rosetta, assuming %v", fallback)
+		return fallback
+	}
+
+	return ret != 0
+}

--- a/pkg/osutil/rosetta_others.go
+++ b/pkg/osutil/rosetta_others.go
@@ -1,0 +1,8 @@
+//go:build !darwin
+// +build !darwin
+
+package osutil
+
+func IsBeingRosettaTranslated() bool {
+	return false
+}


### PR DESCRIPTION
This PR closes #740, reports error if `limactl` is being rosetta translated. Implementation based on https://developer.apple.com/forums/thread/652667?answerId=618217022&page=1#622923022.