### PR TITLE
templates: use yq's indentation style

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,21 +25,21 @@ task:
       EXAMPLE: opensuse.yaml
       EXAMPLE: experimental/net-user-v2.yaml
   info_script:
-  - uname -a
-  - df -T
-  - ls -l /dev/kvm
-  - cat /proc/cpuinfo
+    - uname -a
+    - df -T
+    - ls -l /dev/kvm
+    - cat /proc/cpuinfo
   install_deps_script:
-  - apt-get update
-  - apt-get install -y --no-install-recommends ca-certificates curl git golang jq openssh-client make netcat ovmf sudo qemu-system-x86 qemu-utils
+    - apt-get update
+    - apt-get install -y --no-install-recommends ca-certificates curl git golang jq openssh-client make netcat ovmf sudo qemu-system-x86 qemu-utils
   go_cache:
     fingerprint_script: uname -s ; cat go.sum
     folder: $GOPATH/pkg/mod
   build_script: make
   install_script: make install
   prepare_user_script:
-  - groupadd -g $(stat -c '%g' /dev/kvm) kvm
-  - useradd -m -G kvm testuser
+    - groupadd -g $(stat -c '%g' /dev/kvm) kvm
+    - useradd -m -G kvm testuser
   lima_cache:
     fingerprint_script: uname -s ; cat examples/$EXAMPLE
     folder: /home/testuser/.cache/lima

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Report a potential bug
 body:
-- type: textarea
-  attributes:
-    label: Description
-    description: Please make sure to include the version of Lima and the host OS
+  - type: textarea
+    attributes:
+      label: Description
+      description: Please make sure to include the version of Lima and the host OS

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-- name: Ask a question (GitHub Discussions)
-  url: https://github.com/lima-vm/lima/discussions
-  about: We use GitHub Discussions for questions, GitHub issues for tracking bug reports and feature requests
-- name: Chat with Lima users and developers
-  url: https://slack.cncf.io/
-  about: CNCF slack has `#lima` channel
+  - name: Ask a question (GitHub Discussions)
+    url: https://github.com/lima-vm/lima/discussions
+    about: We use GitHub Discussions for questions, GitHub issues for tracking bug reports and feature requests
+  - name: Chat with Lima users and developers
+    url: https://slack.cncf.io/
+    about: CNCF slack has `#lima` channel

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Request a feature
 body:
-- type: textarea
-  attributes:
-    label: Description
+  - type: textarea
+    attributes:
+      label: Description

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,16 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  reviewers:
-  - AkihiroSuda
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  reviewers:
-  - AkihiroSuda
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - AkihiroSuda
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - AkihiroSuda

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,12 @@ name: Release
 on:
   push:
     branches:
-    - 'master'
+      - 'master'
     tags:
-    - 'v*'
+      - 'v*'
   pull_request:
     branches:
-    - 'master'
+      - 'master'
 env:
   GO111MODULE: on
 jobs:
@@ -19,84 +19,84 @@ jobs:
     runs-on: macos-12
     timeout-minutes: 20
     steps:
-    - name: "Switch Xcode version to enable macOS 13 SDK"
-      # Xcode 14.1 added support for macOS 13 SDK.
-      # The default version is still 14.0.1, as of November 2022.
-      # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
-      run: |
-        sudo xcode-select --switch /Applications/Xcode_14.1.app
-        xcrun --show-sdk-version
-    - uses: actions/setup-go@v4
-      with:
-        go-version: 1.20.x
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 1
-    - name: Make darwin artifacts
-      run: make artifacts-darwin
-    - name: "Upload artifacts"
-      uses: actions/upload-artifact@v3
-      with:
-        name: artifacts-darwin
-        path: _artifacts/
+      - name: "Switch Xcode version to enable macOS 13 SDK"
+        # Xcode 14.1 added support for macOS 13 SDK.
+        # The default version is still 14.0.1, as of November 2022.
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
+        run: |
+          sudo xcode-select --switch /Applications/Xcode_14.1.app
+          xcrun --show-sdk-version
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.x
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Make darwin artifacts
+        run: make artifacts-darwin
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts-darwin
+          path: _artifacts/
   release:
     runs-on: ubuntu-22.04
     needs: artifacts-darwin
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v3
-      with:
-        name: artifacts-darwin
-        path: _artifacts/
-    - uses: actions/setup-go@v4
-      with:
-        go-version: 1.20.x
-    - name: Install gcc-aarch64-linux-gnu
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y gcc-aarch64-linux-gnu
-    - name: "Compile binaries"
-      run: make artifacts-linux
-    - name: "Make misc artifacts"
-      run: make artifacts-misc
-    - name: "SHA256SUMS"
-      run: |
-        ( cd _artifacts; sha256sum *.tar.gz ) | tee /tmp/SHA256SUMS
-        mv /tmp/SHA256SUMS _artifacts/SHA256SUMS
-    - name: "The sha256sum of the SHA256SUMS file"
-      run: (cd _artifacts; sha256sum SHA256SUMS)
-    - name: "Prepare the release note"
-      run: |
-        tag="${GITHUB_REF##*/}"
-        shasha=$(sha256sum _artifacts/SHA256SUMS | awk '{print $1}')
-        cat <<-EOF | tee /tmp/release-note.txt
-        ${tag}
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifacts-darwin
+          path: _artifacts/
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.x
+      - name: Install gcc-aarch64-linux-gnu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+      - name: "Compile binaries"
+        run: make artifacts-linux
+      - name: "Make misc artifacts"
+        run: make artifacts-misc
+      - name: "SHA256SUMS"
+        run: |
+          ( cd _artifacts; sha256sum *.tar.gz ) | tee /tmp/SHA256SUMS
+          mv /tmp/SHA256SUMS _artifacts/SHA256SUMS
+      - name: "The sha256sum of the SHA256SUMS file"
+        run: (cd _artifacts; sha256sum SHA256SUMS)
+      - name: "Prepare the release note"
+        run: |
+          tag="${GITHUB_REF##*/}"
+          shasha=$(sha256sum _artifacts/SHA256SUMS | awk '{print $1}')
+          cat <<-EOF | tee /tmp/release-note.txt
+          ${tag}
 
-        (Changes to be documented)
+          (Changes to be documented)
 
