### PR TITLE
Fix unable to use the network proxy configuration of the MacOS(10.15)

### DIFF
--- a/pkg/osutil/dns_darwin.go
+++ b/pkg/osutil/dns_darwin.go
@@ -28,13 +28,19 @@ func DNSAddresses() ([]string, error) {
 }
 
 func proxyURL(proxy string, port interface{}) string {
-	if !strings.Contains(proxy, "://") {
+	if strings.Contains(proxy, "://") {
+		if portNumber, ok := port.(float64); ok && portNumber != 0 {
+			proxy = fmt.Sprintf("%s:%.0f", proxy, portNumber)
+		} else if portString, ok := port.(string); ok && portString != "" {
+			proxy = fmt.Sprintf("%s:%s", proxy, portString)
+		}
+	} else {
+		if portNumber, ok := port.(float64); ok && portNumber != 0 {
+			proxy = net.JoinHostPort(proxy, fmt.Sprintf("%.0f", portNumber))
+		} else if portString, ok := port.(string); ok && portString != "" {
+			proxy = net.JoinHostPort(proxy, portString)
+		}
 		proxy = "http://" + proxy
-	}
-	if portNumber, ok := port.(float64); ok && portNumber != 0 {
-		proxy = net.JoinHostPort(proxy, fmt.Sprintf("%.0f", portNumber))
-	} else if portString, ok := port.(string); ok && portString != "" {
-		proxy = net.JoinHostPort(proxy, portString)
 	}
 	return proxy
 }


### PR DESCRIPTION
The proxyURL method always returns wrong URL format.
    For example: before the repair, input parameters "127.0.0.1" and "8090" to the proxyURL method, and the output URL result will be "[http://127.0.0.1]:8090". But the expected result should be "http://127.0.0.1:8090", unexpectedly there are two extra square brackets. 
    This bug eventually caused lima to be unable to use the network proxy configuration of the MacOS.
    The reason for this bug is that the proxyURL method calls JoinHostPort to distinguish splicing of IPv4 or IPv6 addresses. The JoinHostPort method distinguishes by judging whether the host parameter contains a ":" string. However, in the proxyURL method, the prefix "http://" is added to the host in advance, so that the host parameter passed into JoinHostPort always has a ":" string.