### PR TITLE
Use debian genericcloud instead of generic images

### DIFF
--- a/examples/debian.yaml
+++ b/examples/debian.yaml
@@ -1,11 +1,19 @@
 # This example requires Lima v0.7.0 or later
 images:
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
 - location: "https://cloud.debian.org/images/cloud/bullseye/20230515-1381/debian-11-genericcloud-amd64-20230515-1381.qcow2"
   arch: "x86_64"
   digest: "sha512:bf6e2e8550dd1f296338e8f6dedaa7bd3d4e31de73ef33e46882430af055a2ce0df9da27c30c159f8d544220a6cf428083724685c4472334fcd7c1191cbbfe27"
 - location: "https://cloud.debian.org/images/cloud/bullseye/20230515-1381/debian-11-genericcloud-arm64-20230515-1381.qcow2"
   arch: "aarch64"
   digest: "sha512:895806e31400c6322fbf240349228a5cf8040e1fac8d1ab3e12ee3a0e11d15ee733ff6d27e0b4db9cbd7adac02dfda1eff34f3174c7898caefb4026c51269823"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-genericcloud-amd64.qcow2"
+  arch: "x86_64"
+- location: "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-genericcloud-arm64.qcow2"
+  arch: "aarch64"
+
 mounts:
 - location: "~"
 - location: "/tmp/lima"

--- a/examples/debian.yaml
+++ b/examples/debian.yaml
@@ -1,11 +1,11 @@
 # This example requires Lima v0.7.0 or later
 images:
-- location: "https://cloud.debian.org/images/cloud/bullseye/20230515-1381/debian-11-generic-amd64-20230515-1381.qcow2"
+- location: "https://cloud.debian.org/images/cloud/bullseye/20230515-1381/debian-11-genericcloud-amd64-20230515-1381.qcow2"
   arch: "x86_64"
-  digest: "sha512:73cfdf17f6b4b52516935ba77d85296ed680033cd3dc3f117f5d9974b9b9148b4852bc752b72608f56583bef253390156b09aee5af49e76dda8f28c4d6b59e06"
-- location: "https://cloud.debian.org/images/cloud/bullseye/20230515-1381/debian-11-generic-arm64-20230515-1381.qcow2"
+  digest: "sha512:bf6e2e8550dd1f296338e8f6dedaa7bd3d4e31de73ef33e46882430af055a2ce0df9da27c30c159f8d544220a6cf428083724685c4472334fcd7c1191cbbfe27"
+- location: "https://cloud.debian.org/images/cloud/bullseye/20230515-1381/debian-11-genericcloud-arm64-20230515-1381.qcow2"
   arch: "aarch64"
-  digest: "sha512:97b888a2c59571494c628a1ef178c715914eac4de7e448fbc5d0673eae78336a37f0ac0c1d5a5ae8af201c67b84d6d2476cda6367cc5d00d2416f5e1ee9f912c"
+  digest: "sha512:895806e31400c6322fbf240349228a5cf8040e1fac8d1ab3e12ee3a0e11d15ee733ff6d27e0b4db9cbd7adac02dfda1eff34f3174c7898caefb4026c51269823"
 mounts:
 - location: "~"
 - location: "/tmp/lima"


### PR DESCRIPTION
This saves download time and disk space, by not including
drivers for physical hardware but only for virtual cloud.

https://cloud.debian.org/images/cloud/

> _generic_: Should run in any environment using cloud-init, for e.g. OpenStack, DigitalOcean and also on bare metal.
> _genericcloud_: Similar to generic. Should run in any virtualised environment. Is smaller than `generic` by excluding drivers for physical hardware.

Add fallback URLs, similar to the others.