### PR TITLE
Avoid warning about OS with vz driver

### DIFF
--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -73,8 +73,9 @@ func (l *LimaVzDriver) Validate() error {
 		"AdditionalDisks",
 		"Audio",
 		"Video",
+		"OS",
 	); len(unknown) > 0 {
-		logrus.Warnf("Ignoring: vmType %s: %+v", *l.Yaml.VMType, unknown)
+		logrus.Warnf("vmType %s: ignoring %+v", *l.Yaml.VMType, unknown)
 	}
 
 	if !limayaml.IsNativeArch(*l.Yaml.Arch) {
@@ -83,13 +84,13 @@ func (l *LimaVzDriver) Validate() error {
 
 	for k, v := range l.Yaml.CPUType {
 		if v != "" {
-			logrus.Warnf("Ignoring: vmType %s: cpuType[%q]: %q", *l.Yaml.VMType, k, v)
+			logrus.Warnf("vmType %s: ignoring cpuType[%q]: %q", *l.Yaml.VMType, k, v)
 		}
 	}
 
 	for i, image := range l.Yaml.Images {
 		if unknown := reflectutil.UnknownNonEmptyFields(image, "File"); len(unknown) > 0 {
-			logrus.Warnf("Ignoring: vmType %s: images[%d]: %+v", *l.Yaml.VMType, i, unknown)
+			logrus.Warnf("vmType %s: ignoring images[%d]: %+v", *l.Yaml.VMType, i, unknown)
 		}
 	}
 
@@ -100,7 +101,7 @@ func (l *LimaVzDriver) Validate() error {
 			"SSHFS",
 			"NineP",
 		); len(unknown) > 0 {
-			logrus.Warnf("Ignoring: vmType %s: mounts[%d]: %+v", *l.Yaml.VMType, i, unknown)
+			logrus.Warnf("vmType %s: ignoring mounts[%d]: %+v", *l.Yaml.VMType, i, unknown)
 		}
 	}
 
@@ -111,7 +112,7 @@ func (l *LimaVzDriver) Validate() error {
 			"MACAddress",
 			"Interface",
 		); len(unknown) > 0 {
-			logrus.Warnf("Ignoring: vmType %s: networks[%d]: %+v", *l.Yaml.VMType, i, unknown)
+			logrus.Warnf("vmType %s: ignoring networks[%d]: %+v", *l.Yaml.VMType, i, unknown)
 		}
 	}
 


### PR DESCRIPTION
Fix #1768 by:

1. add `"OS"` to the know list since #1735 introduced this field. 
2. make the log message more clear: `Ignoring: vmType vz: [...]` -> `Ignoring following configuration due to the use of vmType vz: [...]` 
