### PR TITLE
qemu: armv7l, aarch64: add pci-serial

### DIFF
--- a/docs/internal.md
+++ b/docs/internal.md
@@ -51,8 +51,10 @@ VZ:
 - `vz-efi`: EFIVariable store file for a VM
 
 Serial:
-- `serial.log`: legacy serial log (QEMU only), for debugging
-- `serial.sock`: legacy serial socket (QEMU only), for debugging (Usage: `socat -,echo=0,icanon=0 unix-connect:serial.sock`)
+- `serial.log`: default serial log (QEMU only), for debugging
+- `serial.sock`: default serial socket (QEMU only), for debugging (Usage: `socat -,echo=0,icanon=0 unix-connect:serial.sock`)
+- `serialp.log`: PCI serial log (QEMU (ARM) only), for debugging
+- `serialp.sock`: PCI serial socket (QEMU (ARM) only), for debugging (Usage: `socat -,echo=0,icanon=0 unix-connect:serialp.sock`)
 - `serialv.log`: virtio serial log, for debugging
 - `serialv.sock`: virtio serial socket (QEMU only), for debugging (Usage: `socat -,echo=0,icanon=0 unix-connect:serialv.sock`)
 

--- a/examples/experimental/armv7l.yaml
+++ b/examples/experimental/armv7l.yaml
@@ -1,4 +1,4 @@
-# This example requires Lima v0.7.0 or later.
+# This example requires Lima v0.17.0 or later.
 
 arch: "armv7l"
 images:
@@ -15,6 +15,7 @@ mounts:
 - location: "~"
 - location: "/tmp/lima"
   writable: true
+mountType: "9p"
 
 # We do not have arm-v7 binaries of containerd
 containerd:

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -789,15 +789,9 @@ func Cmdline(cfg Config) (string, []string, error) {
 		args = append(args, "-device", "virtio-keyboard-pci")
 		args = append(args, "-device", "virtio-mouse-pci")
 		args = append(args, "-device", "qemu-xhci,id=usb-bus")
-	case limayaml.AARCH64:
-		// QEMU does not seem to support virtio-vga for aarch64
+	case limayaml.AARCH64, limayaml.ARMV7L:
+		// QEMU does not seem to support virtio-vga for aarch64 and arm
 		args = append(args, "-vga", "none", "-device", "ramfb")
-		args = append(args, "-device", "qemu-xhci,id=usb-bus")
-		args = append(args, "-device", "usb-kbd,bus=usb-bus.0")
-		args = append(args, "-device", "usb-mouse,bus=usb-bus.0")
-	case limayaml.ARMV7L:
-		// QEMU does not seem to support virtio-vga for arm
-		args = append(args, "-vga", "cirrus", "-device", "cirrus-vga")
 		args = append(args, "-device", "qemu-xhci,id=usb-bus")
 		args = append(args, "-device", "usb-kbd,bus=usb-bus.0")
 		args = append(args, "-device", "usb-mouse,bus=usb-bus.0")

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -800,7 +800,8 @@ func Cmdline(cfg Config) (string, []string, error) {
 	// Parallel
 	args = append(args, "-parallel", "none")
 
-	// Serial (legacy)
+	// Serial (default)
+	// This is ttyS0 for Intel and RISC-V, ttyAMA0 for ARM.
 	serialSock := filepath.Join(cfg.InstanceDir, filenames.SerialSock)
 	if err := os.RemoveAll(serialSock); err != nil {
 		return "", nil, err
@@ -812,6 +813,24 @@ func Cmdline(cfg Config) (string, []string, error) {
 	const serialChardev = "char-serial"
 	args = append(args, "-chardev", fmt.Sprintf("socket,id=%s,path=%s,server=on,wait=off,logfile=%s", serialChardev, serialSock, serialLog))
 	args = append(args, "-serial", "chardev:"+serialChardev)
+
+	// Serial (PCI, ARM only)
+	// On ARM, the default serial is ttyAMA0, this PCI serial is ttyS0.
+	// https://gitlab.com/qemu-project/qemu/-/issues/1801#note_1494720586
+	switch *y.Arch {
+	case limayaml.AARCH64, limayaml.ARMV7L:
+		serialpSock := filepath.Join(cfg.InstanceDir, filenames.SerialPCISock)
+		if err := os.RemoveAll(serialpSock); err != nil {
+			return "", nil, err
+		}
+		serialpLog := filepath.Join(cfg.InstanceDir, filenames.SerialPCILog)
+		if err := os.RemoveAll(serialpLog); err != nil {
+			return "", nil, err
+		}
+		const serialpChardev = "char-serial-pci"
+		args = append(args, "-chardev", fmt.Sprintf("socket,id=%s,path=%s,server=on,wait=off,logfile=%s", serialpChardev, serialpSock, serialpLog))
+		args = append(args, "-device", "pci-serial,chardev="+serialpChardev)
+	}
 
 	// Serial (virtio)
 	serialvSock := filepath.Join(cfg.InstanceDir, filenames.SerialVirtioSock)

--- a/pkg/store/filenames/filenames.go
+++ b/pkg/store/filenames/filenames.go
@@ -34,8 +34,10 @@ const (
 	KernelCmdline      = "kernel.cmdline"
 	Initrd             = "initrd"
 	QMPSock            = "qmp.sock"
-	SerialLog          = "serial.log" // legacy
+	SerialLog          = "serial.log" // default serial (ttyS0, but ttyAMA0 on qemu-system-{arm,aarch64})
 	SerialSock         = "serial.sock"
+	SerialPCILog       = "serialp.log" // pci serial (ttyS0 on qemu-system-{arm,aarch64})
+	SerialPCISock      = "serialp.sock"
 	SerialVirtioLog    = "serialv.log" // virtio serial
 	SerialVirtioSock   = "serialv.sock"
 	SSHSock            = "ssh.sock"


### PR DESCRIPTION
On armv7l, dmesg is not shown in the default serial (ttyAMA0).
On aarch64, dmesg is still shown but cloud-init logs are not shown.

Add `pci-serial` device to enable ttyS0.
    
The default ttyAMA0 is still kept to show UEFI logs.

Fix #1701 