### PR TITLE
Allow changing prefix for the installations

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -430,6 +430,10 @@ hostResolver:
 # - 1.1.1.1
 # - 1.0.0.1
 
+# Prefix to use for installing guest agent, and containerd with dependencies (if configured)
+# 🟢 Builtin default: /usr/local
+guestInstallPrefix: null
+
 # ===================================================================== #
 # GLOBAL DEFAULTS AND OVERRIDES
 # ===================================================================== #

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
@@ -15,7 +15,7 @@ if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
 fi
 
 # Install or update the guestagent binary
-install -m 755 "${LIMA_CIDATA_MNT}"/lima-guestagent /usr/local/bin/lima-guestagent
+install -m 755 "${LIMA_CIDATA_MNT}"/lima-guestagent "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/lima-guestagent
 
 # Launch the guestagent service
 if [ -f /sbin/openrc-run ]; then
@@ -27,7 +27,7 @@ supervisor=supervise-daemon
 name="lima-guestagent"
 description="Forward ports to the lima-hostagent"
 
-command=/usr/local/bin/lima-guestagent
+command=${LIMA_CIDATA_GUEST_INSTALL_PREFIX}/bin/lima-guestagent
 command_args="daemon"
 command_background=true
 pidfile="/run/lima-guestagent.pid"
@@ -40,5 +40,5 @@ else
 	# Remove legacy systemd service
 	rm -f "/home/${LIMA_CIDATA_USER}.linux/.config/systemd/user/lima-guestagent.service"
 
-	sudo /usr/local/bin/lima-guestagent install-systemd
+	sudo "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/lima-guestagent install-systemd
 fi

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh
@@ -13,18 +13,18 @@ command -v systemctl >/dev/null 2>&1 || exit 0
 tmp_extract_nerdctl="$(mktemp -d)"
 tar Cxzf "${tmp_extract_nerdctl}" "${LIMA_CIDATA_MNT}"/nerdctl-full.tgz bin/nerdctl
 
