### PR TITLE
Improve the "failed to download" error message

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -76,8 +76,7 @@ func EnsureDisk(cfg Config) error {
 			break
 		}
 		if !ensuredBaseDisk {
-			return fmt.Errorf("failed to download the image, attempted %d candidates, errors=%v",
-				len(cfg.LimaYAML.Images), errs)
+			return fileutils.Errors(errs)
 		}
 	}
 	diskSize, _ := units.RAMInBytes(*cfg.LimaYAML.Disk)

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -53,8 +53,7 @@ func ensureNerdctlArchiveCache(y *limayaml.LimaYAML) (string, error) {
 		return path, nil
 	}
 
-	return "", fmt.Errorf("failed to download the nerdctl archive, attempted %d candidates, errors=%v",
-		len(y.Containerd.Archives), errs)
+	return "", fileutils.Errors(errs)
 }
 
 func Start(ctx context.Context, inst *store.Instance) error {

--- a/pkg/vz/disk.go
+++ b/pkg/vz/disk.go
@@ -37,8 +37,7 @@ func EnsureDisk(driver *driver.BaseDriver) error {
 			break
 		}
 		if !ensuredBaseDisk {
-			return fmt.Errorf("failed to download the image, attempted %d candidates, errors=%v",
-				len(driver.Yaml.Images), errs)
+			return fileutils.Errors(errs)
 		}
 	}
 	diskSize, _ := units.RAMInBytes(*driver.Yaml.Disk)


### PR DESCRIPTION
Example:
```yaml
images:
- location: "https://example.com/dummy-x86_64"
  arch: "x86_64"
- location: "https://example.com/dummy-aarch64"
  arch: "aarch64"
```

Before:
```console
$ limactl start dummy
INFO[0000] Using the existing instance "dummy"
INFO[0000] Attempting to download the image              arch=x86_64 digest= location="https://example.com/dummy-x86_64"
FATA[0000] failed to download the image, attempted 2 candidates, errors=[failed to download "https://example.com/dummy-x86_64": expected HTTP status 200, got 404 Not Found unsupported arch: "aarch64"]
```

After:
```console
$ limactl start dummy
INFO[0000] Using the existing instance "dummy"
INFO[0000] Attempting to download the image              arch=x86_64 digest= location="https://example.com/dummy-x86_64"
FATA[0000] failed to download "https://example.com/dummy-x86_64": expected HTTP status 200, got 404 Not Found
```