### PR TITLE
Add audio device to limayaml and qemu

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -244,6 +244,12 @@ firmware:
   # 🟢 Builtin default: false
   legacyBIOS: null
 
+audio:
+  # QEMU audiodev, e.g., "none", "coreaudio", "pa", "alsa", "oss".
+  # Choosing "none" will mute the audio output, and not play any sound.
+  # 🟢 Builtin default: ""
+  device: null
+
 video:
   # QEMU display, e.g., "none", "cocoa", "sdl", "gtk", "vnc", "default".
   # Choosing "none" will hide the video output, and not show any window.

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -199,6 +199,16 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 
 	y.AdditionalDisks = append(append(o.AdditionalDisks, y.AdditionalDisks...), d.AdditionalDisks...)
 
+	if y.Audio.Device == nil {
+		y.Audio.Device = d.Audio.Device
+	}
+	if o.Audio.Device != nil {
+		y.Audio.Device = o.Audio.Device
+	}
+	if y.Audio.Device == nil {
+		y.Audio.Device = pointer.String("")
+	}
+
 	if y.Video.Display == nil {
 		y.Video.Display = d.Video.Display
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -77,6 +77,9 @@ func TestFillDefault(t *testing.T) {
 		Firmware: Firmware{
 			LegacyBIOS: pointer.Bool(false),
 		},
+		Audio: Audio{
+			Device: pointer.String(""),
+		},
 		Video: Video{
 			Display: pointer.String("none"),
 			VNC: VNCOptions{
@@ -281,6 +284,9 @@ func TestFillDefault(t *testing.T) {
 		Firmware: Firmware{
 			LegacyBIOS: pointer.Bool(true),
 		},
+		Audio: Audio{
+			Device: pointer.String("coreaudio"),
+		},
 		Video: Video{
 			Display: pointer.String("cocoa"),
 			VNC: VNCOptions{
@@ -448,6 +454,9 @@ func TestFillDefault(t *testing.T) {
 		},
 		Firmware: Firmware{
 			LegacyBIOS: pointer.Bool(true),
+		},
+		Audio: Audio{
+			Device: pointer.String("coreaudio"),
 		},
 		Video: Video{
 			Display: pointer.String("cocoa"),

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -19,6 +19,7 @@ type LimaYAML struct {
 	MountType       *MountType      `yaml:"mountType,omitempty" json:"mountType,omitempty"`
 	SSH             SSH             `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
 	Firmware        Firmware        `yaml:"firmware,omitempty" json:"firmware,omitempty"`
+	Audio           Audio           `yaml:"audio,omitempty" json:"audio,omitempty"`
 	Video           Video           `yaml:"video,omitempty" json:"video,omitempty"`
 	Provision       []Provision     `yaml:"provision,omitempty" json:"provision,omitempty"`
 	Containerd      Containerd      `yaml:"containerd,omitempty" json:"containerd,omitempty"`
@@ -120,6 +121,11 @@ type Firmware struct {
 	// LegacyBIOS disables UEFI if set.
 	// LegacyBIOS is ignored for aarch64.
 	LegacyBIOS *bool `yaml:"legacyBIOS,omitempty" json:"legacyBIOS,omitempty"`
+}
+
+type Audio struct {
+	// Device is a QEMU audiodev string
+	Device *string `yaml:"device,omitempty" json:"device,omitempty"`
 }
 
 type VNCOptions struct {


### PR DESCRIPTION
Tested with `mikmod` and https://modarchive.org/, seems to work fine (used ALSA)

Only tricky part was that the kernel module was in `linux-modules-extra`, then `alsa`


```console
anders@lima-default:~$ sudo aplay -l
**** List of PLAYBACK Hardware Devices ****
card 0: Intel [HDA Intel], device 0: Generic Analog [Generic Analog]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
```

Closes #1526