### PR TITLE
Add support for armv7l architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ binaries: clean \
 	_output/bin/kubectl.lima \
 	_output/share/lima/lima-guestagent.Linux-x86_64 \
 	_output/share/lima/lima-guestagent.Linux-aarch64 \
+	_output/share/lima/lima-guestagent.Linux-armv7l \
 	_output/share/lima/lima-guestagent.Linux-riscv64
 	cp -aL examples _output/share/lima
 	mkdir -p _output/share/doc/lima
@@ -106,6 +107,11 @@ _output/share/lima/lima-guestagent.Linux-x86_64:
 .PHONY: _output/share/lima/lima-guestagent.Linux-aarch64
 _output/share/lima/lima-guestagent.Linux-aarch64:
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $(GO_BUILD) -o $@ ./cmd/lima-guestagent
+	chmod 644 $@
+
+.PHONY: _output/share/lima/lima-guestagent.Linux-armv7l
+_output/share/lima/lima-guestagent.Linux-armv7l:
+	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 $(GO_BUILD) -o $@ ./cmd/lima-guestagent
 	chmod 644 $@
 
 .PHONY: _output/share/lima/lima-guestagent.Linux-riscv64

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -9,6 +9,7 @@ The following features are experimental and subject to change:
 - `video.display: vnc` and relevant configuration (`video.vnc.display`)
 - `mode: user-v2` in `networks.yml` and relevant configuration in `lima.yaml`
 - `audio.device`
+- `arch: armv7l`
 
 The following commands are experimental and subject to change:
 

--- a/docs/internal.md
+++ b/docs/internal.md
@@ -116,6 +116,9 @@ The directory contains the following files:
 - `$QEMU_SYSTEM_AARCH64`: path of `qemu-system-aarch64`
   - Default: `qemu-system-aarch64` in `$PATH`
 
+- `$QEMU_SYSTEM_ARM`: path of `qemu-system-arm`
+  - Default: `qemu-system-arm` in `$PATH`
+
 ## `cidata.iso`
 `cidata.iso` contains the following files:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,6 +46,7 @@ Optional feature enablers:
 - [`vmnet.yaml`](./vmnet.yaml): ⭐enable [`vmnet.framework`](../docs/network.md)
 - [`experimental/9p.yaml`](experimental/9p.yaml): [experimental] use 9p mount type
 - [`experimental/virtiofs-linux.yaml`](experimental/9p.yaml): [experimental] use virtiofs mount type for Linux
+- [`experimental/armv7l.yaml`](experimental/armv7l.yaml): [experimental] ARMv7
 - [`experimental/riscv64.yaml`](experimental/riscv64.yaml): [experimental] RISC-V
 - [`experimental/net-user-v2.yaml`](experimental/net-user-v2.yaml): [experimental] user-v2 network
   to enable VM-to-VM communication without root privilege

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -237,6 +237,8 @@ containerd:
 cpuType:
   # 🟢 Builtin default: "cortex-a72" (or "host" when running on aarch64 host)
   aarch64: null
+  # 🟢 Builtin default: "cortex-a7" (or "host" when running on armv7l host)
+  armv7l: null
   # 🟢 Builtin default: "qemu64" (or "host,-pdpe1gb" when running on x86_64 host)
   x86_64: null
 

