### PR TITLE
docs: faq: remove outdated comparison with Docker for Mac

### DIFF
--- a/website/content/en/docs/faq/_index.md
+++ b/website/content/en/docs/faq/_index.md
@@ -96,12 +96,6 @@ and forward `localhost:8080` to the port 80 of the remote machine.
 
 #### "Advantages compared to Docker for Mac?"
 Lima is free software (Apache License 2.0), while Docker for Mac is not.
-Their [EULA](https://www.docker.com/legal/docker-software-end-user-license-agreement) even prohibits disclosure of benchmarking result.
-
-On the other hand, [Moby](https://github.com/moby/moby), aka Docker for Linux, is free software, but Moby/Docker lacks several novel features of containerd, such as:
-- [On-demand image pulling (aka lazy-pulling, eStargz)](https://github.com/containerd/nerdctl/blob/master/docs/stargz.md)
-- [Running an encrypted container](https://github.com/containerd/nerdctl/blob/master/docs/ocicrypt.md)
-- Importing and exporting [local OCI archives](https://github.com/opencontainers/image-spec/blob/master/image-layout.md)
 
 ### QEMU
 #### "QEMU crashes with `HV_ERROR`"


### PR DESCRIPTION
Remove "Their EULA even prohibits disclosure of benchmarking result", as the following clause no longer seems to exist:

> 3. RESTRICTED ACTIVITIES
> You shall not, and shall not encourage any third party to:
> ...
> (g) disclose the results of any benchmark tests on the Licensed
> Software without Docker’s prior written consent;
> ...

(From <https://web.archive.org/web/20230222093254/https://www.docker.com/legal/docker-software-end-user-license-agreement/>)

The comparison with Moby was outdated too since Moby v24, which experimentally supports the containerd-snapshotter mode.