### PR TITLE
Update DNS set up script to use a dedicated chain 

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/09-host-dns-setup.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/09-host-dns-setup.sh
@@ -1,24 +1,25 @@
 #!/bin/sh
 set -eux
 
+readonly chain=LIMADNS
+
+chain_exists() {
+	iptables --table nat -n --list "${chain}" >/dev/null 2>&1
+}
+
 # Wait until iptables has been installed; 35-configure-packages.sh will call this script again
 if command -v iptables >/dev/null 2>&1; then
-	if [ -n "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" ] && [ "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" -ne 0 ]; then
-		# Only add the rule once
-		if ! iptables-save | grep "udp.*${LIMA_CIDATA_SLIRP_GATEWAY}:${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}"; then
-			iptables -t nat -A PREROUTING -d "${LIMA_CIDATA_SLIRP_DNS}" -p udp --dport 53 -j DNAT \
-				--to-destination "${LIMA_CIDATA_SLIRP_GATEWAY}:${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}"
-			iptables -t nat -A OUTPUT -d "${LIMA_CIDATA_SLIRP_DNS}" -p udp --dport 53 -j DNAT \
-				--to-destination "${LIMA_CIDATA_SLIRP_GATEWAY}:${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}"
-		fi
+	if ! chain_exists; then
+		iptables --table nat --new-chain ${chain}
+		iptables --table nat --insert PREROUTING 1 --jump "${chain}"
+		iptables --table nat --insert OUTPUT 1 --jump "${chain}"
 	fi
-	if [ -n "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" ] && [ "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" -ne 0 ]; then
-		# Only add the rule once
-		if ! iptables-save | grep "tcp.*${LIMA_CIDATA_SLIRP_GATEWAY}:${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}"; then
-			iptables -t nat -A PREROUTING -d "${LIMA_CIDATA_SLIRP_DNS}" -p tcp --dport 53 -j DNAT \
-				--to-destination "${LIMA_CIDATA_SLIRP_GATEWAY}:${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}"
-			iptables -t nat -A OUTPUT -d "${LIMA_CIDATA_SLIRP_DNS}" -p tcp --dport 53 -j DNAT \
-				--to-destination "${LIMA_CIDATA_SLIRP_GATEWAY}:${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}"
-		fi
-	fi
+
+	# Remove old rules
+	iptables --table nat --flush ${chain}
+	# Add rules for the existing ip:port
+	iptables --table nat --append "${chain}" --destination "${LIMA_CIDATA_SLIRP_DNS}" --protocol udp --dport 53 --jump DNAT \
+		--to-destination "${LIMA_CIDATA_SLIRP_GATEWAY}:${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}"
+	iptables --table nat --append "${chain}" --destination "${LIMA_CIDATA_SLIRP_DNS}" --protocol tcp --dport 53 --jump DNAT \
+		--to-destination "${LIMA_CIDATA_SLIRP_GATEWAY}:${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}"
 fi


### PR DESCRIPTION
This PR updates the behavior of the host DNS configuration script to avoid hiccups on VM restarts (or rather stop/start attempts).
The issue is that when hostagent starts up, it picks a random free port for UDP/TCP which is then reflected in the guest's nat table in append mode. If there was a previous rule to route the DNS traffic on a (now potentially invalid) port, the DNS requests will time out.

This changeset moves the host DNS rules to a dedicated chain to be able to update them seamless on restart and when hostagent ports change.