### PR TITLE
[examples/k8s.yaml] the url to get gpg key for kubernetes is moved

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -55,7 +55,7 @@ provision:
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
     apt-get install -y apt-transport-https ca-certificates curl
-    curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
     echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
     apt-get update
     # cri-tools


### PR DESCRIPTION
the url to get gpg key for kubernetes is moved
cloud-init-out.log
```
Err:4 https://packages.cloud.google.com/apt kubernetes-xenial InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
Reading package lists...
W: GPG error: https://packages.cloud.google.com/apt kubernetes-xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
E: The repository 'https://apt.kubernetes.io/ kubernetes-xenial InRelease' is not signed.
```
referring to https://github.com/kubernetes/k8s.io/pull/4837

testes it on both of intel & m1 mac