### PR TITLE
Fix QEMU issue on binding multiple disks in M1

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -457,17 +457,10 @@ func Cmdline(cfg Config) (string, []string, error) {
 	}
 
 	// cloud-init
-	switch *y.Arch {
-	case limayaml.RISCV64:
-		// -cdrom does not seem recognized for RISCV64
-		args = append(args,
-			"-drive", "id=cdrom0,if=none,format=raw,readonly=on,file="+filepath.Join(cfg.InstanceDir, filenames.CIDataISO),
-			"-device", "virtio-scsi-pci,id=scsi0",
-			"-device", "scsi-cd,bus=scsi0.0,drive=cdrom0")
-	default:
-		// TODO: consider using virtio cdrom for all the architectures
-		args = append(args, "-cdrom", filepath.Join(cfg.InstanceDir, filenames.CIDataISO))
-	}
+	args = append(args,
+		"-drive", "id=cdrom0,if=none,format=raw,readonly=on,file="+filepath.Join(cfg.InstanceDir, filenames.CIDataISO),
+		"-device", "virtio-scsi-pci,id=scsi0",
+		"-device", "scsi-cd,bus=scsi0.0,drive=cdrom0")
 
 	// Kernel
 	kernel := filepath.Join(cfg.InstanceDir, filenames.Kernel)


### PR DESCRIPTION
fixes #1328 

Not sure on why happening only in M1. Changing the -cdrom to -device as mentioned in https://lists.gnu.org/archive/html/qemu-discuss/2014-04/msg00052.html fixes this issue