### PR TITLE
Support for configurable network address for user-v2

### DIFF
--- a/cmd/limactl/usernet.go
+++ b/cmd/limactl/usernet.go
@@ -22,6 +22,7 @@ func newUsernetCommand() *cobra.Command {
 	hostagentCommand.Flags().StringP("endpoint", "e", "", "exposes usernet api(s) on this endpoint")
 	hostagentCommand.Flags().String("listen-qemu", "", "listen for qemu connections")
 	hostagentCommand.Flags().String("listen", "", "listen on a Unix socket and receive Bess-compatible FDs as SCM_RIGHTS messages")
+	hostagentCommand.Flags().String("subnet", "192.168.5.0/24", "sets subnet value for the usernet network")
 	hostagentCommand.Flags().Int("mtu", 1500, "mtu")
 	return hostagentCommand
 }
@@ -52,6 +53,10 @@ func usernetAction(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	subnet, err := cmd.Flags().GetString("subnet")
+	if err != nil {
+		return err
+	}
 
 	mtu, err := cmd.Flags().GetInt("mtu")
 	if err != nil {
@@ -67,5 +72,6 @@ func usernetAction(cmd *cobra.Command, _ []string) error {
 		Endpoint:   endpoint,
 		QemuSocket: qemuSocket,
 		FdSocket:   fdSocket,
+		Subnet:     subnet,
 	})
 }

--- a/examples/experimental/net-user-v2.yaml
+++ b/examples/experimental/net-user-v2.yaml
@@ -6,6 +6,9 @@ images:
 - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
   arch: "aarch64"
 
+hostResolver:
+  hosts:
+    host.docker.internal: host.lima.internal
 mounts:
 - location: "~"
 - location: "/tmp/lima"

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Code-Hex/vz/v3 v3.0.6
 	github.com/alessio/shellescape v1.4.2
+	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/balajiv113/fd v0.0.0-20230330094840-143eec500f3e
 	github.com/cheggaaa/pb/v3 v3.1.4
 	github.com/containerd/containerd v1.7.3
@@ -55,7 +56,6 @@ require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/a8m/envsubst v1.4.2 // indirect
 	github.com/alecthomas/participle/v2 v2.0.0 // indirect
-	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/digitalocean/go-libvirt v0.0.0-20220804181439-8648fbde413e // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/09-host-dns-setup.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/09-host-dns-setup.sh
@@ -18,8 +18,12 @@ if command -v iptables >/dev/null 2>&1; then
 	# Remove old rules
 	iptables --table nat --flush ${chain}
 	# Add rules for the existing ip:port
-	iptables --table nat --append "${chain}" --destination "${LIMA_CIDATA_SLIRP_DNS}" --protocol udp --dport 53 --jump DNAT \
-		--to-destination "${LIMA_CIDATA_SLIRP_GATEWAY}:${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}"
-	iptables --table nat --append "${chain}" --destination "${LIMA_CIDATA_SLIRP_DNS}" --protocol tcp --dport 53 --jump DNAT \
-		--to-destination "${LIMA_CIDATA_SLIRP_GATEWAY}:${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}"
+	if [ -n "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" ] && [ "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" -ne 0 ]; then
+		iptables --table nat --append "${chain}" --destination "${LIMA_CIDATA_SLIRP_DNS}" --protocol udp --dport 53 --jump DNAT \
+			--to-destination "${LIMA_CIDATA_SLIRP_GATEWAY}:${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}"
+	fi
+	if [ -n "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" ] && [ "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" -ne 0 ]; then
+		iptables --table nat --append "${chain}" --destination "${LIMA_CIDATA_SLIRP_DNS}" --protocol tcp --dport 53 --jump DNAT \
+			--to-destination "${LIMA_CIDATA_SLIRP_GATEWAY}:${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}"
+	fi
 fi

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -12,12 +12,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lima-vm/lima/pkg/networks"
-
 	"github.com/docker/go-units"
 	"github.com/lima-vm/lima/pkg/iso9660util"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/localpathutil"
