### PR TITLE
limactl shell flags MUST come before the instance name

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -33,7 +33,7 @@ Hint: try --debug to show the detailed logs, if it seems hanging (mostly due to 
 
 func newShellCommand() *cobra.Command {
 	var shellCmd = &cobra.Command{
-		Use:               "shell INSTANCE [COMMAND...]",
+		Use:               "shell [flags] INSTANCE [COMMAND...]",
 		Short:             "Execute shell in Lima",
 		Long:              shellHelp,
 		Args:              WrapArgsError(cobra.MinimumNArgs(1)),


### PR DESCRIPTION
Everything after the instance name is sent to the shell.

Updated usage:

```
  $ limactl shell --help
  Execute shell in Lima
  ...
  Usage:
    limactl shell [flags] INSTANCE [COMMAND...]
```

Ref: https://github.com/lima-vm/lima/discussions/586#discussioncomment-5477505