### PR TITLE
Alpine 3.18 on VZ requires macOS 13.3+

### DIFF
--- a/examples/alpine.yaml
+++ b/examples/alpine.yaml
@@ -1,4 +1,6 @@
 # This example requires Lima v0.7.0 or later.
+# Using the Alpine 3.18 aarch64 image with vmType=vz requires macOS Ventura 13.3 or later.
+
 images:
 - location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.28/alpine-lima-std-3.18.0-x86_64.iso"
   arch: "x86_64"


### PR DESCRIPTION
(Alpine 3.16 works on 13.1+; Alpine 3.17 also requires 13.3+)