### PR TITLE
qemu: ask to sign QEMU binary when the binary is not properly signed

### DIFF
--- a/pkg/qemu/entitlementutil/entitlementutil.go
+++ b/pkg/qemu/entitlementutil/entitlementutil.go
@@ -1,0 +1,94 @@
+// Package entitlementutil provides a workaround for https://github.com/lima-vm/lima/issues/1742
+package entitlementutil
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/mattn/go-isatty"
+	"github.com/sirupsen/logrus"
+)
+
+// IsSigned returns an error if the binary is not signed, or the sign is invalid,
+// or not associated with the "com.apple.security.hypervisor" entitlement.
+func IsSigned(qExe string) error {
+	cmd := exec.Command("codesign", "--verify", qExe)
+	out, err := cmd.CombinedOutput()
+	logrus.WithError(err).Debugf("Executed %v: out=%q", cmd.Args, string(out))
+	if err != nil {
+		return fmt.Errorf("failed to run %v: %w (out=%q)", cmd.Args, err, string(out))
+	}
+
+	cmd = exec.Command("codesign", "--display", "--entitlements", "-", "--xml", qExe)
+	out, err = cmd.CombinedOutput()
+	logrus.WithError(err).Debugf("Executed %v: out=%q", cmd.Args, string(out))
+	if err != nil {
+		return fmt.Errorf("failed to run %v: %w (out=%q)", cmd.Args, err, string(out))
+	}
+	if !strings.Contains(string(out), "com.apple.security.hypervisor") {
+		return fmt.Errorf("binary %q seems signed but lacking the \"com.apple.security.hypervisor\" entitlement", qExe)
+	}
+	return nil
+}
+
+func Sign(qExe string) error {
+	ent, err := os.CreateTemp("", "lima-qemu-entitlements-*.xml")
+	if err != nil {
+		return fmt.Errorf("failed to create a temporary file for signing QEMU binary: %w", err)
+	}
+	entName := ent.Name()
+	defer os.RemoveAll(entName)
+	const entXML = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.hypervisor</key>
+    <true/>
+  </dict>
+</plist>`
+	if _, err = ent.Write([]byte(entXML)); err != nil {
+		return fmt.Errorf("Failed to write to a temporary file %q for signing QEMU binary: %w", entName, err)
+	}
+	ent.Close()
+	signCmd := exec.Command("codesign", "--sign", "-", "--entitlements", entName, "--force", qExe)
+	out, err := signCmd.CombinedOutput()
+	logrus.WithError(err).Debugf("Executed %v: out=%q", signCmd.Args, string(out))
+	if err != nil {
+		return fmt.Errorf("failed to run %v: %w (out=%q)", signCmd.Args, err, string(out))
+	}
+	return nil
+}
+
+// AskToSignIfNotSignedProperly asks to sign the QEMU binary with the "com.apple.security.hypervisor" entitlement.
+//
+// On Homebrew, QEMU binaries are usually already signed, but Homebrew's signing infrastructure is broken for Intel as of Augest 2023.
+// https://github.com/lima-vm/lima/issues/1742
+func AskToSignIfNotSignedProperly(qExe string) {
+	if isSignedErr := IsSigned(qExe); isSignedErr != nil {
+		logrus.WithError(isSignedErr).Warnf("QEMU binary %q is not properly signed with the \"com.apple.security.hypervisor\" entitlement", qExe)
+		var ans bool
+		if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+			prompt := &survey.Confirm{
+				Message: fmt.Sprintf("Try to sign %q with the \"com.apple.security.hypervisor\" entitlement?", qExe),
+				Default: true,
+			}
+			if askErr := survey.AskOne(prompt, &ans); askErr != nil {
+				logrus.WithError(askErr).Warn("No answer was given")
+			}
+		}
+		if ans {
+			if signErr := Sign(qExe); signErr != nil {
+				logrus.WithError(signErr).Warnf("Failed to sign %q", qExe)
+			} else {
+				logrus.Infof("Successfully signed %q with the \"com.apple.security.hypervisor\" entitlement", qExe)
+			}
+		} else {
+			logrus.Warn("You have to sign the QEMU binary with the \"com.apple.security.hypervisor\" entitlement manually. See https://github.com/lima-vm/lima/issues/1742 .")
+		}
+	} else {
+		logrus.Infof("QEMU binary %q seems properly signed with the \"com.apple.security.hypervisor\" entitlement", qExe)
+	}
+}

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -469,7 +469,7 @@ func qemuMachine(arch limayaml.Arch) string {
 
 func Cmdline(cfg Config) (string, []string, error) {
 	y := cfg.LimaYAML
-	exe, args, err := getExe(*y.Arch)
+	exe, args, err := Exe(*y.Arch)
 	if err != nil {
 		return "", nil, err
 	}
@@ -490,7 +490,7 @@ func Cmdline(cfg Config) (string, []string, error) {
 	}
 
 	// Architecture
-	accel := getAccel(*y.Arch)
+	accel := Accel(*y.Arch)
 	if !strings.Contains(string(features.AccelHelp), accel) {
 		return "", nil, fmt.Errorf("accelerator %q is not supported by %s", accel, exe)
 	}
@@ -1003,7 +1003,7 @@ func qemuArch(arch limayaml.Arch) string {
 	return arch
 }
 
-func getExe(arch limayaml.Arch) (string, []string, error) {
+func Exe(arch limayaml.Arch) (string, []string, error) {
 	exeBase := "qemu-system-" + qemuArch(arch)
 	var args []string
 	envK := "QEMU_SYSTEM_" + strings.ToUpper(qemuArch(arch))
@@ -1024,7 +1024,7 @@ func getExe(arch limayaml.Arch) (string, []string, error) {
 	return exe, args, nil
 }
 
-func getAccel(arch limayaml.Arch) string {
+func Accel(arch limayaml.Arch) string {
 	if limayaml.IsNativeArch(arch) {
 		switch runtime.GOOS {
 		case "darwin":


### PR DESCRIPTION
```console
$ limactl start
INFO[0000] Using the existing instance "default"        
WARN[0000] QEMU binary "/usr/local/bin/qemu-system-x86_64" is not properly signed with the "com.apple.security.hypervisor" entitlement  error="failed to run [codesign --verify /usr/local/bin/qemu-system-x86_64]: exit status 1 (out=\"/usr/local/bin/qemu-system-x86_64: invalid signature (code or signature have been modified)\\nIn architecture: x86_64\\n\")"
? Try to sign "/usr/local/bin/qemu-system-x86_64" with the "com.apple.security.hypervisor" entitlement? Yes
...
```

- - -

Workaround for:
- #1742

This workaround is needed because Homebrew's QEMU binary is not properly signed since v8.0.4. https://github.com/Homebrew/homebrew-core/pull/139409#issuecomment-1676165225