### PR TITLE
Revert "templates: opensuse-tumbleweed: remove aarch64 image due to 404"

### DIFF
--- a/examples/experimental/opensuse-tumbleweed.yaml
+++ b/examples/experimental/opensuse-tumbleweed.yaml
@@ -3,7 +3,12 @@ images:
 # Hint: run `limactl prune` to invalidate the "Current" cache
 - location: "https://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2"
   arch: "x86_64"
-# No aarch64 build is found in https://download.opensuse.org/ports/aarch64/tumbleweed/appliances/
+# JeOS is deprecated and will be removed probably
+- location: "http://download.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-Tumbleweed-ARM-JeOS-efi.aarch64.qcow2"
+  arch: "aarch64"
+# Minimal-VM.aarch64-kvm-and-xen is known to hang: https://github.com/lima-vm/lima/pull/1194#issuecomment-1326943869
+# - location: "https://download.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.aarch64-kvm-and-xen.qcow2"
+#   arch: "aarch64"
 mounts:
 - location: "~"
 - location: "/tmp/lima"


### PR DESCRIPTION
This reverts commit 7430e5c08195a1362563045b278dfa9e4137012d.