### PR TITLE
Add possibility to copy files from host to guest

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -339,6 +339,13 @@ networks:
 #   hostPortRange: [1, 65535]
 # # Any port still not matched by a rule will not be forwarded (ignored)
 
+# Copy files from the host to the guest. Copied before provisioning scripts have been started.
+# copyToGuest:
+# - host: "{{.Pwd}}/myscript"
+#   guest: "/tmp/myscript.sh"
+# # "guest" can include these template variables: {{.Home}}, {{.UID}}, and {{.User}}.
+# # "host" can include {{.Pwd}}, {{.Home}}, {{.Dir}}, {{.Name}}, {{.UID}}, and {{.User}}.
+
 # Copy files from the guest to the host. Copied after provisioning scripts have been completed.
 # copyToHost:
 # - guest: "/etc/myconfig.cfg"

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -37,6 +37,8 @@ func TestFillDefault(t *testing.T) {
 	assert.NilError(t, err)
 	user, err := osutil.LimaUser(false)
 	assert.NilError(t, err)
+	pwd, err := os.Getwd()
+	assert.NilError(t, err)
 
 	guestHome := fmt.Sprintf("/home/%s.linux", user.Username)
 	instName := "instance"
@@ -135,6 +137,12 @@ func TestFillDefault(t *testing.T) {
 				HostSocket:  "{{.Home}} | {{.Dir}} | {{.Name}} | {{.UID}} | {{.User}}",
 			},
 		},
