### PR TITLE
Allow leaving additional disks unformatted

### DIFF
--- a/cmd/limactl/disk.go
+++ b/cmd/limactl/disk.go
@@ -245,7 +245,7 @@ func diskDeleteAction(cmd *cobra.Command, args []string) error {
 			for _, inst := range instances {
 				if len(inst.AdditionalDisks) > 0 {
 					for _, d := range inst.AdditionalDisks {
-						if d == diskName {
+						if d.Name == diskName {
 							refInstances = append(refInstances, inst.Name)
 						}
 					}

--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -113,7 +113,8 @@ func stopInstanceForcibly(inst *store.Instance) {
 		logrus.Infof("The %s driver process seems already stopped", inst.VMType)
 	}
 
-	for _, diskName := range inst.AdditionalDisks {
+	for _, d := range inst.AdditionalDisks {
+		diskName := d.Name
 		disk, err := store.InspectDisk(diskName)
 		if err != nil {
 			logrus.Warnf("Disk %q does not exist", diskName)

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -109,6 +109,8 @@ additionalDisks:
 # - "data"
 # or a list of disk objects with extra parameters, for example:
 # - name: "data"
+#   format: true
+#   fsType: "ext4"
 
 ssh:
   # A localhost port of the host. Forwarded to port 22 of the guest.

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -105,8 +105,10 @@ mountType: null
 # `/mnt/lima-${VOLUME}`.
 # 🟢 Builtin default: null
 additionalDisks:
-# disks should be a list of disk name strings, for example:
+# disks should either be a list of disk name strings, for example:
 # - "data"
+# or a list of disk objects with extra parameters, for example:
+# - name: "data"
 
 ssh:
   # A localhost port of the host. Forwarded to port 22 of the guest.

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-lima-disks.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-lima-disks.sh
@@ -14,6 +14,7 @@ for i in $(seq 0 $((LIMA_CIDATA_DISKS - 1))); do
 	DEVICE_NAME="$(get_disk_var "$i" "DEVICE")"
 	FORMAT_DISK="$(get_disk_var "$i" "FORMAT")"
 	FORMAT_FSTYPE="$(get_disk_var "$i" "FSTYPE")"
+	FORMAT_FSARGS="$(get_disk_var "$i" "FSARGS")"
 
 	test -n "$FORMAT_DISK" || FORMAT_DISK=true
 	test -n "$FORMAT_FSTYPE" || FORMAT_FSTYPE=ext4
@@ -22,7 +23,8 @@ for i in $(seq 0 $((LIMA_CIDATA_DISKS - 1))); do
 	if [[ ! -b "/dev/disk/by-label/lima-${DISK_NAME}" ]]; then
 		if $FORMAT_DISK; then
 			echo 'type=linux' | sfdisk --label gpt "/dev/${DEVICE_NAME}"
-			mkfs.$FORMAT_FSTYPE -L "lima-${DISK_NAME}" "/dev/${DEVICE_NAME}1"
+			# shellcheck disable=SC2086
+			mkfs.$FORMAT_FSTYPE $FORMAT_FSARGS -L "lima-${DISK_NAME}" "/dev/${DEVICE_NAME}1"
 		fi
 	fi
 

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-lima-disks.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-lima-disks.sh
@@ -12,14 +12,20 @@ get_disk_var() {
 for i in $(seq 0 $((LIMA_CIDATA_DISKS - 1))); do
 	DISK_NAME="$(get_disk_var "$i" "NAME")"
 	DEVICE_NAME="$(get_disk_var "$i" "DEVICE")"
+	FORMAT_DISK="$(get_disk_var "$i" "FORMAT")"
+	FORMAT_FSTYPE="$(get_disk_var "$i" "FSTYPE")"
+
+	test -n "$FORMAT_DISK" || FORMAT_DISK=true
+	test -n "$FORMAT_FSTYPE" || FORMAT_FSTYPE=ext4
 
 	# first time setup
 	if [[ ! -b "/dev/disk/by-label/lima-${DISK_NAME}" ]]; then
-		# TODO: skip if disk is tagged as "raw"
-		echo 'type=linux' | sfdisk --label gpt "/dev/${DEVICE_NAME}"
-		mkfs.ext4 -L "lima-${DISK_NAME}" "/dev/${DEVICE_NAME}1"
+		if $FORMAT_DISK; then
+			echo 'type=linux' | sfdisk --label gpt "/dev/${DEVICE_NAME}"
+			mkfs.$FORMAT_FSTYPE -L "lima-${DISK_NAME}" "/dev/${DEVICE_NAME}1"
+		fi
 	fi
 
 	mkdir -p "/mnt/lima-${DISK_NAME}"
-	mount -t ext4 "/dev/${DEVICE_NAME}1" "/mnt/lima-${DISK_NAME}"
+	mount -t $FORMAT_FSTYPE "/dev/${DEVICE_NAME}1" "/mnt/lima-${DISK_NAME}"
 done

--- a/pkg/cidata/cidata.TEMPLATE.d/lima.env
+++ b/pkg/cidata/cidata.TEMPLATE.d/lima.env
@@ -11,6 +11,8 @@ LIMA_CIDATA_DISKS={{ len .Disks }}
 {{- range $i, $disk := .Disks}}
 LIMA_CIDATA_DISK_{{$i}}_NAME={{$disk.Name}}
 LIMA_CIDATA_DISK_{{$i}}_DEVICE={{$disk.Device}}
+LIMA_CIDATA_DISK_{{$i}}_FORMAT={{$disk.Format}}
+LIMA_CIDATA_DISK_{{$i}}_FSTYPE={{$disk.FSType}}
 {{- end}}
 LIMA_CIDATA_GUEST_INSTALL_PREFIX={{ .GuestInstallPrefix }}
 {{- if .Containerd.User}}

--- a/pkg/cidata/cidata.TEMPLATE.d/lima.env
+++ b/pkg/cidata/cidata.TEMPLATE.d/lima.env
@@ -13,6 +13,7 @@ LIMA_CIDATA_DISK_{{$i}}_NAME={{$disk.Name}}
 LIMA_CIDATA_DISK_{{$i}}_DEVICE={{$disk.Device}}
 LIMA_CIDATA_DISK_{{$i}}_FORMAT={{$disk.Format}}
 LIMA_CIDATA_DISK_{{$i}}_FSTYPE={{$disk.FSType}}
+LIMA_CIDATA_DISK_{{$i}}_FSARGS={{range $j, $arg := $disk.FSArgs}}{{if $j}} {{end}}{{$arg}}{{end}}
 {{- end}}
 LIMA_CIDATA_GUEST_INSTALL_PREFIX={{ .GuestInstallPrefix }}
 {{- if .Containerd.User}}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -204,9 +204,19 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 	}
 
 	for i, d := range y.AdditionalDisks {
+		format := true
+		if d.Format != nil {
+			format = *d.Format
+		}
+		fstype := ""
+		if d.FSType != nil {
+			fstype = *d.FSType
+		}
 		args.Disks = append(args.Disks, Disk{
 			Name:   d.Name,
 			Device: diskDeviceNameFromOrder(i),
+			Format: format,
+			FSType: fstype,
 		})
 	}
 

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -203,9 +203,9 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 		args.MountType = "virtiofs"
 	}
 
-	for i, disk := range y.AdditionalDisks {
+	for i, d := range y.AdditionalDisks {
 		args.Disks = append(args.Disks, Disk{
-			Name:   disk,
+			Name:   d.Name,
 			Device: diskDeviceNameFromOrder(i),
 		})
 	}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -217,6 +217,7 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 			Device: diskDeviceNameFromOrder(i),
 			Format: format,
 			FSType: fstype,
+			FSArgs: d.FSArgs,
 		})
 	}
 

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -50,6 +50,7 @@ type Disk struct {
 	Device string
 	Format bool
 	FSType string
+	FSArgs []string
 }
 type TemplateArgs struct {
 	Name                            string // instance name

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -48,6 +48,8 @@ type BootCmds struct {
 type Disk struct {
 	Name   string
 	Device string
+	Format bool
+	FSType string
 }
 type TemplateArgs struct {
 	Name                            string // instance name

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -436,7 +436,7 @@ sudo chown -R "${USER}" /run/host-services`
 		a.onClose = append(a.onClose, func() error {
 			var unlockMErr error
 			for _, d := range a.y.AdditionalDisks {
-				disk, inspectErr := store.InspectDisk(d)
+				disk, inspectErr := store.InspectDisk(d.Name)
 				if inspectErr != nil {
 					unlockMErr = multierror.Append(unlockMErr, inspectErr)
 					continue

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -277,7 +277,7 @@ func TestFillDefault(t *testing.T) {
 		Memory: pointer.String("5GiB"),
 		Disk:   pointer.String("105GiB"),
 		AdditionalDisks: []Disk{
-			"data",
+			{Name: "data"},
 		},
 		GuestInstallPrefix: pointer.String("/opt"),
 		Containerd: Containerd{
@@ -413,7 +413,7 @@ func TestFillDefault(t *testing.T) {
 
 	y = filledDefaults
 	y.DNS = []net.IP{net.ParseIP("8.8.8.8")}
-	y.AdditionalDisks = []Disk{"overridden"}
+	y.AdditionalDisks = []Disk{{Name: "overridden"}}
 
 	expect = y
 
@@ -454,7 +454,7 @@ func TestFillDefault(t *testing.T) {
 		Memory: pointer.String("7GiB"),
 		Disk:   pointer.String("117GiB"),
 		AdditionalDisks: []Disk{
-			"test",
+			{Name: "test"},
 		},
 		GuestInstallPrefix: pointer.String("/usr"),
 		Containerd: Containerd{

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -80,9 +80,10 @@ type Image struct {
 }
 
 type Disk struct {
-	Name   string  `yaml:"name" json:"name"` // REQUIRED
-	Format *bool   `yaml:"format,omitempty" json:"format,omitempty"`
-	FSType *string `yaml:"fsType,omitempty" json:"fsType,omitempty"`
+	Name   string   `yaml:"name" json:"name"` // REQUIRED
+	Format *bool    `yaml:"format,omitempty" json:"format,omitempty"`
+	FSType *string  `yaml:"fsType,omitempty" json:"fsType,omitempty"`
+	FSArgs []string `yaml:"fsArgs,omitempty" json:"fsArgs,omitempty"`
 }
 
 type Mount struct {

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -79,7 +79,9 @@ type Image struct {
 	Initrd *File   `yaml:"initrd,omitempty" json:"initrd,omitempty"`
 }
 
-type Disk = string
+type Disk struct {
+	Name string `yaml:"name" json:"name"` // REQUIRED
+}
 
 type Mount struct {
 	Location   string   `yaml:"location" json:"location"` // REQUIRED

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -80,7 +80,9 @@ type Image struct {
 }
 
 type Disk struct {
-	Name string `yaml:"name" json:"name"` // REQUIRED
+	Name   string  `yaml:"name" json:"name"` // REQUIRED
+	Format *bool   `yaml:"format,omitempty" json:"format,omitempty"`
+	FSType *string `yaml:"fsType,omitempty" json:"fsType,omitempty"`
 }
 
 type Mount struct {

--- a/pkg/limayaml/load_test.go
+++ b/pkg/limayaml/load_test.go
@@ -42,6 +42,7 @@ additionalDisks:
 	assert.Equal(t, y.AdditionalDisks[0].Name, "name")
 	assert.Assert(t, y.AdditionalDisks[0].Format == nil)
 	assert.Assert(t, y.AdditionalDisks[0].FSType == nil)
+	assert.Assert(t, y.AdditionalDisks[0].FSArgs == nil)
 }
 
 func TestLoadDiskStruct(t *testing.T) {
@@ -50,6 +51,7 @@ additionalDisks:
 - name: "name"
   format: false
   fsType: "xfs"
+  fsArgs: ["-i","size=512"]
 `
 	y, err := Load([]byte(s), "disk.yaml")
 	assert.NilError(t, err)
@@ -59,4 +61,7 @@ additionalDisks:
 	assert.Equal(t, *y.AdditionalDisks[0].Format, false)
 	assert.Assert(t, y.AdditionalDisks[0].FSType != nil)
 	assert.Equal(t, *y.AdditionalDisks[0].FSType, "xfs")
+	assert.Assert(t, len(y.AdditionalDisks[0].FSArgs) == 2)
+	assert.Equal(t, y.AdditionalDisks[0].FSArgs[0], "-i")
+	assert.Equal(t, y.AdditionalDisks[0].FSArgs[1], "size=512")
 }

--- a/pkg/limayaml/load_test.go
+++ b/pkg/limayaml/load_test.go
@@ -40,15 +40,23 @@ additionalDisks:
 	assert.NilError(t, err)
 	assert.Equal(t, len(y.AdditionalDisks), 1)
 	assert.Equal(t, y.AdditionalDisks[0].Name, "name")
+	assert.Assert(t, y.AdditionalDisks[0].Format == nil)
+	assert.Assert(t, y.AdditionalDisks[0].FSType == nil)
 }
 
 func TestLoadDiskStruct(t *testing.T) {
 	s := `
 additionalDisks:
 - name: "name"
+  format: false
+  fsType: "xfs"
 `
 	y, err := Load([]byte(s), "disk.yaml")
 	assert.NilError(t, err)
 	assert.Assert(t, len(y.AdditionalDisks) == 1)
 	assert.Equal(t, y.AdditionalDisks[0].Name, "name")
+	assert.Assert(t, y.AdditionalDisks[0].Format != nil)
+	assert.Equal(t, *y.AdditionalDisks[0].Format, false)
+	assert.Assert(t, y.AdditionalDisks[0].FSType != nil)
+	assert.Equal(t, *y.AdditionalDisks[0].FSType, "xfs")
 }

--- a/pkg/limayaml/load_test.go
+++ b/pkg/limayaml/load_test.go
@@ -30,3 +30,25 @@ provision:
 	_, err := Load([]byte(s), "error.yaml")
 	assert.ErrorContains(t, err, "failed to unmarshal YAML")
 }
+
+func TestLoadDiskString(t *testing.T) {
+	s := `
+additionalDisks:
+- name
+`
+	y, err := Load([]byte(s), "disk.yaml")
+	assert.NilError(t, err)
+	assert.Equal(t, len(y.AdditionalDisks), 1)
+	assert.Equal(t, y.AdditionalDisks[0].Name, "name")
+}
+
+func TestLoadDiskStruct(t *testing.T) {
+	s := `
+additionalDisks:
+- name: "name"
+`
+	y, err := Load([]byte(s), "disk.yaml")
+	assert.NilError(t, err)
+	assert.Assert(t, len(y.AdditionalDisks) == 1)
+	assert.Equal(t, y.AdditionalDisks[0].Name, "name")
+}

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -587,24 +587,25 @@ func Cmdline(cfg Config) (string, []string, error) {
 	diffDisk := filepath.Join(cfg.InstanceDir, filenames.DiffDisk)
 	extraDisks := []string{}
 	if len(y.AdditionalDisks) > 0 {
-		for _, diskName := range y.AdditionalDisks {
-			d, err := store.InspectDisk(diskName)
+		for _, d := range y.AdditionalDisks {
+			diskName := d.Name
+			disk, err := store.InspectDisk(diskName)
 			if err != nil {
 				logrus.Errorf("could not load disk %q: %q", diskName, err)
 				return "", nil, err
 			}
 
-			if d.Instance != "" {
-				logrus.Errorf("could not attach disk %q, in use by instance %q", diskName, d.Instance)
+			if disk.Instance != "" {
+				logrus.Errorf("could not attach disk %q, in use by instance %q", diskName, disk.Instance)
 				return "", nil, err
 			}
-			logrus.Infof("Mounting disk %q on %q", diskName, d.MountPoint)
-			err = d.Lock(cfg.InstanceDir)
+			logrus.Infof("Mounting disk %q on %q", diskName, disk.MountPoint)
+			err = disk.Lock(cfg.InstanceDir)
 			if err != nil {
 				logrus.Errorf("could not lock disk %q: %q", diskName, err)
 				return "", nil, err
 			}
-			dataDisk := filepath.Join(d.Dir, filenames.DataDisk)
+			dataDisk := filepath.Join(disk.Dir, filenames.DataDisk)
 			extraDisks = append(extraDisks, dataDisk)
 		}
 	}

--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -437,21 +437,22 @@ func attachDisks(driver *driver.BaseDriver, vmConfig *vz.VirtualMachineConfigura
 	}
 	configurations = append(configurations, diffDisk)
 
-	for _, diskName := range driver.Yaml.AdditionalDisks {
-		d, err := store.InspectDisk(diskName)
+	for _, d := range driver.Yaml.AdditionalDisks {
+		diskName := d.Name
+		disk, err := store.InspectDisk(diskName)
 		if err != nil {
 			return fmt.Errorf("failed to run load disk %q: %q", diskName, err)
 		}
 
-		if d.Instance != "" {
-			return fmt.Errorf("failed to run attach disk %q, in use by instance %q", diskName, d.Instance)
+		if disk.Instance != "" {
+			return fmt.Errorf("failed to run attach disk %q, in use by instance %q", diskName, disk.Instance)
 		}
-		logrus.Infof("Mounting disk %q on %q", diskName, d.MountPoint)
-		err = d.Lock(driver.Instance.Dir)
+		logrus.Infof("Mounting disk %q on %q", diskName, disk.MountPoint)
+		err = disk.Lock(driver.Instance.Dir)
 		if err != nil {
 			return fmt.Errorf("failed to run lock disk %q: %q", diskName, err)
 		}
-		extraDiskPath := filepath.Join(d.Dir, filenames.DataDisk)
+		extraDiskPath := filepath.Join(disk.Dir, filenames.DataDisk)
 		// ConvertToRaw is a NOP if no conversion is needed
 		logrus.Debugf("Converting extra disk %q to a raw disk (if it is not a raw)", extraDiskPath)
 		if err = nativeimgutil.ConvertToRaw(extraDiskPath, extraDiskPath, nil, true); err != nil {


### PR DESCRIPTION
Default to a simple string with name, just like before.

```yaml
additionalDisks:
- "disk"
```

But also allow skipping the partitioning and formatting.

```yaml
additionalDisks:
- name: "disk"
  format: true
  fsType: "ext4"
```

----

Example 1)

Like when running something like [ceph](https://ceph.io), which uses LVM.

It requires the entire disk device to be "raw", unformatted:

```yaml
additionalDisks:
- name: "disk"
  format: false
```

https://docs.ceph.com/en/latest/cephadm/install/

> A storage device is considered available if all of the following conditions are met:
>
> * The device must have no partitions.
> * The device must not have any LVM state.
> * The device must not be mounted.
> * The device must not contain a file system.
> * The device must not contain a Ceph BlueStore OSD.
> * The device must be larger than 5 GB.

Example 2)

Also allow using something else than "ext4", like "xfs".

Or for adding custom arguments, such as with [glusterfs](https://www.gluster.org/):

```yaml
additionalDisks:
- name: "disk"
  format: true
  fsType: "xfs"
  fsArgs: ["-i","size=512"]
```

https://docs.gluster.org/en/latest/Quick-Start-Guide/Quickstart/

> The inode size is set to 512 bytes to accommodate for the extended attributes used by GlusterFS.

-----

Closes #1393