-        ## Usage
-        \`\`\`console
-        [macOS]$ limactl start
-        ...
-        INFO[0029] READY. Run \`lima\` to open the shell.
+          ## Usage
+          \`\`\`console
+          [macOS]$ limactl start
+          ...
+          INFO[0029] READY. Run \`lima\` to open the shell.
 
-        [macOS]$ lima uname
-        Linux
-        \`\`\`
+          [macOS]$ lima uname
+          Linux
+          \`\`\`
 
-        - - -
-        The binaries were built automatically on GitHub Actions.
-        The build log is available for 90 days: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          - - -
+          The binaries were built automatically on GitHub Actions.
+          The build log is available for 90 days: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-        The sha256sum of the SHA256SUMS file itself is \`${shasha}\` .
-        EOF
-    - name: "Create release"
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        tag="${GITHUB_REF##*/}"
-        asset_flags=()
-        for f in _artifacts/*; do asset_flags+=("-a" "$f"); done
-        hub release create "${asset_flags[@]}" -F /tmp/release-note.txt --draft "${tag}"
+          The sha256sum of the SHA256SUMS file itself is \`${shasha}\` .
+          EOF
+      - name: "Create release"
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF##*/}"
+          asset_flags=()
+          for f in _artifacts/*; do asset_flags+=("-a" "$f"); done
+          hub release create "${asset_flags[@]}" -F /tmp/release-note.txt --draft "${tag}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,211 +1,205 @@
 name: test
-
 on:
   push:
     branches:
-    - master
-    - 'release/**'
+      - master
+      - 'release/**'
   pull_request:
-
 jobs:
   basic:
     name: "Lints & Unit tests"
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
-    - uses: actions/setup-go@v4
-      with:
-        go-version: 1.20.x
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 1
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v3.4.0
-      with:
-        version: v1.51.1
-        args: --verbose
-    - name: Run yamllint
-      run: yamllint .
-    - name: Install shellcheck
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y shellcheck
-    - name: Run shellcheck
-      run: find . -name '*.sh' | xargs shellcheck
-    - name: Install shfmt
-      run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.4.3
-    - name: Run shfmt
-      run: find . -name '*.sh' | xargs shfmt -s -d
-    - name: Check hyperlinks
-      uses: docker://dkhamsing/awesome_bot:latest
-      with:
-        args: /github/workspace/README.md --allow-dupe --allow-redirect --request-delay 1 --white-list https://img.shields.io,http://127.0.0.1:8080,https://github.com/lima-vm/lima/releases/download,https://xbarapp.com,https://api.github.com
-    - name: Unit tests
-      run: go test -v ./...
-    - name: Make
-      run: make
-    - name: Install
-      run: sudo make install
-    - name: Uninstall
-      run: sudo make uninstall
-
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.x
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3.4.0
+        with:
+          version: v1.51.1
+          args: --verbose
+      - name: Run yamllint
+        run: yamllint .
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+      - name: Run shellcheck
+        run: find . -name '*.sh' | xargs shellcheck
+      - name: Install shfmt
+        run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.4.3
+      - name: Run shfmt
+        run: find . -name '*.sh' | xargs shfmt -s -d
+      - name: Check hyperlinks
+        uses: docker://dkhamsing/awesome_bot:latest
+        with:
+          args: /github/workspace/README.md --allow-dupe --allow-redirect --request-delay 1 --white-list https://img.shields.io,http://127.0.0.1:8080,https://github.com/lima-vm/lima/releases/download,https://xbarapp.com,https://api.github.com
+      - name: Unit tests
+        run: go test -v ./...
+      - name: Make
+        run: make
+      - name: Install
+        run: sudo make install
+      - name: Uninstall
+        run: sudo make uninstall
   cross-windows:
     name: "Windows tests (cross)"
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
-    - uses: actions/setup-go@v4
-      with:
-        go-version: 1.20.x
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 1
-    - name: Install wine
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y wine-binfmt wine64
-        sudo apt-get remove -y mono-runtime || true
-    - name: Unit tests
-      run: GOOS=windows GOARCH=amd64 go test -v ./...
-    - name: Make
-      run: make GOOS=windows GOARCH=amd64
-
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.x
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Install wine
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wine-binfmt wine64
+          sudo apt-get remove -y mono-runtime || true
+      - name: Unit tests
+        run: GOOS=windows GOARCH=amd64 go test -v ./...
+      - name: Make
+        run: make GOOS=windows GOARCH=amd64
   integration:
     name: Integration tests
     runs-on: macos-12
     timeout-minutes: 120
     steps:
-    - uses: actions/setup-go@v4
-      with:
-        go-version: 1.20.x
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 1
-    - name: Unit tests
-      run: go test -v ./...
-    - name: Make
-      run: make
-    - name: Install
-      run: make install
-    - name: Validate examples
-      run: find examples -name '*.yaml' | xargs limactl validate
-    - name: Install test dependencies
-      # QEMU:      required by Lima itself
-      # bash:      required by test-example.sh (OS version of bash is too old)
-      # coreutils: required by test-example.sh for the "timeout" command
-      # curl:      required by test-example.sh to download nerdctl for alpine
-      # jq:        required by test-example.sh to determine download URL for nerdctl
-      run: |
-        set -x
-        # Github runners seem to have lima installed by brew already; we don't want/need it
-        time brew uninstall --ignore-dependencies lima colima
-        time brew install qemu bash coreutils curl jq
-    - name: Cache ~/Library/Caches/lima/download
-      uses: actions/cache@v3
-      with:
-        path: ~/Library/Caches/lima/download
-        key: ${{ runner.os }}-integration
-    - name: "Test default.yaml"
-      uses: nick-invision/retry@v2
-      with:
-        timeout_minutes: 30
-        retry_on: error
-        max_attempts: 3
-        command: ./hack/test-example.sh examples/default.yaml
-    - name: "Test alpine.yaml"
-      uses: nick-invision/retry@v2
-      with:
-        timeout_minutes: 30
-        retry_on: error
-        max_attempts: 3
-        command: ./hack/test-example.sh examples/alpine.yaml
-    - name: "Test experimental/9p.yaml"
-      uses: nick-invision/retry@v2
-      with:
-        timeout_minutes: 30
-        retry_on: error
-        max_attempts: 3
-        command: ./hack/test-example.sh examples/experimental/9p.yaml
-    - name: "Test test-misc.yaml"
-      uses: nick-invision/retry@v2
-      with:
-        timeout_minutes: 30
-        retry_on: error
-        max_attempts: 3
-        command: ./hack/test-example.sh hack/test-templates/test-misc.yaml
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.x
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Unit tests
+        run: go test -v ./...
+      - name: Make
+        run: make
+      - name: Install
+        run: make install
+      - name: Validate examples
+        run: find examples -name '*.yaml' | xargs limactl validate
+      - name: Install test dependencies
+        # QEMU:      required by Lima itself
+        # bash:      required by test-example.sh (OS version of bash is too old)
+        # coreutils: required by test-example.sh for the "timeout" command
+        # curl:      required by test-example.sh to download nerdctl for alpine
+        # jq:        required by test-example.sh to determine download URL for nerdctl
+        run: |
+          set -x
+          # Github runners seem to have lima installed by brew already; we don't want/need it
+          time brew uninstall --ignore-dependencies lima colima
+          time brew install qemu bash coreutils curl jq
+      - name: Cache ~/Library/Caches/lima/download
+        uses: actions/cache@v3
+        with:
+          path: ~/Library/Caches/lima/download
+          key: ${{ runner.os }}-integration
+      - name: "Test default.yaml"
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 30
+          retry_on: error
+          max_attempts: 3
+          command: ./hack/test-example.sh examples/default.yaml
+      - name: "Test alpine.yaml"
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 30
+          retry_on: error
+          max_attempts: 3
+          command: ./hack/test-example.sh examples/alpine.yaml
+      - name: "Test experimental/9p.yaml"
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 30
+          retry_on: error
+          max_attempts: 3
+          command: ./hack/test-example.sh examples/experimental/9p.yaml
+      - name: "Test test-misc.yaml"
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 30
+          retry_on: error
+          max_attempts: 3
+          command: ./hack/test-example.sh hack/test-templates/test-misc.yaml
     # GHA macOS is slow and flaky, so we only test a few YAMLS here.
     # Other yamls are tested on Linux instances of Cirrus.
-
   vmnet:
     name: "VMNet test"
     runs-on: macos-11
     timeout-minutes: 120
     steps:
-    - uses: actions/setup-go@v4
-      with:
-        go-version: 1.20.x
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 1
-    - name: Make
-      run: make
-    - name: Install
-      run: make install
-    - name: Install test dependencies
-      run: brew install qemu bash coreutils iperf3
-    - name: Cache ~/Library/Caches/lima/download
-      uses: actions/cache@v3
-      with:
-        path: ~/Library/Caches/lima/download
-        key: ${{ runner.os }}-vmnet
-    - name: Install vde_switch and vde_vmnet (Deprecated)
-      env:
-        VDE_VMNET_VERSION: v0.6.0
-      run: |
-        (
-          brew install autoconf automake
-          cd ~
-          git clone https://github.com/lima-vm/vde_vmnet
-          cd vde_vmnet
-          git checkout $VDE_VMNET_VERSION
-          sudo git config --global --add safe.directory /Users/runner/vde_vmnet
-          sudo make PREFIX=/opt/vde install
-        )
-        limactl sudoers | sudo tee /etc/sudoers.d/lima
-    - name: Unit test (pkg/networks) with vde_vmnet (Deprecated)
-      # Set -count=1 to disable cache
-      run: go test -v -count=1 ./pkg/networks/...
-    - name: Test vde_vmnet (Deprecated)
-      uses: nick-invision/retry@v2
-      with:
-        timeout_minutes: 30
-        retry_on: error
-        max_attempts: 3
-        command: ./hack/test-example.sh examples/vmnet.yaml
-    - name: Install socket_vmnet
-      env:
-        SOCKET_VMNET_VERSION: v1.1.1
-      run: |
-        (
-          cd ~
-          git clone https://github.com/lima-vm/socket_vmnet
-          cd socket_vmnet
-          git checkout $SOCKET_VMNET_VERSION
-          sudo git config --global --add safe.directory /Users/runner/socket_vmnet
-          sudo make PREFIX=/opt/socket_vmnet install
-        )
-        limactl sudoers | sudo tee /etc/sudoers.d/lima
-    - name: Unit test (pkg/networks) with socket_vmnet
-      # Set -count=1 to disable cache
-      run: go test -v -count=1 ./pkg/networks/...
-    - name: Test socket_vmnet
-      uses: nick-invision/retry@v2
-      with:
-        timeout_minutes: 30
-        retry_on: error
-        max_attempts: 3
-        command: ./hack/test-example.sh examples/vmnet.yaml
-
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.x
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Make
+        run: make
+      - name: Install
+        run: make install
+      - name: Install test dependencies
+        run: brew install qemu bash coreutils iperf3
+      - name: Cache ~/Library/Caches/lima/download
+        uses: actions/cache@v3
+        with:
+          path: ~/Library/Caches/lima/download
+          key: ${{ runner.os }}-vmnet
+      - name: Install vde_switch and vde_vmnet (Deprecated)
+        env:
+          VDE_VMNET_VERSION: v0.6.0
+        run: |
+          (
+            brew install autoconf automake
+            cd ~
+            git clone https://github.com/lima-vm/vde_vmnet
+            cd vde_vmnet
+            git checkout $VDE_VMNET_VERSION
+            sudo git config --global --add safe.directory /Users/runner/vde_vmnet
+            sudo make PREFIX=/opt/vde install
+          )
+          limactl sudoers | sudo tee /etc/sudoers.d/lima
+      - name: Unit test (pkg/networks) with vde_vmnet (Deprecated)
+        # Set -count=1 to disable cache
+        run: go test -v -count=1 ./pkg/networks/...
+      - name: Test vde_vmnet (Deprecated)
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 30
+          retry_on: error
+          max_attempts: 3
+          command: ./hack/test-example.sh examples/vmnet.yaml
+      - name: Install socket_vmnet
+        env:
+          SOCKET_VMNET_VERSION: v1.1.1
+        run: |
+          (
+            cd ~
+            git clone https://github.com/lima-vm/socket_vmnet
+            cd socket_vmnet
+            git checkout $SOCKET_VMNET_VERSION
+            sudo git config --global --add safe.directory /Users/runner/socket_vmnet
+            sudo make PREFIX=/opt/socket_vmnet install
+          )
+          limactl sudoers | sudo tee /etc/sudoers.d/lima
+      - name: Unit test (pkg/networks) with socket_vmnet
+        # Set -count=1 to disable cache
+        run: go test -v -count=1 ./pkg/networks/...
+      - name: Test socket_vmnet
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 30
+          retry_on: error
+          max_attempts: 3
+          command: ./hack/test-example.sh examples/vmnet.yaml
   upgrade:
     name: "Upgrade test"
     runs-on: macos-12
@@ -214,23 +208,23 @@ jobs:
       matrix:
         oldver: ["v0.10.0"]
     steps:
-    - uses: actions/setup-go@v4
-      with:
-        go-version: 1.20.x
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Install test dependencies
-      run: brew install qemu bash coreutils
-    - name: Cache ~/Library/Caches/lima/download
-      uses: actions/cache@v3
-      with:
-        path: ~/Library/Caches/lima/download
-        key: ${{ runner.os }}-upgrade-${{ matrix.oldver }}
-    - name: Test
-      uses: nick-invision/retry@v2
-      with:
-        timeout_minutes: 30
-        retry_on: error
-        max_attempts: 3
-        command: ./hack/test-upgrade.sh ${{ matrix.oldver }} ${{ github.sha }}
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.x
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install test dependencies
+        run: brew install qemu bash coreutils
+      - name: Cache ~/Library/Caches/lima/download
+        uses: actions/cache@v3
+        with:
+          path: ~/Library/Caches/lima/download
+          key: ${{ runner.os }}-upgrade-${{ matrix.oldver }}
+      - name: Test
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 30
+          retry_on: error
+          max_attempts: 3
+          command: ./hack/test-upgrade.sh ${{ matrix.oldver }} ${{ github.sha }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,132 +22,132 @@ run:
 linters:
   disable-all: true
   enable:
-  - depguard
-  - gofmt
-  - goimports
-  - govet
-  - ineffassign
-  - misspell
-  - nakedret
-  # - prealloc
-  - typecheck
-  # - asciicheck
-  # - bodyclose
-  # - dogsled
-  # - dupl
-  # - errcheck
-  # - errorlint
-  # - exhaustive
-  # - exhaustivestruct
-  # - exportloopref
-  # - funlen
-  # - gci
-  # - gochecknoglobals
-  # - gochecknoinits
-  # - gocognit
-  # - goconst
-  # - gocritic
-  # - gocyclo
-  # - godot
-  # - godox
-  # - goerr113
-  # - gofumpt
-  # - goheader
-  # - golint
-  # - gomnd
-  # - gomodguard
-  # - goprintffuncname
-  # - gosec (gas)
-  # - gosimple (megacheck)
-  # - interfacer
-  # - lll
-  # - maligned
-  # - nestif
-  # - nlreturn
-  # - noctx
-  # - nolintlint
-  # - rowserrcheck
-  # - scopelint
-  # - sqlclosecheck
-  # - staticcheck
-  # - stylecheck
-  # - testpackage
-  # - tparallel
-  - revive
-  # - unconvert
-  # - unparam
-  - unused
-  # - whitespace
-  # - wrapcheck
-  # - wsl
+    - depguard
+    - gofmt
+    - goimports
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    # - prealloc
+    - typecheck
+    # - asciicheck
+    # - bodyclose
+    # - dogsled
+    # - dupl
+    # - errcheck
+    # - errorlint
+    # - exhaustive
+    # - exhaustivestruct
+    # - exportloopref
+    # - funlen
+    # - gci
+    # - gochecknoglobals
+    # - gochecknoinits
+    # - gocognit
+    # - goconst
+    # - gocritic
+    # - gocyclo
+    # - godot
+    # - godox
+    # - goerr113
+    # - gofumpt
+    # - goheader
+    # - golint
+    # - gomnd
+    # - gomodguard
+    # - goprintffuncname
+    # - gosec (gas)
+    # - gosimple (megacheck)
+    # - interfacer
+    # - lll
+    # - maligned
+    # - nestif
+    # - nlreturn
+    # - noctx
+    # - nolintlint
+    # - rowserrcheck
+    # - scopelint
+    # - sqlclosecheck
+    # - staticcheck
+    # - stylecheck
+    # - testpackage
+    # - tparallel
+    - revive
+    # - unconvert
+    # - unparam
+    - unused
+    # - whitespace
+    # - wrapcheck
+    # - wsl
 linters-settings:
   gocritic:
     enabled-checks:
-    # Diagnostic
-    - appendAssign
-    - argOrder
-    - badCond
-    - caseOrder
-    - codegenComment
-    - commentedOutCode
-    - deprecatedComment
-    - dupArg
-    - dupBranchBody
-    - dupCase
-    - dupSubExpr
-    - exitAfterDefer
-    - flagDeref
-    - flagName
-    - nilValReturn
-    - offBy1
-    - sloppyReassign
-    - weakCond
-    - octalLiteral
+      # Diagnostic
+      - appendAssign
+      - argOrder
+      - badCond
+      - caseOrder
+      - codegenComment
+      - commentedOutCode
+      - deprecatedComment
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - dupSubExpr
+      - exitAfterDefer
+      - flagDeref
+      - flagName
+      - nilValReturn
+      - offBy1
+      - sloppyReassign
+      - weakCond
+      - octalLiteral
 
-    # Performance
-    - appendCombine
-    - equalFold
-    - hugeParam
-    - indexAlloc
-    - rangeExprCopy
-    - rangeValCopy
+      # Performance
+      - appendCombine
+      - equalFold
+      - hugeParam
+      - indexAlloc
+      - rangeExprCopy
+      - rangeValCopy
 
-    # Style
-    - assignOp
-    - boolExprSimplify
-    - captLocal
-    - commentFormatting
-    - commentedOutImport
-    - defaultCaseOrder
-    - docStub
-    - elseif
-    - emptyFallthrough
-    - emptyStringTest
-    - hexLiteral
-    - ifElseChain
-    - methodExprCall
-    - regexpMust
-    - singleCaseSwitch
-    - sloppyLen
-    - stringXbytes
-    - switchTrue
-    - typeAssertChain
-    - typeSwitchVar
-    - underef
-    - unlabelStmt
-    - unlambda
-    - unslice
-    - valSwap
-    - wrapperFunc
-    - yodaStyleExpr
+      # Style
+      - assignOp
+      - boolExprSimplify
+      - captLocal
+      - commentFormatting
+      - commentedOutImport
+      - defaultCaseOrder
+      - docStub
+      - elseif
+      - emptyFallthrough
+      - emptyStringTest
+      - hexLiteral
+      - ifElseChain
+      - methodExprCall
+      - regexpMust
+      - singleCaseSwitch
+      - sloppyLen
+      - stringXbytes
+      - switchTrue
+      - typeAssertChain
+      - typeSwitchVar
+      - underef
+      - unlabelStmt
+      - unlambda
+      - unslice
+      - valSwap
+      - wrapperFunc
+      - yodaStyleExpr
 
-    # Opinionated
-    - builtinShadow
-    - importShadow
-    - initClause
-    - nestingReduce
-    - paramTypeCombine
-    - ptrToRefParam
-    - typeUnparen
-    - unnamedResult
-    - unnecessaryBlock
+      # Opinionated
+      - builtinShadow
+      - importShadow
+      - initClause
+      - nestingReduce
+      - paramTypeCombine
+      - ptrToRefParam
+      - typeUnparen
+      - unnamedResult
+      - unnecessaryBlock

--- a/.yamllint
+++ b/.yamllint
@@ -3,8 +3,6 @@
 extends: default
 
 rules:
-  indentation:
-    indent-sequences: false
   truthy:
     allowed-values: ['true', 'false', 'on', 'off']
   comments-indentation: disable

--- a/docs/mount.md
+++ b/docs/mount.md
@@ -21,23 +21,23 @@ An example configuration:
 ```yaml
 mountType: "reverse-sshfs"
 mounts:
-- location: "~"
-  sshfs:
-    # Enabling the SSHFS cache will increase performance of the mounted filesystem, at
-    # the cost of potentially not reflecting changes made on the host in a timely manner.
-    # Warning: It looks like PHP filesystem access does not work correctly when
-    # the cache is disabled.
-    # 🟢 Builtin default: true
-    cache: null
-    # SSHFS has an optional flag called 'follow_symlinks'. This allows mounts
-    # to be properly resolved in the guest os and allow for access to the
-    # contents of the symlink. As a result, symlinked files & folders on the Host
-    # system will look and feel like regular files directories in the Guest OS.
-    # 🟢 Builtin default: false
-    followSymlinks: null
-    # SFTP driver, "builtin" or "openssh-sftp-server". "openssh-sftp-server" is recommended.
-    # 🟢 Builtin default: "openssh-sftp-server" if OpenSSH SFTP Server binary is found, otherwise "builtin"
-    sftpDriver: null
+  - location: "~"
+    sshfs:
+      # Enabling the SSHFS cache will increase performance of the mounted filesystem, at
+      # the cost of potentially not reflecting changes made on the host in a timely manner.
+      # Warning: It looks like PHP filesystem access does not work correctly when
+      # the cache is disabled.
+      # 🟢 Builtin default: true
+      cache: null
+      # SSHFS has an optional flag called 'follow_symlinks'. This allows mounts
+      # to be properly resolved in the guest os and allow for access to the
+      # contents of the symlink. As a result, symlinked files & folders on the Host
+      # system will look and feel like regular files directories in the Guest OS.
+      # 🟢 Builtin default: false
+      followSymlinks: null
+      # SFTP driver, "builtin" or "openssh-sftp-server". "openssh-sftp-server" is recommended.
+      # 🟢 Builtin default: "openssh-sftp-server" if OpenSSH SFTP Server binary is found, otherwise "builtin"
+      sftpDriver: null
 ```
 
 The default value of `sftpDriver` has been set to "openssh-sftp-server" since Lima v0.10, when an OpenSSH SFTP Server binary
@@ -59,23 +59,23 @@ An example configuration:
 ```yaml
 mountType: "9p"
 mounts:
-- location: "~"
-  9p:
-    # Supported security models are "passthrough", "mapped-xattr", "mapped-file" and "none".
-    # "mapped-xattr" and "mapped-file" are useful for persistent chown but incompatible with symlinks.
-    # 🟢 Builtin default: "none" (since Lima v0.13)
-    securityModel: null
-    # Select 9P protocol version. Valid options are: "9p2000" (legacy), "9p2000.u", "9p2000.L".
-    # 🟢 Builtin default: "9p2000.L"
-    protocolVersion: null
-    # The number of bytes to use for 9p packet payload, where 4KiB is the absolute minimum.
-    # 🟢 Builtin default: "128KiB"
-    msize: null
-    # Specifies a caching policy. Valid options are: "none", "loose", "fscache" and "mmap".
-    # Try choosing "mmap" or "none" if you see a stability issue with the default "fscache".
-    # See https://www.kernel.org/doc/Documentation/filesystems/9p.txt
-    # 🟢 Builtin default: "fscache" for non-writable mounts, "mmap" for writable mounts
-    cache: null
+  - location: "~"
+    9p:
+      # Supported security models are "passthrough", "mapped-xattr", "mapped-file" and "none".
+      # "mapped-xattr" and "mapped-file" are useful for persistent chown but incompatible with symlinks.
+      # 🟢 Builtin default: "none" (since Lima v0.13)
+      securityModel: null
+      # Select 9P protocol version. Valid options are: "9p2000" (legacy), "9p2000.u", "9p2000.L".
+      # 🟢 Builtin default: "9p2000.L"
+      protocolVersion: null
+      # The number of bytes to use for 9p packet payload, where 4KiB is the absolute minimum.
+      # 🟢 Builtin default: "128KiB"
+      msize: null
+      # Specifies a caching policy. Valid options are: "none", "loose", "fscache" and "mmap".
+      # Try choosing "mmap" or "none" if you see a stability issue with the default "fscache".
+      # See https://www.kernel.org/doc/Documentation/filesystems/9p.txt
+      # 🟢 Builtin default: "fscache" for non-writable mounts, "mmap" for writable mounts
+      cache: null
 ```
 
 The "9p" mount type requires Lima v0.10.0 or later.
@@ -98,7 +98,7 @@ An example configuration:
 vmType: "vz"
 mountType: "virtiofs"
 mounts:
-- location: "~"
+  - location: "~"
 ```
 
 #### Caveats

