### PR TITLE
Delete the conf file when instance is stopped

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -379,8 +379,10 @@ networks:
 # copyToHost:
 # - guest: "/etc/myconfig.cfg"
 #   host: "{{.Dir}}/copied-from-guest/myconfig"
+# # deleteOnStop: false
 # # "guest" can include these template variables: {{.Home}}, {{.UID}}, and {{.User}}.
 # # "host" can include {{.Home}}, {{.Dir}}, {{.Name}}, {{.UID}}, and {{.User}}.
+# # "deleteOnStop" will delete the file from the host when the instance is stopped.
 
 # Message. Information to be shown to the user, given as a Go template for the instance.
 # The same template variables as for listing instances can be used, for example {{.Dir}}.

--- a/examples/experimental/rke2.yaml
+++ b/examples/experimental/rke2.yaml
@@ -67,6 +67,7 @@ probes:
 copyToHost:
 - guest: "/etc/rancher/rke2/rke2.yaml"
   host: "{{.Dir}}/copied-from-guest/kubeconfig.yaml"
+  deleteOnStop: true
 message: |
   To run `kubectl` on the host (assumes kubectl is installed), run the following commands:
   ------

--- a/examples/k3s.yaml
+++ b/examples/k3s.yaml
@@ -57,6 +57,7 @@ probes:
 copyToHost:
 - guest: "/etc/rancher/k3s/k3s.yaml"
   host: "{{.Dir}}/copied-from-guest/kubeconfig.yaml"
+  deleteOnStop: true
 message: |
   To run `kubectl` on the host (assumes kubectl is installed), run the following commands:
   ------

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -156,6 +156,7 @@ probes:
 copyToHost:
 - guest: "/etc/kubernetes/admin.conf"
   host: "{{.Dir}}/copied-from-guest/kubeconfig.yaml"
+  deleteOnStop: true
 message: |
   To run `kubectl` on the host (assumes kubectl is installed), run the following commands:
   ------

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -461,6 +461,18 @@ sudo chown -R "${USER}" /run/host-services`
 			mErr = errors.Join(mErr, err)
 		}
 	}
+	a.onClose = append(a.onClose, func() error {
+		var mErr error
+		for _, rule := range a.y.CopyToHost {
+			if rule.DeleteOnStop {
+				logrus.Infof("Deleting %s", rule.HostFile)
+				if err := os.RemoveAll(rule.HostFile); err != nil {
+					mErr = errors.Join(mErr, err)
+				}
+			}
+		}
+		return mErr
+	})
 	return mErr
 }
 

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -210,8 +210,9 @@ type PortForward struct {
 }
 
 type CopyToHost struct {
-	GuestFile string `yaml:"guest,omitempty" json:"guest,omitempty"`
-	HostFile  string `yaml:"host,omitempty" json:"host,omitempty"`
+	GuestFile    string `yaml:"guest,omitempty" json:"guest,omitempty"`
+	HostFile     string `yaml:"host,omitempty" json:"host,omitempty"`
+	DeleteOnStop bool   `yaml:"deleteOnStop,omitempty" json:"deleteOnStop,omitempty"`
 }
 
 type Network struct {


### PR DESCRIPTION
Closes #1737

start
```
INFO[0027] [hostagent] The final requirement 1 of 1 is satisfied 
INFO[0027] [hostagent] Copying config from /etc/rancher/k3s/k3s.yaml to /home/anders/.lima/k3s/copied-from-guest/kubeconfig.yaml 
```

stop
```
INFO[0000] [hostagent] Shutting down the host agent     
INFO[0000] [hostagent] Deleting /home/anders/.lima/k3s/copied-from-guest/kubeconfig.yaml 
```