### PR TITLE
CI: hyperlink check: allow 403 https://api.github.com

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Check hyperlinks
       uses: docker://dkhamsing/awesome_bot:latest
       with:
-        args: /github/workspace/README.md --allow-dupe --allow-redirect --request-delay 1 --white-list https://img.shields.io,http://127.0.0.1:8080,https://github.com/lima-vm/lima/releases/download,https://xbarapp.com
+        args: /github/workspace/README.md --allow-dupe --allow-redirect --request-delay 1 --white-list https://img.shields.io,http://127.0.0.1:8080,https://github.com/lima-vm/lima/releases/download,https://xbarapp.com,https://api.github.com
     - name: Unit tests
       run: go test -v ./...
     - name: Make


### PR DESCRIPTION
The hyperlink checker was often failing:

```
> White listed:
  1. [L052] 200 https://xbarapp.com/
  2. [L100]  http://127.0.0.1:8080 Failed to open TCP connection to 127.0.0.1:8080 (Connection refused - connect(2) for "127.0.0.1" port 8080)
  3. [L129] 404 https://github.com/lima-vm/lima/releases/download/$

Issues :-(
> Links
  1. [L128] 403 https://api.github.com/repos/lima-vm/lima/releases/latest
```

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>