--- a/examples/experimental/armv7l.yaml
+++ b/examples/experimental/armv7l.yaml
@@ -1,0 +1,22 @@
+# This example requires Lima v0.7.0 or later.
+
+arch: "armv7l"
+images:
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20230518/ubuntu-22.04-server-cloudimg-armhf.img"
+  arch: "armv7l"
+  digest: "sha256:f9baf349e9f4bb4acc6cbd14dc82aa2aa514fd76e06c74678e5453f0e6717fd2"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-armhf.img"
+  arch: "armv7l"
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+
+# We do not have arm-v7 binaries of containerd
+containerd:
+  system: false
+  user: false

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -32,6 +32,14 @@ func TestFillDefault(t *testing.T) {
 		arch = X8664
 	case "arm64":
 		arch = AARCH64
+	case "arm":
+		if runtime.GOOS != "linux" {
+			t.Skipf("unsupported GOOS: %s", runtime.GOOS)
+		}
+		if arm := goarm(); arm < 7 {
+			t.Skipf("unsupported GOARM: %d", arm)
+		}
+		arch = ARMV7L
 	case "riscv64":
 		arch = RISCV64
 	default:
@@ -56,6 +64,7 @@ func TestFillDefault(t *testing.T) {
 		Arch:   pointer.String(arch),
 		CPUType: map[Arch]string{
 			AARCH64: "cortex-a72",
+			ARMV7L:  "cortex-a7",
 			X8664:   "qemu64",
 			RISCV64: "rv64",
 		},
@@ -259,6 +268,7 @@ func TestFillDefault(t *testing.T) {
 		Arch:   pointer.String("unknown"),
 		CPUType: map[Arch]string{
 			AARCH64: "arm64",
+			ARMV7L:  "armhf",
 			X8664:   "amd64",
 			RISCV64: "riscv64",
 		},
@@ -434,6 +444,7 @@ func TestFillDefault(t *testing.T) {
 		Arch:   pointer.String(arch),
 		CPUType: map[Arch]string{
 			AARCH64: "uber-arm",
+			ARMV7L:  "armv8",
 			X8664:   "pentium",
 			RISCV64: "sifive-u54",
 		},

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -45,6 +45,7 @@ type VMType = string
 const (
 	X8664   Arch = "x86_64"
 	AARCH64 Arch = "aarch64"
+	ARMV7L  Arch = "armv7l"
 	RISCV64 Arch = "riscv64"
 
 	REVSSHFS MountType = "reverse-sshfs"

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -26,9 +26,9 @@ func validateFileObject(f File, fieldName string) error {
 		// f.Location does NOT need to be accessible, so we do NOT check os.Stat(f.Location)
 	}
 	switch f.Arch {
-	case X8664, AARCH64, RISCV64:
+	case X8664, AARCH64, ARMV7L, RISCV64:
 	default:
-		return fmt.Errorf("field `arch` must be %q, %q, or %q; got %q", X8664, AARCH64, RISCV64, f.Arch)
+		return fmt.Errorf("field `arch` must be %q, %q, %q, or %q; got %q", X8664, AARCH64, ARMV7L, RISCV64, f.Arch)
 	}
 	if f.Digest != "" {
 		if !f.Digest.Algorithm().Available() {
@@ -43,9 +43,9 @@ func validateFileObject(f File, fieldName string) error {
 
 func Validate(y LimaYAML, warn bool) error {
 	switch *y.Arch {
-	case X8664, AARCH64, RISCV64:
+	case X8664, AARCH64, ARMV7L, RISCV64:
 	default:
-		return fmt.Errorf("field `arch` must be %q, %q, or %q; got %q", X8664, AARCH64, RISCV64, *y.Arch)
+		return fmt.Errorf("field `arch` must be %q, %q, %q or %q; got %q", X8664, AARCH64, ARMV7L, RISCV64, *y.Arch)
 	}
 
 	switch *y.VMType {
@@ -91,7 +91,7 @@ func Validate(y LimaYAML, warn bool) error {
 
 	for arch := range y.CPUType {
 		switch arch {
-		case AARCH64, X8664, RISCV64:
+		case AARCH64, X8664, ARMV7L, RISCV64:
 			// these are the only supported architectures
 		default:
 			return fmt.Errorf("field `cpuType` uses unsupported arch %q", arch)


### PR DESCRIPTION
Closes: #1622

The name was selected to match `uname` output, like with all the other Lima architectures.

Note that armv5 and armv6 are **not** supported, only armv7 (container architecture: `linux/arm/v7`)
This architecture is expected to be emulated, there is no arm32 hardware with CPU virt support - afaik.