### PR TITLE
feat: mount additional disks when using vz

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Use `<INSTANCE>:<FILENAME>` to specify a source or target inside an instance.
 
 #### `limactl disk`
 
-`limactl disk create <DISK> --size <SIZE>`: create a new external disk to attach to an instance
+`limactl disk create <DISK> --size <SIZE> [--format qcow2]`: create a new external disk to attach to an instance
 
 `limactl disk delete <DISK>`: delete an existing disk
 

--- a/docs/internal.md
+++ b/docs/internal.md
@@ -74,10 +74,14 @@ Host agent:
 A disk directory contains the following files:
 
 data disk:
-- `datadisk`: the qcow2 disk that is attached to an instance
+- `datadisk`: the qcow2 or raw disk that is attached to an instance
 
 lock:
 - `in_use_by`: symlink to the instance directory that is using the disk
+
+When using `vmType: vz` (Virtualization.framework), on boot, any qcow2 (default) formatted disks that are specified in `additionalDisks` will be converted to RAW since [Virtualization.framework only supports mounting RAW disks](https://developer.apple.com/documentation/virtualization/vzdiskimagestoragedeviceattachment). This conversion enables additional disks to work with both Virtualization.framework and QEMU, but it has some consequences when it comes to interacting with the disks. Most importantly, a regular macOS default `cp` command will copy the _entire_ virtual disk size, instead of just the _used/allocated_ portion. The easiest way to copy only the used data is by adding the `-c` option to cp: `cp -c old_path new_path`. `cp -c` uses clonefile(2) to create a copy-on-write clone of the disk, and should return instantly.
+
+`ls` will also only show the full/virtual size of the disks. To see the allocated space, `du -h disk_path` or `qemu-img info disk_path` can be used instead. See [#1405](https://github.com/lima-vm/lima/pull/1405) for more details.
 
 ## Lima cache directory (`~/Library/Caches/lima`)
 

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -104,14 +104,14 @@ func EnsureDisk(cfg Config) error {
 	return nil
 }
 
-func CreateDataDisk(dir string, size int) error {
+func CreateDataDisk(dir, format string, size int) error {
 	dataDisk := filepath.Join(dir, filenames.DataDisk)
 	if _, err := os.Stat(dataDisk); err == nil || !errors.Is(err, fs.ErrNotExist) {
 		// datadisk already exists
 		return err
 	}
 
-	args := []string{"create", "-f", "qcow2", dataDisk, strconv.Itoa(size)}
+	args := []string{"create", "-f", format, dataDisk, strconv.Itoa(size)}
 	cmd := exec.Command("qemu-img", args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to run %v: %q: %w", cmd.Args, string(out), err)

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -64,6 +64,7 @@ func (l *LimaVzDriver) Validate() error {
 		"PropagateProxyEnv",
 		"CACertificates",
 		"Rosetta",
+		"AdditionalDisks",
 	); len(unknown) > 0 {
 		logrus.Warnf("Ignoring: vmType %s: %+v", *l.Yaml.VMType, unknown)
 	}


### PR DESCRIPTION
This PR adds support for using the additional disks feature with Virtualization.framework. I noticed it was missing, so I figured I'd add it.

Considerations:
- [Virtualization.framework can only mount RAW disk images](https://developer.apple.com/documentation/virtualization/vzdiskimagestoragedeviceattachment). The additional disk feature [currently creates QCOW2 images](https://github.com/lima-vm/lima/blob/5a9bca3d09481ed7109b14f8d3f0074816731f43/pkg/qemu/qemu.go#L115). Since QEMU can support RAW images, is it ok to change the additional disk feature to create RAW images by default?
  - This change already included in this diff, but I can remove it
- Should Lima automatically convert QCOW2 disks to RAW before trying to mount a QCOW2 additional with `vmType: vz`? There's already [precedent for runtime conversion of disks in imgutil](https://github.com/lima-vm/lima/blob/5a9bca3d09481ed7109b14f8d3f0074816731f43/pkg/qemu/imgutil/imgutil.go#L18-L28), just wanted to make sure we want to do it for additional disks before adding
  - Auto conversion is already included in this diff, but I can remove it
  - I was having issues doing an in place conversion (I saw in place conversion in other uses of `imgutil.QCOWToRaw`), causing data loss, which is why there's an intermediate file right now. Not sure if there's a better way to do this?

Test:

```shell
$ qemu-img info --output=json ~/.lima/_disks/test/datadisk
{
    "virtual-size": 53687091200,
    "filename": "/Users/alvajus/.lima/_disks/test/datadisk",
    "cluster-size": 65536,
    "format": "qcow2",
    "actual-size": 14221312,
    "format-specific": {
        "type": "qcow2",
        "data": {
            "compat": "1.1",
            "compression-type": "zlib",
            "lazy-refcounts": false,
            "refcount-bits": 16,
            "corrupt": false,
            "extended-l2": false
        }
    },
    "dirty-flag": false
}

# Create an instance using the default fedora.yaml template with addition of additionalDisks: - test (note: test was created as QCOW2 as seen above)
$ ./_output/bin/limactl start --name=fedora template://fedora
...
INFO[0129] READY. Run `limactl shell fedora` to open the shell.

$ ./_output/bin/limactl shell fedora
[alvajus@lima-fedora lima]$
[alvajus@lima-fedora lima]$ ls /mnt/lima-test/
lost+found
[alvajus@lima-fedora lima]$ echo "THIS IS MY TEST FILE" | sudo tee /mnt/lima-test/testfile
THIS IS MY TEST FILE
[alvajus@lima-fedora lima]$ cat /mnt/lima-test/testfile
THIS IS MY TEST FILE
[alvajus@lima-fedora lima]$ exit
logout

$ ./_output/bin/limactl stop fedora
...
INFO[0002] [hostagent] QEMU has exited

$ ./_output/bin/limactl remove fedora
...
INFO[0000] Deleted "fedora" ("/Users/alvajus/.lima/fedora")

# Modify fedora.yaml to still use the same disk, but also include vmType: "vz" and recreate the VM
$ ./_output/bin/limactl start --name=fedora template://fedora
? Creating an instance "fedora" Proceed with the current configuration
WARN[0000] `vmType: vz` is experimental
...
INFO[0146] READY. Run `limactl shell fedora` to open the shell.

$ ./_output/bin/limactl shell fedora
[alvajus@lima-fedora lima]$ ls /mnt/lima-test/
lost+found  testfile
[alvajus@lima-fedora lima]$ cat /mnt/lima-test/testfile
THIS IS MY TEST FILE
[alvajus@lima-fedora lima]$ exit
logout

$ qemu-img info --output=json /Users/alvajus/.lima/_disks/test/datadisk
{
    "virtual-size": 53687091200,
    "filename": "/Users/alvajus/.lima/_disks/test/datadisk",
    "format": "raw",
    "actual-size": 6107136,
    "dirty-flag": false
}
```