### PR TITLE
Setup apk cache on persistent volume

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/04-persistent-data-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/04-persistent-data-volume.sh
@@ -50,6 +50,11 @@ if [ "$(awk '$2 == "/" {print $3}' /proc/mounts)" == "tmpfs" ]; then
 				for MP in $(mount | awk '$3 ~ /^\/tmp\// {print $3}'); do
 					umount "${MP}"
 				done
+				# setup apk package cache
+				mkdir -p /mnt/data/apk/cache
+				mkdir -p /etc/apk
+				ln -s /mnt/data/apk/cache /etc/apk/cache
+				# Move all persisted directories to the data volume
 				for DIR in ${DATADIRS}; do
 					DEST="/mnt/data$(dirname "${DIR}")"
 					mkdir -p "${DIR}" "${DEST}"


### PR DESCRIPTION
Added packages must be reinstalled on each boot because Alpine runs from an ISO. Setting up the package cache avoid having to re-download the packages each time.