### PR TITLE
fix(lint): update homebrew formula links

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -114,7 +114,7 @@ containerd とnerdctl (contaiNERD ctl)の使い方については、 https://git
 ## 始める
 ### インストール
 
-[Homebrewパッケージ](https://github.com/Homebrew/homebrew-core/blob/master/Formula/lima.rb)があります。
+[Homebrewパッケージ](https://github.com/Homebrew/homebrew-core/blob/master/Formula/l/lima.rb)があります。
 
 ```console
 brew install lima

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For the usage of containerd and nerdctl (contaiNERD ctl), visit <https://github.
 ## Getting started
 ### Installation
 
-[Homebrew package](https://github.com/Homebrew/homebrew-core/blob/master/Formula/lima.rb) is available.
+[Homebrew package](https://github.com/Homebrew/homebrew-core/blob/master/Formula/l/lima.rb) is available.
 
 ```console
 brew install lima

--- a/README.zh.md
+++ b/README.zh.md
@@ -109,7 +109,7 @@ $ lima nerdctl run -d --name nginx -p 127.0.0.1:8080:80 nginx:alpine
 ## 开始使用
 ### 安装
 
-可以直接使用 [Homebrew 上的包](https://github.com/Homebrew/homebrew-core/blob/master/Formula/lima.rb) 进行安装。
+可以直接使用 [Homebrew 上的包](https://github.com/Homebrew/homebrew-core/blob/master/Formula/l/lima.rb) 进行安装。
 
 ```console
 brew install lima


### PR DESCRIPTION
Noticed that link linting started failing on another PR (https://github.com/lima-vm/lima/pull/1726) because of the new sharding of Homebrew formulas (see https://github.com/Homebrew/homebrew-core/pull/139592).