### PR TITLE
Don't repeatedly download get.k3s.io

### DIFF
--- a/examples/k3s.yaml
+++ b/examples/k3s.yaml
@@ -39,8 +39,9 @@ provision:
 - mode: system
   script: |
     #!/bin/sh
-    curl -sfL https://get.k3s.io | sh -
-
+    if [ ! -d /var/lib/rancher/k3s ]; then
+            curl -sfL https://get.k3s.io | sh -
+    fi
 probes:
 - script: |
     #!/bin/bash


### PR DESCRIPTION
We only need to install k3s once on first boot.