### PR TITLE
Add OS to lima.yaml for future guests

### DIFF
--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -29,7 +29,7 @@ func newHostagentCommand() *cobra.Command {
 	hostagentCommand.Flags().StringP("pidfile", "p", "", "write pid to file")
 	hostagentCommand.Flags().String("socket", "", "hostagent socket")
 	hostagentCommand.Flags().Bool("run-gui", false, "run gui synchronously within hostagent")
-	hostagentCommand.Flags().String("nerdctl-archive", "", "local file path (not URL) of nerdctl-full-VERSION-linux-GOARCH.tar.gz")
+	hostagentCommand.Flags().String("nerdctl-archive", "", "local file path (not URL) of nerdctl-full-VERSION-GOOS-GOARCH.tar.gz")
 	return hostagentCommand
 }
 

--- a/docs/internal.md
+++ b/docs/internal.md
@@ -133,7 +133,7 @@ The directory contains the following files:
 - `network-config`: [Cloud-init Networking Config Version 2](https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v2.html)
 - `lima.env`: The `LIMA_CIDATA_*` environment variables (see below) available during `boot.sh` processing
 - `lima-guestagent`: Lima guest agent binary
-- `nerdctl-full.tgz`: [`nerdctl-full-<VERSION>-linux-<ARCH>.tar.gz`](https://github.com/containerd/nerdctl/releases)
+- `nerdctl-full.tgz`: [`nerdctl-full-<VERSION>-<OS>-<ARCH>.tar.gz`](https://github.com/containerd/nerdctl/releases)
 - `boot.sh`: Boot script
 - `boot/*`: Boot script modules
 - `util/*`: Utility command scripts, executed in the boot script modules

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -11,6 +11,10 @@
 # 🟢 Builtin default: "qemu"
 vmType: null
 
+# OS: "Linux".
+# 🟢 Builtin default: "Linux"
+os: null
+
 # Arch: "default", "x86_64", "aarch64".
 # 🟢 Builtin default: "default" (corresponds to the host architecture)
 arch: null

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -303,7 +303,7 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 		}
 	}
 
-	guestAgentBinary, err := GuestAgentBinary(*y.Arch)
+	guestAgentBinary, err := GuestAgentBinary(*y.OS, *y.Arch)
 	if err != nil {
 		return err
 	}
@@ -329,7 +329,10 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 	return iso9660util.Write(filepath.Join(instDir, filenames.CIDataISO), "cidata", layout)
 }
 
