### PR TITLE
limactl: add `--cpus`, `--memory`, `--mount-type`, `--vm-type`, ...

### DIFF
--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -1,0 +1,252 @@
+package editflags
+
+import (
+	"fmt"
+	"math/bits"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/pbnjay/memory"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+)
+
+// RegisterEdit registers flags related to in-place YAML modification, for `limactl edit`.
+func RegisterEdit(cmd *cobra.Command) {
+	registerEdit(cmd, "")
+}
+
+func registerEdit(cmd *cobra.Command, commentPrefix string) {
+	flags := cmd.Flags()
+
+	flags.Int("cpus", 0, commentPrefix+"number of CPUs") // Similar to colima's --cpu, but the flag name is slightly different (cpu vs cpus)
+	_ = cmd.RegisterFlagCompletionFunc("cpus", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		var res []string
+		for _, f := range completeCPUs(runtime.NumCPU()) {
+			res = append(res, strconv.Itoa(f))
+		}
+		return res, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	flags.IPSlice("dns", nil, commentPrefix+"specify custom DNS (disable host resolver)") // colima-compatible
+
+	flags.Float32("memory", 0, commentPrefix+"memory in GiB") // colima-compatible
+	_ = cmd.RegisterFlagCompletionFunc("memory", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		var res []string
+		for _, f := range completeMemoryGiB(memory.TotalMemory()) {
+			res = append(res, fmt.Sprintf("%.1f", f))
+		}
+		return res, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	flags.StringSlice("mount", nil, commentPrefix+"directories to mount, suffix ':w' for writable (Do not specify directories that overlap with the existing mounts)") // colima-compatible
+
+	flags.String("mount-type", "", commentPrefix+"mount type (reverse-sshfs, 9p, virtiofs)") // Similar to colima's --mount-type=(sshfs|9p|virtiofs), but "reverse-sshfs" is Lima is called "sshfs" in colima
+	_ = cmd.RegisterFlagCompletionFunc("mount-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"reverse-sshfs", "9p", "virtiofs"}, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	flags.Bool("mount-writable", false, commentPrefix+"make all mounts writable")
+
+	flags.StringSlice("network", nil, commentPrefix+"additional networks, e.g., \"vzNAT\" or \"lima:shared\" to assign vmnet IP")
+	_ = cmd.RegisterFlagCompletionFunc("network", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// TODO: retrieve the lima:* network list from networks.yaml
+		return []string{"lima:shared", "lima:bridged", "lima:host", "lima:user-v2", "vzNAT"}, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	flags.Bool("rosetta", false, commentPrefix+"enable Rosetta (for vz instances)")
+
+	flags.String("set", "", commentPrefix+"modify the template inplace, using yq syntax")
+}
+
+// RegisterCreate registers flags related to in-place YAML modification, for `limactl create`.
+func RegisterCreate(cmd *cobra.Command, commentPrefix string) {
+	registerEdit(cmd, commentPrefix)
+	flags := cmd.Flags()
+
+	flags.String("arch", "", commentPrefix+"machine architecture (x86_64, aarch64, riscv64)") // colima-compatible
+	_ = cmd.RegisterFlagCompletionFunc("arch", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"x86_64", "aarch64", "riscv64"}, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	flags.String("containerd", "", commentPrefix+"containerd mode (user, system, user+system, none)")
+	_ = cmd.RegisterFlagCompletionFunc("vm-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"user", "system", "user+system", "none"}, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	flags.Float32("disk", 0, commentPrefix+"disk size in GiB") // colima-compatible
+	_ = cmd.RegisterFlagCompletionFunc("memory", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"10", "30", "50", "100", "200"}, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	flags.String("vm-type", "", commentPrefix+"virtual machine type (qemu, vz)") // colima-compatible
+	_ = cmd.RegisterFlagCompletionFunc("vm-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"qemu", "vz"}, cobra.ShellCompDirectiveNoFileComp
+	})
+}
+
+func defaultExprFunc(expr string) func(v *flag.Flag) (string, error) {
+	return func(v *flag.Flag) (string, error) {
+		return fmt.Sprintf(expr, v.Value), nil
+	}
+}
+
+// YQExpressions returns YQ expressions.
+func YQExpressions(flags *flag.FlagSet) ([]string, error) {
+	type def struct {
+		flagName     string
+		exprFunc     func(*flag.Flag) (string, error)
+		experimental bool
+	}
+	d := defaultExprFunc
+	defs := []def{
+		{"cpus", d(".cpus = %s"), false},
+		{"dns",
+			func(_ *flag.Flag) (string, error) {
+				ipSlice, err := flags.GetIPSlice("dns")
+				if err != nil {
+					return "", err
+				}
+				expr := `.dns += [`
+				for i, ip := range ipSlice {
+					expr += fmt.Sprintf("%q", ip)
+					if i < len(ipSlice)-1 {
+						expr += ","
+					}
+				}
+				expr += `] | .dns |= unique | .hostResolver.enabled=false`
+				logrus.Warnf("Disabling HostResolver, as custom DNS addresses (%v) are specified", ipSlice)
+				return expr, nil
+			},
+			false},
+		{"memory", d(".memory = \"%sGiB\""), false},
+		{"mount",
+			func(_ *flag.Flag) (string, error) {
+				ss, err := flags.GetStringSlice("mount")
+				if err != nil {
+					return "", err
+				}
+				expr := `.mounts += [`
+				for i, s := range ss {
+					writable := strings.HasSuffix(s, ":w")
+					loc := strings.TrimSuffix(s, ":w")
+					expr += fmt.Sprintf(`{"location": %q, "writable": %v}`, loc, writable)
+					if i < len(ss)-1 {
+						expr += ","
+					}
+				}
+				expr += `] | .mounts |= unique_by(.location)`
+				return expr, nil
+			},
+			false},
+		{"mount-type", d(".mountType = %q"), false},
+		{"mount-writable", d(".mounts[].writable = %s"), false},
+		{"network",
+			func(_ *flag.Flag) (string, error) {
+				ss, err := flags.GetStringSlice("network")
+				if err != nil {
+					return "", err
+				}
+				expr := `.networks += [`
+				for i, s := range ss {
+					// CLI syntax is still experimental (YAML syntax is out of experimental)
+					switch {
+					case s == "vzNAT":
+						expr += `{"vzNAT": true}`
+					case strings.HasPrefix(s, "lima:"):
+						network := strings.TrimPrefix(s, "lima:")
+						expr += fmt.Sprintf(`{"lima": %q}`, network)
+					default:
+						return "", fmt.Errorf("network name must be \"vzNAT\" or \"lima:*\", got %q", s)
+					}
+					if i < len(ss)-1 {
+						expr += ","
+					}
+				}
+				expr += `] | .networks |= unique_by(.lima)`
+				return expr, nil
+			},
+			true},
+		{"rosetta",
+			func(_ *flag.Flag) (string, error) {
+				b, err := flags.GetBool("rosetta")
+				if err != nil {
+					return "", err
+				}
+				return fmt.Sprintf(".rosetta.enabled = %v | .rosetta.binfmt = %v", b, b), nil
+			},
+			true},
+		{"set", d("%s"), true},
+		{"arch", d(".arch = %q"), false},
+		{"containerd",
+			func(_ *flag.Flag) (string, error) {
+				s, err := flags.GetString("containerd")
+				if err != nil {
+					return "", err
+				}
+				switch s {
+				case "user":
+					return `.containerd.user = true | .containerd.system = false`, nil
+				case "system":
+					return `.containerd.user = false | .containerd.system = true`, nil
+				case "user+system", "system+user":
+					return `.containerd.user = true | .containerd.system = true`, nil
+				case "none":
+					return `.containerd.user = false | .containerd.system = false`, nil
+				default:
+					return "", fmt.Errorf(`expected one of ["user", "system", "user+system", "none"], got %q`, s)
+				}
+			},
+			false},
+
+		{"disk", d(".disk= \"%sGiB\""), false},
+		{"vm-type", d(".vmType = %q"), false},
+	}
+	var exprs []string
+	for _, def := range defs {
+		v := flags.Lookup(def.flagName)
+		if v != nil && v.Changed {
+			if def.experimental {
+				logrus.Warnf("`--%s` is experimental", def.flagName)
+			}
+			expr, err := def.exprFunc(v)
+			if err != nil {
+				return exprs, fmt.Errorf("error while processing flag %q: %w", def.flagName, err)
+			}
+			exprs = append(exprs, expr)
+		}
+	}
+	return exprs, nil
+}
+
+func isPowerOfTwo(x int) bool {
+	return bits.OnesCount(uint(x)) == 1
+}
+
+func completeCPUs(hostCPUs int) []int {
+	var res []int
+	for i := 1; i <= hostCPUs; i *= 2 {
+		res = append(res, i)
+	}
+	if !isPowerOfTwo(hostCPUs) {
+		res = append(res, hostCPUs)
+	}
+	return res
+}
+
+func completeMemoryGiB(hostMemory uint64) []float32 {
+	hostMemoryHalfGiB := int(hostMemory / 2 / 1024 / 1024 / 1024)
+	var res []float32
+	if hostMemoryHalfGiB < 1 {
+		res = append(res, 0.5)
+	}
+	for i := 1; i <= hostMemoryHalfGiB; i *= 2 {
+		res = append(res, float32(i))
+	}
+	if hostMemoryHalfGiB > 1 && !isPowerOfTwo(hostMemoryHalfGiB) {
+		res = append(res, float32(hostMemoryHalfGiB))
+	}
+	return res
+}

--- a/cmd/limactl/editflags/editflags_test.go
+++ b/cmd/limactl/editflags/editflags_test.go
@@ -1,0 +1,22 @@
+package editflags
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCompleteCPUs(t *testing.T) {
+	assert.DeepEqual(t, []int{1}, completeCPUs(1))
+	assert.DeepEqual(t, []int{1, 2}, completeCPUs(2))
+	assert.DeepEqual(t, []int{1, 2, 4, 8}, completeCPUs(8))
+	assert.DeepEqual(t, []int{1, 2, 4, 8, 16, 20}, completeCPUs(20))
+}
+
+func TestCompleteMemoryGiB(t *testing.T) {
+	assert.DeepEqual(t, []float32{0.5}, completeMemoryGiB(1<<30))
+	assert.DeepEqual(t, []float32{1}, completeMemoryGiB(2<<30))
+	assert.DeepEqual(t, []float32{1, 2}, completeMemoryGiB(4<<30))
+	assert.DeepEqual(t, []float32{1, 2, 4}, completeMemoryGiB(8<<30))
+	assert.DeepEqual(t, []float32{1, 2, 4, 8, 10}, completeMemoryGiB(20<<30))
+}

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -13,5 +13,6 @@ The following features are experimental and subject to change:
 
 The following commands are experimental and subject to change:
 
-- `limactl (start|edit) --set=<YQ EXPRESSION>`
+- `limactl (create|start|edit) --set=<YQ EXPRESSION>`
+- `limactl (create|start|edit) --network=<NETWORK>`
 - `limactl snapshot *`

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -17,8 +17,7 @@ INFO "Validating \"$FILE\""
 limactl validate "$FILE"
 
 # --cpus=1 is needed for running vz on GHA: https://github.com/lima-vm/lima/pull/1511#issuecomment-1574937888
-LIMACTL_CREATE_SET='.cpus = 1 | .memory="1GiB"'
-LIMACTL_CREATE=(limactl create --tty=false --set="${LIMACTL_CREATE_SET}")
+LIMACTL_CREATE=(limactl create --tty=false --cpus=1 --memory=1)
 
 declare -A CHECKS=(
 	["systemd"]="1"

--- a/pkg/yqutil/yqutil.go
+++ b/pkg/yqutil/yqutil.go
@@ -12,6 +12,7 @@ import (
 
 // EvaluateExpression evaluates the yq expression, and returns the modified yaml.
 func EvaluateExpression(expression string, content []byte) ([]byte, error) {
+	logrus.Debugf("Evaluating yq expression: %q", expression)
 	tmpYAMLFile, err := os.CreateTemp("", "lima-yq-*.yaml")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`limactl create`, `limactl start`, `limactl edit`:
- `--cpus=INT` (Similar to `colima start --cpu`, but the flag name is slightly different)
- `--dns=IP` (Similar to `colima start --dns`)
- `--memory=FLOAT` (Similar to `colima start --memory`)
- `--mount=DIR[:w]` (Similar to `colima start --mount`)
- `--mount-type=(reverse-sshfs|9p|virtiofs)` (Similar to `colima start --mount-type`)
- `--mount-writable=BOOL`
- `--network=(lima:shared|lima:bridged|lima:host|lima:user-v2|vzNAT)`
- `--rosetta=BOOL`


`limactl create` and `limactl start` only:
- `--arch=(x86_64|aarch64|riscv64)` (Similar to `colima start --arch`)
- `--containerd=(user|system|user+system|none)`
- `--disk=FLOAT` (Similar to `colima start --disk`)
- `--vm-type=(qemu|vz)` (Similar to `colima start --vm-type`)
