### PR TITLE
Prompt the user to also start the created instance

### DIFF
--- a/cmd/apptainer.lima
+++ b/cmd/apptainer.lima
@@ -6,6 +6,9 @@ set -eu
 if [ "$(limactl ls -q "$LIMA_INSTANCE" 2>/dev/null)" != "$LIMA_INSTANCE" ]; then
   echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl create --name=$LIMA_INSTANCE template://apptainer\` to create a new instance" >&2
   exit 1
+elif [ "$(limactl ls -f '{{ .Status }}' "$LIMA_INSTANCE" 2>/dev/null)" != "Running" ]; then
+  echo "instance \"$LIMA_INSTANCE\" is not running, run \`limactl start $LIMA_INSTANCE\` to start the existing instance" >&2
+  exit 1
 fi
 export LIMA_INSTANCE
 if [ -n "$APPTAINER_BINDPATH" ]; then

--- a/cmd/docker.lima
+++ b/cmd/docker.lima
@@ -6,6 +6,9 @@ set -eu
 if [ "$(limactl ls -q "$LIMA_INSTANCE" 2>/dev/null)" != "$LIMA_INSTANCE" ]; then
   echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl create --name=$LIMA_INSTANCE template://docker\` to create a new instance" >&2
   exit 1
+elif [ "$(limactl ls -f '{{ .Status }}' "$LIMA_INSTANCE" 2>/dev/null)" != "Running" ]; then
+  echo "instance \"$LIMA_INSTANCE\" is not running, run \`limactl start $LIMA_INSTANCE\` to start the existing instance" >&2
+  exit 1
 fi
 DOCKER=$(command -v "$DOCKER" || true)
 if [ -n "$DOCKER" ]; then

--- a/cmd/kubectl.lima
+++ b/cmd/kubectl.lima
@@ -4,19 +4,26 @@ set -eu
 : "${KUBECTL:=kubectl}"
 
 if [ -z "$LIMA_INSTANCE" ]; then
-  if [ "$(limactl ls -f '{{.Status}}' k3s 2>/dev/null)" = "Running" ]; then
+  if [ "$(limactl ls -q k3s 2>/dev/null)" = "k3s" ]; then
     LIMA_INSTANCE=k3s
-  elif [ "$(limactl ls -f '{{.Status}}' k8s 2>/dev/null)" = "Running" ]; then
+  elif [ "$(limactl ls -q k8s 2>/dev/null)" = "k8s" ]; then
     LIMA_INSTANCE=k8s
   else
-    echo "No k3s or k8s running instances found. Either create one with" >&2
+    echo "No k3s or k8s existing instances found. Either create one with" >&2
     echo "limactl create --name=k3s template://k3s" >&2
     echo "limactl create --name=k8s template://k8s" >&2
     echo "or set LIMA_INSTANCE to the name of your Kubernetes instance" >&2
     exit 1
   fi
+  if [ "$(limactl ls -f '{{.Status}}' "$LIMA_INSTANCE" 2>/dev/null)" != "Running" ]; then
+    echo "instance \"$LIMA_INSTANCE\" is not running, run \`limactl start $LIMA_INSTANCE\` to start the existing instance" >&2
+    exit 1
+  fi
 elif [ "$(limactl ls -q "$LIMA_INSTANCE" 2>/dev/null)" != "$LIMA_INSTANCE" ]; then
   echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl create --name=$LIMA_INSTANCE\` to create a new instance" >&2
+  exit 1
+elif [ "$(limactl ls -f '{{ .Status }}' "$LIMA_INSTANCE" 2>/dev/null)" != "Running" ]; then
+  echo "instance \"$LIMA_INSTANCE\" is not running, run \`limactl start $LIMA_INSTANCE\` to start the existing instance" >&2
   exit 1
 fi
 KUBECTL=$(command -v "$KUBECTL" || true)

--- a/cmd/podman.lima
+++ b/cmd/podman.lima
@@ -6,6 +6,9 @@ set -eu
 if [ "$(limactl ls -q "$LIMA_INSTANCE" 2>/dev/null)" != "$LIMA_INSTANCE" ]; then
   echo "instance \"$LIMA_INSTANCE\" does not exist, run \`limactl create --name=$LIMA_INSTANCE template://podman\` to create a new instance" >&2
   exit 1
+elif [ "$(limactl ls -f '{{ .Status }}' "$LIMA_INSTANCE" 2>/dev/null)" != "Running" ]; then
+  echo "instance \"$LIMA_INSTANCE\" is not running, run \`limactl start $LIMA_INSTANCE\` to start the existing instance" >&2
+  exit 1
 fi
 PODMAN=$(command -v "$PODMAN" || true)
 if [ -n "$PODMAN" ]; then


### PR DESCRIPTION
Now that lima doesn't start the instances by default after creation, we need to suggest the user to do so.

----

```console
$ docker.lima version
instance "docker" does not exist, run `limactl create --name=docker template://docker` to create a new instance
$ limactl create --name=docker template://docker
? Creating an instance "docker" Proceed with the current configuration
INFO[0000] Attempting to download the image              arch=x86_64 digest="sha256:d5b419272e01cd69bfc15cbbbc5700d2196242478a54b9f19746da3a1269b7c8" location="https://cloud-images.ubuntu.com/releases/22.04/release-20230729/ubuntu-22.04-server-cloudimg-amd64.img"
INFO[0001] Using cache "/home/anders/.cache/lima/download/by-url-sha256/625afb7f7a4fbe30a232043af243cca76e06866624604da5ba5ec130d56c4244/data" 
INFO[0001] Run `limactl start docker` to start the instance. 
$ docker.lima version
instance "docker" is not running, run `limactl start docker` to start the existing instance
```

Otherwise it will just show error.

```
Cannot connect to the Docker daemon at unix:///home/anders/.lima/docker/sock/docker.sock. Is the docker daemon running?
```