### PR TITLE
Add example for Fedora CoreOS, running ignition not cloud-init

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,10 @@
 
 extends: default
 
+ignore: |
+  # this is a yaml template, needs to executed
+  pkg/cidata/cidata.TEMPLATE.d/ignition.yaml
+
 rules:
   indentation:
     indent-sequences: false

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,7 @@ Distro:
 - [`ubuntu`](./ubuntu.yaml): Ubuntu (same as `default.yaml` but without extra YAML lines)
 - [`ubuntu-lts`](./ubuntu-lts.yaml): Ubuntu LTS (same as `ubuntu.yaml` but pinned to an LTS version)
 - [`deprecated/centos-7`](./deprecated/centos-7.yaml): [deprecated] CentOS Linux 7
+- [`experimental/fedora-coreos`](./experimental/fedora-coreos.yaml): [experimental] Fedora CoreOS
 - [`experimental/opensuse-tumbleweed`](./experimental/opensuse-tumbleweed.yaml): [experimental] openSUSE Tumbleweed
 
 Container engines:

--- a/examples/experimental/fedora-coreos.yaml
+++ b/examples/experimental/fedora-coreos.yaml
@@ -1,0 +1,20 @@
+# This example requires Lima v0.15.1 or later.
+# <https://fedoraproject.org/coreos/download/>
+
+images:
+- location: "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-qemu.x86_64.qcow2.xz"
+  arch: "x86_64"
+  digest: "sha256:52d98121563a61fdab6924a8e3190bc1cbf7775942d8a8046f9ef2a689ed7aa0"
+- location: "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-qemu.aarch64.qcow2.xz"
+  arch: "aarch64"
+  digest: "sha256:432b5af49f56fcf6d2ed9046ee7b3654adb6345203d69fa14fe8d37b72b79eb9"
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+
+# The built-in containerd installer does not support CoreOS currently.
+containerd:
+  system: false
+  user: false

--- a/examples/experimental/fedora-coreos.yaml
+++ b/examples/experimental/fedora-coreos.yaml
@@ -13,8 +13,3 @@ images:
 mounts:
 - location: "/tmp/lima"
   writable: true
-
-# The built-in containerd installer does not support CoreOS currently.
-containerd:
-  system: false
-  user: false

--- a/examples/experimental/fedora-coreos.yaml
+++ b/examples/experimental/fedora-coreos.yaml
@@ -9,8 +9,8 @@ images:
   arch: "aarch64"
   digest: "sha256:432b5af49f56fcf6d2ed9046ee7b3654adb6345203d69fa14fe8d37b72b79eb9"
 
+# The guest home directory can not be changed with CoreOS currently.
 mounts:
-- location: "~"
 - location: "/tmp/lima"
   writable: true
 

