### PR TITLE
Make sure that yaml is valid with gopkg.in/yaml.v3 as well

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.7.0
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.4.0
 	inet.af/tcpproxy v0.0.0-20220326234310-be3ee21c9fa0
 	k8s.io/api v0.26.3
@@ -112,7 +113,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gvisor.dev/gvisor v0.0.0-20221216231429-a78e892a26d2 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect

--- a/pkg/limayaml/load.go
+++ b/pkg/limayaml/load.go
@@ -10,10 +10,16 @@ import (
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/sirupsen/logrus"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 func unmarshalYAML(data []byte, v interface{}, comment string) error {
 	if err := yaml.UnmarshalWithOptions(data, v, yaml.DisallowDuplicateKey()); err != nil {
+		return fmt.Errorf("failed to unmarshal YAML (%s): %w", comment, err)
+	}
+	// the go-yaml library doesn't catch all markup errors, unfortunately
+	// make sure to get a "second opinion", using the same library as "yq"
+	if err := yamlv3.Unmarshal(data, v); err != nil {
 		return fmt.Errorf("failed to unmarshal YAML (%s): %w", comment, err)
 	}
 	if err := yaml.UnmarshalWithOptions(data, v, yaml.Strict()); err != nil {

--- a/pkg/limayaml/load_test.go
+++ b/pkg/limayaml/load_test.go
@@ -1,0 +1,32 @@
+package limayaml
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestLoadEmpty(t *testing.T) {
+	_, err := Load([]byte{}, "empty.yaml")
+	assert.NilError(t, err)
+}
+
+func TestLoadError(t *testing.T) {
+	// missing a "script:" line
+	s := `
+provision:
+- mode: system
+  script: |
+    #!/bin/sh
+    echo one
+- mode: system
+    #!/bin/sh
+    echo two
+- mode: system
+  script: |
+    #!/bin/sh
+    echo three
+`
+	_, err := Load([]byte(s), "error.yaml")
+	assert.ErrorContains(t, err, "failed to unmarshal YAML")
+}


### PR DESCRIPTION
The goccy library doesn't catch all the errors, that other libraries such as the one used by "yq" does.
So check the yaml with both of them.

Now catches things such as missing `script:` line:

`FATA[0000] failed to load YAML file "examples/distrobox.yaml": failed to unmarshal YAML (main file "/home/anders/lima/examples/distrobox.yaml"): yaml: line 12: did not find expected key`

Closes #1503