### PR TITLE
Adjust table test for longer architectures

### DIFF
--- a/pkg/store/instance_test.go
+++ b/pkg/store/instance_test.go
@@ -5,6 +5,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/lima-vm/lima/pkg/limayaml"
@@ -15,6 +16,7 @@ const separator = string(filepath.Separator)
 
 var vmtype = limayaml.QEMU
 var goarch = limayaml.NewArch(runtime.GOARCH)
+var space = strings.Repeat(" ", len(goarch)-4)
 
 var instance = Instance{
 	Name:   "foo",
@@ -33,7 +35,7 @@ var tableEmu = "NAME    STATUS     SSH            ARCH       CPUS    MEMORY    D
 var tableHome = "NAME    STATUS     SSH            CPUS    MEMORY    DISK    DIR\n" +
 	"foo     Stopped    127.0.0.1:0    0       0B        0B      ~" + separator + "dir\n"
 
-var tableAll = "NAME    STATUS     SSH            VMTYPE    ARCH      CPUS    MEMORY    DISK    DIR\n" +
+var tableAll = "NAME    STATUS     SSH            VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
 	"foo     Stopped    127.0.0.1:0    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
 
 // for width 60, everything is hidden
@@ -49,7 +51,7 @@ var table80d = "NAME    STATUS     SSH            ARCH       CPUS    MEMORY    D
 	"foo     Stopped    127.0.0.1:0    unknown    0       0B        0B\n"
 
 // for width 100, nothing is hidden
-var table100 = "NAME    STATUS     SSH            VMTYPE    ARCH      CPUS    MEMORY    DISK    DIR\n" +
+var table100 = "NAME    STATUS     SSH            VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
 	"foo     Stopped    127.0.0.1:0    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
 
 // for width 80, directory is hidden (if not identical)


### PR DESCRIPTION
Turns out that "aarch64" is one character longer than "x86_64".

In the future, we might want to have a special tablewriter mod.

----

Fixes tests breaking:

GOARCH=amd64 gotestsum ./...
DONE 77 tests, 4 skipped in 0.645s
GOARCH=arm64 gotestsum ./...
DONE 77 tests, 4 skipped, 2 failures in 1.233s

Might want to add a cross-platform test target, to catch these ?