### PR TITLE
Hide download progress when running tests

### DIFF
--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -19,6 +19,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var HideProgress bool
+
 type Status = string
 
 const (
@@ -297,6 +299,9 @@ func createBar(size int64) (*pb.ProgressBar, error) {
 	if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
 		bar.SetTemplateString(`{{counters . }} {{bar . | green }} {{percent .}} {{speed . "%s/s"}}`)
 		bar.SetRefreshRate(200 * time.Millisecond)
+	} else if HideProgress {
+		bar.Set(pb.ReturnSymbol, "")
+		bar.SetTemplateString("")
 	} else {
 		bar.Set(pb.Terminal, false)
 		bar.Set(pb.ReturnSymbol, "\n")

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -17,6 +17,11 @@ const (
 	dummyRemoteFileDigest = "sha256:58d2de96f9d91f0acd93cb1e28bf7c42fc86079037768d6aa63b4e7e7b3c9be0"
 )
 
+func TestMain(m *testing.M) {
+	HideProgress = true
+	os.Exit(m.Run())
+}
+
 func TestDownloadRemote(t *testing.T) {
 	if testing.Short() {
 		t.Skip()


### PR DESCRIPTION
The progressbar was messing with the test output.

This confused some test tools into thinking it failed.

```
=== RUN   TestDownloadRemote
=== RUN   TestDownloadRemote/without_cache
=== RUN   TestDownloadRemote/without_cache/without_digest

7.68 KiB (?%) ? p/s=== RUN   TestDownloadRemote/without_cache/with_digest

7.68 KiB (?%) ? p/s
7.68 KiB (?%) ? p/s=== RUN   TestDownloadRemote/with_cache

7.68 KiB (?%) ? p/s=== RUN   TestDownloadRemote/caching-only_mode

7.68 KiB (?%) ? p/s--- PASS: TestDownloadRemote (0.21s)
    --- PASS: TestDownloadRemote/without_cache (0.16s)
        --- PASS: TestDownloadRemote/without_cache/without_digest (0.11s)
        --- PASS: TestDownloadRemote/without_cache/with_digest (0.05s)
    --- PASS: TestDownloadRemote/with_cache (0.03s)
    --- PASS: TestDownloadRemote/caching-only_mode (0.02s)
=== RUN   TestDownloadLocal
=== RUN   TestDownloadLocal/without_digest
=== RUN   TestDownloadLocal/with_file_digest
--- PASS: TestDownloadLocal (0.00s)
    --- PASS: TestDownloadLocal/without_digest (0.00s)
    --- PASS: TestDownloadLocal/with_file_digest (0.00s)
PASS
ok  	github.com/lima-vm/lima/pkg/downloader	0.214s
```

For instance https://github.com/vakenbolt/go-test-report