### PR TITLE
feat: add Register/Unregister to Driver interface

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -35,6 +35,14 @@ type Driver interface {
 	// It returns error if there are any errors during Stop
 	Stop(_ context.Context) error
 
+	// Register will add an instance to a registry.
+	// It returns error if there are any errors during Register
+	Register(_ context.Context) error
+
+	// Unregister will perform any cleanup related to the vm instance.
+	// It returns error if there are any errors during Unregister
+	Unregister(_ context.Context) error
+
 	ChangeDisplayPassword(_ context.Context, password string) error
 
 	GetDisplayConnection(_ context.Context) (string, error)
@@ -54,6 +62,8 @@ type BaseDriver struct {
 
 	SSHLocalPort int
 }
+
+var _ Driver = (*BaseDriver)(nil)
 
 func (d *BaseDriver) Validate() error {
 	return nil
@@ -76,6 +86,14 @@ func (d *BaseDriver) RunGUI() error {
 }
 
 func (d *BaseDriver) Stop(_ context.Context) error {
+	return nil
+}
+
+func (d *BaseDriver) Register(_ context.Context) error {
+	return nil
+}
+
+func (d *BaseDriver) Unregister(_ context.Context) error {
 	return nil
 }
 

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -285,6 +285,7 @@ func (a *HostAgent) Run(ctx context.Context) error {
 		}
 		defer dnsServer.Shutdown()
 	}
+
 	errCh, err := a.driver.Start(ctx)
 	if err != nil {
 		return err

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -311,3 +311,17 @@ func ShowMessage(inst *store.Instance) error {
 	}
 	return scanner.Err()
 }
+
+func Register(ctx context.Context, inst *store.Instance) error {
+	y, err := inst.LoadYAML()
+	if err != nil {
+		return err
+	}
+
+	limaDriver := driverutil.CreateTargetDriverInstance(&driver.BaseDriver{
+		Instance: inst,
+		Yaml:     y,
+	})
+
+	return limaDriver.Register(ctx)
+}

--- a/pkg/stop/stop.go
+++ b/pkg/stop/stop.go
@@ -1,0 +1,24 @@
+package stop
+
+import (
+	"context"
+
+	"github.com/lima-vm/lima/pkg/driver"
+	"github.com/lima-vm/lima/pkg/driverutil"
+
+	"github.com/lima-vm/lima/pkg/store"
+)
+
+func Unregister(ctx context.Context, inst *store.Instance) error {
+	y, err := inst.LoadYAML()
+	if err != nil {
+		return err
+	}
+
+	limaDriver := driverutil.CreateTargetDriverInstance(&driver.BaseDriver{
+		Instance: inst,
+		Yaml:     y,
+	})
+
+	return limaDriver.Unregister(ctx)
+}


### PR DESCRIPTION
Addresses comment on https://github.com/lima-vm/lima/pull/1721#discussion_r1286619203 regarding reusing the Register/Unregister interface for both the new VBox and WSL2 drivers.

Refactored the implementation out of @afbjorklund's PR https://github.com/lima-vm/lima/pull/1277. I didn't see a call to `Register`, so I just added it before `Start` in the `pkg/hostagent`. Also added a nil instantiation of the `BaseDriver` in `pkg/driver` to help with typechecking/noticing if there are unimplemented members of the interface (can remove).

Added @afbjorklund as a co-author since I mostly just refactored. Let me know if that makes sense to you, happy to change it.