### PR TITLE
Mark `audio.device` experimental

### DIFF
--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -7,6 +7,7 @@ The following features are experimental and subject to change:
 - `arch: riscv64`
 - `video.display: vnc` and relevant configuration (`video.vnc.display`)
 - `mode: user-v2` in `networks.yml` and relevant configuration in `lima.yaml` 
+- `audio.device`
 
 The following flags are experimental and subject to change:
 

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -255,6 +255,7 @@ firmware:
   legacyBIOS: null
 
 audio:
+  # EXPERIMENTAL
   # QEMU audiodev, e.g., "none", "coreaudio", "pa", "alsa", "oss".
   # VZ driver, use "vz" as device name
   # Choosing "none" will mute the audio output, and not play any sound.

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -440,4 +440,7 @@ func warnExperimental(y LimaYAML) {
 	if y.Video.Display != nil && strings.Contains(*y.Video.Display, "vnc") {
 		logrus.Warn("`video.display: vnc` is experimental")
 	}
+	if y.Audio.Device != nil {
+		logrus.Warn("`audio.device` is experimental")
+	}
 }


### PR DESCRIPTION
The design is still subject to change:
- #1536