### PR TITLE
Make cache pruning more flexible

### DIFF
--- a/cmd/limactl/prune.go
+++ b/cmd/limactl/prune.go
@@ -21,12 +21,30 @@ func newPruneCommand() *cobra.Command {
 		ValidArgsFunction: cobra.NoFileCompletions,
 	}
 
+	pruneCommand.Flags().Bool("dry-run", false, "Show which images would be deleted, but don't really delete them")
 	pruneCommand.Flags().Bool("no-digest-only", false, "Only prune images without a digest specified (\"fallback\" images usually)")
 	pruneCommand.Flags().Bool("unreferenced-only", false, "Only prune downloads not referenced in any VM")
 	return pruneCommand
 }
 
+func deletePathMaybe(path string, isDryRun bool) error {
+	if isDryRun {
+		return nil
+	}
+	err := os.RemoveAll(path)
+	if err != nil {
+		logrus.WithError(err).WithFields(logrus.Fields{
+			"path": path,
+		}).Errorf("Cannot delete directory. Skipping...")
+	}
+	return err
+}
+
 func pruneAction(cmd *cobra.Command, args []string) error {
+	pruneDryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		return err
+	}
 	pruneWithoutDigest, err := cmd.Flags().GetBool("no-digest-only")
 	if err != nil {
 		return err
@@ -55,34 +73,28 @@ func pruneAction(cmd *cobra.Command, args []string) error {
 
 			logrus.WithFields(entryFields).Debug("cache entry")
 
+			if pruneDryRun {
+				entryFields["is_dry_run"] = pruneDryRun
+			}
+
 			// check if the cache entry is referenced
 			if refFile, refFound := files[entry.ID]; refFound {
 				if refFile.Location != entry.Location { // sanity check
-					logrus.WithFields(logrus.Fields{
-						"id":                  entry.ID,
-						"location":            entry.Location,
-						"referenced_location": refFile.Location,
-					}).Warnf("Sanity check failed! URL mismatch")
+					ef := entryFields
+					ef["referenced_location"] = refFile.Location
+					logrus.WithFields(ef).Warnf("Sanity check failed! URL mismatch")
 				}
 
 				if pruneWithoutDigest && refFile.Digest == "" {
 					// delete the fallback image entry (entry w/o digest) even if referenced
 					logrus.WithFields(entryFields).Infof("Deleting fallback entry")
-					if err := os.RemoveAll(entry.Path); err != nil {
-						logrus.WithError(err).WithFields(logrus.Fields{
-							"path": entry.Path,
-						}).Errorf("Cannot delete directory. Skipping...")
-					}
+					deletePathMaybe(entry.Path, pruneDryRun)
 				}
 			} else {
 				if pruneUnreferenced {
 					// delete the unreferenced cached entry
 					logrus.WithFields(entryFields).Infof("Deleting unreferenced entry")
-					if err := os.RemoveAll(entry.Path); err != nil {
-						logrus.WithError(err).WithFields(logrus.Fields{
-							"path": entry.Path,
-						}).Errorf("Cannot delete directory. Skipping...")
-					}
+					deletePathMaybe(entry.Path, pruneDryRun)
 				}
 			}
 		}
@@ -95,8 +107,11 @@ func pruneAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	cacheDir := filepath.Join(ucd, "lima")
-	logrus.Infof("Pruning everything in %q", cacheDir)
-	return os.RemoveAll(cacheDir)
+	logrus.WithFields(logrus.Fields{
+		"is_dry_run": pruneDryRun,
+		"location":   cacheDir,
+	}).Infof("Pruning entire cache")
+	return deletePathMaybe(cacheDir, pruneDryRun)
 }
 
 // Collect all downloads referenced in VM definitions and templates

--- a/cmd/limactl/prune.go
+++ b/cmd/limactl/prune.go
@@ -4,6 +4,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/lima-vm/lima/pkg/downloader"
+	"github.com/lima-vm/lima/pkg/limayaml"
+	"github.com/lima-vm/lima/pkg/store"
+	"github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -16,15 +20,101 @@ func newPruneCommand() *cobra.Command {
 		RunE:              pruneAction,
 		ValidArgsFunction: cobra.NoFileCompletions,
 	}
