### PR TITLE
Fix unstable vz driver network issue

### DIFF
--- a/pkg/networks/usernet/UDPFileConn.go
+++ b/pkg/networks/usernet/UDPFileConn.go
@@ -1,0 +1,21 @@
+package usernet
+
+import (
+	"errors"
+	"net"
+	"time"
+)
+
+type UDPFileConn struct {
+	net.Conn
+}
+
+func (conn *UDPFileConn) Read(b []byte) (n int, err error) {
+	// Check if the connection has been closed
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		if opErr, ok := err.(*net.OpError); ok && opErr.Err.Error() == "use of closed network connection" {
+			return 0, errors.New("UDPFileConn connection closed")
+		}
+	}
+	return conn.Conn.Read(b)
+}

--- a/pkg/networks/usernet/gvproxy.go
+++ b/pkg/networks/usernet/gvproxy.go
@@ -163,11 +163,11 @@ func listenFD(ctx context.Context, vn *virtualnetwork.VirtualNetwork) error {
 			files[0].Close()
 
 			go func() {
-				err = vn.AcceptBess(ctx, fileConn)
+				err = vn.AcceptBess(ctx, &UDPFileConn{Conn: fileConn})
 				if err != nil {
 					logrus.Error("FD connection closed with error", err)
 				}
-				defer fileConn.Close()
+				fileConn.Close()
 			}()
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
This should hopefully fix the network freeze when using vz driver

https://github.com/lima-vm/lima/issues/1200#issuecomment-1327740698

I didn't add fix issue id's mainly to try and see if this really fixes or not.


**What is happening, why this change ?**
When we use file.FD(), whenever the file gets closed or garbage collected (finaliser closing file) the FD give before becomes invalid.

In our case, we use file.FD() for both client and server connections. Since these are DGRAM connection, if we try to read on a closed FD we won't get any error instead it get stuck indefinitely. This could be the reason for the freeze of vz network 

Before this change, i verified that that file getting garbage collected in ~2mins. So logically FD would become invalid at some point.