### PR TITLE
Support audio device for vz driver

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -246,6 +246,7 @@ firmware:
 
 audio:
   # QEMU audiodev, e.g., "none", "coreaudio", "pa", "alsa", "oss".
+  # VZ driver, use "vz" as device name
   # Choosing "none" will mute the audio output, and not play any sound.
   # 🟢 Builtin default: ""
   device: null

--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -158,6 +158,10 @@ func createVM(driver *driver.BaseDriver) (*vz.VirtualMachine, error) {
 		return nil, err
 	}
 
+	if err = attachAudio(driver, vmConfig); err != nil {
+		return nil, err
+	}
+
 	if err = attachOtherDevices(driver, vmConfig); err != nil {
 		return nil, err
 	}
@@ -552,6 +556,28 @@ func attachFolderMounts(driver *driver.BaseDriver, vmConfig *vz.VirtualMachineCo
 
 	if len(mounts) > 0 {
 		vmConfig.SetDirectorySharingDevicesVirtualMachineConfiguration(mounts)
+	}
+	return nil
+}
+
+func attachAudio(driver *driver.BaseDriver, config *vz.VirtualMachineConfiguration) error {
+	if *driver.Yaml.Audio.Device == "vz" {
+		outputStream, err := vz.NewVirtioSoundDeviceHostOutputStreamConfiguration()
+		if err != nil {
+			return err
+		}
+		inputStream, err := vz.NewVirtioSoundDeviceHostInputStreamConfiguration()
+		if err != nil {
+			return err
+		}
+		soundDeviceConfiguration, err := vz.NewVirtioSoundDeviceConfiguration()
+		if err != nil {
+			return err
+		}
+		soundDeviceConfiguration.SetStreams(outputStream, inputStream)
+		config.SetAudioDevicesVirtualMachineConfiguration([]vz.AudioDeviceConfiguration{
+			soundDeviceConfiguration,
+		})
 	}
 	return nil
 }

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -65,6 +65,7 @@ func (l *LimaVzDriver) Validate() error {
 		"CACertificates",
 		"Rosetta",
 		"AdditionalDisks",
+		"Audio",
 	); len(unknown) > 0 {
 		logrus.Warnf("Ignoring: vmType %s: %+v", *l.Yaml.VMType, unknown)
 	}
@@ -95,6 +96,11 @@ func (l *LimaVzDriver) Validate() error {
 		); len(unknown) > 0 {
 			logrus.Warnf("Ignoring: vmType %s: networks[%d]: %+v", *l.Yaml.VMType, i, unknown)
 		}
+	}
+
+	audioDevice := *l.Yaml.Audio.Device
+	if audioDevice != "" && audioDevice != "vz" {
+		logrus.Warnf("field `audio.device` must be %q for VZ driver , got %q", "vz", audioDevice)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #1531 

Had to do some setup to configure audio. Steps are as follows,
- Install `linux-image-extra-virtual` to enable virtio-snd
- Restart the VM
- Run `aplay -l` to verify if device is shown
- Install `alsa-utils`
- Run `usermod -a -G audio <user>`
- Restart the vm
- Run `nano ~/.asoundrc and add the following
```
pcm.!default {
        type hw
        card 1
}

ctl.!default {
        type hw
        card 1
}
```
- Run `speaker-test -t wav` and verify audio working

_Note: These are the steps worked for me, there might be some simplified steps to configure as well._ 