### PR TITLE
feat: allow rosetta fields to be overridden

### DIFF
--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -126,8 +126,8 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 		SlirpGateway:   networks.SlirpGateway,
 		SlirpDNS:       networks.SlirpDNS,
 		SlirpIPAddress: networks.SlirpIPAddress,
-		RosettaEnabled: y.Rosetta.Enabled,
-		RosettaBinFmt:  y.Rosetta.BinFmt,
+		RosettaEnabled: *y.Rosetta.Enabled,
+		RosettaBinFmt:  *y.Rosetta.BinFmt,
 	}
 
 	// change instance id on every boot so network config will be processed again

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -540,6 +540,26 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 
 	caCerts := unique(append(append(d.CACertificates.Certs, y.CACertificates.Certs...), o.CACertificates.Certs...))
 	y.CACertificates.Certs = caCerts
+
+	if y.Rosetta.Enabled == nil {
+		y.Rosetta.Enabled = d.Rosetta.Enabled
+	}
+	if o.Rosetta.Enabled != nil {
+		y.Rosetta.Enabled = o.Rosetta.Enabled
+	}
+	if y.Rosetta.Enabled == nil {
+		y.Rosetta.Enabled = pointer.Bool(false)
+	}
+
+	if y.Rosetta.BinFmt == nil {
+		y.Rosetta.BinFmt = d.Rosetta.BinFmt
+	}
+	if o.Rosetta.BinFmt != nil {
+		y.Rosetta.BinFmt = o.Rosetta.BinFmt
+	}
+	if y.Rosetta.BinFmt == nil {
+		y.Rosetta.BinFmt = pointer.Bool(false)
+	}
 }
 
 func executeGuestTemplate(format string) (bytes.Buffer, error) {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -223,6 +223,11 @@ func TestFillDefault(t *testing.T) {
 		},
 	}
 
+	expect.Rosetta = Rosetta{
+		Enabled: pointer.Bool(false),
+		BinFmt:  pointer.Bool(false),
+	}
+
 	FillDefault(&y, &LimaYAML{}, &LimaYAML{}, filePath)
 	assert.DeepEqual(t, &y, &expect, opts...)
 
@@ -328,6 +333,10 @@ func TestFillDefault(t *testing.T) {
 				"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT\n-----END CERTIFICATE-----\n",
 			},
 		},
+		Rosetta: Rosetta{
+			Enabled: pointer.Bool(true),
+			BinFmt:  pointer.Bool(true),
+		},
 	}
 
 	expect = d
@@ -348,6 +357,11 @@ func TestFillDefault(t *testing.T) {
 	expect.CACertificates.RemoveDefaults = pointer.Bool(true)
 	expect.CACertificates.Certs = []string{
 		"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT\n-----END CERTIFICATE-----\n",
+	}
+
+	expect.Rosetta = Rosetta{
+		Enabled: pointer.Bool(true),
+		BinFmt:  pointer.Bool(true),
 	}
 
 	y = LimaYAML{}
@@ -497,6 +511,10 @@ func TestFillDefault(t *testing.T) {
 		CACertificates: CACertificates{
 			RemoveDefaults: pointer.Bool(true),
 		},
+		Rosetta: Rosetta{
+			Enabled: pointer.Bool(false),
+			BinFmt:  pointer.Bool(false),
+		},
 	}
 
 	y = filledDefaults
@@ -541,6 +559,11 @@ func TestFillDefault(t *testing.T) {
 	expect.CACertificates.Files = []string{"ca.crt"}
 	expect.CACertificates.Certs = []string{
 		"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT\n-----END CERTIFICATE-----\n",
+	}
+
+	expect.Rosetta = Rosetta{
+		Enabled: pointer.Bool(false),
+		BinFmt:  pointer.Bool(false),
 	}
 
 	FillDefault(&y, &d, &o, filePath)

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -55,8 +55,8 @@ const (
 )
 
 type Rosetta struct {
-	Enabled bool `yaml:"enabled" json:"enabled"`
-	BinFmt  bool `yaml:"binfmt" json:"binfmt"`
+	Enabled *bool `yaml:"enabled" json:"enabled"`
+	BinFmt  *bool `yaml:"binfmt" json:"binfmt"`
 }
 
 type File struct {

--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -404,7 +404,7 @@ func attachFolderMounts(driver *driver.BaseDriver, vmConfig *vz.VirtualMachineCo
 		}
 	}
 
-	if driver.Yaml.Rosetta.Enabled {
+	if *driver.Yaml.Rosetta.Enabled {
 		logrus.Info("Setting up Rosetta share")
 		directorySharingDeviceConfig, err := createRosettaDirectoryShareConfiguration()
 		if err != nil {


### PR DESCRIPTION
Allow Rosetta fields to be overridden by making them pointers and setting default values based the same way they are set for other config options.