### PR TITLE
Use pkgs.k8s.io instead of apt.k8s.io for k8s

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -55,8 +55,9 @@ provision:
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
     apt-get install -y apt-transport-https ca-certificates curl
-    curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
-    echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+    VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt | sed -e 's/v//' | cut -d'.' -f1-2)
+    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${VERSION}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+    curl -fsSL https://pkgs.k8s.io/core:/stable:/v${VERSION}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     apt-get update
     # cri-tools
     apt-get install -y cri-tools


### PR DESCRIPTION
The package hosting is moving from Google to OBS.

https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/

There is now one repository per release version.

It is the exact _same_ binary content, as is available on [dl.k8s.io](https://www.downloadkubernetes.com/)

----

No building, just packaging:

```
12ea68bfef0377ccedc1a7c98a05ea76907decbcf1e1ec858a60a7b9b73211bb  kubeadm_1.28.0-00_amd64/usr/bin/kubeadm
12ea68bfef0377ccedc1a7c98a05ea76907decbcf1e1ec858a60a7b9b73211bb  kubeadm_1.28.0-1.1_amd64/usr/bin/kubeadm
```

https://dl.k8s.io/v1.28.0/bin/linux/amd64/kubeadm.sha256