--- a/docs/network.md
+++ b/docs/network.md
@@ -90,10 +90,10 @@ settings:
 # None of the paths segments may be symlinks, why it has to be /private/var
 # instead of /var etc.
 paths:
-# socketVMNet requires Lima >= 0.12 .
-# socketVMNet has precedence over vdeVMNet.
+  # socketVMNet requires Lima >= 0.12 .
+  # socketVMNet has precedence over vdeVMNet.
   socketVMNet: /opt/socket_vmnet/bin/socket_vmnet
-# vdeSwitch and vdeVMNet are DEPRECATED.
+  # vdeSwitch and vdeVMNet are DEPRECATED.
   vdeSwitch: /opt/vde/bin/vde_switch
   vdeVMNet: /opt/vde/bin/vde_vmnet
   varRun: /private/var/run/lima
@@ -187,7 +187,7 @@ networks:
 For [VZ](./vmtype.md) instances, the "vzNAT" network can be configured as follows:
 ```yaml
 networks:
-- vzNAT: true
+  - vzNAT: true
 ```
 
 The range of the IP address is not specifiable.

--- a/docs/vmtype.md
+++ b/docs/vmtype.md
@@ -25,10 +25,10 @@ An example configuration:
 # Example to run ubuntu using vmType: vz instead of qemu (Default)
 vmType: "vz"
 images:
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
 mounts:
   - location: "~"
 mountType: "virtiofs"

--- a/examples/almalinux-8.yaml
+++ b/examples/almalinux-8.yaml
@@ -4,16 +4,16 @@
 # EL9-based distros are known to work.
 
 images:
-- location: "https://repo.almalinux.org/almalinux/8.7/cloud/x86_64/images/AlmaLinux-8-GenericCloud-UEFI-8.7-20221111.x86_64.qcow2"
-  arch: "x86_64"
-  digest: "sha256:6b1a852614e906c55b26f2a27056ab6cabf09f4d963e080bbd70e15da3c88733"
-- location: "https://repo.almalinux.org/almalinux/8.7/cloud/aarch64/images/AlmaLinux-8-GenericCloud-8.7-20221111.aarch64.qcow2"
-  arch: "aarch64"
-  digest: "sha256:46773980934297efef24c3fe769d2e6d804a2da37af805f6182cfcfea5211767"
+  - location: "https://repo.almalinux.org/almalinux/8.7/cloud/x86_64/images/AlmaLinux-8-GenericCloud-UEFI-8.7-20221111.x86_64.qcow2"
+    arch: "x86_64"
+    digest: "sha256:6b1a852614e906c55b26f2a27056ab6cabf09f4d963e080bbd70e15da3c88733"
+  - location: "https://repo.almalinux.org/almalinux/8.7/cloud/aarch64/images/AlmaLinux-8-GenericCloud-8.7-20221111.aarch64.qcow2"
+    arch: "aarch64"
+    digest: "sha256:46773980934297efef24c3fe769d2e6d804a2da37af805f6182cfcfea5211767"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 cpuType:
   # Workaround for "vmx_write_mem: mmu_gva_to_gpa XXXXXXXXXXXXXXXX failed" on Intel Mac
   # https://bugs.launchpad.net/qemu/+bug/1838390

--- a/examples/almalinux-9.yaml
+++ b/examples/almalinux-9.yaml
@@ -1,13 +1,13 @@
 # This example requires Lima v0.11.1 or later.
 
 images:
-- location: "https://repo.almalinux.org/almalinux/9.1/cloud/x86_64/images/AlmaLinux-9-GenericCloud-9.1-20221118.x86_64.qcow2"
-  arch: "x86_64"
-  digest: "sha256:1e93210a0c534de76ae01dc02e8224be14264fa8d54ad6cff9af15b673c6db1a"
-- location: "https://repo.almalinux.org/almalinux/9.1/cloud/aarch64/images/AlmaLinux-9-GenericCloud-9.1-20221118.aarch64.qcow2"
-  arch: "aarch64"
-  digest: "sha256:3405f30db62441c18258c21c01754addeb4dfdf9714d151f042942d223ab3865"
+  - location: "https://repo.almalinux.org/almalinux/9.1/cloud/x86_64/images/AlmaLinux-9-GenericCloud-9.1-20221118.x86_64.qcow2"
+    arch: "x86_64"
+    digest: "sha256:1e93210a0c534de76ae01dc02e8224be14264fa8d54ad6cff9af15b673c6db1a"
+  - location: "https://repo.almalinux.org/almalinux/9.1/cloud/aarch64/images/AlmaLinux-9-GenericCloud-9.1-20221118.aarch64.qcow2"
+    arch: "aarch64"
+    digest: "sha256:3405f30db62441c18258c21c01754addeb4dfdf9714d151f042942d223ab3865"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true

--- a/examples/alpine.yaml
+++ b/examples/alpine.yaml
@@ -1,17 +1,15 @@
 # This example requires Lima v0.7.0 or later.
 images:
-- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.27/alpine-lima-std-3.17.0-x86_64.iso"
-  arch: "x86_64"
-  digest: "sha512:07b88838734de63edf302a531aaf57f5a48ec31b31b8a95740faa4fac11852b375c5c83180ff34311ee284b8123536b86b70f0606591b1986e9af2268f3ea675"
-- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.27/alpine-lima-std-3.17.0-aarch64.iso"
-  arch: "aarch64"
-  digest: "sha512:b8028c96385ea5be499e37c142cb9e9d9c861f2647ff7f8cceaf867961ef8878e34a8ba0e8cfe2e01ac082191048e7acc30534782b13c5ec4bea53dad5919c33"
-
+  - location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.27/alpine-lima-std-3.17.0-x86_64.iso"
+    arch: "x86_64"
+    digest: "sha512:07b88838734de63edf302a531aaf57f5a48ec31b31b8a95740faa4fac11852b375c5c83180ff34311ee284b8123536b86b70f0606591b1986e9af2268f3ea675"
+  - location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.27/alpine-lima-std-3.17.0-aarch64.iso"
+    arch: "aarch64"
+    digest: "sha512:b8028c96385ea5be499e37c142cb9e9d9c861f2647ff7f8cceaf867961ef8878e34a8ba0e8cfe2e01ac082191048e7acc30534782b13c5ec4bea53dad5919c33"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
-
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 # The built-in containerd installer does not support Alpine currently.
 # Hint: use the "rd" ISO instead of the "std" ISO to enable containerd: https://github.com/lima-vm/alpine-lima/releases/
 containerd:

--- a/examples/apptainer-rootful.yaml
+++ b/examples/apptainer-rootful.yaml
@@ -5,41 +5,41 @@
 # Fedora provides Apptainer in the default dnf.
 # Ubuntu does not seem to provide Apptainer in the default apt.
 images:
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
-  arch: "x86_64"
-  digest: "sha256:d334670401ff3d5b4129fcc662cf64f5a6e568228af59076cc449a4945318482"
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/aarch64/images/Fedora-Cloud-Base-38-1.6.aarch64.qcow2"
-  arch: "aarch64"
-  digest: "sha256:ad71d22104a16e4f9efa93e61e8c7bce28de693f59c802586abbe85e9db55a65"
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
+    arch: "x86_64"
+    digest: "sha256:d334670401ff3d5b4129fcc662cf64f5a6e568228af59076cc449a4945318482"
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/aarch64/images/Fedora-Cloud-Base-38-1.6.aarch64.qcow2"
+    arch: "aarch64"
+    digest: "sha256:ad71d22104a16e4f9efa93e61e8c7bce28de693f59c802586abbe85e9db55a65"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 containerd:
   system: false
   user: false
 provision:
-- mode: system
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    modprobe squashfs >/dev/null 2>&1 && exit 0
-    dnf install -y kernel-modules-$(uname -r)
-- mode: system
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    command -v apptainer >/dev/null 2>&1 && exit 0
-    dnf -y install apptainer apptainer-suid
-    # See https://fedoraproject.org/wiki/Features/tmp-on-tmpfs
-    echo "APPTAINER_TMPDIR=/var/tmp" > /etc/profile.d/apptainer.sh
-    echo "export APPTAINER_TMPDIR" >> /etc/profile.d/apptainer.sh
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      modprobe squashfs >/dev/null 2>&1 && exit 0
+      dnf install -y kernel-modules-$(uname -r)
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      command -v apptainer >/dev/null 2>&1 && exit 0
+      dnf -y install apptainer apptainer-suid
+      # See https://fedoraproject.org/wiki/Features/tmp-on-tmpfs
+      echo "APPTAINER_TMPDIR=/var/tmp" > /etc/profile.d/apptainer.sh
+      echo "export APPTAINER_TMPDIR" >> /etc/profile.d/apptainer.sh
 probes:
-- script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    if ! timeout 30s bash -c "until command -v apptainer >/dev/null 2>&1; do sleep 3; done"; then
-      echo >&2 "apptainer is not installed yet"
-      exit 1
-    fi
-  hint: See "/var/log/cloud-init-output.log" in the guest
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until command -v apptainer >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "apptainer is not installed yet"
+        exit 1
+      fi
+    hint: See "/var/log/cloud-init-output.log" in the guest

--- a/examples/apptainer.yaml
+++ b/examples/apptainer.yaml
@@ -5,35 +5,35 @@
 # Fedora provides Apptainer in the default dnf.
 # Ubuntu does not seem to provide Apptainer in the default apt.
 images:
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
-  arch: "x86_64"
-  digest: "sha256:d334670401ff3d5b4129fcc662cf64f5a6e568228af59076cc449a4945318482"
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/aarch64/images/Fedora-Cloud-Base-38-1.6.aarch64.qcow2"
-  arch: "aarch64"
-  digest: "sha256:ad71d22104a16e4f9efa93e61e8c7bce28de693f59c802586abbe85e9db55a65"
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
+    arch: "x86_64"
+    digest: "sha256:d334670401ff3d5b4129fcc662cf64f5a6e568228af59076cc449a4945318482"
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/aarch64/images/Fedora-Cloud-Base-38-1.6.aarch64.qcow2"
+    arch: "aarch64"
+    digest: "sha256:ad71d22104a16e4f9efa93e61e8c7bce28de693f59c802586abbe85e9db55a65"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 containerd:
   system: false
   user: false
 provision:
-- mode: system
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    command -v apptainer >/dev/null 2>&1 && exit 0
-    dnf -y install apptainer
-    # See https://fedoraproject.org/wiki/Features/tmp-on-tmpfs
-    echo "APPTAINER_TMPDIR=/var/tmp" > /etc/profile.d/apptainer.sh
-    echo "export APPTAINER_TMPDIR" >> /etc/profile.d/apptainer.sh
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      command -v apptainer >/dev/null 2>&1 && exit 0
+      dnf -y install apptainer
+      # See https://fedoraproject.org/wiki/Features/tmp-on-tmpfs
+      echo "APPTAINER_TMPDIR=/var/tmp" > /etc/profile.d/apptainer.sh
+      echo "export APPTAINER_TMPDIR" >> /etc/profile.d/apptainer.sh
 probes:
-- script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    if ! timeout 30s bash -c "until command -v apptainer >/dev/null 2>&1; do sleep 3; done"; then
-      echo >&2 "apptainer is not installed yet"
-      exit 1
-    fi
-  hint: See "/var/log/cloud-init-output.log" in the guest
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until command -v apptainer >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "apptainer is not installed yet"
+        exit 1
+      fi
+    hint: See "/var/log/cloud-init-output.log" in the guest

--- a/examples/archlinux.yaml
+++ b/examples/archlinux.yaml
@@ -1,20 +1,19 @@
 # This example requires Lima v0.7.0 or later
 images:
-# Try to use yyyyMMdd.REV image if available. Note that yyyyMMdd.REV will be removed after several months.
-- location: "https://geo.mirror.pkgbuild.com/images/v20230415.143207/Arch-Linux-x86_64-cloudimg-20230415.143207.qcow2"
-  arch: "x86_64"
-  digest: "sha256:ff733ead933d25f168c690ad0fe6b66cb8187d88191c8dc6e88ec50687539265"
-- location: "https://github.com/mcginty/arch-boxes-arm/releases/download/v20220323/Arch-Linux-aarch64-cloudimg-20220323.0.qcow2"
-  arch: "aarch64"
-  digest: "sha512:27524910bf41cb9b3223c8749c6e67fd2f2fdb8b70d40648708e64d6b03c0b4a01b3c5e72d51fefd3e0c3f58487dbb400a79ca378cde2da341a3a19873612be8"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://geo.mirror.pkgbuild.com/images/latest/Arch-Linux-x86_64-cloudimg.qcow2"
-  arch: "x86_64"
-
+  # Try to use yyyyMMdd.REV image if available. Note that yyyyMMdd.REV will be removed after several months.
+  - location: "https://geo.mirror.pkgbuild.com/images/v20230415.143207/Arch-Linux-x86_64-cloudimg-20230415.143207.qcow2"
+    arch: "x86_64"
+    digest: "sha256:ff733ead933d25f168c690ad0fe6b66cb8187d88191c8dc6e88ec50687539265"
+  - location: "https://github.com/mcginty/arch-boxes-arm/releases/download/v20220323/Arch-Linux-aarch64-cloudimg-20220323.0.qcow2"
+    arch: "aarch64"
+    digest: "sha512:27524910bf41cb9b3223c8749c6e67fd2f2fdb8b70d40648708e64d6b03c0b4a01b3c5e72d51fefd3e0c3f58487dbb400a79ca378cde2da341a3a19873612be8"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://geo.mirror.pkgbuild.com/images/latest/Arch-Linux-x86_64-cloudimg.qcow2"
+    arch: "x86_64"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 firmware:
   legacyBIOS: true

