### PR TITLE
limactl: deprecate `limactl show-ssh` (Use `ssh -F ...` instead)

### DIFF
--- a/cmd/limactl/show_ssh.go
+++ b/cmd/limactl/show_ssh.go
@@ -4,10 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/lima-vm/lima/pkg/sshutil"
 	"github.com/lima-vm/lima/pkg/store"
+	"github.com/lima-vm/lima/pkg/store/dirnames"
+	"github.com/lima-vm/lima/pkg/store/filenames"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -41,9 +45,18 @@ const showSSHExample = `
 `
 
 func newShowSSHCommand() *cobra.Command {
+	limaHome := "~/" + dirnames.DotLima
+	if s, err := dirnames.LimaDir(); err == nil {
+		limaHome = s
+	}
 	var shellCmd = &cobra.Command{
-		Use:               "show-ssh [flags] INSTANCE",
-		Short:             "Show the ssh command line",
+		Use:   "show-ssh [flags] INSTANCE",
+		Short: "Show the ssh command line (DEPRECATED; use `ssh -F` instead)",
+		Long: fmt.Sprintf(`Show the ssh command line (DEPRECATED)
+
+WARNING: 'limactl show-ssh' is deprecated.
+Instead, use 'ssh -F %s/default/ssh.config lima-default' .
+`, limaHome),
 		Example:           showSSHExample,
 		Args:              WrapArgsError(cobra.ExactArgs(1)),
 		RunE:              showSSHAction,
@@ -72,6 +85,8 @@ func showSSHAction(cmd *cobra.Command, args []string) error {
 		}
 		return err
 	}
+	logrus.Warnf("`limactl show-ssh` is deprecated. Instead, use `ssh -F %s lima-%s`.",
+		filepath.Join(inst.Dir, filenames.SSHConfig), inst.Name)
 	y, err := inst.LoadYAML()
 	if err != nil {
 		return err

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -5,6 +5,7 @@ The following features are deprecated:
 - VDE support, including VNL and `vde_vmnet`
 - CentOS 7 support
 - Loading non-strict YAMLs (i.e., YAMLs with unknown properties)
+- `limactl show-ssh` command (Use `ssh -F ~/.lima/default/ssh.config lima-default` instead)
 
 ## Removed features
 - YAML property `network`: deprecated in [Lima v0.7.0](https://github.com/lima-vm/lima/commit/07e68230e70b21108d2db3ca5e0efd0e43842fbd)

--- a/website/content/en/docs/Usage/_index.md
+++ b/website/content/en/docs/Usage/_index.md
@@ -59,13 +59,7 @@ $ limactl start --name=default https://raw.githubusercontent.com/lima-vm/lima/ma
 For the "default" instance, this command can be shortened as `lima <COMMAND>`.
 The `lima` command also accepts the instance name as the environment variable `$LIMA_INSTANCE`.
 
-#### limactl show-ssh
-- `limactl show-ssh --format=cmd <INSTANCE>` (default): Full `ssh` command line
-- `limactl show-ssh --format=args <INSTANCE>`: Similar to the `cmd` format but omits `ssh` and the destination address
-- `limactl show-ssh --format=options <INSTANCE>`: ssh option key value pairs
-- `limactl show-ssh --format=config <INSTANCE>`: `~/.ssh/config` format
-
-The config file is also automatically created inside the instance directory:
+SSH can be used too:
 ```console
 $ limactl ls --format='{{.SSHConfigFile}}' default
 /Users/example/.lima/default/ssh.config


### PR DESCRIPTION
`limactl show-ssh` is now deprecated.
Instead, use `ssh -F ~/.lima/default/ssh.config lima-default` .