### PR TITLE
limactl: add `limactl create` command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
 
         ## Usage
         \`\`\`console
+        [macOS]$ limactl create
         [macOS]$ limactl start
         ...
         INFO[0029] READY. Run \`lima\` to open the shell.

--- a/cmd/apptainer.lima
+++ b/cmd/apptainer.lima
@@ -3,7 +3,7 @@ set -eu
 : "${LIMA_INSTANCE:=apptainer}"
 
 if [ "$(limactl ls -q "$LIMA_INSTANCE" 2>/dev/null)" != "$LIMA_INSTANCE" ]; then
-  echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl start --name=$LIMA_INSTANCE template://apptainer\` to create a new instance" >&2
+  echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl create --name=$LIMA_INSTANCE template://apptainer\` to create a new instance" >&2
   exit 1
 fi
 export LIMA_INSTANCE

--- a/cmd/docker.lima
+++ b/cmd/docker.lima
@@ -4,7 +4,7 @@ set -eu
 : "${DOCKER:=docker}"
 
 if [ "$(limactl ls -q "$LIMA_INSTANCE" 2>/dev/null)" != "$LIMA_INSTANCE" ]; then
-  echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl start --name=$LIMA_INSTANCE template://docker\` to create a new instance" >&2
+  echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl create --name=$LIMA_INSTANCE template://docker\` to create a new instance" >&2
   exit 1
 fi
 DOCKER=$(command -v "$DOCKER" || true)

--- a/cmd/kubectl.lima
+++ b/cmd/kubectl.lima
@@ -9,14 +9,14 @@ if [ -z "$LIMA_INSTANCE" ]; then
   elif [ "$(limactl ls -f '{{.Status}}' k8s 2>/dev/null)" = "Running" ]; then
     LIMA_INSTANCE=k8s
   else
-    echo "No k3s or k8s running instances found. Either start one with" >&2
-    echo "limactl start --name=k3s template://k3s" >&2
-    echo "limactl start --name=k8s template://k8s" >&2
+    echo "No k3s or k8s running instances found. Either create one with" >&2
+    echo "limactl create --name=k3s template://k3s" >&2
+    echo "limactl create --name=k8s template://k8s" >&2
     echo "or set LIMA_INSTANCE to the name of your Kubernetes instance" >&2
     exit 1
   fi
 elif [ "$(limactl ls -q "$LIMA_INSTANCE" 2>/dev/null)" != "$LIMA_INSTANCE" ]; then
-  echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl start --name=$LIMA_INSTANCE\` to create a new instance" >&2
+  echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl create --name=$LIMA_INSTANCE\` to create a new instance" >&2
   exit 1
 fi
 KUBECTL=$(command -v "$KUBECTL" || true)

--- a/cmd/limactl/completion.go
+++ b/cmd/limactl/completion.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/lima-vm/lima/pkg/store"
+	"github.com/lima-vm/lima/pkg/templatestore"
 	"github.com/spf13/cobra"
 )
 
@@ -11,4 +12,14 @@ func bashCompleteInstanceNames(_ *cobra.Command) ([]string, cobra.ShellCompDirec
 		return nil, cobra.ShellCompDirectiveDefault
 	}
 	return instances, cobra.ShellCompDirectiveNoFileComp
+}
+
+func bashCompleteTemplateNames(_ *cobra.Command) ([]string, cobra.ShellCompDirective) {
+	var comp []string
+	if templates, err := templatestore.Templates(); err == nil {
+		for _, f := range templates {
+			comp = append(comp, "template://"+f.Name)
+		}
+	}
+	return comp, cobra.ShellCompDirectiveDefault
 }

--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -78,7 +78,7 @@ func copyAction(cmd *cobra.Command, args []string) error {
 			inst, err := store.Inspect(instName)
 			if err != nil {
 				if errors.Is(err, os.ErrNotExist) {
-					return fmt.Errorf("instance %q does not exist, run `limactl start %s` to create a new instance", instName, instName)
+					return fmt.Errorf("instance %q does not exist, run `limactl create %s` to create a new instance", instName, instName)
 				}
 				return err
 			}

--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -119,7 +119,7 @@ func listAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if len(allinstances) == 0 {
-		logrus.Warn("No instance found. Run `limactl start` to create an instance.")
+		logrus.Warn("No instance found. Run `limactl create` to create an instance.")
 		return nil
 	}
 

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -94,6 +94,7 @@ func newApp() *cobra.Command {
 		return nil
 	}
 	rootCmd.AddCommand(
+		newCreateCommand(),
 		newStartCommand(),
 		newStopCommand(),
 		newShellCommand(),

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -61,7 +61,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 
 	if len(args) >= 2 {
 		switch args[1] {
-		case "start", "delete", "shell":
+		case "create", "start", "delete", "shell":
 			// `lima start` (alias of `limactl $LIMA_INSTANCE start`) is probably a typo of `limactl start`
 			logrus.Warnf("Perhaps you meant `limactl %s`?", strings.Join(args[1:], " "))
 		}
@@ -70,7 +70,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	inst, err := store.Inspect(instName)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("instance %q does not exist, run `limactl start %s` to create a new instance", instName, instName)
+			return fmt.Errorf("instance %q does not exist, run `limactl create %s` to create a new instance", instName, instName)
 		}
 		return err
 	}

--- a/cmd/limactl/show_ssh.go
+++ b/cmd/limactl/show_ssh.go
@@ -68,7 +68,7 @@ func showSSHAction(cmd *cobra.Command, args []string) error {
 	inst, err := store.Inspect(instName)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("instance %q does not exist, run `limactl start %s` to create a new instance", instName, instName)
+			return fmt.Errorf("instance %q does not exist, run `limactl create %s` to create a new instance", instName, instName)
 		}
 		return err
 	}

--- a/cmd/podman.lima
+++ b/cmd/podman.lima
@@ -4,7 +4,7 @@ set -eu
 : "${PODMAN:=podman}"
 
 if [ "$(limactl ls -q "$LIMA_INSTANCE" 2>/dev/null)" != "$LIMA_INSTANCE" ]; then
-  echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl start --name=$LIMA_INSTANCE template://podman\` to create a new instance" >&2
+  echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl create --name=$LIMA_INSTANCE template://podman\` to create a new instance" >&2
   exit 1
 fi
 PODMAN=$(command -v "$PODMAN" || true)


### PR DESCRIPTION
`limactl create` is similar to `limactl start` but it does not start the created instance, and it does not accept an existing instance name as an argument.

Now it is discouraged (not deprecated) to use `limactl start` for creating new instances.

Discouraged form:
```
limactl start --name=foo template://docker
```

Recommended form:
```
limactl create --name=foo template://docker
limactl start foo
```