### PR TITLE
feat: more friendly cli error message

### DIFF
--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -28,7 +28,7 @@ func newCopyCommand() *cobra.Command {
 		Aliases: []string{"cp"},
 		Short:   "Copy files between host and guest",
 		Long:    copyHelp,
-		Args:    cobra.MinimumNArgs(2),
+		Args:    WrapArgsError(cobra.MinimumNArgs(2)),
 		RunE:    copyAction,
 	}
 

--- a/cmd/limactl/debug.go
+++ b/cmd/limactl/debug.go
@@ -24,7 +24,7 @@ func newDebugDNSCommand() *cobra.Command {
 		Use:   "dns UDPPORT [TCPPORT]",
 		Short: "Debug built-in DNS",
 		Long:  "DO NOT USE! THE COMMAND SYNTAX IS SUBJECT TO CHANGE!",
-		Args:  cobra.RangeArgs(1, 2),
+		Args:  WrapArgsError(cobra.RangeArgs(1, 2)),
 		RunE:  debugDNSAction,
 	}
 	cmd.Flags().BoolP("ipv6", "6", false, "lookup IPv6 addresses too")

--- a/cmd/limactl/delete.go
+++ b/cmd/limactl/delete.go
@@ -16,7 +16,7 @@ func newDeleteCommand() *cobra.Command {
 		Use:               "delete INSTANCE [INSTANCE, ...]",
 		Aliases:           []string{"remove", "rm"},
 		Short:             "Delete an instance of Lima.",
-		Args:              cobra.MinimumNArgs(1),
+		Args:              WrapArgsError(cobra.MinimumNArgs(1)),
 		RunE:              deleteAction,
 		ValidArgsFunction: deleteBashComplete,
 	}

--- a/cmd/limactl/disk.go
+++ b/cmd/limactl/disk.go
@@ -47,7 +47,7 @@ To create a new disk:
 $ limactl disk create DISK --size SIZE
 `,
 		Short: "Create a Lima disk",
-		Args:  cobra.ExactArgs(1),
+		Args:  WrapArgsError(cobra.ExactArgs(1)),
 		RunE:  diskCreateAction,
 	}
 	diskCreateCommand.Flags().String("size", "", "configure the disk size")
@@ -100,7 +100,7 @@ $ limactl disk list
 `,
 		Short:   "List existing Lima disks",
 		Aliases: []string{"ls"},
-		Args:    cobra.ArbitraryArgs,
+		Args:    WrapArgsError(cobra.ArbitraryArgs),
 		RunE:    diskListAction,
 	}
 	diskListCommand.Flags().Bool("json", false, "JSONify output")
@@ -189,7 +189,7 @@ $ limactl disk delete DISK1 DISK2 ...
 `,
 		Aliases: []string{"remove", "rm"},
 		Short:   "Delete one or more Lima disks",
-		Args:    cobra.MinimumNArgs(1),
+		Args:    WrapArgsError(cobra.MinimumNArgs(1)),
 		RunE:    diskDeleteAction,
 	}
 	diskDeleteCommand.Flags().BoolP("force", "f", false, "force delete")
@@ -279,7 +279,7 @@ To unlock multiple disks:
 $ limactl disk unlock DISK1 DISK2 ...
 `,
 		Short: "Unlock one or more Lima disks",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  WrapArgsError(cobra.MinimumNArgs(1)),
 		RunE:  diskUnlockAction,
 	}
 	return diskUnlockCommand