--- a/examples/buildkit.yaml
+++ b/examples/buildkit.yaml
@@ -5,30 +5,28 @@
 # $ export BUILDKIT_HOST=$(limactl list buildkit --format 'unix://{{.Dir}}/sock/buildkitd.sock')
 # $ buildctl debug workers
 message: |
- To run `buildkit` on the host (assumes buildctl is installed), run the following commands:
- -------
- export BUILDKIT_HOST="unix://{{.Dir}}/sock/buildkitd.sock"
- buildctl debug workers
- -------
+  To run `buildkit` on the host (assumes buildctl is installed), run the following commands:
+  -------
+  export BUILDKIT_HOST="unix://{{.Dir}}/sock/buildkitd.sock"
+  buildctl debug workers
+  -------
 images:
-# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-amd64.img"
-  arch: "x86_64"
-  digest: "sha256:d46438111d7a6dfcdfb2e1fb76762a79d56f09dc308cc9ab2300effc0078fd5b"
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-arm64.img"
-  arch: "aarch64"
-  digest: "sha256:e1865c2ebc531600ae6012d86fa2dae5846e7801cdcdbcf90d9c830218ef4ae9"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:d46438111d7a6dfcdfb2e1fb76762a79d56f09dc308cc9ab2300effc0078fd5b"
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:e1865c2ebc531600ae6012d86fa2dae5846e7801cdcdbcf90d9c830218ef4ae9"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
+    arch: "aarch64"
 containerd:
   system: false
   user: true
-
 portForwards:
-- guestSocket: "/run/user/{{.UID}}/buildkit-default/buildkitd.sock"
-  hostSocket: "{{.Dir}}/sock/buildkitd.sock"
+  - guestSocket: "/run/user/{{.UID}}/buildkit-default/buildkitd.sock"
+    hostSocket: "{{.Dir}}/sock/buildkitd.sock"

--- a/examples/centos-stream-8.yaml
+++ b/examples/centos-stream-8.yaml
@@ -4,17 +4,17 @@
 # EL9-based distros are known to work.
 
 images:
-- location: "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230404.0.x86_64.qcow2"
-  arch: "x86_64"
-  digest: "sha256:1c06cac5c84b44e4d3474b1aafc7189bd84013cd1cb480ed0a280bbcb34f57a6"
-# CentOS-Stream-GenericCloud-8-20230404.0.aarch64.qcow2 is broken (0 byte)
-- location: "https://cloud.centos.org/centos/8-stream/aarch64/images/CentOS-Stream-GenericCloud-8-20230308.3.aarch64.qcow2"
-  arch: "aarch64"
-  digest: "sha256:a982b96bcf3c1e36b5688fcddcd57b85c0ca58d13013e6435234e2497c7c7d82"
+  - location: "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230404.0.x86_64.qcow2"
+    arch: "x86_64"
+    digest: "sha256:1c06cac5c84b44e4d3474b1aafc7189bd84013cd1cb480ed0a280bbcb34f57a6"
+  # CentOS-Stream-GenericCloud-8-20230404.0.aarch64.qcow2 is broken (0 byte)
+  - location: "https://cloud.centos.org/centos/8-stream/aarch64/images/CentOS-Stream-GenericCloud-8-20230308.3.aarch64.qcow2"
+    arch: "aarch64"
+    digest: "sha256:a982b96bcf3c1e36b5688fcddcd57b85c0ca58d13013e6435234e2497c7c7d82"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 firmware:
   # CentOS Stream 8 still requires legacyBIOS, while AlmaLinux 8 and Rocky Linux 8 do not.
   legacyBIOS: true

--- a/examples/centos-stream-9.yaml
+++ b/examples/centos-stream-9.yaml
@@ -1,16 +1,16 @@
 # This example requires Lima v0.11.1 or later.
 
 images:
-- location: "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230410.0.x86_64.qcow2"
-  arch: "x86_64"
-  digest: "sha256:8a5abbf8b0dda3e4e49b5112ffae3fff022bf97a5f53b868adbfb80c75c313fe"
-- location: "https://cloud.centos.org/centos/9-stream/aarch64/images/CentOS-Stream-GenericCloud-9-20230410.0.aarch64.qcow2"
-  arch: "aarch64"
-  digest: "sha256:8e954f2b931e51d4cd331497b11a1bbd0180639791352a8da4c7f2b0d38d51c8"
+  - location: "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230410.0.x86_64.qcow2"
+    arch: "x86_64"
+    digest: "sha256:8a5abbf8b0dda3e4e49b5112ffae3fff022bf97a5f53b868adbfb80c75c313fe"
+  - location: "https://cloud.centos.org/centos/9-stream/aarch64/images/CentOS-Stream-GenericCloud-9-20230410.0.aarch64.qcow2"
+    arch: "aarch64"
+    digest: "sha256:8e954f2b931e51d4cd331497b11a1bbd0180639791352a8da4c7f2b0d38d51c8"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 firmware:
   # CentOS Stream 9 still requires legacyBIOS, while AlmaLinux 9 and Rocky Linux 9 do not.
   legacyBIOS: true

--- a/examples/debian.yaml
+++ b/examples/debian.yaml
@@ -1,12 +1,12 @@
 # This example requires Lima v0.7.0 or later
 images:
-- location: "https://cloud.debian.org/images/cloud/bullseye/20230124-1270/debian-11-generic-amd64-20230124-1270.qcow2"
-  arch: "x86_64"
-  digest: "sha512:fa152c6159dcb73adb1b573da3631937068c6a465ce7565a16dcce7aebd27c9a62ad783296d408300b99616cad89b8c0092e11df0fc2aa423334d741ac83b1a2"
-- location: "https://cloud.debian.org/images/cloud/bullseye/20230124-1270/debian-11-generic-arm64-20230124-1270.qcow2"
-  arch: "aarch64"
-  digest: "sha512:d714ed2b70322bb2c4adc588f96671192a5ca67f70e20c3fb51c89d55b6a9646f00a6e6f0e5da241b7017916bb19b65a5703a1e3b3869a89c0da7047ac6c4e53"
+  - location: "https://cloud.debian.org/images/cloud/bullseye/20230124-1270/debian-11-generic-amd64-20230124-1270.qcow2"
+    arch: "x86_64"
+    digest: "sha512:fa152c6159dcb73adb1b573da3631937068c6a465ce7565a16dcce7aebd27c9a62ad783296d408300b99616cad89b8c0092e11df0fc2aa423334d741ac83b1a2"
+  - location: "https://cloud.debian.org/images/cloud/bullseye/20230124-1270/debian-11-generic-arm64-20230124-1270.qcow2"
+    arch: "aarch64"
+    digest: "sha512:d714ed2b70322bb2c4adc588f96671192a5ca67f70e20c3fb51c89d55b6a9646f00a6e6f0e5da241b7017916bb19b65a5703a1e3b3869a89c0da7047ac6c4e53"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -10,95 +10,87 @@
 # The vmType of existing instances cannot be changed.
 # 🟢 Builtin default: "qemu"
 vmType: null
-
 # Arch: "default", "x86_64", "aarch64".
 # 🟢 Builtin default: "default" (corresponds to the host architecture)
 arch: null
-
 # OpenStack-compatible disk image.
 # 🟢 Builtin default: null (must be specified)
 # 🔵 This file: Ubuntu 22.10 Kinetic Kudu images
 images:
-# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-amd64.img"
-  arch: "x86_64"
-  digest: "sha256:d46438111d7a6dfcdfb2e1fb76762a79d56f09dc308cc9ab2300effc0078fd5b"
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-arm64.img"
-  arch: "aarch64"
-  digest: "sha256:e1865c2ebc531600ae6012d86fa2dae5846e7801cdcdbcf90d9c830218ef4ae9"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:d46438111d7a6dfcdfb2e1fb76762a79d56f09dc308cc9ab2300effc0078fd5b"
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:e1865c2ebc531600ae6012d86fa2dae5846e7801cdcdbcf90d9c830218ef4ae9"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
+    arch: "aarch64"
 # CPUs: if you see performance issues, try limiting cpus to 1.
 # 🟢 Builtin default: 4
 cpus: null
-
 # Memory size
 # 🟢 Builtin default: "4GiB"
 memory: null
-
 # Disk size
 # 🟢 Builtin default: "100GiB"
 disk: null
-
 # Expose host directories to the guest, the mount point might be accessible from all UIDs in the guest
 # 🟢 Builtin default: null (Mount nothing)
 # 🔵 This file: Mount the home as read-only, /tmp/lima as writable
 mounts:
-- location: "~"
-  # Configure the mountPoint inside the guest.
-  # 🟢 Builtin default: value of location
-  mountPoint: null
-  # CAUTION: `writable` SHOULD be false for the home directory.
-  # Setting `writable` to true is possible, but untested and dangerous.
-  # 🟢 Builtin default: false
-  writable: null
-  sshfs:
-    # Enabling the SSHFS cache will increase performance of the mounted filesystem, at
-    # the cost of potentially not reflecting changes made on the host in a timely manner.
-    # Warning: It looks like PHP filesystem access does not work correctly when
-    # the cache is disabled.
-    # 🟢 Builtin default: true
-    cache: null
-    # SSHFS has an optional flag called 'follow_symlinks'. This allows mounts
-    # to be properly resolved in the guest os and allow for access to the
-    # contents of the symlink. As a result, symlinked files & folders on the Host
-    # system will look and feel like regular files directories in the Guest OS.
+  - location: "~"
+    # Configure the mountPoint inside the guest.
+    # 🟢 Builtin default: value of location
+    mountPoint: null
+    # CAUTION: `writable` SHOULD be false for the home directory.
+    # Setting `writable` to true is possible, but untested and dangerous.
     # 🟢 Builtin default: false
-    followSymlinks: null
-    # SFTP driver, "builtin" or "openssh-sftp-server". "openssh-sftp-server" is recommended.
-    # 🟢 Builtin default: "openssh-sftp-server" if OpenSSH SFTP Server binary is found, otherwise "builtin"
-    sftpDriver: null
-  9p:
-    # Supported security models are "passthrough", "mapped-xattr", "mapped-file" and "none".
-    # "mapped-xattr" and "mapped-file" are useful for persistent chown but incompatible with symlinks.
-    # 🟢 Builtin default: "none" (since Lima v0.13)
-    securityModel: null
-    # Select 9P protocol version. Valid options are: "9p2000" (legacy), "9p2000.u", "9p2000.L".
-    # 🟢 Builtin default: "9p2000.L"
-    protocolVersion: null
-    # The number of bytes to use for 9p packet payload, where 4KiB is the absolute minimum.
-    # 🟢 Builtin default: "128KiB"
-    msize: null
-    # Specifies a caching policy. Valid options are: "none", "loose", "fscache" and "mmap".
-    # Try choosing "mmap" or "none" if you see a stability issue with the default "fscache".
-    # See https://www.kernel.org/doc/Documentation/filesystems/9p.txt
-    # 🟢 Builtin default: "fscache" for non-writable mounts, "mmap" for writable mounts
-    cache: null
-- location: "/tmp/lima"
-  # 🟢 Builtin default: false
-  # 🔵 This file: true (only for "/tmp/lima")
-  writable: true
-
+    writable: null
+    sshfs:
+      # Enabling the SSHFS cache will increase performance of the mounted filesystem, at
+      # the cost of potentially not reflecting changes made on the host in a timely manner.
+      # Warning: It looks like PHP filesystem access does not work correctly when
+      # the cache is disabled.
+      # 🟢 Builtin default: true
+      cache: null
+      # SSHFS has an optional flag called 'follow_symlinks'. This allows mounts
+      # to be properly resolved in the guest os and allow for access to the
+      # contents of the symlink. As a result, symlinked files & folders on the Host
+      # system will look and feel like regular files directories in the Guest OS.
+      # 🟢 Builtin default: false
+      followSymlinks: null
+      # SFTP driver, "builtin" or "openssh-sftp-server". "openssh-sftp-server" is recommended.
+      # 🟢 Builtin default: "openssh-sftp-server" if OpenSSH SFTP Server binary is found, otherwise "builtin"
+      sftpDriver: null
+    9p:
+      # Supported security models are "passthrough", "mapped-xattr", "mapped-file" and "none".
+      # "mapped-xattr" and "mapped-file" are useful for persistent chown but incompatible with symlinks.
+      # 🟢 Builtin default: "none" (since Lima v0.13)
+      securityModel: null
+      # Select 9P protocol version. Valid options are: "9p2000" (legacy), "9p2000.u", "9p2000.L".
+      # 🟢 Builtin default: "9p2000.L"
+      protocolVersion: null
+      # The number of bytes to use for 9p packet payload, where 4KiB is the absolute minimum.
+      # 🟢 Builtin default: "128KiB"
+      msize: null
+      # Specifies a caching policy. Valid options are: "none", "loose", "fscache" and "mmap".
+      # Try choosing "mmap" or "none" if you see a stability issue with the default "fscache".
+      # See https://www.kernel.org/doc/Documentation/filesystems/9p.txt
+      # 🟢 Builtin default: "fscache" for non-writable mounts, "mmap" for writable mounts
+      cache: null
+  - location: "/tmp/lima"
+    # 🟢 Builtin default: false
+    # 🔵 This file: true (only for "/tmp/lima")
+    writable: true
 # Mount type for above mounts, such as "reverse-sshfs" (from sshocker), "9p" (EXPERIMENTAL, from QEMU’s virtio-9p-pci, aka virtfs),
 # or "virtiofs" (EXPERIMENTAL, needs `vmType: vz`)
 # 🟢 Builtin default: "reverse-sshfs"
 mountType: null
-
 # Lima disks to attach to the instance. The disks will be accessible from inside the
 # instance, labeled by name. (e.g. if the disk is named "data", it will be labeled
 # "lima-data" inside the instance). The disk will be mounted inside the instance at
@@ -107,7 +99,6 @@ mountType: null
 additionalDisks:
 # disks should be a list of disk name strings, for example:
 # - "data"
-
 ssh:
   # A localhost port of the host. Forwarded to port 22 of the guest.
   # 🟢 Builtin default: 0 (automatically assigned to a free port)
@@ -132,17 +123,14 @@ ssh:
   # Trust forwarded X11 clients
   # 🟢 Builtin default: false
   forwardX11Trusted: null
-
 # ===================================================================== #
 # ADVANCED CONFIGURATION
 # ===================================================================== #
-
 caCerts:
   # If set to `true`, this will remove all the default trusted CA certificates that
   # are normally shipped with the OS.
   # 🟢 Builtin default: false
   removeDefaults: null
-
   # A list of trusted CA certificate files. The files will be read and passed to cloud-init.
   files:
   # - examples/hello.crt
@@ -157,7 +145,6 @@ caCerts:
   #   -----BEGIN CERTIFICATE-----
   #   YOUR-ORGS-TRUSTED-CA-CERT-HERE
   #   -----END CERTIFICATE-----
-
 containerd:
   # Enable system-wide (aka rootful)  containerd and its dependencies (BuildKit, Stargz Snapshotter)
   # Note that `nerdctl.lima` only works in rootless mode; you have to use `lima sudo nerdctl ...`