+	"github.com/lima-vm/lima/pkg/networks"
+	"github.com/lima-vm/lima/pkg/networks/usernet"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/sshutil"
 	"github.com/lima-vm/lima/pkg/store/filenames"
@@ -35,7 +35,7 @@ var netLookupIP = func(host string) []net.IP {
 	return ips
 }
 
-func setupEnv(y *limayaml.LimaYAML) (map[string]string, error) {
+func setupEnv(y *limayaml.LimaYAML, args TemplateArgs) (map[string]string, error) {
 	// Start with the proxy variables from the system settings.
 	env, err := osutil.ProxySettings()
 	if err != nil {
@@ -74,7 +74,7 @@ func setupEnv(y *limayaml.LimaYAML) (map[string]string, error) {
 
 			for _, ip := range netLookupIP(u.Hostname()) {
 				if ip.IsLoopback() {
-					newHost := networks.SlirpGateway
+					newHost := args.SlirpGateway
 					if u.Port() != "" {
 						newHost = net.JoinHostPort(newHost, u.Port())
 					}
@@ -124,11 +124,34 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 		GuestInstallPrefix: *y.GuestInstallPrefix,
 		Containerd:         Containerd{System: *y.Containerd.System, User: *y.Containerd.User},
 		SlirpNICName:       networks.SlirpNICName,
-		SlirpGateway:       networks.SlirpGateway,
-		SlirpDNS:           networks.SlirpDNS,
-		SlirpIPAddress:     networks.SlirpIPAddress,
-		RosettaEnabled:     *y.Rosetta.Enabled,
-		RosettaBinFmt:      *y.Rosetta.BinFmt,
+
+		RosettaEnabled: *y.Rosetta.Enabled,
+		RosettaBinFmt:  *y.Rosetta.BinFmt,
+	}
+
+	firstUsernetIndex := limayaml.FirstUsernetIndex(y)
+	var subnet net.IP
+
+	if firstUsernetIndex != -1 {
+		usernetName := y.Networks[firstUsernetIndex].Lima
+		subnet, err = usernet.Subnet(usernetName)
+		if err != nil {
+			return err
+		}
+		args.SlirpGateway = usernet.GatewayIP(subnet)
+		args.SlirpDNS = usernet.GatewayIP(subnet)
+	} else {
+		subnet, err = usernet.ParseSubnet(networks.SlirpNetwork)
+		if err != nil {
+			return err
+		}
+		args.SlirpGateway = usernet.GatewayIP(subnet)
+		if *y.VMType == limayaml.VZ {
+			args.SlirpDNS = usernet.GatewayIP(subnet)
+		} else {
+			args.SlirpDNS = usernet.DNSIP(subnet)
+		}
+		args.SlirpIPAddress = networks.SlirpIPAddress
 	}
 
 	// change instance id on every boot so network config will be processed again
@@ -221,9 +244,7 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 		})
 	}
 
-	slirpMACAddress := limayaml.MACAddress(instDir)
-	args.Networks = append(args.Networks, Network{MACAddress: slirpMACAddress, Interface: networks.SlirpNICName})
-	firstUsernetIndex := limayaml.FirstUsernetIndex(y)
+	args.Networks = append(args.Networks, Network{MACAddress: limayaml.MACAddress(instDir), Interface: networks.SlirpNICName})
 	for i, nw := range y.Networks {
 		if i == firstUsernetIndex {
 			continue
@@ -231,14 +252,16 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 		args.Networks = append(args.Networks, Network{MACAddress: nw.MACAddress, Interface: nw.Interface})
 	}
 
-	args.Env, err = setupEnv(y)
+	args.Env, err = setupEnv(y, args)
 	if err != nil {
 		return err
 	}
-	if *y.HostResolver.Enabled {
+	if firstUsernetIndex != -1 || *y.VMType == limayaml.VZ {
+		args.DNSAddresses = append(args.DNSAddresses, args.SlirpDNS)
+	} else if *y.HostResolver.Enabled {
 		args.UDPDNSLocalPort = udpDNSLocalPort
 		args.TCPDNSLocalPort = tcpDNSLocalPort
-		args.DNSAddresses = append(args.DNSAddresses, networks.SlirpDNS)
+		args.DNSAddresses = append(args.DNSAddresses, args.SlirpDNS)
 	} else if len(y.DNS) > 0 {
 		for _, addr := range y.DNS {
 			args.DNSAddresses = append(args.DNSAddresses, addr.String())

--- a/pkg/cidata/cidata_test.go
+++ b/pkg/cidata/cidata_test.go
@@ -48,7 +48,8 @@ func TestSetupEnv(t *testing.T) {
 		t.Run(httpProxy.Host, func(t *testing.T) {
 			envKey := "http_proxy"
 			envValue := httpProxy.String()
-			envs, err := setupEnv(&limayaml.LimaYAML{PropagateProxyEnv: pointer.Bool(false), Env: map[string]string{envKey: envValue}})
+			templateArgs := TemplateArgs{SlirpGateway: networks.SlirpGateway}
+			envs, err := setupEnv(&limayaml.LimaYAML{PropagateProxyEnv: pointer.Bool(false), Env: map[string]string{envKey: envValue}}, templateArgs)
 			assert.NilError(t, err)
 			assert.Equal(t, envs[envKey], strings.ReplaceAll(envValue, httpProxy.Hostname(), networks.SlirpGateway))
 		})
@@ -58,7 +59,8 @@ func TestSetupEnv(t *testing.T) {
 func TestSetupInvalidEnv(t *testing.T) {
 	envKey := "http_proxy"
 	envValue := "://localhost:8080"
-	envs, err := setupEnv(&limayaml.LimaYAML{PropagateProxyEnv: pointer.Bool(false), Env: map[string]string{envKey: envValue}})
+	templateArgs := TemplateArgs{SlirpGateway: networks.SlirpGateway}
+	envs, err := setupEnv(&limayaml.LimaYAML{PropagateProxyEnv: pointer.Bool(false), Env: map[string]string{envKey: envValue}}, templateArgs)
 	assert.NilError(t, err)
 	assert.Equal(t, envs[envKey], envValue)
 }

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -267,7 +267,8 @@ func (a *HostAgent) Run(ctx context.Context) error {
 		a.emitEvent(ctx, exitingEv)
 	}()
 
-	if *a.y.HostResolver.Enabled {
+	firstUsernetIndex := limayaml.FirstUsernetIndex(a.y)
+	if firstUsernetIndex == -1 && *a.y.HostResolver.Enabled {
 		hosts := a.y.HostResolver.Hosts
 		hosts["host.lima.internal"] = networks.SlirpGateway
 		hosts[fmt.Sprintf("lima-%s", a.instName)] = networks.SlirpIPAddress

--- a/pkg/networks/config_test.go
+++ b/pkg/networks/config_test.go
@@ -15,7 +15,7 @@ func TestFillDefault(t *testing.T) {
 	userNet := newYaml.Networks[ModeUserV2]
 	assert.Equal(t, userNet.Mode, ModeUserV2)
 	assert.Equal(t, userNet.Interface, "")
-	assert.DeepEqual(t, userNet.NetMask, net.IP{})
-	assert.DeepEqual(t, userNet.Gateway, net.IP{})
+	assert.DeepEqual(t, userNet.NetMask, net.ParseIP("255.255.255.0"))
+	assert.DeepEqual(t, userNet.Gateway, net.ParseIP("192.168.104.1"))
 	assert.DeepEqual(t, userNet.DHCPEnd, net.IP{})
 }

--- a/pkg/networks/const.go
+++ b/pkg/networks/const.go
@@ -5,6 +5,5 @@ const (
 	// CIDR is intentionally hardcoded to 192.168.5.0/24, as each of QEMU has its own independent slirp network.
 	SlirpNetwork   = "192.168.5.0/24"
 	SlirpGateway   = "192.168.5.2"
-	SlirpDNS       = "192.168.5.3"
 	SlirpIPAddress = "192.168.5.15"
 )

--- a/pkg/networks/networks.TEMPLATE.yaml
+++ b/pkg/networks/networks.TEMPLATE.yaml
@@ -24,6 +24,8 @@ group: everyone
 networks:
   user-v2:
     mode: user-v2
+    gateway: 192.168.104.1
+    netmask: 255.255.255.0
     # user-v2 network is experimental network mode which supports all functionalities of default usernet network and also allows vm -> vm communication.
     # Doesn't support configuration of custom gateway; hardcoded to 192.168.5.0/24
   shared:

--- a/pkg/networks/usernet/dnshosts/dnshosts.go
+++ b/pkg/networks/usernet/dnshosts/dnshosts.go
@@ -1,0 +1,107 @@
+// From https://raw.githubusercontent.com/abiosoft/colima/v0.5.5/daemon/process/gvproxy/dnshosts_test.go
+/*
+	MIT License
+
+	Copyright (c) 2021 Abiola Ibrahim
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in all
+	copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+	SOFTWARE.
+*/
+
+package dnshosts
+
+import (
+	"net"
+	"strings"
+
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
+)
+
+func ExtractZones(hosts hostMap) (zones []types.Zone) {
+	list := make(map[string]types.Zone)
+
+	for host := range hosts {
+		h := zoneHost(host)
+
+		zone := types.Zone{Name: h.name()}
+		if existingZone, ok := list[h.name()]; ok {
+			zone = existingZone
+		}
+
+		if h.recordName() == "" {
+			if zone.DefaultIP == nil {
+				zone.DefaultIP = hosts.hostIP(host)
+			}
+		} else {
+			zone.Records = append(zone.Records, types.Record{
+				Name: h.recordName(),
+				IP:   hosts.hostIP(host),
+			})
+		}
+
+		list[h.name()] = zone
+	}
+
+	for _, zone := range list {
+		zones = append(zones, zone)
+	}
+	return
+}
+
+type hostMap map[string]string
+
+func (z hostMap) hostIP(host string) net.IP {
+	for {
+		// check if host entry exists
+		h, ok := z[host]
+		if !ok || h == "" {
+			return nil
+		}
+
+		// if it's a valid ip, return
+		if ip := net.ParseIP(h); ip != nil {
+			return ip
+		}
+
+		// otherwise, a string i.e. another host
+		// loop through the process again.
+		host = h
+	}
+}
+
+type zoneHost string
+
+func (z zoneHost) name() string {
+	i := z.dotIndex()
+	if i < 0 {
+		return string(z)
+	}
+	return string(z)[i+1:] + "."
+}
+
+func (z zoneHost) recordName() string {
+	i := z.dotIndex()
+	if i < 0 {
+		return ""
+	}
+	return string(z)[:i]
+}
+
+func (z zoneHost) dotIndex() int {
+	return strings.LastIndex(string(z), ".")
+}

--- a/pkg/networks/usernet/dnshosts/dnshosts_test.go
+++ b/pkg/networks/usernet/dnshosts/dnshosts_test.go
@@ -1,0 +1,231 @@
+// From https://raw.githubusercontent.com/abiosoft/colima/v0.5.5/daemon/process/gvproxy/dnshosts_test.go
+/*
+	MIT License
+
+	Copyright (c) 2021 Abiola Ibrahim
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in all
+	copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+	SOFTWARE.
+*/
+
+package dnshosts
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"testing"
+
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
+)
+
+func Test_hostsMapIP(t *testing.T) {
+	hosts := hostMap{}
+	hosts["sample"] = "1.1.1.1"
+	hosts["another.sample"] = "1.2.2.1"
+	hosts["google.com"] = "8.8.8.8"
+	hosts["google.ae"] = "google.com"
+	hosts["google.ie"] = "google.ae"
+
+	tests := []struct {
+		host string
+		want net.IP
+	}{
+		{host: "sample", want: net.ParseIP("1.1.1.1")},
+		{host: "another.sample", want: net.ParseIP("1.2.2.1")},
+		{host: "google.com", want: net.ParseIP("8.8.8.8")},
+		{host: "google.ae", want: net.ParseIP("8.8.8.8")},
+		{host: "google.ie", want: net.ParseIP("8.8.8.8")},
+		{host: "google.sample", want: nil},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			got := hosts.hostIP(tt.host)
+			if !got.Equal(tt.want) {
+				t.Errorf("hostsMapIP() = %v, want %v", got, tt.want)
+				return
+			}
+		})
+	}
+}
+
+func Test_zoneHost(t *testing.T) {
+	type val struct {
+		name       string
+		recordName string
+	}
+	tests := []struct {
+		host zoneHost
+		want val
+	}{
+		{}, // test for empty value as well
+		{host: "sample", want: val{name: "sample"}},
+		{host: "another.sample", want: val{name: "sample.", recordName: "another"}},
+		{host: "another.sample.com", want: val{name: "com.", recordName: "another.sample"}},
+		{host: "a.c", want: val{name: "c.", recordName: "a"}},
+		{host: "a.b.c.d", want: val{name: "d.", recordName: "a.b.c"}},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			got := val{
+				name:       tt.host.name(),
+				recordName: tt.host.recordName(),
+			}
+			if got != tt.want {
+				t.Errorf("host = %+v, want %+v", got, tt.want)
+				return
+			}
+		})
+	}
+}
+
+func Test_extractZones(t *testing.T) {
+	equalZones := func(za, zb []types.Zone) bool {
+		find := func(list []types.Zone, name string) (types.Zone, bool) {
+			for _, z := range list {
+				if z.Name == name {
+					return z, true
+				}
+			}
+			return types.Zone{}, false
+		}
+		equal := func(a, b types.Zone) bool {
+			if a.Name != b.Name {
+				return false
+			}
+			if !a.DefaultIP.Equal(b.DefaultIP) {
+				return false
+			}
+			for i := range a.Records {
+				a, b := a.Records[i], b.Records[i]
+				if !a.IP.Equal(b.IP) {
+					return false
+				}
+				if a.Name != b.Name {
+					return false
+				}
+			}
+
+			return true
+		}
+
+		for _, a := range za {
+			b, ok := find(zb, a.Name)
+			if !ok {
+				return false
+			}
+			if !equal(a, b) {
+				return false
+			}
+		}
+		return true
+	}
+
+	hosts := hostMap{
+		"google.com":           "8.8.4.4",
+		"local.google.com":     "8.8.8.8",
+		"google.ae":            "google.com",
+		"localhost":            "127.0.0.1",
+		"host.lima.internal":   "192.168.5.2",
+		"host.docker.internal": "host.lima.internal",
+	}
+
+	tests := []struct {
+		wantZones []types.Zone
+	}{
+		{
+			wantZones: []types.Zone{
+				{
+					Name: "ae.",
+					Records: []types.Record{
+						{Name: "google", IP: net.ParseIP("8.8.4.4")},
+					},
+				},
+				{
+					Name: "com.",
+					Records: []types.Record{
+						{Name: "google", IP: net.ParseIP("8.8.4.4")},
+						{Name: "local.google", IP: net.ParseIP("8.8.8.8")},
+					},
+				},
+				{
+					Name: "internal.",
+					Records: []types.Record{
+						{Name: "host.docker", IP: net.ParseIP("192.168.5.2")},
+						{Name: "host.lima", IP: net.ParseIP("192.168.5.2")},
+					},
+				},
+				{
+					Name:      "localhost",
+					DefaultIP: net.ParseIP("127.0.0.1"),
+				},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			gotZones := ExtractZones(hosts)
+			for _, zone := range gotZones {
+				sort.Sort(recordSorter(zone.Records))
+			}
+			sort.Sort(zoneSorter(gotZones))
+
+			if !equalZones(gotZones, tt.wantZones) {
+				t.Errorf("extractZones() = %+v, want %+v", gotZones, tt.wantZones)
+			}
+		})
+	}
+}
+
+var _ sort.Interface = (recordSorter)(nil)
+var _ sort.Interface = (zoneSorter)(nil)
+
+type recordSorter []types.Record
+
+// Len implements sort.Interface
+func (r recordSorter) Len() int {
+	return len(r)
+}
+
+// Less implements sort.Interface
+func (r recordSorter) Less(i int, j int) bool {
+	return r[i].Name < r[j].Name
+}
+
+// Swap implements sort.Interface
+func (r recordSorter) Swap(i int, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
+type zoneSorter []types.Zone
+
+// Len implements sort.Interface
+func (z zoneSorter) Len() int {
+	return len(z)
+}
+
+// Less implements sort.Interface
+func (z zoneSorter) Less(i int, j int) bool {
+	return z[i].Name < z[j].Name
+}
+
+// Swap implements sort.Interface
+func (z zoneSorter) Swap(i int, j int) {
+	z[i], z[j] = z[j], z[i]
+}

--- a/pkg/networks/usernet/recoincile.go
+++ b/pkg/networks/usernet/recoincile.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/lima-vm/lima/pkg/lockutil"
-
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/sirupsen/logrus"
@@ -53,6 +52,11 @@ func Start(ctx context.Context, name string) error {
 			return err
 		}
 
+		subnet, err := SubnetCIDR(name)
+		if err != nil {
+			return err
+		}
+
 		err = lockutil.WithDirLock(usernetDir, func() error {
 			self, err := os.Executable()
 			if err != nil {
@@ -61,7 +65,8 @@ func Start(ctx context.Context, name string) error {
 			args := []string{"usernet", "-p", pidFile,
 				"-e", endpointSock,
 				"--listen-qemu", qemuSock,
-				"--listen", fdSock}
+				"--listen", fdSock,
+				"--subnet", subnet.String()}
 			cmd := exec.CommandContext(ctx, self, args...)
 
 			stdoutPath := filepath.Join(usernetDir, fmt.Sprintf("%s.%s.%s.log", "usernet", name, "stdout"))


### PR DESCRIPTION
Fixes #1551 #1333 

Keep the PR as draft for the following to be resolved
- https://github.com/containers/gvisor-tap-vsock/pull/236
- https://github.com/containers/gvisor-tap-vsock/issues/233

**What's done**
The user-v2 now honours gateway and netmask properties.

```
networks:
  user-v2:
    mode: user-v2
    gateway: 192.168.109.1
    netmask: 255.255.255.0
```

With the support of configurable subnet, we also required to provided support for dynamic DNS for user-v2

**Changes to DNS resolving for usernet**

_Before_
VM <-> gvisor-tap-vsock <-> hostagent dns resolver

_Now_
VM <-> gvisor-tap-vsock

No UDP or TCP forwarding will happen. So DNS lookup's will be faster now

**How to enable new way of DNS resolver ?**
Disabling the hostResolver will enable this new DNS for vz driver and for user-v2 network.

```
hostResolver:
  enabled: false
```
Need opinion on this, as we will still use `hostResolver.hosts` even after enabled is false.

**Behaviour change**
- With user-v2 we will not set LIMA_CIDATA_SLIRP_IP_ADDRESS. As IP address are assigned dynamically
- DNS record for instance is changed from `lima-default` to `lima-default.internal`

**TODO**
- [x] Fix tests with hardcoded IP