--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -22,7 +22,7 @@ func newEditCommand() *cobra.Command {
 	var editCommand = &cobra.Command{
 		Use:               "edit INSTANCE",
 		Short:             "Edit an instance of Lima",
-		Args:              cobra.MaximumNArgs(1),
+		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
 		RunE:              editAction,
 		ValidArgsFunction: editBashComplete,
 	}

--- a/cmd/limactl/factory-reset.go
+++ b/cmd/limactl/factory-reset.go
@@ -15,7 +15,7 @@ func newFactoryResetCommand() *cobra.Command {
 	var resetCommand = &cobra.Command{
 		Use:               "factory-reset INSTANCE",
 		Short:             "Factory reset an instance of Lima",
-		Args:              cobra.MaximumNArgs(1),
+		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
 		RunE:              factoryResetAction,
 		ValidArgsFunction: factoryResetBashComplete,
 	}

--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -21,7 +21,7 @@ func newHostagentCommand() *cobra.Command {
 	var hostagentCommand = &cobra.Command{
 		Use:    "hostagent INSTANCE",
 		Short:  "run hostagent",
-		Args:   cobra.ExactArgs(1),
+		Args:   WrapArgsError(cobra.ExactArgs(1)),
 		RunE:   hostagentAction,
 		Hidden: true,
 	}

--- a/cmd/limactl/info.go
+++ b/cmd/limactl/info.go
@@ -12,7 +12,7 @@ func newInfoCommand() *cobra.Command {
 	infoCommand := &cobra.Command{
 		Use:   "info",
 		Short: "Show diagnostic information",
-		Args:  cobra.NoArgs,
+		Args:  WrapArgsError(cobra.NoArgs),
 		RunE:  infoAction,
 	}
 	return infoCommand

--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -40,7 +40,7 @@ func newListCommand() *cobra.Command {
 		Short:   "List instances of Lima.",
 		Long: "List instances of Lima.\n" + dedent.Dedent(`
 		The output can be presented in one of several formats, using the --format <format> flag.
-		
+
 		  --format json  - output in json format
 		  --format yaml  - output in yaml format
 		  --format table - output in table format
@@ -49,7 +49,7 @@ func newListCommand() *cobra.Command {
 		The following legacy flags continue to function:
 		  --json - equal to '--format json'
 		`),
-		Args:              cobra.ArbitraryArgs,
+		Args:              WrapArgsError(cobra.ArbitraryArgs),
 		RunE:              listAction,
 		ValidArgsFunction: listBashComplete,
 	}

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -119,3 +119,19 @@ func handleExitCoder(err error) {
 		return
 	}
 }
+
+// WrapArgsError annotates cobra args error with some context, so the error message is more user-friendly
+func WrapArgsError(argFn cobra.PositionalArgs) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		err := argFn(cmd, args)
+		if err == nil {
+			return nil
+		}
+
+		return fmt.Errorf("%q %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
+			cmd.CommandPath(), err.Error(),
+			cmd.CommandPath(),
+			cmd.UseLine(), cmd.Short,
+		)
+	}
+}

--- a/cmd/limactl/prune.go
+++ b/cmd/limactl/prune.go
@@ -12,7 +12,7 @@ func newPruneCommand() *cobra.Command {
 	pruneCommand := &cobra.Command{
 		Use:               "prune",
 		Short:             "Prune garbage objects",
-		Args:              cobra.NoArgs,
+		Args:              WrapArgsError(cobra.NoArgs),
 		RunE:              pruneAction,
 		ValidArgsFunction: cobra.NoFileCompletions,
 	}

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -36,7 +36,7 @@ func newShellCommand() *cobra.Command {
 		Use:               "shell INSTANCE [COMMAND...]",
 		Short:             "Execute shell in Lima",
 		Long:              shellHelp,
-		Args:              cobra.MinimumNArgs(1),
+		Args:              WrapArgsError(cobra.MinimumNArgs(1)),
 		RunE:              shellAction,
 		ValidArgsFunction: shellBashComplete,
 		SilenceErrors:     true,

--- a/cmd/limactl/show_ssh.go
+++ b/cmd/limactl/show_ssh.go
@@ -45,7 +45,7 @@ func newShowSSHCommand() *cobra.Command {
 		Use:               "show-ssh [flags] INSTANCE",
 		Short:             "Show the ssh command line",
 		Example:           showSSHExample,
-		Args:              cobra.ExactArgs(1),
+		Args:              WrapArgsError(cobra.ExactArgs(1)),
 		RunE:              showSSHAction,
 		ValidArgsFunction: showSSHBashComplete,
 		SilenceErrors:     true,

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -53,7 +53,7 @@ To create an instance "local" from a template passed to stdin (--name parameter 
 $ cat template.yaml | limactl start --name=local -
 `,
 		Short:             "Start an instance of Lima",
-		Args:              cobra.MaximumNArgs(1),
+		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
 		ValidArgsFunction: startBashComplete,
 		RunE:              startAction,
 	}

--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -22,7 +22,7 @@ func newStopCommand() *cobra.Command {
 	var stopCmd = &cobra.Command{
 		Use:               "stop INSTANCE",
 		Short:             "Stop an instance",
-		Args:              cobra.MaximumNArgs(1),
+		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
 		RunE:              stopAction,
 		ValidArgsFunction: stopBashComplete,
 	}

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -32,7 +32,7 @@ $ limactl sudoers --check /etc/sudoers.d/lima
 The content is written to stdout, NOT to the file.
 This command must not run as the root.
 See %s for the usage.`, networksMD),
-		Args: cobra.MaximumNArgs(1),
+		Args: WrapArgsError(cobra.MaximumNArgs(1)),
 		RunE: sudoersAction,
 	}
 	configFile, _ := networks.ConfigFile()

--- a/cmd/limactl/validate.go
+++ b/cmd/limactl/validate.go
@@ -14,7 +14,7 @@ func newValidateCommand() *cobra.Command {
 	var validateCommand = &cobra.Command{
 		Use:   "validate FILE.yaml [FILE.yaml, ...]",
 		Short: "Validate YAML files",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  WrapArgsError(cobra.MinimumNArgs(1)),
 		RunE:  validateAction,
 	}
 	return validateCommand


### PR DESCRIPTION
This PR closes #1211, show more user friendly error message on argument error. The output is similar to nerdctl and docker cli.

It looks like below:
<img width="599" alt="Screenshot 2023-02-28 at 19 01 06" src="https://user-images.githubusercontent.com/65525602/221852770-851b70c2-a46d-42db-b615-01c699c13b90.png">