@@ -229,7 +216,6 @@ cpuType:
   aarch64: null
   # 🟢 Builtin default: "qemu64" (or "host,-pdpe1gb" when running on x86_64 host)
   x86_64: null
-
 rosetta:
   # Enable Rosetta for Linux (EXPERIMENTAL).
   # Hint: try `softwareupdate --install-rosetta` if Lima gets stuck at `Installing rosetta...`
@@ -238,19 +224,16 @@ rosetta:
   # Register rosetta to /proc/sys/fs/binfmt_misc
   # 🟢 Builtin default: false
   binfmt: null
-
 firmware:
   # Use legacy BIOS instead of UEFI. Ignored for aarch64.
   # 🟢 Builtin default: false
   legacyBIOS: null
-
 audio:
   # QEMU audiodev, e.g., "none", "coreaudio", "pa", "alsa", "oss".
   # VZ driver, use "vz" as device name
   # Choosing "none" will mute the audio output, and not play any sound.
   # 🟢 Builtin default: ""
   device: null
-
 video:
   # QEMU display, e.g., "none", "cocoa", "sdl", "gtk", "vnc", "default".
   # Choosing "none" will hide the video output, and not show any window.
@@ -267,7 +250,6 @@ video:
     # By convention the TCP port is 5900+d, connections from any host.
     # 🟢 Builtin default: "127.0.0.1:0,to=9"
     display: null
-
 # The instance can get routable IP addresses from the vmnet framework using
 # https://github.com/lima-vm/socket_vmnet.
 # 🟢 Builtin default: null
@@ -288,7 +270,6 @@ networks:
 # before the instance.  The interface type (host, shared, or bridged) is
 # configured in socket_vmnet and not in lima.
 # - socket: "/var/run/socket_vmnet"
-
 
 # The "vzNAT" IP address is accessible from the host, but not from other guests.
 # Needs `vmType: vz` (EXPERIMENTAL).
@@ -385,7 +366,6 @@ networks:
 # propagateProxyEnv to false.
 # 🟢 Builtn default: true
 propagateProxyEnv: null
-
 # The host agent implements a DNS server that looks up host names on the host
 # using the local system resolver. This means changing VPN and network settings
 # are reflected automatically into the guest, including conditional forward,
@@ -402,9 +382,8 @@ hostResolver:
   # predefined to specify the gateway address to the host.
   # 🟢 Builtin default: null
   hosts:
-    # guest.name: 127.1.1.1
-    # host.name: host.lima.internal
-
+  # guest.name: 127.1.1.1
+  # host.name: host.lima.internal
 # If useHostResolver is false, then the following rules apply for configuring dns:
 # Explicitly set DNS addresses for qemu user-mode networking. By default qemu picks *one*
 # nameserver from the host config and forwards all queries to this server. On macOS

--- a/examples/deprecated/centos-7.yaml
+++ b/examples/deprecated/centos-7.yaml
@@ -1,21 +1,21 @@
 # This example requires Lima v0.10.0 or later.
 # WARNING: RHEL-like below version 8 is unsupported, use at your own risk!
 images:
-- location: "https://cloud.centos.org/altarch/7/images/CentOS-7-x86_64-GenericCloud-2009.qcow2"
-  arch: "x86_64"
-  digest: "sha256:e38bab0475cc6d004d2e17015969c659e5a308111851b0e2715e84646035bdd3"
-- location: "https://cloud.centos.org/altarch/7/images/CentOS-7-aarch64-GenericCloud-2009.qcow2"
-  arch: "aarch64"
-  digest: "sha256:51c0222aa4bc7d966fc044eb6ce9182993a1dc398eaa595e58abd0d361439baf"
+  - location: "https://cloud.centos.org/altarch/7/images/CentOS-7-x86_64-GenericCloud-2009.qcow2"
+    arch: "x86_64"
+    digest: "sha256:e38bab0475cc6d004d2e17015969c659e5a308111851b0e2715e84646035bdd3"
+  - location: "https://cloud.centos.org/altarch/7/images/CentOS-7-aarch64-GenericCloud-2009.qcow2"
+    arch: "aarch64"
+    digest: "sha256:51c0222aa4bc7d966fc044eb6ce9182993a1dc398eaa595e58abd0d361439baf"
 # CentOS7 doesn't have support to systemd-user (https://bugzilla.redhat.com/show_bug.cgi?id=1173278)
 # containerd as system works, but you'd need to use nerdctl in the shell of the instance as root
 containerd:
   system: false
   user: false
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 firmware:
   legacyBIOS: true
 cpuType:

--- a/examples/docker-rootful.yaml
+++ b/examples/docker-rootful.yaml
@@ -8,73 +8,72 @@
 
 # This example requires Lima v0.8.0 or later
 images:
-# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-  digest: "sha256:345fbbb6ec827ca02ec1a1ced90f7d40d3fd345811ba97c5772ac40e951458e1"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-  digest: "sha256:f6b5b3a980f28f25fe5203ae74b79cc664ae5505cf255a62f3b01be46ab9967a"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:345fbbb6ec827ca02ec1a1ced90f7d40d3fd345811ba97c5772ac40e951458e1"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:f6b5b3a980f28f25fe5203ae74b79cc664ae5505cf255a62f3b01be46ab9967a"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 # containerd is managed by Docker, not by Lima, so the values are set to false here.
 containerd:
   system: false
   user: false
 provision:
-- mode: system
-  # This script defines the host.docker.internal hostname when hostResolver is disabled.
-  # It is also needed for lima 0.8.2 and earlier, which does not support hostResolver.hosts.
-  # Names defined in /etc/hosts inside the VM are not resolved inside containers when
-  # using the hostResolver; use hostResolver.hosts instead (requires lima 0.8.3 or later).
-  script: |
-    #!/bin/sh
-    sed -i 's/host.lima.internal.*/host.lima.internal host.docker.internal/' /etc/hosts
-- mode: system
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    command -v docker >/dev/null 2>&1 && exit 0
-    if [ ! -e /etc/systemd/system/docker.socket.d/override.conf ]; then
-      mkdir -p /etc/systemd/system/docker.socket.d
-      # Alternatively we could just add the user to the "docker" group, but that requires restarting the user session
-      cat <<-EOF >/etc/systemd/system/docker.socket.d/override.conf
-      [Socket]
-      SocketUser=${LIMA_CIDATA_USER}
-    EOF
-    fi
-    export DEBIAN_FRONTEND=noninteractive
-    curl -fsSL https://get.docker.com | sh
+  - mode: system
+    # This script defines the host.docker.internal hostname when hostResolver is disabled.
+    # It is also needed for lima 0.8.2 and earlier, which does not support hostResolver.hosts.
+    # Names defined in /etc/hosts inside the VM are not resolved inside containers when
+    # using the hostResolver; use hostResolver.hosts instead (requires lima 0.8.3 or later).
+    script: |
+      #!/bin/sh
+      sed -i 's/host.lima.internal.*/host.lima.internal host.docker.internal/' /etc/hosts
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      command -v docker >/dev/null 2>&1 && exit 0
+      if [ ! -e /etc/systemd/system/docker.socket.d/override.conf ]; then
+        mkdir -p /etc/systemd/system/docker.socket.d
+        # Alternatively we could just add the user to the "docker" group, but that requires restarting the user session
+        cat <<-EOF >/etc/systemd/system/docker.socket.d/override.conf
+        [Socket]
+        SocketUser=${LIMA_CIDATA_USER}
+      EOF
+      fi
+      export DEBIAN_FRONTEND=noninteractive
+      curl -fsSL https://get.docker.com | sh
 probes:
-- script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    if ! timeout 30s bash -c "until command -v docker >/dev/null 2>&1; do sleep 3; done"; then
-      echo >&2 "docker is not installed yet"
-      exit 1
-    fi
-    if ! timeout 30s bash -c "until pgrep dockerd; do sleep 3; done"; then
-      echo >&2 "dockerd is not running"
-      exit 1
-    fi
-  hint: See "/var/log/cloud-init-output.log". in the guest
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until command -v docker >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "docker is not installed yet"
+        exit 1
+      fi
+      if ! timeout 30s bash -c "until pgrep dockerd; do sleep 3; done"; then
+        echo >&2 "dockerd is not running"
+        exit 1
+      fi
+    hint: See "/var/log/cloud-init-output.log". in the guest
 hostResolver:
   # hostResolver.hosts requires lima 0.8.3 or later. Names defined here will also
   # resolve inside containers, and not just inside the VM itself.
   hosts:
     host.docker.internal: host.lima.internal
 portForwards:
-- guestSocket: "/var/run/docker.sock"
-  hostSocket: "{{.Dir}}/sock/docker.sock"
+  - guestSocket: "/var/run/docker.sock"
+    hostSocket: "{{.Dir}}/sock/docker.sock"
 message: |
   To run `docker` on the host (assumes docker-cli is installed), run the following commands:
   ------

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -8,75 +8,74 @@
 
 # This example requires Lima v0.8.0 or later
 images:
-# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-  digest: "sha256:345fbbb6ec827ca02ec1a1ced90f7d40d3fd345811ba97c5772ac40e951458e1"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-  digest: "sha256:f6b5b3a980f28f25fe5203ae74b79cc664ae5505cf255a62f3b01be46ab9967a"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:345fbbb6ec827ca02ec1a1ced90f7d40d3fd345811ba97c5772ac40e951458e1"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:f6b5b3a980f28f25fe5203ae74b79cc664ae5505cf255a62f3b01be46ab9967a"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 # containerd is managed by Docker, not by Lima, so the values are set to false here.
 containerd:
   system: false
   user: false
 provision:
-- mode: system
-  # This script defines the host.docker.internal hostname when hostResolver is disabled.
-  # It is also needed for lima 0.8.2 and earlier, which does not support hostResolver.hosts.
-  # Names defined in /etc/hosts inside the VM are not resolved inside containers when
-  # using the hostResolver; use hostResolver.hosts instead (requires lima 0.8.3 or later).
-  script: |
-    #!/bin/sh
-    sed -i 's/host.lima.internal.*/host.lima.internal host.docker.internal/' /etc/hosts
-- mode: system
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    command -v docker >/dev/null 2>&1 && exit 0
-    export DEBIAN_FRONTEND=noninteractive
-    curl -fsSL https://get.docker.com | sh
-    # NOTE: you may remove the lines below, if you prefer to use rootful docker, not rootless
-    systemctl disable --now docker
-    apt-get install -y uidmap dbus-user-session
-- mode: user
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    systemctl --user start dbus
-    dockerd-rootless-setuptool.sh install
-    docker context use rootless
+  - mode: system
+    # This script defines the host.docker.internal hostname when hostResolver is disabled.
+    # It is also needed for lima 0.8.2 and earlier, which does not support hostResolver.hosts.
+    # Names defined in /etc/hosts inside the VM are not resolved inside containers when
+    # using the hostResolver; use hostResolver.hosts instead (requires lima 0.8.3 or later).
+    script: |
+      #!/bin/sh
+      sed -i 's/host.lima.internal.*/host.lima.internal host.docker.internal/' /etc/hosts
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      command -v docker >/dev/null 2>&1 && exit 0
+      export DEBIAN_FRONTEND=noninteractive
+      curl -fsSL https://get.docker.com | sh
+      # NOTE: you may remove the lines below, if you prefer to use rootful docker, not rootless
+      systemctl disable --now docker
+      apt-get install -y uidmap dbus-user-session
+  - mode: user
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      systemctl --user start dbus
+      dockerd-rootless-setuptool.sh install
+      docker context use rootless
 probes:
-- script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    if ! timeout 30s bash -c "until command -v docker >/dev/null 2>&1; do sleep 3; done"; then
-      echo >&2 "docker is not installed yet"
-      exit 1
-    fi
-    if ! timeout 30s bash -c "until pgrep rootlesskit; do sleep 3; done"; then
-      echo >&2 "rootlesskit (used by rootless docker) is not running"
-      exit 1
-    fi
-  hint: See "/var/log/cloud-init-output.log". in the guest
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until command -v docker >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "docker is not installed yet"
+        exit 1
+      fi
+      if ! timeout 30s bash -c "until pgrep rootlesskit; do sleep 3; done"; then
+        echo >&2 "rootlesskit (used by rootless docker) is not running"
+        exit 1
+      fi
+    hint: See "/var/log/cloud-init-output.log". in the guest
 hostResolver:
   # hostResolver.hosts requires lima 0.8.3 or later. Names defined here will also
   # resolve inside containers, and not just inside the VM itself.
   hosts:
     host.docker.internal: host.lima.internal
 portForwards:
-- guestSocket: "/run/user/{{.UID}}/docker.sock"
-  hostSocket: "{{.Dir}}/sock/docker.sock"
+  - guestSocket: "/run/user/{{.UID}}/docker.sock"
+    hostSocket: "{{.Dir}}/sock/docker.sock"
 message: |
   To run `docker` on the host (assumes docker-cli is installed), run the following commands:
   ------

--- a/examples/experimental/9p.yaml
+++ b/examples/experimental/9p.yaml
@@ -2,28 +2,26 @@
 # On macOS hosts, QEMU needs to be v7.0.0 or later. Homebrew's QEMU v6.2.0_1 can be used too.
 # This example is planned to be merged to default.yaml in Lima v1.0 (ETA: 2022 Q2).
 images:
-# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-amd64.img"
-  arch: "x86_64"
-  digest: "sha256:d46438111d7a6dfcdfb2e1fb76762a79d56f09dc308cc9ab2300effc0078fd5b"
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-arm64.img"
-  arch: "aarch64"
-  digest: "sha256:e1865c2ebc531600ae6012d86fa2dae5846e7801cdcdbcf90d9c830218ef4ae9"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:d46438111d7a6dfcdfb2e1fb76762a79d56f09dc308cc9ab2300effc0078fd5b"
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:e1865c2ebc531600ae6012d86fa2dae5846e7801cdcdbcf90d9c830218ef4ae9"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
+    arch: "aarch64"
 mounts:
-- location: "~"
-  9p:
-    # Try choosing "mmap" or "none" if you see a stability issue with the default "fscache".
-    cache: "fscache"
-- location: "/tmp/lima"
-  writable: true
-  9p:
-    cache: "mmap"
-
+  - location: "~"
+    9p:
+      # Try choosing "mmap" or "none" if you see a stability issue with the default "fscache".
+      cache: "fscache"
+  - location: "/tmp/lima"
+    writable: true
+    9p:
+      cache: "mmap"
 mountType: "9p"

--- a/examples/experimental/net-user-v2.yaml
+++ b/examples/experimental/net-user-v2.yaml
@@ -1,13 +1,12 @@
 # Example to run lima instance with experimental user-v2 network enabled
 images:
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 networks:
-- lima: user-v2
+  - lima: user-v2

