### PR TITLE
Show a user-readable description of the download

### DIFF
--- a/pkg/fileutils/download.go
+++ b/pkg/fileutils/download.go
@@ -2,6 +2,7 @@ package fileutils
 
 import (
 	"fmt"
+	"path"
 
 	"github.com/lima-vm/lima/pkg/downloader"
 	"github.com/lima-vm/lima/pkg/limayaml"
@@ -13,9 +14,11 @@ func DownloadFile(dest string, f limayaml.File, description string, expectedArch
 	if f.Arch != expectedArch {
 		return "", fmt.Errorf("unsupported arch: %q", f.Arch)
 	}
-	logrus.WithField("digest", f.Digest).Infof("Attempting to download %s from %q", description, f.Location)
+	fields := logrus.Fields{"location": f.Location, "arch": f.Arch, "digest": f.Digest}
+	logrus.WithFields(fields).Infof("Attempting to download %s", description)
 	res, err := downloader.Download(dest, f.Location,
 		downloader.WithCache(),
+		downloader.WithDescription(fmt.Sprintf("%s (%s)", description, path.Base(f.Location))),
 		downloader.WithExpectedDigest(f.Digest),
 	)
 	if err != nil {

--- a/pkg/fileutils/download.go
+++ b/pkg/fileutils/download.go
@@ -8,9 +8,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func DownloadFile(dest string, f limayaml.File, description string, expectedArch limayaml.Arch) error {
+// DownloadFile downloads a file to the cache, optionally copying it to the destination. Returns path in cache.
+func DownloadFile(dest string, f limayaml.File, description string, expectedArch limayaml.Arch) (string, error) {
 	if f.Arch != expectedArch {
-		return fmt.Errorf("unsupported arch: %q", f.Arch)
+		return "", fmt.Errorf("unsupported arch: %q", f.Arch)
 	}
 	logrus.WithField("digest", f.Digest).Infof("Attempting to download %s from %q", description, f.Location)
 	res, err := downloader.Download(dest, f.Location,
@@ -18,7 +19,7 @@ func DownloadFile(dest string, f limayaml.File, description string, expectedArch
 		downloader.WithExpectedDigest(f.Digest),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to download %q: %w", f.Location, err)
+		return "", fmt.Errorf("failed to download %q: %w", f.Location, err)
 	}
 	logrus.Debugf("res.ValidatedDigest=%v", res.ValidatedDigest)
 	switch res.Status {
@@ -29,5 +30,5 @@ func DownloadFile(dest string, f limayaml.File, description string, expectedArch
 	default:
 		logrus.Warnf("Unexpected result from downloader.Download(): %+v", res)
 	}
-	return nil
+	return res.CachePath, nil
 }

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -50,12 +50,12 @@ func EnsureDisk(cfg Config) error {
 		var ensuredBaseDisk bool
 		errs := make([]error, len(cfg.LimaYAML.Images))
 		for i, f := range cfg.LimaYAML.Images {
-			if err := fileutils.DownloadFile(baseDisk, f.File, "the image", *cfg.LimaYAML.Arch); err != nil {
+			if _, err := fileutils.DownloadFile(baseDisk, f.File, "the image", *cfg.LimaYAML.Arch); err != nil {
 				errs[i] = err
 				continue
 			}
 			if f.Kernel != nil {
-				if err := fileutils.DownloadFile(kernel, f.Kernel.File, "the kernel", *cfg.LimaYAML.Arch); err != nil {
+				if _, err := fileutils.DownloadFile(kernel, f.Kernel.File, "the kernel", *cfg.LimaYAML.Arch); err != nil {
 					errs[i] = err
 					continue
 				}
@@ -67,7 +67,7 @@ func EnsureDisk(cfg Config) error {
 				}
 			}
 			if f.Initrd != nil {
-				if err := fileutils.DownloadFile(initrd, *f.Initrd, "the initrd", *cfg.LimaYAML.Arch); err != nil {
+				if _, err := fileutils.DownloadFile(initrd, *f.Initrd, "the initrd", *cfg.LimaYAML.Arch); err != nil {
 					errs[i] = err
 					continue
 				}

--- a/pkg/vz/disk.go
+++ b/pkg/vz/disk.go
@@ -29,7 +29,7 @@ func EnsureDisk(driver *driver.BaseDriver) error {
 		var ensuredBaseDisk bool
 		errs := make([]error, len(driver.Yaml.Images))
 		for i, f := range driver.Yaml.Images {
-			if err := fileutils.DownloadFile(baseDisk, f.File, "the image", *driver.Yaml.Arch); err != nil {
+			if _, err := fileutils.DownloadFile(baseDisk, f.File, "the image", *driver.Yaml.Arch); err != nil {
 				errs[i] = err
 				continue
 			}


### PR DESCRIPTION
When downloading a file, show a one-line description of what is being downloaded...

This is useful when hiding the log, so that the user knows what the progress is about.

* https://github.com/lima-vm/lima/issues/1311#issuecomment-1399269734

Refactor the code (fileutils), to not have a special case for the nerdctl archive download.

```
Downloading the image (ubuntu-22.10-server-cloudimg-amd64.img)
697.56 MiB / 697.56 MiB [----------------------------------] 100.00% 15.95 MiB/s
Downloading the nerdctl archive (nerdctl-full-1.2.1-linux-amd64.tar.gz)
230.56 MiB / 230.56 MiB [-----------------------------------] 100.00% 2.75 MiB/s
Starting "default"
Waiting 1 / 8 [--->________________________]  "ssh" (essential 1/5)                                 
Waiting 2 / 8 [------>_____________________]  "user session is ready for ssh" (essential 2/5)       
Waiting 3 / 8 [---------->_________________]  "sshfs binary to be installed" (essential 3/5)        
Waiting 4 / 8 [------------->______________]  "fuse to \"allow_other\" as user" (essential 4/5)     
Waiting 5 / 8 [----------------->__________]  "the guest agent to be running" (essential 5/5)       
Waiting 6 / 8 [-------------------->_______]  "systemd must be available" (optional 1/2)            
Waiting 7 / 8 [------------------------>___]  "containerd binaries to be installed" (optional 2/2)  
Waiting 8 / 8 [----------------------------]  "boot scripts must have finished" (final 1/1)         
READY.
```

PR #1312

----

There is some redundant information in the log, like URL before and URL after:

```
INFO[0000] Attempting to download the image              arch=x86_64 digest="sha256:5e5c68cb12002111032d3239ade3763ce25639f1287a59d2509a1603c2b1f7e6" location="https://cloud-images.ubuntu.com/releases/22.10/release-20230215/ubuntu-22.10-server-cloudimg-amd64.img"
DEBU[0000] downloading "https://cloud-images.ubuntu.com/releases/22.10/release-20230215/ubuntu-22.10-server-cloudimg-amd64.img" into "/home/anders/.cache/lima/download/by-url-sha256/7db6503d427a306824b1f62ce99d3a19a4c83f3b69af39022477aecca5c69b33/data" 
Downloading the image (ubuntu-22.10-server-cloudimg-amd64.img)
697.56 MiB / 697.56 MiB [----------------------------------] 100.00% 15.95 MiB/s
DEBU[0044] res.ValidatedDigest=true                     
INFO[0044] Downloaded the image from "https://cloud-images.ubuntu.com/releases/22.10/release-20230215/ubuntu-22.10-server-cloudimg-amd64.img" 
INFO[0044] Attempting to download the nerdctl archive    arch=x86_64 digest="sha256:e8a3e40d442c566ee494375a4c563121da69d7c7837f50f4a3a171742757b36c" location="https://github.com/containerd/nerdctl/releases/download/v1.2.1/nerdctl-full-1.2.1-linux-amd64.tar.gz"
DEBU[0044] downloading "https://github.com/containerd/nerdctl/releases/download/v1.2.1/nerdctl-full-1.2.1-linux-amd64.tar.gz" into "/home/anders/.cache/lima/download/by-url-sha256/3ca338b148379fea1376fb450380cb21a2b26d8b1618da6eb1c5c5e352b03ea7/data" 
Downloading the nerdctl archive (nerdctl-full-1.2.1-linux-amd64.tar.gz)
230.56 MiB / 230.56 MiB [-----------------------------------] 100.00% 2.75 MiB/s
DEBU[0139] res.ValidatedDigest=true                     
INFO[0139] Downloaded the nerdctl archive from "https://github.com/containerd/nerdctl/releases/download/v1.2.1/nerdctl-full-1.2.1-linux-amd64.tar.gz" 
```

When the downloads are already cached, there is **no** progress output (only log)

```
INFO[0000] Using the existing instance "default"        
INFO[0000] Hint: To create another instance, run the following command: limactl start --name=NAME template://default 
INFO[0000] Attempting to download the nerdctl archive    arch=x86_64 digest="sha256:e8a3e40d442c566ee494375a4c563121da69d7c7837f50f4a3a171742757b36c" location="https://github.com/containerd/nerdctl/releases/download/v1.2.1/nerdctl-full-1.2.1-linux-amd64.tar.gz"
DEBU[0000] file "" is cached as "/home/anders/.cache/lima/download/by-url-sha256/3ca338b148379fea1376fb450380cb21a2b26d8b1618da6eb1c5c5e352b03ea7/data" 
DEBU[0000] Comparing digest "sha256:e8a3e40d442c566ee494375a4c563121da69d7c7837f50f4a3a171742757b36c" with the cached digest file "/home/anders/.cache/lima/download/by-url-sha256/3ca338b148379fea1376fb450380cb21a2b26d8b1618da6eb1c5c5e352b03ea7/sha256.digest", not computing the actual digest of "/home/anders/.cache/lima/download/by-url-sha256/3ca338b148379fea1376fb450380cb21a2b26d8b1618da6eb1c5c5e352b03ea7/data" 
DEBU[0000] res.ValidatedDigest=true                     
INFO[0000] Using cache "/home/anders/.cache/lima/download/by-url-sha256/3ca338b148379fea1376fb450380cb21a2b26d8b1618da6eb1c5c5e352b03ea7/data" 
```