### PR TITLE
refactor: vz disk conversion

### DIFF
--- a/pkg/qemu/imgutil/imgutil.go
+++ b/pkg/qemu/imgutil/imgutil.go
@@ -15,9 +15,9 @@ type Info struct {
 	VSize  int64  `json:"virtual-size,omitempty"`
 }
 
-func QCOWToRaw(source string, dest string) error {
+func ConvertToRaw(source string, dest string) error {
 	var stdout, stderr bytes.Buffer
-	cmd := exec.Command("qemu-img", "convert", source, dest)
+	cmd := exec.Command("qemu-img", "convert", "-O", "raw", source, dest)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {

--- a/pkg/vz/disk.go
+++ b/pkg/vz/disk.go
@@ -63,7 +63,7 @@ func EnsureDisk(driver *driver.BaseDriver) error {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to run %v: %q: %w", cmd.Args, string(out), err)
 	}
-	if err = imgutil.QCOWToRaw(diffDisk, diffDisk); err != nil {
+	if err = imgutil.ConvertToRaw(diffDisk, diffDisk); err != nil {
 		return fmt.Errorf("cannot convert qcow2 to raw for vz driver")
 	}
 	return nil


### PR DESCRIPTION
Closes: #1438 

Refactored disk conversion functions to be more explicit and used new `imgutil.ConvertToRaw` function in VZ driver, like suggested in https://github.com/lima-vm/lima/pull/1405#discussion_r1148315941.