### PR TITLE
docs: Usage: remove scaring caution

### DIFF
--- a/website/content/en/docs/Usage/_index.md
+++ b/website/content/en/docs/Usage/_index.md
@@ -3,14 +3,6 @@ title: Usage
 weight: 2
 ---
 
-> **CAUTION**
-> Lima may have bugs that result in loss of data.
-> **Make sure to back up your data before running Lima.**
-> Especially, the following data might be easily lost:
-> - Data in the shared writable directories (`/tmp/lima` by default),
->  probably after hibernation of the host machine (e.g., after closing and reopening the laptop lid)
-> - Data in the VM image, mostly when upgrading the version of lima
-
 ## Start a linux instance
 
 ```console


### PR DESCRIPTION
`Lima may have bugs that result in loss of data` sounds too scary for the current version of Lima.

It is still true that Lima, as well as any software, may have such bugs, but it does no longer need to be particularly documented here.

In Lima v0.14.0, we had a regression (issue #1242, fixed in v0.14.1) that accidentally leaved `/var/lib/docker` in Colima instances unmounted, but the actualy data were not lost, and could be easily recovered by downgrading or upgrading Lima to other versions.