### PR TITLE
Add Alpine examples with the container engines

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,11 @@ Container engines:
 - [`podman-rootful`](./podman-rootful.yaml): Podman (rootful)
 - LXD is installed in the default Ubuntu template, so there is no `lxd.yaml`
 
+Distro and engine examples:
+- [`experimental/alpine-nerdctl`](./experimental/alpine-nerdctl.yaml): Alpine Linux, with containerd/nerdctl
+- [`experimental/alpine-docker`](./experimental/alpine-docker.yaml): Alpine Linux, with Docker (rootful)
+- [`experimental/alpine-podman`](./experimental/alpine-podman.yaml): Alpine Linux, with Podman (rootless)
+
 Container image builders:
 - [`buildkit`](./buildkit.yaml): BuildKit
 

--- a/examples/experimental/alpine-docker.yaml
+++ b/examples/experimental/alpine-docker.yaml
@@ -1,0 +1,62 @@
+# This template requires Lima v0.7.0 or later.
+# Using the Alpine 3.18 aarch64 image with vmType=vz requires macOS Ventura 13.3 or later.
+
+images:
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.32/alpine-lima-std-3.18.0-x86_64.iso"
+  arch: "x86_64"
+  digest: "sha512:7b00fff78736a27a24e4a7de5f28037e9c7cf0fc539a33ec551c6ac619eb54237b5f25bfa35512fa7233cf23396dc249592710ef9150f619afa15267f9c8cbd4"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.32/alpine-lima-std-3.18.0-aarch64.iso"
+  arch: "aarch64"
+  digest: "sha512:bf23a22e05854670eef74d9bfad056caa249832f22d5594eb6bb02fa9aae109d33c764242f862d48de5b6715c4792a3ee29c19888a0711fb27113ba5cf1ccf21"
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+# containerd is managed by Docker, not by Lima, so the values are set to false here.
+containerd:
+  system: false
+  user: false
+provision:
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    command -v docker >/dev/null 2>&1 && exit 0
+    apk add docker
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! grep -q -- --group /etc/conf.d/docker; then
+      # Alternatively we could just add the user to the "docker" group, but that requires restarting the user session
+      echo "DOCKER_OPTS=\"--group ${LIMA_CIDATA_USER}\"" >> /etc/conf.d/docker
+    fi
+    rc-update add docker boot
+    service docker start
+probes:
+- description: "docker to be installed"
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! timeout 30s bash -c "until command -v docker >/dev/null 2>&1; do sleep 3; done"; then
+      echo >&2 "docker is not installed yet"
+      exit 1
+    fi
+- description: "docker to be runnning"
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! timeout 30s bash -c "until pgrep dockerd; do sleep 3; done"; then
+      echo >&2 "dockerd is not running"
+      exit 1
+    fi
+portForwards:
+- guestSocket: "/var/run/docker.sock"
+  hostSocket: "{{.Dir}}/sock/docker.sock"
+message: |
+  To run `docker` on the host (assumes docker-cli is installed), run the following commands:
+  ------
+  export DOCKER_HOST="unix://{{.Dir}}/sock/docker.sock"
+  docker run hello-world
+  ------