--- a/examples/experimental/opensuse-tumbleweed.yaml
+++ b/examples/experimental/opensuse-tumbleweed.yaml
@@ -1,20 +1,19 @@
 # This example requires Lima v0.11.3 or later
 images:
-# Hint: run `limactl prune` to invalidate the "Current" cache
-- location: "https://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2"
-  arch: "x86_64"
-# JeOS is deprecated and will be removed probably, but Minimal-VM.aarch64-kvm-and-xen still lacks cloud-init
-# https://bugzilla.opensuse.org/show_bug.cgi?id=1210246
-- location: "https://download.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-Tumbleweed-ARM-JeOS-efi.aarch64.qcow2"
-  arch: "aarch64"
-# download.opensuse.org is inaccessible from Japan (500 Internal Server Error)
-# https://bugzilla.opensuse.org/show_bug.cgi?id=1210240
-- location: "https://provo-mirror.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2"
-  arch: "x86_64"
-- location: "https://provo-mirror.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-Tumbleweed-ARM-JeOS-efi.aarch64.qcow2"
-  arch: "aarch64"
-
+  # Hint: run `limactl prune` to invalidate the "Current" cache
+  - location: "https://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2"
+    arch: "x86_64"
+  # JeOS is deprecated and will be removed probably, but Minimal-VM.aarch64-kvm-and-xen still lacks cloud-init
+  # https://bugzilla.opensuse.org/show_bug.cgi?id=1210246
+  - location: "https://download.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-Tumbleweed-ARM-JeOS-efi.aarch64.qcow2"
+    arch: "aarch64"
+  # download.opensuse.org is inaccessible from Japan (500 Internal Server Error)
+  # https://bugzilla.opensuse.org/show_bug.cgi?id=1210240
+  - location: "https://provo-mirror.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2"
+    arch: "x86_64"
+  - location: "https://provo-mirror.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-Tumbleweed-ARM-JeOS-efi.aarch64.qcow2"
+    arch: "aarch64"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true

--- a/examples/experimental/riscv64.yaml
+++ b/examples/experimental/riscv64.yaml
@@ -2,26 +2,24 @@
 
 arch: "riscv64"
 images:
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-riscv64.img"
-  digest: "sha256:dbe28fb7c46d28980087b30f2df842bbde02f7a034ce1e0021ee6035ef87674a"
-  kernel:
-    # Extracted from http://http.us.debian.org/debian/pool/main/u/u-boot/u-boot-qemu_2023.01+dfsg-2_all.deb (GPL-2.0)
-    location: "https://github.com/lima-vm/u-boot-qemu-mirror/releases/download/2023.01%2Bdfsg-2/qemu-riscv64_smode_uboot.elf"
-    digest: "sha256:d688d1afd7fd8266a964437438e7d8744c8c27c50124ac1b05e2d83f312a6ca6"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-riscv64.img"
-  kernel:
-    # Extracted from http://http.us.debian.org/debian/pool/main/u/u-boot/u-boot-qemu_2023.04+dfsg-1_all.deb (GPL-2.0)
-    location: "https://github.com/lima-vm/u-boot-qemu-mirror/releases/download/2023.04%2Bdfsg-1/qemu-riscv64_smode_uboot.elf"
-    digest: "sha256:c3c634d66dca211efe7dece9c83071bc40f1c11db86c9dd7ce6f75bf87edef20"
-
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-riscv64.img"
+    digest: "sha256:dbe28fb7c46d28980087b30f2df842bbde02f7a034ce1e0021ee6035ef87674a"
+    kernel:
+      # Extracted from http://http.us.debian.org/debian/pool/main/u/u-boot/u-boot-qemu_2023.01+dfsg-2_all.deb (GPL-2.0)
+      location: "https://github.com/lima-vm/u-boot-qemu-mirror/releases/download/2023.01%2Bdfsg-2/qemu-riscv64_smode_uboot.elf"
+      digest: "sha256:d688d1afd7fd8266a964437438e7d8744c8c27c50124ac1b05e2d83f312a6ca6"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-riscv64.img"
+    kernel:
+      # Extracted from http://http.us.debian.org/debian/pool/main/u/u-boot/u-boot-qemu_2023.04+dfsg-1_all.deb (GPL-2.0)
+      location: "https://github.com/lima-vm/u-boot-qemu-mirror/releases/download/2023.04%2Bdfsg-1/qemu-riscv64_smode_uboot.elf"
+      digest: "sha256:c3c634d66dca211efe7dece9c83071bc40f1c11db86c9dd7ce6f75bf87edef20"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 mountType: "9p"
-
 # We do not have riscv64 binaries of containerd
 containerd:
   system: false

--- a/examples/experimental/vz.yaml
+++ b/examples/experimental/vz.yaml
@@ -7,19 +7,16 @@ rosetta:
   enabled: true
   # Register rosetta to /proc/sys/fs/binfmt_misc
   binfmt: true
-
 images:
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 mountType: "virtiofs"
-
 networks:
-# The "vzNAT" IP address is accessible from the host, but not from other guests.
-- vzNAT: true
+  # The "vzNAT" IP address is accessible from the host, but not from other guests.
+  - vzNAT: true

--- a/examples/faasd.yaml
+++ b/examples/faasd.yaml
@@ -23,46 +23,41 @@ message: |
   ------
   faas-cli store deploy NodeInfo
   ------
-
 # Image is set to jammy (22.04 LTS) for long-term stability
 images:
-# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-  digest: "sha256:345fbbb6ec827ca02ec1a1ced90f7d40d3fd345811ba97c5772ac40e951458e1"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-  digest: "sha256:f6b5b3a980f28f25fe5203ae74b79cc664ae5505cf255a62f3b01be46ab9967a"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:345fbbb6ec827ca02ec1a1ced90f7d40d3fd345811ba97c5772ac40e951458e1"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:f6b5b3a980f28f25fe5203ae74b79cc664ae5505cf255a62f3b01be46ab9967a"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
 # Mounts are disabled in this example, but can be enabled optionally.
 mounts: []
-
 # containerd is installed by the faasd installer script, not by Lima, so the values are set to false here.
 containerd:
   system: false
   user: false
-
 provision:
-- mode: user
-  script: |
-    #!/bin/sh
-    curl -sfL https://raw.githubusercontent.com/openfaas/faasd/master/hack/install.sh | bash -s -
-
+  - mode: user
+    script: |
+      #!/bin/sh
+      curl -sfL https://raw.githubusercontent.com/openfaas/faasd/master/hack/install.sh | bash -s -
 probes:
-- script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    if ! timeout 30s bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/healthz)" != "200" ]]; do sleep 5; done'; then
-            echo >&2 "faasd is not running yet"
-            exit 1
-    fi
-  hint: |
-    The faasd service is not yet running.
-    Run "limactl shell faasd sudo journalctl -u faasd" to check the log.
-    If that is still empty, check the bottom of the log at "/var/log/cloud-init-output.log".
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/healthz)" != "200" ]]; do sleep 5; done'; then
+              echo >&2 "faasd is not running yet"
+              exit 1
+      fi
+    hint: |
+      The faasd service is not yet running.
+      Run "limactl shell faasd sudo journalctl -u faasd" to check the log.
+      If that is still empty, check the bottom of the log at "/var/log/cloud-init-output.log".

--- a/examples/fedora.yaml
+++ b/examples/fedora.yaml
@@ -1,12 +1,12 @@
 # This example requires Lima v0.7.0 or later.
 images:
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
-  arch: "x86_64"
-  digest: "sha256:d334670401ff3d5b4129fcc662cf64f5a6e568228af59076cc449a4945318482"
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/aarch64/images/Fedora-Cloud-Base-38-1.6.aarch64.qcow2"
-  arch: "aarch64"
-  digest: "sha256:ad71d22104a16e4f9efa93e61e8c7bce28de693f59c802586abbe85e9db55a65"
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
+    arch: "x86_64"
+    digest: "sha256:d334670401ff3d5b4129fcc662cf64f5a6e568228af59076cc449a4945318482"
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/aarch64/images/Fedora-Cloud-Base-38-1.6.aarch64.qcow2"
+    arch: "aarch64"
+    digest: "sha256:ad71d22104a16e4f9efa93e61e8c7bce28de693f59c802586abbe85e9db55a65"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true

--- a/examples/k3s.yaml
+++ b/examples/k3s.yaml
@@ -13,49 +13,45 @@
 # This example requires Lima v0.7.0 or later.
 
 images:
-# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-  digest: "sha256:345fbbb6ec827ca02ec1a1ced90f7d40d3fd345811ba97c5772ac40e951458e1"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-  digest: "sha256:f6b5b3a980f28f25fe5203ae74b79cc664ae5505cf255a62f3b01be46ab9967a"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:345fbbb6ec827ca02ec1a1ced90f7d40d3fd345811ba97c5772ac40e951458e1"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:f6b5b3a980f28f25fe5203ae74b79cc664ae5505cf255a62f3b01be46ab9967a"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
 # Mounts are disabled in this example, but can be enabled optionally.
 mounts: []
-
 # containerd is managed by k3s, not by Lima, so the values are set to false here.
 containerd:
   system: false
   user: false
-
 provision:
-- mode: system
-  script: |
-    #!/bin/sh
-    curl -sfL https://get.k3s.io | sh -
-
+  - mode: system
+    script: |
+      #!/bin/sh
+      curl -sfL https://get.k3s.io | sh -
 probes:
-- script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    if ! timeout 30s bash -c "until test -f /etc/rancher/k3s/k3s.yaml; do sleep 3; done"; then
-            echo >&2 "k3s is not running yet"
-            exit 1
-    fi
-  hint: |
-    The k3s kubeconfig file has not yet been created.
-    Run "limactl shell k3s sudo journalctl -u k3s" to check the log.
-    If that is still empty, check the bottom of the log at "/var/log/cloud-init-output.log".
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until test -f /etc/rancher/k3s/k3s.yaml; do sleep 3; done"; then
+              echo >&2 "k3s is not running yet"
+              exit 1
+      fi
+    hint: |
+      The k3s kubeconfig file has not yet been created.
+      Run "limactl shell k3s sudo journalctl -u k3s" to check the log.
+      If that is still empty, check the bottom of the log at "/var/log/cloud-init-output.log".
 copyToHost:
-- guest: "/etc/rancher/k3s/k3s.yaml"
-  host: "{{.Dir}}/copied-from-guest/kubeconfig.yaml"
+  - guest: "/etc/rancher/k3s/k3s.yaml"
+    host: "{{.Dir}}/copied-from-guest/kubeconfig.yaml"
 message: |
   To run `kubectl` on the host (assumes kubectl is installed), run the following commands:
   ------

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -12,150 +12,149 @@
 
 # This example requires Lima v0.7.0 or later.
 images:
-# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-  digest: "sha256:345fbbb6ec827ca02ec1a1ced90f7d40d3fd345811ba97c5772ac40e951458e1"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-  digest: "sha256:f6b5b3a980f28f25fe5203ae74b79cc664ae5505cf255a62f3b01be46ab9967a"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:345fbbb6ec827ca02ec1a1ced90f7d40d3fd345811ba97c5772ac40e951458e1"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:f6b5b3a980f28f25fe5203ae74b79cc664ae5505cf255a62f3b01be46ab9967a"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
 # Mounts are disabled in this example, but can be enabled optionally.
 mounts: []
 containerd:
   system: true
   user: false
 provision:
