### PR TITLE
fix: windows directory path containing spaces

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -138,10 +138,8 @@ func CommonOpts(useDotSSH bool) ([]string, error) {
 	var opts []string
 	if runtime.GOOS == "windows" {
 		privateKeyPath = ioutilx.CanonicalWindowsPath(privateKeyPath)
-		opts = []string{"IdentityFile=" + privateKeyPath}
-	} else {
-		opts = []string{"IdentityFile=\"" + privateKeyPath + "\""}
 	}
+	opts = []string{fmt.Sprintf(`IdentityFile="%s"`, privateKeyPath)}
 
 	// Append all private keys corresponding to ~/.ssh/*.pub to keep old instances working
 	// that had been created before lima started using an internal identity.
@@ -231,11 +229,10 @@ func SSHOpts(instDir string, useDotSSH, forwardAgent bool, forwardX11 bool, forw
 	if err != nil {
 		return nil, err
 	}
-	controlPath := fmt.Sprintf("ControlPath=\"%s\"", controlSock)
 	if runtime.GOOS == "windows" {
 		controlSock = ioutilx.CanonicalWindowsPath(controlSock)
-		controlPath = fmt.Sprintf("ControlPath=%s", controlSock)
 	}
+	controlPath := fmt.Sprintf(`ControlPath="%s"`, controlSock)
 	opts = append(opts,
 		fmt.Sprintf("User=%s", u.Username), // guest and host have the same username, but we should specify the username explicitly (#85)
 		"ControlMaster=auto",

--- a/pkg/wsl2/lima-init.TEMPLATE
+++ b/pkg/wsl2/lima-init.TEMPLATE
@@ -1,6 +1,5 @@
 set -eu; \
 export LOG_FILE=/var/log/lima-init.log; \
 exec > >(tee \$LOG_FILE) 2>&1; \
-LIMA_CIDATA_MNT=$(/usr/bin/wslpath '{{.CIDataPath}}'); \
-export LIMA_CIDATA_MNT; \
-exec \$LIMA_CIDATA_MNT/boot.sh;
+export LIMA_CIDATA_MNT="$(/usr/bin/wslpath '{{.CIDataPath}}')"; \
+exec "\$LIMA_CIDATA_MNT/boot.sh";


### PR DESCRIPTION
Without this change, Lima can't be used to create a VM in a path that contains a space. For example, if the InstanceDir is `C:\Users\My Name\.lima\data\`, all VM creations would fail.

Tested on a Windows machine.