### PR TITLE
MAINTAINERS.md: use GHSA for reporting security issues

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,13 +1,10 @@
 # Lima maintainers
 
-| Name               | GitHub ID (not Twitter ID)                     | E-mail address for reporting security issues | GPG fingerprint                                                                          |
-|--------------------|------------------------------------------------|----------------------------------------------|------------------------------------------------------------------------------------------|
-| Akihiro Suda       | [@AkihiroSuda](https://github.com/AkihiroSuda) | (See GitHub profile)                         | [C020 EA87 6CE4 E06C 7AB9  5AEF 4952 4C6F 9F63 8F1A](https://github.com/AkihiroSuda.gpg) |
-| Jan Dubois         | [@jandubois](https://github.com/jandubois)     | (See GitHub profile)                         |                                                                                          |
-| Anders F Björklund | [@afbjorklund](https://github.com/afbjorklund) | (See GitHub profile)                         |                                                                                          |
-| Balaji Vijayakumar | [@balajiv113](https://github.com/balajiv113)   | (See GitHub profile)                         |                                                                                          |
+| Name               | GitHub ID (not Twitter ID)                     | GPG fingerprint                                                                          |
+|--------------------|------------------------------------------------|------------------------------------------------------------------------------------------|
+| Akihiro Suda       | [@AkihiroSuda](https://github.com/AkihiroSuda) | [C020 EA87 6CE4 E06C 7AB9  5AEF 4952 4C6F 9F63 8F1A](https://github.com/AkihiroSuda.gpg) |
+| Jan Dubois         | [@jandubois](https://github.com/jandubois)     |                                                                                          |
+| Anders F Björklund | [@afbjorklund](https://github.com/afbjorklund) |                                                                                          |
+| Balaji Vijayakumar | [@balajiv113](https://github.com/balajiv113)   |                                                                                          |
 
-
-E-mail addresses are expected to be used for reporting security issues.
-Please use [GitHub Issues](https://github.com/lima-vm/lima/issues) for reporting non-security issues,
-and [GitHub Discussions](https://github.com/lima-vm/lima/discussions) for asking questions.
+See https://github.com/lima-vm/.github/blob/main/SECURITY.md for how to report security issues.


### PR DESCRIPTION
Security issues can be now reported through https://github.com/lima-vm/lima/security/advisories/new


- https://github.com/lima-vm/.github/pull/6