### PR TITLE
Check qemu version in hostagent so not too old

### DIFF
--- a/pkg/qemu/qemu_test.go
+++ b/pkg/qemu/qemu_test.go
@@ -47,3 +47,42 @@ func TestArgValue(t *testing.T) {
 		assert.Equal(t, tc.expectedOK, ok)
 	}
 }
+
+func TestParseQemuVersion(t *testing.T) {
+	type testCase struct {
+		versionOutput string
+		expectedValue string
+		expectedError string
+	}
+	testCases := []testCase{
+		{
+			// old one line version
+			versionOutput: "QEMU emulator version 1.5.3 (qemu-kvm-1.5.3-175.el7_9.6), " +
+				"Copyright (c) 2003-2008 Fabrice Bellard\n",
+			expectedValue: "1.5.3",
+			expectedError: "",
+		},
+		{
+			// new two line version
+			versionOutput: "QEMU emulator version 8.0.0 (v8.0.0)\n" +
+				"Copyright (c) 2003-2022 Fabrice Bellard and the QEMU Project developers\n",
+			expectedValue: "8.0.0",
+			expectedError: "",
+		},
+		{
+			versionOutput: "foobar",
+			expectedValue: "0.0.0",
+			expectedError: "failed to parse",
+		},
+	}
+
+	for _, tc := range testCases {
+		v, err := parseQemuVersion(tc.versionOutput)
+		if tc.expectedError == "" {
+			assert.NilError(t, err)
+		} else {
+			assert.ErrorContains(t, err, tc.expectedError)
+		}
+		assert.Equal(t, tc.expectedValue, v.String())
+	}
+}


### PR DESCRIPTION
This is mostly to give better error messages, when failing.

The old error would just say that it exited unexpectedly...

Closes #1534 