### PR TITLE
Remove the output directory from the manpages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,8 @@ _output/share/lima/lima-guestagent.Linux-riscv64:
 .PHONY: manpages
 manpages: _output/bin/limactl$(exe)
 	@mkdir -p _output/share/man/man1
-	$< generate-man _output/share/man/man1
+	$< generate-man _output/share/man/man1 \
+		--output _output --prefix $(PREFIX)
 
 .PHONY: diagrams
 diagrams: docs/lima-sequence-diagram.png


### PR DESCRIPTION
We were showing the link to the examples and the documentation, to the build folder...

It is supposed to link to the files in the installed end result, that is to the install prefix.

man _output/share/man/man1/limactl.1

`See also example YAMLs: /usr/local/share/doc/lima/examples`

man _output/share/man/man1/limactl-sudoers.1

`See /usr/local/share/doc/lima/docs/network.md for the usage.`
