### PR TITLE
Add global fields to instance data before executing template

### DIFF
--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -276,7 +276,11 @@ func PrintInstances(w io.Writer, instances []*Instance, format string) error {
 		return fmt.Errorf("invalid go template: %w", err)
 	}
 	for _, instance := range instances {
-		err = tmpl.Execute(w, instance)
+		data, err := AddGlobalFields(instance)
+		if err != nil {
+			return err
+		}
+		err = tmpl.Execute(w, data)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This functionality was lost in 75594fa:

```console
$ limactl ls -f '{{.LimaHome}}' default
FATA[0000] template: format:1:2: executing "format" at <.LimaHome>: can't evaluate field LimaHome in type *store.Instance
```

