### PR TITLE
Add builtin yq support to limactl edit command

### DIFF
--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -10,3 +10,4 @@ The following features are experimental and subject to change:
 The following flags are experimental and subject to change:
 
 - `start --set`, yq expression
+- `edit --set`, yq expression


### PR DESCRIPTION
Also add` --tty` parameter, similar to the start command, for avoiding user interaction asking whether to start it.

```console
$ limactl edit --tty=false --set ".cpus = 2" default
INFO[0000] Instance "default" configuration edited      
$ limactl edit --tty=false --set ".cpus = 2" default
INFO[0000] Aborting, no changes made to the instance  
```

Follow-up to:
* #1359