### PR TITLE
Add progress option for showing progress only

### DIFF
--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -34,6 +34,7 @@ func registerCreateFlags(cmd *cobra.Command, commentPrefix string) {
 	flags := cmd.Flags()
 	flags.String("name", "", commentPrefix+"override the instance name")
 	flags.Bool("list-templates", false, commentPrefix+"list available templates and exit")
+	flags.Bool("progress", false, "show progress")
 	editflags.RegisterCreate(cmd, commentPrefix)
 }
 
@@ -96,7 +97,6 @@ See the examples in 'limactl create --help'.
 	if runtime.GOOS != "windows" {
 		startCommand.Flags().Bool("foreground", false, "run the hostagent in the foreground")
 	}
-	startCommand.Flags().Bool("progress", false, "show progress")
 	startCommand.Flags().Duration("timeout", start.DefaultWatchHostAgentEventsTimeout, "duration to wait for the instance to be running before timing out")
 	return startCommand
 }

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -96,6 +96,7 @@ See the examples in 'limactl create --help'.
 	if runtime.GOOS != "windows" {
 		startCommand.Flags().Bool("foreground", false, "run the hostagent in the foreground")
 	}
+	startCommand.Flags().Bool("progress", false, "show progress")
 	startCommand.Flags().Duration("timeout", start.DefaultWatchHostAgentEventsTimeout, "duration to wait for the instance to be running before timing out")
 	return startCommand
 }
@@ -115,6 +116,11 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 
 	// Create an instance, with menu TUI when TTY is available
 	tty, err := flags.GetBool("tty")
+	if err != nil {
+		return nil, err
+	}
+
+	start.OutputProgress, err = flags.GetBool("progress")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hostagent/events/events.go
+++ b/pkg/hostagent/events/events.go
@@ -16,7 +16,17 @@ type Status struct {
 	SSHLocalPort int `json:"sshLocalPort,omitempty"`
 }
 
+type Requirement struct {
+	Label       string `json:"label"`
+	Number      int    `json:"number"`
+	Count       int    `json:"count"`
+	Description string `json:"description"`
+	Index       int    `json:"index"`
+	Total       int    `json:"total"`
+}
+
 type Event struct {
-	Time   time.Time `json:"time,omitempty"`
-	Status Status    `json:"status,omitempty"`
+	Time        time.Time   `json:"time,omitempty"`
+	Status      Status      `json:"status,omitempty"`
+	Requirement Requirement `json:"requirement,omitempty"`
 }

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -119,7 +119,7 @@ A possible workaround is to run "apt-get install sshfs" in the guest.
 `,
 		})
 		req = append(req, requirement{
-			description: "/etc/fuse.conf (/etc/fuse3.conf) to contain \"user_allow_other\"",
+			description: "fuse to \"allow_other\" as user",
 			script: `#!/bin/bash
 set -eux -o pipefail
 if ! timeout 30s bash -c "until grep -q ^user_allow_other /etc/fuse*.conf; do sleep 3; done"; then

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -381,6 +381,9 @@ func ShowProgress(inst *store.Instance, progress Progress) {
 // Same as pb.Simple, but don't show the `{{percent . }}`
 const tmpl = `{{with string . "prefix"}}{{.}} {{end}}{{counters . }} {{bar . }} {{with string . "suffix"}} {{.}}{{end}}`
 
+// Keep the old progress bar showing, or clean on finish
+const keep = true
+
 func ShowRequirement(_ *store.Instance, req hostagentevents.Requirement) {
 	if !OutputProgress {
 		return
@@ -391,8 +394,9 @@ func ShowRequirement(_ *store.Instance, req hostagentevents.Requirement) {
 		pb.RegisterElement("bar", pb.ElementBar, false)
 		ProgressBar.SetTemplateString(tmpl)
 		ProgressBar.SetWidth(100) // with longest suffix
+		ProgressBar.Set(pb.CleanOnFinish, !keep)
 		ProgressBar.Set("prefix", "Waiting")
-	} else {
+	} else if keep {
 		// Flush the progress bar output for this line
 		ProgressBar.Finish()
 		ProgressBar.Start()

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -390,7 +390,7 @@ func ShowRequirement(_ *store.Instance, req hostagentevents.Requirement) {
 		// Disable the adaptive width of the bar element
 		pb.RegisterElement("bar", pb.ElementBar, false)
 		ProgressBar.SetTemplateString(tmpl)
-		ProgressBar.SetWidth(120)
+		ProgressBar.SetWidth(100) // with longest suffix
 		ProgressBar.Set("prefix", "Waiting")
 	} else {
 		// Flush the progress bar output for this line


### PR DESCRIPTION
After hiding the INFO messages, enable _some_ progress.

`Starting "default"`

`READY.`

Showing the requirements as a progress bar, using `pb`.

Closes #1311