### PR TITLE
Fix toc level of VZ generic category

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,30 +310,30 @@ The current default spec:
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ### Generic
 
-  - [Generic](#generic)
-    - ["What's my login password?"](#whats-my-login-password)
-    - ["Does Lima work on ARM Mac?"](#does-lima-work-on-arm-mac)
-    - ["Can I run non-Ubuntu guests?"](#can-i-run-non-ubuntu-guests)
-    - ["Can I run other container engines such as Docker and Podman? What about Kubernetes?"](#can-i-run-other-container-engines-such-as-docker-and-podman-what-about-kubernetes)
-    - ["Can I run Lima with a remote Linux machine?"](#can-i-run-lima-with-a-remote-linux-machine)
-    - ["Advantages compared to Docker for Mac?"](#advantages-compared-to-docker-for-mac)
-  - [QEMU](#qemu)
-    - ["QEMU crashes with `HV_ERROR`"](#qemu-crashes-with-hv_error)
-    - ["QEMU is slow"](#qemu-is-slow)
-    - [error "killed -9"](#error-killed--9)
-    - ["QEMU crashes with `vmx_write_mem: mmu_gva_to_gpa XXXXXXXXXXXXXXXX failed`"](#qemu-crashes-with-vmx_write_mem-mmu_gva_to_gpa-xxxxxxxxxxxxxxxx-failed)
+- [Generic](#generic)
+  - ["What's my login password?"](#whats-my-login-password)
+  - ["Does Lima work on ARM Mac?"](#does-lima-work-on-arm-mac)
+  - ["Can I run non-Ubuntu guests?"](#can-i-run-non-ubuntu-guests)
+  - ["Can I run other container engines such as Docker and Podman? What about Kubernetes?"](#can-i-run-other-container-engines-such-as-docker-and-podman-what-about-kubernetes)
+  - ["Can I run Lima with a remote Linux machine?"](#can-i-run-lima-with-a-remote-linux-machine)
+  - ["Advantages compared to Docker for Mac?"](#advantages-compared-to-docker-for-mac)
+- [QEMU](#qemu)
+  - ["QEMU crashes with `HV_ERROR`"](#qemu-crashes-with-hv_error)
+  - ["QEMU is slow"](#qemu-is-slow)
+  - [error "killed -9"](#error-killed--9)
+  - ["QEMU crashes with `vmx_write_mem: mmu_gva_to_gpa XXXXXXXXXXXXXXXX failed`"](#qemu-crashes-with-vmx_write_mem-mmu_gva_to_gpa-xxxxxxxxxxxxxxxx-failed)
 - [VZ](#vz)
-    - ["Lima gets stuck at `Installing rosetta...`"](#lima-gets-stuck-at-installing-rosetta)
-  - [Networking](#networking)
-    - ["Cannot access the guest IP 192.168.5.15 from the host"](#cannot-access-the-guest-ip-192168515-from-the-host)
-    - ["Ping shows duplicate packets and massive response times"](#ping-shows-duplicate-packets-and-massive-response-times)
-    - ["IP address is not assigined for vmnet networks"](#ip-address-is-not-assigined-for-vmnet-networks)
-  - [Filesystem sharing](#filesystem-sharing)
-    - ["Filesystem is slow"](#filesystem-is-slow)
-    - ["Filesystem is not writable"](#filesystem-is-not-writable)
-  - [External projects](#external-projects)
-    - ["I am using Rancher Desktop. How to deal with the underlying Lima?"](#i-am-using-rancher-desktop-how-to-deal-with-the-underlying-lima)
-  - ["Hints for debugging other problems?"](#hints-for-debugging-other-problems)
+  - ["Lima gets stuck at `Installing rosetta...`"](#lima-gets-stuck-at-installing-rosetta)
+- [Networking](#networking)
+  - ["Cannot access the guest IP 192.168.5.15 from the host"](#cannot-access-the-guest-ip-192168515-from-the-host)
+  - ["Ping shows duplicate packets and massive response times"](#ping-shows-duplicate-packets-and-massive-response-times)
+  - ["IP address is not assigined for vmnet networks"](#ip-address-is-not-assigined-for-vmnet-networks)
+- [Filesystem sharing](#filesystem-sharing)
+  - ["Filesystem is slow"](#filesystem-is-slow)
+  - ["Filesystem is not writable"](#filesystem-is-not-writable)
+- [External projects](#external-projects)
+  - ["I am using Rancher Desktop. How to deal with the underlying Lima?"](#i-am-using-rancher-desktop-how-to-deal-with-the-underlying-lima)
+- ["Hints for debugging other problems?"](#hints-for-debugging-other-problems)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 ### Generic
@@ -443,7 +443,7 @@ A workaround is to set environment variable `QEMU_SYSTEM_X86_64="qemu-system-x86
 
 https://bugs.launchpad.net/qemu/+bug/1838390
 
-## VZ
+### VZ
 #### "Lima gets stuck at `Installing rosetta...`"
 
 Try `softwareupdate --install-rosetta` from a terminal.


### PR DESCRIPTION
It was indented wrong, causing it to show up in the menu.

Rerun "doctoc" to fix the whitespace in the list as well.

----

Fixes the "Contents" menu on https://lima-vm.io/

Contents
* [Motivation](https://lima-vm.io/#motivation)
* [Community](https://lima-vm.io/#community)
* [Examples](https://lima-vm.io/#examples)
* [Getting started](https://lima-vm.io/#getting-started)
* [How it works](https://lima-vm.io/#how-it-works)
* [Developer guide](https://lima-vm.io/#developer-guide)
* [FAQs & Troubleshooting](https://lima-vm.io/#faqs--troubleshooting)
* ~~[VZ](https://lima-vm.io/#vz)~~