### PR TITLE
fix bug with multiple extra qemu disks

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -34,6 +34,8 @@ type Config struct {
 	SSHLocalPort int
 }
 
+const extra_disk_offset_index = 100
+
 // EnsureDisk also ensures the kernel and the initrd
 func EnsureDisk(cfg Config) error {
 	diffDisk := filepath.Join(cfg.InstanceDir, filenames.DiffDisk)
@@ -452,8 +454,11 @@ func Cmdline(cfg Config) (string, []string, error) {
 	} else if !isBaseDiskCDROM {
 		args = append(args, "-drive", fmt.Sprintf("file=%s,if=virtio,discard=on", baseDisk))
 	}
-	for _, extraDisk := range extraDisks {
-		args = append(args, "-drive", fmt.Sprintf("file=%s,if=virtio,discard=on", extraDisk))
+	for i, extraDisk := range extraDisks {
+		// use a high index for extra disks to reduce ID collision with current or future devices
+		// e.g., boot disk, firmware, CDROM, cloud config, network device
+		args = append(args, "-drive", fmt.Sprintf("file=%s,index=%d,if=virtio,discard=on",
+			extraDisk, extra_disk_offset_index+i))
 	}
 
 	// cloud-init


### PR DESCRIPTION
When starting a lima vm with multiple extra disks on the qemu backend, qemu would be unable to start the vm due to a misconfiguration, showing the error below:

DEBU[0000] [hostagent] qemu[stderr]: qemu-system-aarch64: -cdrom
/Users/blaine/.lima/lima-rook/cidata.iso: drive with bus=0, unit=2 (index=2) exists

When creating extra disks, use the 'index' parameter with a very high offset to ensure extra disks won't collide with any existing virtio devices. e.g., firmware, CDROM, cloud config, data disk, network device. This also allows more devices to be added in the future, even a reasonably arbitrary number of them, without much risk of colliding with extra disks.