+		CopyToGuest: []CopyToGuest{
+			{
+				HostFile:  "{{.Pwd}} | {{.Home}} | {{.Dir}} | {{.Name}} | {{.UID}} | {{.User}}",
+				GuestFile: "{{.Home}} | {{.UID}} | {{.User}}",
+			},
+		},
 		CopyToHost: []CopyToHost{
 			{
 				GuestFile: "{{.Home}} | {{.UID}} | {{.User}}",
@@ -189,6 +197,9 @@ func TestFillDefault(t *testing.T) {
 		defaultPortForward,
 		defaultPortForward,
 	}
+	expect.CopyToGuest = []CopyToGuest{
+		{},
+	}
 	expect.CopyToHost = []CopyToHost{
 		{},
 	}
@@ -206,6 +217,9 @@ func TestFillDefault(t *testing.T) {
 
 	expect.PortForwards[3].GuestSocket = fmt.Sprintf("%s | %s | %s", guestHome, user.Uid, user.Username)
 	expect.PortForwards[3].HostSocket = fmt.Sprintf("%s | %s | %s | %s | %s", hostHome, instDir, instName, user.Uid, user.Username)
+
+	expect.CopyToGuest[0].HostFile = fmt.Sprintf("%s | %s | %s | %s | %s | %s", pwd, hostHome, instDir, instName, user.Uid, user.Username)
+	expect.CopyToGuest[0].GuestFile = fmt.Sprintf("%s | %s | %s", guestHome, user.Uid, user.Username)
 
 	expect.CopyToHost[0].GuestFile = fmt.Sprintf("%s | %s | %s", guestHome, user.Uid, user.Username)
 	expect.CopyToHost[0].HostFile = fmt.Sprintf("%s | %s | %s | %s | %s", hostHome, instDir, instName, user.Uid, user.Username)
@@ -311,7 +325,8 @@ func TestFillDefault(t *testing.T) {
 			HostPortRange:  [2]int{80, 80},
 			Proto:          TCP,
 		}},
-		CopyToHost: []CopyToHost{{}},
+		CopyToGuest: []CopyToGuest{{}},
+		CopyToHost:  []CopyToHost{{}},
 		Env: map[string]string{
 			"ONE": "one",
 			"TWO": "two",
@@ -360,6 +375,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Provision = append(y.Provision, d.Provision...)
 	expect.Probes = append(y.Probes, d.Probes...)
 	expect.PortForwards = append(y.PortForwards, d.PortForwards...)
+	expect.CopyToGuest = append(y.CopyToGuest, d.CopyToGuest...)
 	expect.CopyToHost = append(y.CopyToHost, d.CopyToHost...)
 	expect.Containerd.Archives = append(y.Containerd.Archives, d.Containerd.Archives...)
 	expect.AdditionalDisks = append(y.AdditionalDisks, d.AdditionalDisks...)
@@ -480,7 +496,8 @@ func TestFillDefault(t *testing.T) {
 			HostPortRange:  [2]int{8080, 8080},
 			Proto:          TCP,
 		}},
-		CopyToHost: []CopyToHost{{}},
+		CopyToGuest: []CopyToGuest{{}},
+		CopyToHost:  []CopyToHost{{}},
 		Env: map[string]string{
 			"TWO":   "deux",
 			"THREE": "trois",
@@ -497,6 +514,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Provision = append(append(o.Provision, y.Provision...), d.Provision...)
 	expect.Probes = append(append(o.Probes, y.Probes...), d.Probes...)
 	expect.PortForwards = append(append(o.PortForwards, y.PortForwards...), d.PortForwards...)
+	expect.CopyToGuest = append(append(o.CopyToGuest, y.CopyToGuest...), d.CopyToGuest...)
 	expect.CopyToHost = append(append(o.CopyToHost, y.CopyToHost...), d.CopyToHost...)
 	expect.Containerd.Archives = append(append(o.Containerd.Archives, y.Containerd.Archives...), d.Containerd.Archives...)
 	expect.AdditionalDisks = append(append(o.AdditionalDisks, y.AdditionalDisks...), d.AdditionalDisks...)

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -24,6 +24,7 @@ type LimaYAML struct {
 	Containerd      Containerd      `yaml:"containerd,omitempty" json:"containerd,omitempty"`
 	Probes          []Probe         `yaml:"probes,omitempty" json:"probes,omitempty"`
 	PortForwards    []PortForward   `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
+	CopyToGuest     []CopyToGuest   `yaml:"copyToGuest,omitempty" json:"copyToGuest,omitempty"`
 	CopyToHost      []CopyToHost    `yaml:"copyToHost,omitempty" json:"copyToHost,omitempty"`
 	Message         string          `yaml:"message,omitempty" json:"message,omitempty"`
 	Networks        []Network       `yaml:"networks,omitempty" json:"networks,omitempty"`
@@ -178,6 +179,11 @@ type PortForward struct {
 	Proto             Proto  `yaml:"proto,omitempty" json:"proto,omitempty"`
 	Reverse           bool   `yaml:"reverse,omitempty" json:"reverse,omitempty"`
 	Ignore            bool   `yaml:"ignore,omitempty" json:"ignore,omitempty"`
+}
+
+type CopyToGuest struct {
+	HostFile  string `yaml:"host,omitempty" json:"host,omitempty"`
+	GuestFile string `yaml:"guest,omitempty" json:"guest,omitempty"`
 }
 
 type CopyToHost struct {

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -249,6 +249,19 @@ func Validate(y LimaYAML, warn bool) error {
 		// Not validating that the various GuestPortRanges and HostPortRanges are not overlapping. Rules will be
 		// processed sequentially and the first matching rule for a guest port determines forwarding behavior.
 	}
+	for i, rule := range y.CopyToGuest {
+		field := fmt.Sprintf("CopyToGuest[%d]", i)
+		if rule.GuestFile != "" {
+			if !path.IsAbs(rule.GuestFile) {
+				return fmt.Errorf("field `%s.guest` must be an absolute path", field)
+			}
+		}
+		if rule.HostFile != "" {
+			if !filepath.IsAbs(rule.HostFile) {
+				return fmt.Errorf("field `%s.host` must be an absolute path, but is %q", field, rule.HostFile)
+			}
+		}
+	}
 	for i, rule := range y.CopyToHost {
 		field := fmt.Sprintf("CopyToHost[%d]", i)
 		if rule.GuestFile != "" {


### PR DESCRIPTION
Adding `copyToGuest` script, basically the reverse of `copyToHost` config

Added features of `{{.Pwd}}`, and copying user/group/executable bit.

Feature:

* #893 