### PR TITLE
Run qemu-img info in shared mode for GetInfo

### DIFF
--- a/pkg/qemu/imgutil/imgutil.go
+++ b/pkg/qemu/imgutil/imgutil.go
@@ -29,7 +29,7 @@ func QCOWToRaw(source string, dest string) error {
 
 func GetInfo(f string) (*Info, error) {
 	var stdout, stderr bytes.Buffer
-	cmd := exec.Command("qemu-img", "info", "--output=json", f)
+	cmd := exec.Command("qemu-img", "info", "--output=json", "--force-share", f)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Avoids errors about the disk being in use by the running qemu.

Older versions of qemu default to read-write mode for images.

Closes #1392 