--- a/pkg/cidata/cidata.TEMPLATE.d/ignition.yaml
+++ b/pkg/cidata/cidata.TEMPLATE.d/ignition.yaml
@@ -1,0 +1,85 @@
+variant: fcos
+version: 1.4.0
+passwd:
+  users:
+    - name: "{{.User}}"
+      groups:
+        - sudo
+      ssh_authorized_keys:
+{{- range $val := .SSHPubKeys}}
+        - "{{$val}}"
+{{- end}}
+storage:
+  files:
+    - path: /etc/hostname
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: "lima-{{.Name}}"
+{{- if or (eq .MountType "9p") (eq .MountType "virtiofs") }}
+{{- if .Mounts }}
+    - path: /etc/fstab
+      mode: 0644
+      contents:
+        inline: |
+{{- range $m := $.Mounts}}
+          {{$m.Tag}} {{$m.MountPoint}} {{$m.Type}} {{$m.Options}} 0 0
+{{- end }}
+{{- end }}
+{{- end }}
+    - path: /etc/fuse.conf
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: "user_allow_other\n"
+systemd:
+  units:
+    # Note1: name must systemd-escape path
+    # Note2: path must not contain symlinks
+    - name: "var-mnt-lima\\x2dcidata.mount"
+      enabled: true
+      contents: |
+        [Unit]
+        Before=local-fs.target
+
+        [Mount]
+        What=/dev/disk/by-label/cidata
+        Where=/var/mnt/lima-cidata
+        Options=ro,mode=0700,dmode=0700,overriderockperm,exec,uid=0
+
+        [Install]
+        RequiredBy=local-fs.target
+    - name: lima-ssh-ready.service
+      enabled: true
+      contents: |
+        [Unit]
+        After=sshd.service
+
+        [Service]
+        Type=oneshot
+        ExecStart=/bin/cp /mnt/lima-cidata/meta-data /run/lima-ssh-ready
+
+        [Install]
+        RequiredBy=multi-user.target
+    - name: lima-install-guestagent.service
+      enabled: true
+      contents: |
+        [Service]
+        Type=oneshot
+        ExecStart=/bin/sh -c "install -m 755 /mnt/lima-cidata/lima-guestagent /usr/local/bin/lima-guestagent"
+        ExecStartPost=/usr/local/bin/lima-guestagent install-systemd
+
+        [Install]
+        RequiredBy=multi-user.target
+    - name: lima-boot-done.service
+      enabled: true
+      contents: |
+        [Unit]
+        After=lima-install-guestagent.service
+
+        [Service]
+        Type=oneshot
+        ExecStart=/bin/cp /mnt/lima-cidata/meta-data /run/lima-boot-done
+
+        [Install]
+        RequiredBy=multi-user.target

--- a/pkg/cidata/cidata.TEMPLATE.d/ignition.yaml
+++ b/pkg/cidata/cidata.TEMPLATE.d/ignition.yaml
@@ -61,6 +61,17 @@ systemd:
 
         [Install]
         RequiredBy=multi-user.target
+{{- if or .Containerd.User .Containerd.System }}
+    - name: lima-install-containerd.service
+      enabled: true
+      contents: |
+        [Service]
+        Type=oneshot
+        ExecStart=/bin/sh -c "/usr/bin/tar Cxzf /usr/local /mnt/lima-cidata/nerdctl-full.tgz"
+
+        [Install]
+        RequiredBy=multi-user.target
+{{- end}}
     - name: lima-install-guestagent.service
       enabled: true
       contents: |

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -315,9 +315,14 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 		return err
 	}
 