-func GuestAgentBinary(arch string) (io.ReadCloser, error) {
+func GuestAgentBinary(ostype limayaml.OS, arch limayaml.Arch) (io.ReadCloser, error) {
+	if ostype == "" {
+		return nil, errors.New("os must be set")
+	}
 	if arch == "" {
 		return nil, errors.New("arch must be set")
 	}
@@ -337,7 +340,7 @@ func GuestAgentBinary(arch string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	gaPath := filepath.Join(dir, "lima-guestagent.Linux-"+arch)
+	gaPath := filepath.Join(dir, "lima-guestagent."+ostype+"-"+arch)
 	return os.Open(gaPath)
 }
 

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -61,6 +61,7 @@ func TestFillDefault(t *testing.T) {
 	// Builtin default values
 	builtin := LimaYAML{
 		VMType: pointer.String("qemu"),
+		OS:     pointer.String(LINUX),
 		Arch:   pointer.String(arch),
 		CPUType: map[Arch]string{
 			AARCH64: "cortex-a72",
@@ -266,6 +267,7 @@ func TestFillDefault(t *testing.T) {
 	// Choose values that are different from the "builtin" defaults
 	d = LimaYAML{
 		VMType: pointer.String("vz"),
+		OS:     pointer.String("unknown"),
 		Arch:   pointer.String("unknown"),
 		CPUType: map[Arch]string{
 			AARCH64: "arm64",
@@ -443,6 +445,7 @@ func TestFillDefault(t *testing.T) {
 
 	o = LimaYAML{
 		VMType: pointer.String("qemu"),
+		OS:     pointer.String(LINUX),
 		Arch:   pointer.String(arch),
 		CPUType: map[Arch]string{
 			AARCH64: "uber-arm",

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -8,6 +8,7 @@ import (
 
 type LimaYAML struct {
 	VMType             *VMType         `yaml:"vmType,omitempty" json:"vmType,omitempty"`
+	OS                 *OS             `yaml:"os,omitempty" json:"os,omitempty"`
 	Arch               *Arch           `yaml:"arch,omitempty" json:"arch,omitempty"`
 	Images             []Image         `yaml:"images" json:"images"` // REQUIRED
 	CPUType            map[Arch]string `yaml:"cpuType,omitempty" json:"cpuType,omitempty"`
@@ -39,11 +40,14 @@ type LimaYAML struct {
 	Rosetta           Rosetta        `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
 }
 
+type OS = string
 type Arch = string
 type MountType = string
 type VMType = string
 
 const (
+	LINUX OS = "Linux"
+
 	X8664   Arch = "x86_64"
 	AARCH64 Arch = "aarch64"
 	ARMV7L  Arch = "armv7l"

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -42,6 +42,11 @@ func validateFileObject(f File, fieldName string) error {
 }
 
 func Validate(y LimaYAML, warn bool) error {
+	switch *y.OS {
+	case LINUX:
+	default:
+		return fmt.Errorf("field `os` must be %q; got %q", LINUX, *y.OS)
+	}
 	switch *y.Arch {
 	case X8664, AARCH64, ARMV7L, RISCV64:
 	default:

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -28,7 +28,7 @@ import (
 // to be running before timing out.
 const DefaultWatchHostAgentEventsTimeout = 10 * time.Minute
 
-// ensureNerdctlArchiveCache prefetches the nerdctl-full-VERSION-linux-GOARCH.tar.gz archive
+// ensureNerdctlArchiveCache prefetches the nerdctl-full-VERSION-GOOS-GOARCH.tar.gz archive
 // into the cache before launching the hostagent process, so that we can show the progress in tty.
 // https://github.com/lima-vm/lima/issues/326
 func ensureNerdctlArchiveCache(y *limayaml.LimaYAML) (string, error) {

--- a/pkg/usrlocalsharelima/usrlocalsharelima.go
+++ b/pkg/usrlocalsharelima/usrlocalsharelima.go
@@ -27,6 +27,7 @@ func Dir() (string, error) {
 		}
 	}
 
+	ostype := limayaml.NewOS("linux")
 	arch := limayaml.NewArch(runtime.GOARCH)
 	if arch == "" {
 		return "", fmt.Errorf("failed to get arch for %q", runtime.GOARCH)
@@ -40,12 +41,12 @@ func Dir() (string, error) {
 		// - self:  /Applications/Lima.app/Contents/MacOS/limactl
 		// - agent: /Applications/Lima.app/Contents/MacOS/lima-guestagent.Linux-x86_64
 		// - dir:   /Applications/Lima.app/Contents/MacOS
-		filepath.Join(selfDir, "lima-guestagent.Linux-"+arch),
+		filepath.Join(selfDir, "lima-guestagent."+ostype+"-"+arch),
 		// candidate 1:
 		// - self:  /usr/local/bin/limactl
 		// - agent: /usr/local/share/lima/lima-guestagent.Linux-x86_64
 		// - dir:   /usr/local/share/lima
-		filepath.Join(selfDirDir, "share/lima/lima-guestagent.Linux-"+arch),
+		filepath.Join(selfDirDir, "share/lima/lima-guestagent."+ostype+"-"+arch),
 		// TODO: support custom path
 	}
 	for _, gaCandidate := range gaCandidates {
@@ -56,6 +57,6 @@ func Dir() (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("failed to find \"lima-guestagent.Linux-%s\" binary for %q, attempted %v",
-		arch, self, gaCandidates)
+	return "", fmt.Errorf("failed to find \"lima-guestagent.%s-%s\" binary for %q, attempted %v",
+		ostype, arch, self, gaCandidates)
 }


### PR DESCRIPTION
Avoid hardcoding "linux" everywhere, use OS instead (like Arch).

~~TODO: Add proper cidata template parameter for LIMA_CIDATA_HOME~~

There are some other hardcoded Linux or Systemd specific things too:

`/bin/bash`  or `/run`, those are not addressed here and are left as is.

----

Doing the OS refactoring in a separate PR, makes it easier to add OS

* #1509