### PR TITLE
Added test make target with html test report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 _output/
 _artifacts/
 lima.REJECTED.yaml
+unittest.json
+unittest.html
+coverage.out
+coverage.html

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,23 @@ uninstall:
 	if [ "$$(readlink "$(DEST)/bin/nerdctl")" = "nerdctl.lima" ]; then rm "$(DEST)/bin/nerdctl"; fi
 	if [ "$$(readlink "$(DEST)/bin/apptainer")" = "apptainer.lima" ]; then rm "$(DEST)/bin/apptainer"; fi
 
+# go install gotest.tools/gotestsum@latest
+# go install github.com/vakenbolt/go-test-report@latest
+.PHONY: test
+test:
+	@if command -v gotestsum >/dev/null 2>&1; then \
+		gotestsum --jsonfile unittest.json ./... -coverprofile=coverage.out; \
+	else \
+		go test -v ./... -coverprofile=coverage.out -json >unittest.json; \
+	fi
+	-$(MAKE) --no-print-directory coverage.html unittest.html
+
+unittest.html: unittest.json
+	go-test-report -o $@ <$<
+
+coverage.html: coverage.out
+	go tool cover -o $@ -html=$<
+
 .PHONY: lint
 lint:
 	golangci-lint run ./...


### PR DESCRIPTION
For best results, install [gotestsum](https://github.com/gotestyourself/gotestsum) and [go-test-report](https://github.com/vakenbolt/go-test-report)

Find the test results in unittest.html and coverage.html

`make test`

Will run `go test -v ./...`, similar to what is in CI (github)