-if [ ! -f /usr/local/bin/nerdctl ] || [[ "${tmp_extract_nerdctl}"/bin/nerdctl -nt /usr/local/bin/nerdctl ]]; then
-	if [ -f /usr/local/bin/nerdctl ]; then
+if [ ! -f "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl ] || [[ "${tmp_extract_nerdctl}"/bin/nerdctl -nt "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl ]]; then
+	if [ -f "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl ]; then
 		(
 			set +e
 			echo "Upgrading existing nerdctl"
-			echo "- Old: $(/usr/local/bin/nerdctl --version)"
+			echo "- Old: $("${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl --version)"
 			echo "- New: $("${tmp_extract_nerdctl}"/bin/nerdctl --version)"
 			systemctl disable --now containerd buildkit stargz-snapshotter
 			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" containerd-rootless-setuptool.sh uninstall
 		)
 	fi
-	tar Cxzf /usr/local "${LIMA_CIDATA_MNT}"/nerdctl-full.tgz
+	tar Cxzf "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}" "${LIMA_CIDATA_MNT}"/nerdctl-full.tgz
 
 	mkdir -p /etc/bash_completion.d
 	nerdctl completion bash >/etc/bash_completion.d/nerdctl

--- a/pkg/cidata/cidata.TEMPLATE.d/lima.env
+++ b/pkg/cidata/cidata.TEMPLATE.d/lima.env
@@ -12,6 +12,7 @@ LIMA_CIDATA_DISKS={{ len .Disks }}
 LIMA_CIDATA_DISK_{{$i}}_NAME={{$disk.Name}}
 LIMA_CIDATA_DISK_{{$i}}_DEVICE={{$disk.Device}}
 {{- end}}
+LIMA_CIDATA_GUEST_INSTALL_PREFIX={{ .GuestInstallPrefix }}
 {{- if .Containerd.User}}
 LIMA_CIDATA_CONTAINERD_USER=1
 {{- else}}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -118,16 +118,17 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 		return err
 	}
 	args := TemplateArgs{
-		Name:           name,
-		User:           u.Username,
-		UID:            uid,
-		Containerd:     Containerd{System: *y.Containerd.System, User: *y.Containerd.User},
-		SlirpNICName:   networks.SlirpNICName,
-		SlirpGateway:   networks.SlirpGateway,
-		SlirpDNS:       networks.SlirpDNS,
-		SlirpIPAddress: networks.SlirpIPAddress,
-		RosettaEnabled: *y.Rosetta.Enabled,
-		RosettaBinFmt:  *y.Rosetta.BinFmt,
+		Name:               name,
+		User:               u.Username,
+		UID:                uid,
+		GuestInstallPrefix: *y.GuestInstallPrefix,
+		Containerd:         Containerd{System: *y.Containerd.System, User: *y.Containerd.User},
+		SlirpNICName:       networks.SlirpNICName,
+		SlirpGateway:       networks.SlirpGateway,
+		SlirpDNS:           networks.SlirpDNS,
+		SlirpIPAddress:     networks.SlirpIPAddress,
+		RosettaEnabled:     *y.Rosetta.Enabled,
+		RosettaBinFmt:      *y.Rosetta.BinFmt,
 	}
 
 	// change instance id on every boot so network config will be processed again

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -58,6 +58,7 @@ type TemplateArgs struct {
 	Mounts                          []Mount
 	MountType                       string
 	Disks                           []Disk
+	GuestInstallPrefix              string
 	Containerd                      Containerd
 	Networks                        []Network
 	SlirpNICName                    string

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -158,7 +158,7 @@ are set to 'false' in the config file.
 				description: "containerd binaries to be installed",
 				script: `#!/bin/bash
 set -eux -o pipefail
-if ! timeout 30s bash -c "until command -v nerdctl; do sleep 3; done"; then
+if ! timeout 30s bash -c "until command -v nerdctl || test -x ` + *a.y.GuestInstallPrefix + `/bin/nerdctl; do sleep 3; done"; then
 	echo >&2 "nerdctl is not installed yet"
 	exit 1
 fi

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -108,6 +108,10 @@ func defaultDiskSizeAsString() string {
 	return "100GiB"
 }
 
+func defaultGuestInstallPrefix() string {
+	return "/usr/local"
+}
+
 // FillDefault updates undefined fields in y with defaults from d (or built-in default), and overwrites with values from o.
 // Both d and o may be empty.
 //
@@ -344,6 +348,16 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		if provision.Mode == ProvisionModeDependency && provision.SkipDefaultDependencyResolution == nil {
 			provision.SkipDefaultDependencyResolution = pointer.Bool(false)
 		}
+	}
+
+	if y.GuestInstallPrefix == nil {
+		y.GuestInstallPrefix = d.GuestInstallPrefix
+	}
+	if o.GuestInstallPrefix != nil {
+		y.GuestInstallPrefix = o.GuestInstallPrefix
+	}
+	if y.GuestInstallPrefix == nil {
+		y.GuestInstallPrefix = pointer.String(defaultGuestInstallPrefix())
 	}
 
 	if y.Containerd.System == nil {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -68,9 +68,10 @@ func TestFillDefault(t *testing.T) {
 			X8664:   "qemu64",
 			RISCV64: "rv64",
 		},
-		CPUs:   pointer.Int(defaultCPUs()),
-		Memory: pointer.String(defaultMemoryAsString()),
-		Disk:   pointer.String(defaultDiskSizeAsString()),
+		CPUs:               pointer.Int(defaultCPUs()),
+		Memory:             pointer.String(defaultMemoryAsString()),
+		Disk:               pointer.String(defaultDiskSizeAsString()),
+		GuestInstallPrefix: pointer.String(defaultGuestInstallPrefix()),
 		Containerd: Containerd{
 			System:   pointer.Bool(false),
 			User:     pointer.Bool(true),
@@ -278,6 +279,7 @@ func TestFillDefault(t *testing.T) {
 		AdditionalDisks: []Disk{
 			"data",
 		},
+		GuestInstallPrefix: pointer.String("/opt"),
 		Containerd: Containerd{
 			System: pointer.Bool(true),
 			User:   pointer.Bool(false),
@@ -454,6 +456,7 @@ func TestFillDefault(t *testing.T) {
 		AdditionalDisks: []Disk{
 			"test",
 		},
+		GuestInstallPrefix: pointer.String("/usr"),
 		Containerd: Containerd{
 			System: pointer.Bool(true),
 			User:   pointer.Bool(false),

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -7,27 +7,28 @@ import (
 )
 
 type LimaYAML struct {
-	VMType          *VMType         `yaml:"vmType,omitempty" json:"vmType,omitempty"`
-	Arch            *Arch           `yaml:"arch,omitempty" json:"arch,omitempty"`
-	Images          []Image         `yaml:"images" json:"images"` // REQUIRED
-	CPUType         map[Arch]string `yaml:"cpuType,omitempty" json:"cpuType,omitempty"`
-	CPUs            *int            `yaml:"cpus,omitempty" json:"cpus,omitempty"`
-	Memory          *string         `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
-	Disk            *string         `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes
-	AdditionalDisks []Disk          `yaml:"additionalDisks,omitempty" json:"additionalDisks,omitempty"`
-	Mounts          []Mount         `yaml:"mounts,omitempty" json:"mounts,omitempty"`
-	MountType       *MountType      `yaml:"mountType,omitempty" json:"mountType,omitempty"`
-	SSH             SSH             `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
-	Firmware        Firmware        `yaml:"firmware,omitempty" json:"firmware,omitempty"`
-	Audio           Audio           `yaml:"audio,omitempty" json:"audio,omitempty"`
-	Video           Video           `yaml:"video,omitempty" json:"video,omitempty"`
-	Provision       []Provision     `yaml:"provision,omitempty" json:"provision,omitempty"`
-	Containerd      Containerd      `yaml:"containerd,omitempty" json:"containerd,omitempty"`
-	Probes          []Probe         `yaml:"probes,omitempty" json:"probes,omitempty"`
-	PortForwards    []PortForward   `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
-	CopyToHost      []CopyToHost    `yaml:"copyToHost,omitempty" json:"copyToHost,omitempty"`
-	Message         string          `yaml:"message,omitempty" json:"message,omitempty"`
-	Networks        []Network       `yaml:"networks,omitempty" json:"networks,omitempty"`
+	VMType             *VMType         `yaml:"vmType,omitempty" json:"vmType,omitempty"`
+	Arch               *Arch           `yaml:"arch,omitempty" json:"arch,omitempty"`
+	Images             []Image         `yaml:"images" json:"images"` // REQUIRED
+	CPUType            map[Arch]string `yaml:"cpuType,omitempty" json:"cpuType,omitempty"`
+	CPUs               *int            `yaml:"cpus,omitempty" json:"cpus,omitempty"`
+	Memory             *string         `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
+	Disk               *string         `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes
+	AdditionalDisks    []Disk          `yaml:"additionalDisks,omitempty" json:"additionalDisks,omitempty"`
+	Mounts             []Mount         `yaml:"mounts,omitempty" json:"mounts,omitempty"`
+	MountType          *MountType      `yaml:"mountType,omitempty" json:"mountType,omitempty"`
+	SSH                SSH             `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
+	Firmware           Firmware        `yaml:"firmware,omitempty" json:"firmware,omitempty"`
+	Audio              Audio           `yaml:"audio,omitempty" json:"audio,omitempty"`
+	Video              Video           `yaml:"video,omitempty" json:"video,omitempty"`
+	Provision          []Provision     `yaml:"provision,omitempty" json:"provision,omitempty"`
+	Containerd         Containerd      `yaml:"containerd,omitempty" json:"containerd,omitempty"`
+	GuestInstallPrefix *string         `yaml:"guestInstallPrefix,omitempty" json:"guestInstallPrefix,omitempty"`
+	Probes             []Probe         `yaml:"probes,omitempty" json:"probes,omitempty"`
+	PortForwards       []PortForward   `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
+	CopyToHost         []CopyToHost    `yaml:"copyToHost,omitempty" json:"copyToHost,omitempty"`
+	Message            string          `yaml:"message,omitempty" json:"message,omitempty"`
+	Networks           []Network       `yaml:"networks,omitempty" json:"networks,omitempty"`
 	// `network` was deprecated in Lima v0.7.0, removed in Lima v0.14.0. Use `networks` instead.
 	Env          map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 	DNS          []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`


### PR DESCRIPTION
If /usr/local is read-only, you can override the prefix to use something like /opt instead. But it is assumed that /etc is always read-write...

Closes #1654

----

For some reason /opt/bin was not in the PATH of the check, even if it is the PATH of the actual user later on.

Workaround was to check with `test -x` in addition to `command -v`, to see if `nerdctl` has been installed yet.