-	layout, err := ExecuteTemplate(args)
+	layout, ignition, err := ExecuteTemplate(args)
 	if err != nil {
 		return err
+	}
+	if ignition != nil {
+		if err := os.WriteFile(filepath.Join(instDir, filenames.Ignition), ignition, 0600); err != nil {
+			return err
+		}
 	}
 
 	for i, f := range y.Provision {

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -122,7 +122,7 @@ func ExecuteTemplate(args TemplateArgs) ([]iso9660util.Entry, error) {
 	}
 
 	var layout []iso9660util.Entry
-	walkFn := func(path string, d fs.DirEntry, walkErr error) error {
+	walkFn := func(p string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -130,9 +130,9 @@ func ExecuteTemplate(args TemplateArgs) ([]iso9660util.Entry, error) {
 			return nil
 		}
 		if !d.Type().IsRegular() {
-			return fmt.Errorf("got non-regular file %q", path)
+			return fmt.Errorf("got non-regular file %q", p)
 		}
-		templateB, err := fs.ReadFile(fsys, path)
+		templateB, err := fs.ReadFile(fsys, p)
 		if err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ func ExecuteTemplate(args TemplateArgs) ([]iso9660util.Entry, error) {
 			return err
 		}
 		layout = append(layout, iso9660util.Entry{
-			Path:   path,
+			Path:   p,
 			Reader: bytes.NewReader(b),
 		})
 		return nil

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os/exec"
 	"path"
 
 	"github.com/lima-vm/lima/pkg/iso9660util"
 
 	"github.com/containerd/containerd/identifiers"
 	"github.com/lima-vm/lima/pkg/textutil"
+	"github.com/sirupsen/logrus"
 )
 
 //go:embed cidata.TEMPLATE.d
@@ -111,17 +113,36 @@ func ValidateTemplateArgs(args TemplateArgs) error {
 	return nil
 }
 
-func ExecuteTemplate(args TemplateArgs) ([]iso9660util.Entry, error) {
-	if err := ValidateTemplateArgs(args); err != nil {
+func executeButane(yaml []byte) ([]byte, error) {
+	butane, err := exec.LookPath("butane")
+	if err != nil {
+		logrus.Debug("butane not found in PATH, skipping ignition")
 		return nil, err
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(butane, "--strict")
+	cmd.Stdin = bytes.NewReader(yaml)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		logrus.Warnf("%v %s: %s %s", cmd, yaml, err, stderr.String())
+		return nil, err
+	}
+	return stdout.Bytes(), nil
+}
+
+func ExecuteTemplate(args TemplateArgs) ([]iso9660util.Entry, []byte, error) {
+	if err := ValidateTemplateArgs(args); err != nil {
+		return nil, nil, err
 	}
 
 	fsys, err := fs.Sub(templateFS, templateFSRoot)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var layout []iso9660util.Entry
+	var ignition []byte
 	walkFn := func(p string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -144,12 +165,18 @@ func ExecuteTemplate(args TemplateArgs) ([]iso9660util.Entry, error) {
 			Path:   p,
 			Reader: bytes.NewReader(b),
 		})
+		if path.Base(p) == "ignition.yaml" {
+			ign, err := executeButane([]byte(b))
+			if err == nil {
+				ignition = ign
+			}
+		}
 		return nil
 	}
 
 	if err := fs.WalkDir(fsys, ".", walkFn); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return layout, nil
+	return layout, ignition, nil
 }

--- a/pkg/cidata/template_test.go
+++ b/pkg/cidata/template_test.go
@@ -23,7 +23,7 @@ func TestTemplate(t *testing.T) {
 		},
 		MountType: "reverse-sshfs",
 	}
-	layout, err := ExecuteTemplate(args)
+	layout, _, err := ExecuteTemplate(args)
 	assert.NilError(t, err)
 	for _, f := range layout {
 		t.Logf("=== %q ===", f.Path)
@@ -52,7 +52,7 @@ func TestTemplate9p(t *testing.T) {
 		},
 		MountType: "9p",
 	}
-	layout, err := ExecuteTemplate(args)
+	layout, _, err := ExecuteTemplate(args)
 	assert.NilError(t, err)
 	for _, f := range layout {
 		t.Logf("=== %q ===", f.Path)

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -645,6 +645,13 @@ func Cmdline(cfg Config) (string, []string, error) {
 		"-device", "virtio-scsi-pci,id=scsi0",
 		"-device", "scsi-cd,bus=scsi0.0,drive=cdrom0")
 
+	// ignition
+	ignition := filepath.Join(cfg.InstanceDir, filenames.Ignition)
+	if _, err := os.Stat(ignition); err == nil {
+		args = append(args,
+			"-fw_cfg", "name=opt/com.coreos/config,file="+ignition)
+	}
+
 	// Kernel
 	kernel := filepath.Join(cfg.InstanceDir, filenames.Kernel)
 	kernelCmdline := filepath.Join(cfg.InstanceDir, filenames.KernelCmdline)

--- a/pkg/store/filenames/filenames.go
+++ b/pkg/store/filenames/filenames.go
@@ -29,6 +29,7 @@ const (
 	LimaYAML           = "lima.yaml"
 	CIDataISO          = "cidata.iso"
 	CIDataISODir       = "cidata"
+	Ignition           = "config.ign"
 	BaseDisk           = "basedisk"
 	DiffDisk           = "diffdisk"
 	Kernel             = "kernel"


### PR DESCRIPTION
The default image comes with podman and docker and containerd installed.

It is read-only (for the most part), so the regular scripts wouldn't work anyway.

Apparently the uid conflicts, and setting the home directory doesn't work.

But otherwise it seems to be working - as long you have installed `butane`.

----

https://docs.fedoraproject.org/en-US/fedora-coreos/provisioning-qemu/

https://docs.fedoraproject.org/en-US/fedora-coreos/producing-ign/

* https://github.com/lima-vm/lima/issues/1372

* https://github.com/lima-vm/lima/issues/1406