--- a/examples/experimental/alpine-nerdctl.yaml
+++ b/examples/experimental/alpine-nerdctl.yaml
@@ -1,0 +1,57 @@
+# This template requires Lima v0.7.0 or later.
+# Using the Alpine 3.18 aarch64 image with vmType=vz requires macOS Ventura 13.3 or later.
+
+images:
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.32/alpine-lima-std-3.18.0-x86_64.iso"
+  arch: "x86_64"
+  digest: "sha512:7b00fff78736a27a24e4a7de5f28037e9c7cf0fc539a33ec551c6ac619eb54237b5f25bfa35512fa7233cf23396dc249592710ef9150f619afa15267f9c8cbd4"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.32/alpine-lima-std-3.18.0-aarch64.iso"
+  arch: "aarch64"
+  digest: "sha512:bf23a22e05854670eef74d9bfad056caa249832f22d5594eb6bb02fa9aae109d33c764242f862d48de5b6715c4792a3ee29c19888a0711fb27113ba5cf1ccf21"
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+# The built-in containerd installer does not support Alpine currently.
+containerd:
+  system: false
+  user: false
+provision:
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    command -v nerdctl >/dev/null 2>&1 && exit 0
+    apk add nerdctl containerd buildctl buildkit tini
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    rc-update add containerd boot
+    service containerd start
+    rc-update add buildkitd boot
+    service buildkitd start
+probes:
+- description: "nerdctl to be installed"
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! timeout 30s bash -c "until command -v nerdctl >/dev/null 2>&1; do sleep 3; done"; then
+      echo >&2 "nerdctl is not installed yet"
+      exit 1
+    fi
+- description: "containerd to be runnning"
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! timeout 30s bash -c "until pgrep containerd; do sleep 3; done"; then
+      echo >&2 "containerd is not running"
+      exit 1
+    fi
+message: |
+  To run `nerdctl`, use `lima sudo nerdctl` (not `nerdctl.lima`):
+  ------
+  export LIMA_INSTANCE={{.Name}}
+  lima sudo nerdctl run ghcr.io/afbjorklund/hello-nerd
+  ------

--- a/examples/experimental/alpine-podman.yaml
+++ b/examples/experimental/alpine-podman.yaml
@@ -1,0 +1,68 @@
+# This template requires Lima v0.7.0 or later.
+# Using the Alpine 3.18 aarch64 image with vmType=vz requires macOS Ventura 13.3 or later.
+
+images:
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.32/alpine-lima-std-3.18.0-x86_64.iso"
+  arch: "x86_64"
+  digest: "sha512:7b00fff78736a27a24e4a7de5f28037e9c7cf0fc539a33ec551c6ac619eb54237b5f25bfa35512fa7233cf23396dc249592710ef9150f619afa15267f9c8cbd4"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.32/alpine-lima-std-3.18.0-aarch64.iso"
+  arch: "aarch64"
+  digest: "sha512:bf23a22e05854670eef74d9bfad056caa249832f22d5594eb6bb02fa9aae109d33c764242f862d48de5b6715c4792a3ee29c19888a0711fb27113ba5cf1ccf21"
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+containerd:
+  system: false
+  user: false
+provision:
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    # Set up subuid
+    for f in /etc/subuid /etc/subgid; do
+        grep -qw "${LIMA_CIDATA_USER}" $f || echo "${LIMA_CIDATA_USER}:100000:65536" >>$f
+    done
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    command -v podman >/dev/null 2>&1 && exit 0
+    apk add podman
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! grep -q ^podman_user /etc/conf.d/podman; then
+      echo "podman_user=\"${LIMA_CIDATA_USER}\"" >> /etc/conf.d/podman
+    fi
+    rc-update add podman boot
+    service podman start
+probes:
+- description: "podman to be installed"
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! timeout 30s bash -c "until command -v podman >/dev/null 2>&1; do sleep 3; done"; then
+      echo >&2 "podman is not installed yet"
+      exit 1
+    fi
+- description: "podman to be running"
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! timeout 30s bash -c "until pgrep podman; do sleep 3; done"; then
+      echo >&2 "podman is not running"
+      exit 1
+    fi
+portForwards:
+- guestSocket: "/tmp/podman-run-{{.UID}}/podman/podman.sock"
+  hostSocket: "{{.Dir}}/sock/podman.sock"
+message: |
+  To run `podman` on the host (assumes podman-remote is installed), run the following commands:
+  ------
+  export CONTAINER_HOST="unix://{{.Dir}}/sock/podman.sock"
+  podman{{if eq .HostOS "linux"}}-remote{{end}} run quay.io/podman/hello
+  ------


### PR DESCRIPTION
These are (1G) smaller than the usual Ubuntu or Fedora based

Uses the regular Alpine system packages, for the installation

----

Not sure if we want to add this to the core distribution, though.

It adds to the maintenance, and was _rather_ straightforward?

```
254M	alpine-docker
1,5G	docker
197M	alpine-podman
1,3G	podman
```

I was just comparing it with the custom alpine-lima ISO images.