-# See <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/>
-- mode: system
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    command -v kubeadm >/dev/null 2>&1 && exit 0
-    # Install and configure prerequisites
-    cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
-    overlay
-    br_netfilter
-    EOF
-    modprobe overlay
-    modprobe br_netfilter
-    cat <<EOF | sudo tee /etc/sysctl.d/99-kubernetes-cri.conf
-    net.bridge.bridge-nf-call-iptables  = 1
-    net.ipv4.ip_forward                 = 1
-    net.bridge.bridge-nf-call-ip6tables = 1
-    EOF
-    sysctl --system
-    # Installing kubeadm, kubelet and kubectl
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get update
-    apt-get install -y apt-transport-https ca-certificates curl
-    curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
-    echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-    apt-get update
-    # cri-tools
-    apt-get install -y cri-tools
-    cat  <<EOF | sudo tee /etc/crictl.yaml
-    runtime-endpoint: unix:///run/containerd/containerd.sock
-    EOF
-    # cni-plugins
-    apt-get install -y kubernetes-cni
-    rm -f /etc/cni/net.d/*.conf*
-    apt-get install -y kubelet kubeadm kubectl && apt-mark hold kubelet kubeadm kubectl
-    systemctl enable --now kubelet
-# See <https://kubernetes.io/docs/setup/production-environment/container-runtimes/>
-- mode: system
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    grep SystemdCgroup /etc/containerd/config.toml && exit 0
-    grep "version = 2" /etc/containerd/config.toml || exit 1
-    # Configuring the systemd cgroup driver
-    # Overriding the sandbox (pause) image
-    cat <<EOF >>/etc/containerd/config.toml
-      [plugins]
-        [plugins."io.containerd.grpc.v1.cri"]
-          sandbox_image = "$(kubeadm config images list | grep pause | sort -r | head -n1)"
-          [plugins."io.containerd.grpc.v1.cri".containerd]
-            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-                runtime_type = "io.containerd.runc.v2"
-                [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-                  SystemdCgroup = true
-    EOF
-    systemctl restart containerd
-# See <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/>
-- mode: system
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    test -e /etc/kubernetes/admin.conf && exit 0
-    export KUBECONFIG=/etc/kubernetes/admin.conf
-    kubeadm config images list
-    kubeadm config images pull --cri-socket=unix:///run/containerd/containerd.sock
-    # Initializing your control-plane node
-    cat <<EOF >kubeadm-config.yaml
-    kind: InitConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta3
-    nodeRegistration:
-      criSocket: unix:///run/containerd/containerd.sock
-    ---
-    kind: ClusterConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta3
-    apiServer:
-      certSANs: # --apiserver-cert-extra-sans
-      - "127.0.0.1"
-    networking:
-      podSubnet: "10.244.0.0/16" # --pod-network-cidr
-    ---
-    kind: KubeletConfiguration
-    apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
-    EOF
-    kubeadm init --config kubeadm-config.yaml
-    # Installing a Pod network add-on
-    kubectl apply -f https://github.com/flannel-io/flannel/releases/download/v0.21.4/kube-flannel.yml
-    # Control plane node isolation
-    kubectl taint nodes --all node-role.kubernetes.io/control-plane-
-    sed -e "s/${LIMA_CIDATA_SLIRP_IP_ADDRESS:-192.168.5.15}/127.0.0.1/" -i $KUBECONFIG
-    mkdir -p ${HOME:-/root}/.kube && cp -f $KUBECONFIG ${HOME:-/root}/.kube/config
+  # See <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/>
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      command -v kubeadm >/dev/null 2>&1 && exit 0
+      # Install and configure prerequisites
+      cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+      overlay
+      br_netfilter
+      EOF
+      modprobe overlay
+      modprobe br_netfilter
+      cat <<EOF | sudo tee /etc/sysctl.d/99-kubernetes-cri.conf
+      net.bridge.bridge-nf-call-iptables  = 1
+      net.ipv4.ip_forward                 = 1
+      net.bridge.bridge-nf-call-ip6tables = 1
+      EOF
+      sysctl --system
+      # Installing kubeadm, kubelet and kubectl
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      apt-get install -y apt-transport-https ca-certificates curl
+      curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+      echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+      apt-get update
+      # cri-tools
+      apt-get install -y cri-tools
+      cat  <<EOF | sudo tee /etc/crictl.yaml
+      runtime-endpoint: unix:///run/containerd/containerd.sock
+      EOF
+      # cni-plugins
+      apt-get install -y kubernetes-cni
+      rm -f /etc/cni/net.d/*.conf*
+      apt-get install -y kubelet kubeadm kubectl && apt-mark hold kubelet kubeadm kubectl
+      systemctl enable --now kubelet
+  # See <https://kubernetes.io/docs/setup/production-environment/container-runtimes/>
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      grep SystemdCgroup /etc/containerd/config.toml && exit 0
+      grep "version = 2" /etc/containerd/config.toml || exit 1
+      # Configuring the systemd cgroup driver
+      # Overriding the sandbox (pause) image
+      cat <<EOF >>/etc/containerd/config.toml
+        [plugins]
+          [plugins."io.containerd.grpc.v1.cri"]
+            sandbox_image = "$(kubeadm config images list | grep pause | sort -r | head -n1)"
+            [plugins."io.containerd.grpc.v1.cri".containerd]
+              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+                [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+                  runtime_type = "io.containerd.runc.v2"
+                  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+                    SystemdCgroup = true
+      EOF
+      systemctl restart containerd
+  # See <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/>
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      test -e /etc/kubernetes/admin.conf && exit 0
+      export KUBECONFIG=/etc/kubernetes/admin.conf
+      kubeadm config images list
+      kubeadm config images pull --cri-socket=unix:///run/containerd/containerd.sock
+      # Initializing your control-plane node
+      cat <<EOF >kubeadm-config.yaml
+      kind: InitConfiguration
+      apiVersion: kubeadm.k8s.io/v1beta3
+      nodeRegistration:
+        criSocket: unix:///run/containerd/containerd.sock
+      ---
+      kind: ClusterConfiguration
+      apiVersion: kubeadm.k8s.io/v1beta3
+      apiServer:
+        certSANs: # --apiserver-cert-extra-sans
+        - "127.0.0.1"
+      networking:
+        podSubnet: "10.244.0.0/16" # --pod-network-cidr
+      ---
+      kind: KubeletConfiguration
+      apiVersion: kubelet.config.k8s.io/v1beta1
+      cgroupDriver: systemd
+      EOF
+      kubeadm init --config kubeadm-config.yaml
+      # Installing a Pod network add-on
+      kubectl apply -f https://github.com/flannel-io/flannel/releases/download/v0.21.4/kube-flannel.yml
+      # Control plane node isolation
+      kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+      sed -e "s/${LIMA_CIDATA_SLIRP_IP_ADDRESS:-192.168.5.15}/127.0.0.1/" -i $KUBECONFIG
+      mkdir -p ${HOME:-/root}/.kube && cp -f $KUBECONFIG ${HOME:-/root}/.kube/config
 probes:
-- description: "kubeadm to be installed"
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    if ! timeout 30s bash -c "until command -v kubeadm >/dev/null 2>&1; do sleep 3; done"; then
-      echo >&2 "kubeadm is not installed yet"
-      exit 1
-    fi
-  hint: |
-    See "/var/log/cloud-init-output.log". in the guest
-- description: "kubeadm to be completed"
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    if ! timeout 300s bash -c "until test -f /etc/kubernetes/admin.conf; do sleep 3; done"; then
-      echo >&2 "k8s is not running yet"
-      exit 1
-    fi
-  hint: |
-    The k8s kubeconfig file has not yet been created.
-- description: "kubernetes cluster to be running"
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    if ! timeout 300s bash -c "until sudo kubectl version >/dev/null 2>&1; do sleep 3; done"; then
-      echo >&2 "kubernetes cluster is not up and running yet"
-      exit 1
-    fi
+  - description: "kubeadm to be installed"
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until command -v kubeadm >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "kubeadm is not installed yet"
+        exit 1
+      fi
+    hint: |
+      See "/var/log/cloud-init-output.log". in the guest
+  - description: "kubeadm to be completed"
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 300s bash -c "until test -f /etc/kubernetes/admin.conf; do sleep 3; done"; then
+        echo >&2 "k8s is not running yet"
+        exit 1
+      fi
+    hint: |
+      The k8s kubeconfig file has not yet been created.
+  - description: "kubernetes cluster to be running"
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 300s bash -c "until sudo kubectl version >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "kubernetes cluster is not up and running yet"
+        exit 1
+      fi
 copyToHost:
-- guest: "/etc/kubernetes/admin.conf"
-  host: "{{.Dir}}/copied-from-guest/kubeconfig.yaml"
+  - guest: "/etc/kubernetes/admin.conf"
+    host: "{{.Dir}}/copied-from-guest/kubeconfig.yaml"
 message: |
   To run `kubectl` on the host (assumes kubectl is installed), run the following commands:
   ------

--- a/examples/nomad.yaml
+++ b/examples/nomad.yaml
@@ -12,20 +12,19 @@
 # Image is set to focal (20.04 LTS) for long-term stability
 # TODO: Upgrade to 22.04 LTS when nomad-driver-containerd supports cgroup v2: https://github.com/Roblox/nomad-driver-containerd/pull/133
 images:
-# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-  digest: "sha256:243157ea0390890d6e60ce5e08e0249b16e23b6b313b63aed50f39f92b020afe"
-- location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-  digest: "sha256:fb2b4efdbf0011bd2a9fd49e9d31efdd252966c889f07b5d246351ec5734a329"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+  - location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:243157ea0390890d6e60ce5e08e0249b16e23b6b313b63aed50f39f92b020afe"
+  - location: "https://cloud-images.ubuntu.com/releases/20.04/release-20220302/ubuntu-20.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:fb2b4efdbf0011bd2a9fd49e9d31efdd252966c889f07b5d246351ec5734a329"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
 # Mounts are disabled in this example, but can be enabled optionally.
 mounts: []
 containerd:
@@ -33,47 +32,47 @@ containerd:
   user: false
 # See https://learn.hashicorp.com/tutorials/nomad/get-started-install
 provision:
-- mode: system
-  script: |
-    #!/bin/sh
-    command -v nomad >/dev/null 2>&1 && exit 0
-    curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-    echo "deb https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-    apt-get update
-    apt-get install -y nomad consul golang-cfssl
-    sed -e '/^client/a \ \ cni_path = "/usr/local/libexec/cni"\n\ \ cni_config_dir = "/etc/cni/net.d"' -i /etc/nomad.d/nomad.hcl
-    # install containerd-driver
-    DRIVER_VERSION=0.9.3
-    case $(uname -m) in
-      amd64|x86_64)
-        curl -sSL -o containerd-driver https://github.com/Roblox/nomad-driver-containerd/releases/download/v${DRIVER_VERSION}/containerd-driver
-        ;;
-      arm64|aarch64)
-        curl -sSL -o containerd-driver https://github.com/Roblox/nomad-driver-containerd/releases/download/v${DRIVER_VERSION}/containerd-driver-arm64
-        ;;
-    esac
-    sudo install -D containerd-driver /opt/nomad/data/plugins/containerd-driver
-    cat <<EOF | sudo tee -a /etc/nomad.d/nomad.hcl
+  - mode: system
+    script: |
+      #!/bin/sh
+      command -v nomad >/dev/null 2>&1 && exit 0
+      curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+      echo "deb https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+      apt-get update
+      apt-get install -y nomad consul golang-cfssl
+      sed -e '/^client/a \ \ cni_path = "/usr/local/libexec/cni"\n\ \ cni_config_dir = "/etc/cni/net.d"' -i /etc/nomad.d/nomad.hcl
+      # install containerd-driver
+      DRIVER_VERSION=0.9.3
+      case $(uname -m) in
+        amd64|x86_64)
+          curl -sSL -o containerd-driver https://github.com/Roblox/nomad-driver-containerd/releases/download/v${DRIVER_VERSION}/containerd-driver
+          ;;
+        arm64|aarch64)
+          curl -sSL -o containerd-driver https://github.com/Roblox/nomad-driver-containerd/releases/download/v${DRIVER_VERSION}/containerd-driver-arm64
+          ;;
+      esac
+      sudo install -D containerd-driver /opt/nomad/data/plugins/containerd-driver
+      cat <<EOF | sudo tee -a /etc/nomad.d/nomad.hcl
 
-    plugin "containerd-driver" {
-      config {
-          enabled = true
-          containerd_runtime = "io.containerd.runc.v2"
-          stats_interval = "5s"
+      plugin "containerd-driver" {
+        config {
+            enabled = true
+            containerd_runtime = "io.containerd.runc.v2"
+            stats_interval = "5s"
+        }
       }
-    }
-    EOF
-    systemctl enable --now nomad consul
-- mode: user
-  script: |
-    #!/bin/sh
-    nomad -autocomplete-install
+      EOF
+      systemctl enable --now nomad consul
+  - mode: user
+    script: |
+      #!/bin/sh
+      nomad -autocomplete-install
 probes:
-- script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    if ! timeout 30s bash -c "until command -v nomad >/dev/null 2>&1; do sleep 3; done"; then
-      echo >&2 "nomad is not installed yet"
-      exit 1
-    fi
-  hint: See "/var/log/cloud-init-output.log". in the guest
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until command -v nomad >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "nomad is not installed yet"
+        exit 1
+      fi
+    hint: See "/var/log/cloud-init-output.log". in the guest

--- a/examples/opensuse.yaml
+++ b/examples/opensuse.yaml
@@ -1,19 +1,18 @@
 # This example requires Lima v0.7.0 or later
 images:
-# Hint: run `limactl prune` to invalidate the "Current" cache
-- location: "https://download.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-15.4-OpenStack-Cloud-Current.qcow2"
-  arch: "x86_64"
-- location: "https://download.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-ARM-JeOS-efi.aarch64.qcow2"
-  arch: "aarch64"
-# download.opensuse.org is inaccessible from Japan (500 Internal Server Error)
-# https://bugzilla.opensuse.org/show_bug.cgi?id=1210240
-# NOTE: the file name on provo-mirror.opensuse.org lacks the "-Current" suffix.
-- location: "https://provo-mirror.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2"
-  arch: "x86_64"
-- location: "https://provo-mirror.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-ARM-JeOS-efi.aarch64.qcow2"
-  arch: "aarch64"
-
+  # Hint: run `limactl prune` to invalidate the "Current" cache
+  - location: "https://download.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-15.4-OpenStack-Cloud-Current.qcow2"
+    arch: "x86_64"
+  - location: "https://download.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-ARM-JeOS-efi.aarch64.qcow2"
+    arch: "aarch64"
+  # download.opensuse.org is inaccessible from Japan (500 Internal Server Error)
+  # https://bugzilla.opensuse.org/show_bug.cgi?id=1210240
+  # NOTE: the file name on provo-mirror.opensuse.org lacks the "-Current" suffix.
+  - location: "https://provo-mirror.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2"
+    arch: "x86_64"
+  - location: "https://provo-mirror.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-ARM-JeOS-efi.aarch64.qcow2"
+    arch: "aarch64"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true

--- a/examples/oraclelinux-8.yaml
+++ b/examples/oraclelinux-8.yaml
@@ -6,16 +6,16 @@
 # EL9-based distros are known to work.
 
 images:
-- location: "https://yum.oracle.com/templates/OracleLinux/OL8/u7/x86_64/OL8U7_x86_64-kvm-b148.qcow"
-  arch: "x86_64"
-  digest: "sha256:4a98e22908333dae1423e0bb4032c88aed60dbf1267addb73a6905778e9930df"
-- location: "https://yum.oracle.com/templates/OracleLinux/OL8/u7/aarch64/OL8U7_aarch64-kvm-b10.qcow"
-  arch: "aarch64"
-  digest: "sha256:158e748c74a6316e7fdd185e1c6931d6c6d3e55650bdaf098d8019b96886477d"
+  - location: "https://yum.oracle.com/templates/OracleLinux/OL8/u7/x86_64/OL8U7_x86_64-kvm-b148.qcow"
+    arch: "x86_64"
+    digest: "sha256:4a98e22908333dae1423e0bb4032c88aed60dbf1267addb73a6905778e9930df"
+  - location: "https://yum.oracle.com/templates/OracleLinux/OL8/u7/aarch64/OL8U7_aarch64-kvm-b10.qcow"
+    arch: "aarch64"
+    digest: "sha256:158e748c74a6316e7fdd185e1c6931d6c6d3e55650bdaf098d8019b96886477d"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 firmware:
   # Oracle Linux 8 still requires legacyBIOS, while AlmaLinux 8 and Rocky Linux 8 do not.
   legacyBIOS: true

--- a/examples/oraclelinux-9.yaml
+++ b/examples/oraclelinux-9.yaml
@@ -3,16 +3,16 @@
 # Image source: https://yum.oracle.com/oracle-linux-templates.html
 
 images:
-- location: "https://yum.oracle.com/templates/OracleLinux/OL9/u1/x86_64/OL9U1_x86_64-kvm-b158.qcow"
-  arch: "x86_64"
-  digest: "sha256:ca655beba34038349827c5ab365df4f7936a7f6226a04d0452bbe4430f4d6658"
-- location: "https://yum.oracle.com/templates/OracleLinux/OL9/u1/aarch64/OL9U1_aarch64-kvm-b13.qcow"
-  arch: "aarch64"
-  digest: "sha256:a71abfd60713cd5c37443287dd267efd30f1715f8db075e0377b43e2d6ec44cf"
+  - location: "https://yum.oracle.com/templates/OracleLinux/OL9/u1/x86_64/OL9U1_x86_64-kvm-b158.qcow"
+    arch: "x86_64"
+    digest: "sha256:ca655beba34038349827c5ab365df4f7936a7f6226a04d0452bbe4430f4d6658"
+  - location: "https://yum.oracle.com/templates/OracleLinux/OL9/u1/aarch64/OL9U1_aarch64-kvm-b13.qcow"
+    arch: "aarch64"
+    digest: "sha256:a71abfd60713cd5c37443287dd267efd30f1715f8db075e0377b43e2d6ec44cf"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 firmware:
   # Oracle Linux 9 still requires legacyBIOS, while AlmaLinux 9 and Rocky Linux 9 do not.
   legacyBIOS: true

--- a/examples/podman-rootful.yaml
+++ b/examples/podman-rootful.yaml
@@ -12,55 +12,54 @@
 
 # This example requires Lima v0.8.0 or later
 images:
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
-  arch: "x86_64"
-  digest: "sha256:d334670401ff3d5b4129fcc662cf64f5a6e568228af59076cc449a4945318482"
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/aarch64/images/Fedora-Cloud-Base-38-1.6.aarch64.qcow2"
-  arch: "aarch64"
-  digest: "sha256:ad71d22104a16e4f9efa93e61e8c7bce28de693f59c802586abbe85e9db55a65"
-
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
+    arch: "x86_64"
+    digest: "sha256:d334670401ff3d5b4129fcc662cf64f5a6e568228af59076cc449a4945318482"
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/aarch64/images/Fedora-Cloud-Base-38-1.6.aarch64.qcow2"
+    arch: "aarch64"
+    digest: "sha256:ad71d22104a16e4f9efa93e61e8c7bce28de693f59c802586abbe85e9db55a65"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 containerd:
   system: false
   user: false
 provision:
-- mode: system
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    command -v podman >/dev/null 2>&1 && exit 0
-    if [ ! -e /etc/systemd/system/podman.socket.d/override.conf ]; then
-      mkdir -p /etc/systemd/system/podman.socket.d
-      cat <<-EOF >/etc/systemd/system/podman.socket.d/override.conf
-      [Socket]
-      SocketUser=${LIMA_CIDATA_USER}
-    EOF
-    fi
-    if [ ! -e /etc/tmpfiles.d/podman.conf ]; then
-      mkdir -p /etc/tmpfiles.d
-      echo "d /run/podman 0700 ${LIMA_CIDATA_USER} -" > /etc/tmpfiles.d/podman.conf
-    fi
-    dnf -y install podman
-- mode: system
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    systemctl --system enable --now podman.socket
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      command -v podman >/dev/null 2>&1 && exit 0
+      if [ ! -e /etc/systemd/system/podman.socket.d/override.conf ]; then
+        mkdir -p /etc/systemd/system/podman.socket.d
+        cat <<-EOF >/etc/systemd/system/podman.socket.d/override.conf
+        [Socket]
+        SocketUser=${LIMA_CIDATA_USER}
+      EOF
+      fi
+      if [ ! -e /etc/tmpfiles.d/podman.conf ]; then
+        mkdir -p /etc/tmpfiles.d
+        echo "d /run/podman 0700 ${LIMA_CIDATA_USER} -" > /etc/tmpfiles.d/podman.conf
+      fi
+      dnf -y install podman
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      systemctl --system enable --now podman.socket
 probes:
-- script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    if ! timeout 30s bash -c "until command -v podman >/dev/null 2>&1; do sleep 3; done"; then
-      echo >&2 "podman is not installed yet"
-      exit 1
-    fi
-  hint: See "/var/log/cloud-init-output.log" in the guest
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until command -v podman >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "podman is not installed yet"
+        exit 1
+      fi
+    hint: See "/var/log/cloud-init-output.log" in the guest
 portForwards:
-- guestSocket: "/run/podman/podman.sock"
-  hostSocket: "{{.Dir}}/sock/podman.sock"
+  - guestSocket: "/run/podman/podman.sock"
+    hostSocket: "{{.Dir}}/sock/podman.sock"
 message: |
   To run `podman` on the host (assumes podman-remote is installed), run the following commands:
   ------

--- a/examples/podman.yaml
+++ b/examples/podman.yaml
@@ -12,44 +12,43 @@
 
 # This example requires Lima v0.8.0 or later
 images:
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
-  arch: "x86_64"
-  digest: "sha256:d334670401ff3d5b4129fcc662cf64f5a6e568228af59076cc449a4945318482"
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/aarch64/images/Fedora-Cloud-Base-38-1.6.aarch64.qcow2"
-  arch: "aarch64"
-  digest: "sha256:ad71d22104a16e4f9efa93e61e8c7bce28de693f59c802586abbe85e9db55a65"
-
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
+    arch: "x86_64"
+    digest: "sha256:d334670401ff3d5b4129fcc662cf64f5a6e568228af59076cc449a4945318482"
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/aarch64/images/Fedora-Cloud-Base-38-1.6.aarch64.qcow2"
+    arch: "aarch64"
+    digest: "sha256:ad71d22104a16e4f9efa93e61e8c7bce28de693f59c802586abbe85e9db55a65"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 containerd:
   system: false
   user: false
 provision:
-- mode: system
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    command -v podman >/dev/null 2>&1 && exit 0
-    dnf -y install podman
-- mode: user
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    systemctl --user enable --now podman.socket
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      command -v podman >/dev/null 2>&1 && exit 0
+      dnf -y install podman
+  - mode: user
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      systemctl --user enable --now podman.socket
 probes:
-- script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    if ! timeout 30s bash -c "until command -v podman >/dev/null 2>&1; do sleep 3; done"; then
-      echo >&2 "podman is not installed yet"
-      exit 1
-    fi
-  hint: See "/var/log/cloud-init-output.log" in the guest
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until command -v podman >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "podman is not installed yet"
+        exit 1
+      fi
+    hint: See "/var/log/cloud-init-output.log" in the guest
 portForwards:
-- guestSocket: "/run/user/{{.UID}}/podman/podman.sock"
-  hostSocket: "{{.Dir}}/sock/podman.sock"
+  - guestSocket: "/run/user/{{.UID}}/podman/podman.sock"
+    hostSocket: "{{.Dir}}/sock/podman.sock"
 message: |
   To run `podman` on the host (assumes podman-remote is installed), run the following commands:
   ------

--- a/examples/rocky-8.yaml
+++ b/examples/rocky-8.yaml
@@ -4,16 +4,16 @@
 # EL9-based distros are known to work.
 
 images:
-- location: "https://dl.rockylinux.org/pub/rocky/8.7/images/x86_64/Rocky-8-GenericCloud-Base-8.7-20230215.0.x86_64.qcow2"
-  arch: "x86_64"
-  digest: "sha256:f242e06b76124b8ea3495fc6d69eb6e89e0a1826e3d9bdabed0ef4e68880eb5a"
-- location: "https://dl.rockylinux.org/pub/rocky/8.7/images/aarch64/Rocky-8-GenericCloud-Base-8.7-20230215.0.aarch64.qcow2"
-  arch: "aarch64"
-  digest: "sha256:f06698cb5e1631eb4ba9b90b8fce73407e285c953ab0e49b451899a8d6558fab"
+  - location: "https://dl.rockylinux.org/pub/rocky/8.7/images/x86_64/Rocky-8-GenericCloud-Base-8.7-20230215.0.x86_64.qcow2"
+    arch: "x86_64"
+    digest: "sha256:f242e06b76124b8ea3495fc6d69eb6e89e0a1826e3d9bdabed0ef4e68880eb5a"
+  - location: "https://dl.rockylinux.org/pub/rocky/8.7/images/aarch64/Rocky-8-GenericCloud-Base-8.7-20230215.0.aarch64.qcow2"
+    arch: "aarch64"
+    digest: "sha256:f06698cb5e1631eb4ba9b90b8fce73407e285c953ab0e49b451899a8d6558fab"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 cpuType:
   # Workaround for "vmx_write_mem: mmu_gva_to_gpa XXXXXXXXXXXXXXXX failed" on Intel Mac
   # https://bugs.launchpad.net/qemu/+bug/1838390

--- a/examples/rocky-9.yaml
+++ b/examples/rocky-9.yaml
@@ -1,13 +1,13 @@
 # This example requires Lima v0.11.1 or later.
 
 images:
-- location: "https://dl.rockylinux.org/pub/rocky/9.1/images/x86_64/Rocky-9-GenericCloud-Base-9.1-20230215.0.x86_64.qcow2"
-  arch: "x86_64"
-  digest: "sha256:53850338cd7e918052e13fc0a34b8383675ac747e168f640cfb7f483e65eac65"
-- location: "https://dl.rockylinux.org/pub/rocky/9.1/images/aarch64/Rocky-9-GenericCloud-Base-9.1-20230215.0.aarch64.qcow2"
-  arch: "aarch64"
-  digest: "sha256:6991592f3308376d63c5a69b353586cee1d67077f1af6d0a3f12126b11a13829"
+  - location: "https://dl.rockylinux.org/pub/rocky/9.1/images/x86_64/Rocky-9-GenericCloud-Base-9.1-20230215.0.x86_64.qcow2"
+    arch: "x86_64"
+    digest: "sha256:53850338cd7e918052e13fc0a34b8383675ac747e168f640cfb7f483e65eac65"
+  - location: "https://dl.rockylinux.org/pub/rocky/9.1/images/aarch64/Rocky-9-GenericCloud-Base-9.1-20230215.0.aarch64.qcow2"
+    arch: "aarch64"
+    digest: "sha256:6991592f3308376d63c5a69b353586cee1d67077f1af6d0a3f12126b11a13829"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true

--- a/examples/ubuntu-lts.yaml
+++ b/examples/ubuntu-lts.yaml
@@ -1,20 +1,19 @@
 # This example requires Lima v0.7.0 or later.
 images:
-# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-  digest: "sha256:345fbbb6ec827ca02ec1a1ced90f7d40d3fd345811ba97c5772ac40e951458e1"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-  digest: "sha256:f6b5b3a980f28f25fe5203ae74b79cc664ae5505cf255a62f3b01be46ab9967a"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:345fbbb6ec827ca02ec1a1ced90f7d40d3fd345811ba97c5772ac40e951458e1"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230302/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:f6b5b3a980f28f25fe5203ae74b79cc664ae5505cf255a62f3b01be46ab9967a"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true

--- a/examples/ubuntu.yaml
+++ b/examples/ubuntu.yaml
@@ -1,20 +1,19 @@
 # This example requires Lima v0.7.0 or later.
 images:
-# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-amd64.img"
-  arch: "x86_64"
-  digest: "sha256:d46438111d7a6dfcdfb2e1fb76762a79d56f09dc308cc9ab2300effc0078fd5b"
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-arm64.img"
-  arch: "aarch64"
-  digest: "sha256:e1865c2ebc531600ae6012d86fa2dae5846e7801cdcdbcf90d9c830218ef4ae9"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:d46438111d7a6dfcdfb2e1fb76762a79d56f09dc308cc9ab2300effc0078fd5b"
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:e1865c2ebc531600ae6012d86fa2dae5846e7801cdcdbcf90d9c830218ef4ae9"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
+    arch: "aarch64"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true

--- a/examples/vmnet.yaml
+++ b/examples/vmnet.yaml
@@ -9,33 +9,32 @@
 # This example requires Lima v0.7.0 or later.
 # Older versions of Lima were using a different syntax for supporting vmnet.framework.
 images:
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-amd64.img"
-  arch: "x86_64"
-  digest: "sha256:d46438111d7a6dfcdfb2e1fb76762a79d56f09dc308cc9ab2300effc0078fd5b"
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-arm64.img"
-  arch: "aarch64"
-  digest: "sha256:e1865c2ebc531600ae6012d86fa2dae5846e7801cdcdbcf90d9c830218ef4ae9"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:d46438111d7a6dfcdfb2e1fb76762a79d56f09dc308cc9ab2300effc0078fd5b"
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release-20230413/ubuntu-22.10-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:e1865c2ebc531600ae6012d86fa2dae5846e7801cdcdbcf90d9c830218ef4ae9"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.10/release/ubuntu-22.10-server-cloudimg-arm64.img"
+    arch: "aarch64"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 networks:
-# The instance can get routable IP addresses from the vmnet framework using
-# https://github.com/lima-vm/socket_vmnet (since Lima v0.12) or
-# https://github.com/lima-vm/vde_vmnet (deprecated) .
-#
-# Available networks are defined in
-# $LIMA_HOME/_config/networks.yaml. Supported network types are "host",
-# "shared", or "bridged".
-#
-# Interface "lima0": shared mode  (IP is assigned by macOS's bootpd)
-- lima: shared
+  # The instance can get routable IP addresses from the vmnet framework using
+  # https://github.com/lima-vm/socket_vmnet (since Lima v0.12) or
+  # https://github.com/lima-vm/vde_vmnet (deprecated) .
+  #
+  # Available networks are defined in
+  # $LIMA_HOME/_config/networks.yaml. Supported network types are "host",
+  # "shared", or "bridged".
+  #
+  # Interface "lima0": shared mode  (IP is assigned by macOS's bootpd)
+  - lima: shared
 # Interface "lima1": bridged mode (IP is assigned by a DHCP server on the physical network)
 # - lima: bridged

--- a/hack/test-templates/test-misc.yaml
+++ b/hack/test-templates/test-misc.yaml
@@ -4,26 +4,24 @@
 #
 # This example requires Lima v0.14.0 or later.
 images:
-# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-  digest: "sha256:c777670007cc5f132417b9e0bc01367ccfc2a989951ffa225bb1952917c3aa81"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-  digest: "sha256:9620f479bd5a6cbf1e805654d41b27f4fc56ef20f916c8331558241734de81ae"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-
+  # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:c777670007cc5f132417b9e0bc01367ccfc2a989951ffa225bb1952917c3aa81"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:9620f479bd5a6cbf1e805654d41b27f4fc56ef20f916c8331558241734de81ae"
+  # Fallback to the latest release image.
+  # Hint: run `limactl prune` to invalidate the cache
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
 mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
-
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
 # in order to use this example, you must first create the disk "data". run:
 # $ limactl disk create data --size 10G
 additionalDisks:
-- "data"
+  - "data"

--- a/pkg/networks/networks.TEMPLATE.yaml
+++ b/pkg/networks/networks.TEMPLATE.yaml
@@ -10,17 +10,15 @@
 # None of the paths segments may be symlinks, why it has to be /private/var
 # instead of /var etc.
 paths:
-# socketVMNet requires Lima >= 0.12 .
-# socketVMNet has precedence over vdeVMNet.
+  # socketVMNet requires Lima >= 0.12 .
+  # socketVMNet has precedence over vdeVMNet.
   socketVMNet: "{{.SocketVMNet}}"
-# vdeSwitch and vdeVMNet are DEPRECATED.
+  # vdeSwitch and vdeVMNet are DEPRECATED.
   vdeSwitch: /opt/vde/bin/vde_switch
   vdeVMNet: /opt/vde/bin/vde_vmnet
   varRun: /private/var/run/lima
   sudoers: /private/etc/sudoers.d/lima
-
 group: everyone
-
 networks:
   user-v2:
     mode: user-v2


### PR DESCRIPTION
Fix #1389 so that we can eventually automate updating yamls (#1347) using [`yq`](https://github.com/mikefarah/yq).

Use `git show --ignore-all-space --ignore-blank-lines` to review this commit.

```diff
diff --git a/.yamllint b/.yamllint
index a7c8c3f..20183f4 100644
--- a/.yamllint
+++ b/.yamllint
@@ -3,8 +3,6 @@
 extends: default
 
 rules:
-  indentation:
-    indent-sequences: false
   truthy:
     allowed-values: ['true', 'false', 'on', 'off']
   comments-indentation: disable
```