+
+	pruneCommand.Flags().Bool("no-digest-only", false, "Only prune images without a digest specified (\"fallback\" images usually)")
+	pruneCommand.Flags().Bool("unreferenced-only", false, "Only prune downloads not referenced in any VM")
 	return pruneCommand
 }
 
 func pruneAction(cmd *cobra.Command, args []string) error {
+	pruneWithoutDigest, err := cmd.Flags().GetBool("no-digest-only")
+	if err != nil {
+		return err
+	}
+	pruneUnreferenced, err := cmd.Flags().GetBool("unreferenced-only")
+	if err != nil {
+		return err
+	}
+
+	if pruneWithoutDigest || pruneUnreferenced {
+		files, err := getReferencedDownloads()
+		if err != nil {
+			return err
+		}
+
+		cacheEntries, err := downloader.CachedDownloads(downloader.WithCache())
+		if err != nil {
+			return err
+		}
+
+		for _, entry := range cacheEntries {
+			entryFields := logrus.Fields{
+				"id":       entry.ID,
+				"location": entry.Location,
+			}
+
+			logrus.WithFields(entryFields).Debug("cache entry")
+
+			// check if the cache entry is referenced
+			if refFile, refFound := files[entry.ID]; refFound {
+				if refFile.Location != entry.Location { // sanity check
+					logrus.WithFields(logrus.Fields{
+						"id":                  entry.ID,
+						"location":            entry.Location,
+						"referenced_location": refFile.Location,
+					}).Warnf("Sanity check failed! URL mismatch")
+				}
+
+				if pruneWithoutDigest && refFile.Digest == "" {
+					// delete the fallback image entry (entry w/o digest) even if referenced
+					logrus.WithFields(entryFields).Infof("Deleting fallback entry")
+					if err := os.RemoveAll(entry.Path); err != nil {
+						logrus.WithError(err).WithFields(logrus.Fields{
+							"path": entry.Path,
+						}).Errorf("Cannot delete directory. Skipping...")
+					}
+				}
+			} else {
+				if pruneUnreferenced {
+					// delete the unreferenced cached entry
+					logrus.WithFields(entryFields).Infof("Deleting unreferenced entry")
+					if err := os.RemoveAll(entry.Path); err != nil {
+						logrus.WithError(err).WithFields(logrus.Fields{
+							"path": entry.Path,
+						}).Errorf("Cannot delete directory. Skipping...")
+					}
+				}
+			}
+		}
+		return nil
+	}
+
+	// prune everything if no options specified
 	ucd, err := os.UserCacheDir()
 	if err != nil {
 		return err
 	}
 	cacheDir := filepath.Join(ucd, "lima")
-	logrus.Infof("Pruning %q", cacheDir)
+	logrus.Infof("Pruning everything in %q", cacheDir)
 	return os.RemoveAll(cacheDir)
+}
+
+// Collect all downloads referenced in VM definitions and templates
+func getReferencedDownloads() (map[string]limayaml.File, error) {
+	digests := make(map[string]limayaml.File)
+
+	vmRefs, err := store.Downloads()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range vmRefs {
+		d := digest.SHA256.FromString(f.Location).Encoded()
+		logrus.WithFields(logrus.Fields{
+			"id":       d,
+			"location": f.Location,
+		}).Debugf("referenced file")
+		digests[d] = f
+	}
+	return digests, nil
 }

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -38,6 +38,24 @@ type LimaYAML struct {
 	Rosetta           Rosetta        `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
 }
 
+// Returns list of all the files referred by the LimaYAML instance
+func (y *LimaYAML) ReferredFiles() []File {
+	files := []File{}
+	for _, img := range y.Images {
+		files = append(files, img.File)
+		if img.Kernel != nil {
+			files = append(files, img.Kernel.File)
+		}
+		if img.Initrd != nil {
+			files = append(files, *img.Initrd)
+		}
+	}
+	for _, archive := range y.Containerd.Archives {
+		files = append(files, archive)
+	}
+	return files
+}
+
 type Arch = string
 type MountType = string
 type VMType = string

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -102,3 +102,20 @@ func LoadYAMLByFilePath(filePath string) (*limayaml.LimaYAML, error) {
 	}
 	return y, nil
 }
+
+func Downloads() ([]limayaml.File, error) {
+	instanceNames, err := Instances()
+	if err != nil {
+		return nil, err
+	}
+	files := []limayaml.File{}
+
+	for _, instanceName := range instanceNames {
+		instance, err := Inspect(instanceName)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, instance.Config.ReferredFiles()...)
+	}
+	return files, nil
+}


### PR DESCRIPTION
This command deletes only those cached downloads which are not referenced by any existing VM configs.