### PR TITLE
improvement(hostagent): link ssh agent socket to predetermined location

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -121,6 +121,9 @@ ssh:
   # 🟢 Builtin default: true
   loadDotSSHPubKeys: null
   # Forward ssh agent into the instance.
+  # The ssh agent socket can be mounted in a container at the path `/run/host-services/ssh-auth.sock`.
+  # Set the environment variable `SSH_AUTH_SOCK` value to the path above.
+  # The socket is accessible by the non-root user inside the Lima instance.
   # 🟢 Builtin default: false
   forwardAgent: null
   # Forward X11 into the instance

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -317,6 +317,19 @@ func (a *HostAgent) startHostAgentRoutines(ctx context.Context) error {
 	if err := a.waitForRequirements(ctx, "essential", a.essentialRequirements()); err != nil {
 		mErr = multierror.Append(mErr, err)
 	}
+	if *a.y.SSH.ForwardAgent {
+		faScript := `#!/bin/bash
+set -eux -o pipefail
+sudo mkdir -p -m 700 /run/host-services
+sudo ln -sf "${SSH_AUTH_SOCK}" /run/host-services/ssh-auth.sock
+sudo chown -R "${USER}" /run/host-services`
+		faDesc := "linking ssh auth socket to static location /run/host-services/ssh-auth.sock"
+		stdout, stderr, err := ssh.ExecuteScript("127.0.0.1", a.sshLocalPort, a.sshConfig, faScript, faDesc)
+		logrus.Debugf("stdout=%q, stderr=%q, err=%v", stdout, stderr, err)
+		if err != nil {
+			mErr = multierror.Append(mErr, fmt.Errorf("stdout=%q, stderr=%q: %w", stdout, stderr, err))
+		}
+	}
 	if *a.y.MountType == limayaml.REVSSHFS {
 		mounts, err := a.setupMounts(ctx)
 		if err != nil {


### PR DESCRIPTION
This PR resolves the issue https://github.com/rancher-sandbox/rancher-desktop/issues/3042 and relates to the comment https://github.com/rancher-sandbox/rancher-desktop/issues/3488. 

This change ensures the ssh agent socket can be mounted into containers without having to determine the location first. The location will be in a static location /run/host-services/ssh-auth.sock. This is the same location as Docker Desktop uses.

Signed-off-by: Ryan Currah <ryan@currah.ca>