### PR TITLE
fix: adding full Podman Desktop logo

### DIFF
--- a/website/data/adoptors.yaml
+++ b/website/data/adoptors.yaml
@@ -13,4 +13,4 @@
 - name: Podman Desktop
   link: https://podman-desktop.io
   image: podman-desktop.svg
-  width: 75
+  width: 200

--- a/website/static/images/users/podman-desktop.svg
+++ b/website/static/images/users/podman-desktop.svg
@@ -1,91 +1,432 @@
-<svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect x="100" y="100" width="824" height="824" rx="184" fill="url(#paint0_linear_1_2)"/>
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M516.867 211.683C513.488 209.994 509.512 209.994 506.133 211.683L215.633 356.933C211.568 358.966 209 363.121 209 367.666V655.334C209 659.879 211.568 664.034 215.633 666.067L506.133 811.317C509.512 813.006 513.488 813.006 516.867 811.317L807.367 666.067C811.432 664.034 814 659.879 814 655.334V367.666C814 363.121 811.432 358.966 807.367 356.933L516.867 211.683Z" fill="url(#paint1_linear_1_2)"/>
-    <g filter="url(#filter0_d_1_2)">
-        <path d="M506.133 211.683C509.512 209.994 513.488 209.994 516.867 211.683L807.367 356.933C811.432 358.966 814 363.121 814 367.666V655.334C814 659.879 811.432 664.034 807.367 666.067L516.867 811.317C513.488 813.006 509.512 813.006 506.133 811.317L215.633 666.067C211.568 664.034 209 659.879 209 655.334V367.666C209 363.121 211.568 358.966 215.633 356.933L506.133 211.683Z" fill="url(#paint2_linear_1_2)" fill-opacity="0.2" shape-rendering="crispEdges"/>
-        <path d="M506.133 211.683C509.512 209.994 513.488 209.994 516.867 211.683L807.367 356.933C811.432 358.966 814 363.121 814 367.666V655.334C814 659.879 811.432 664.034 807.367 666.067L516.867 811.317C513.488 813.006 509.512 813.006 506.133 811.317L215.633 666.067C211.568 664.034 209 659.879 209 655.334V367.666C209 363.121 211.568 358.966 215.633 356.933L506.133 211.683Z" stroke="url(#paint3_linear_1_2)" stroke-width="32" stroke-linecap="square" stroke-linejoin="round" shape-rendering="crispEdges"/>
-    </g>
-    <g filter="url(#filter1_i_1_2)">
-        <path d="M512.5 227L798 371V653.5L510.5 795.5L225 653.5V371L512.5 227Z" fill="url(#paint4_linear_1_2)" fill-opacity="0.2"/>
-    </g>
-    <path d="M511 228L225 370.5L511 516L798 370.5L511 228Z" fill="url(#paint5_linear_1_2)" fill-opacity="0.3"/>
-    <path d="M296.914 585.234H725.141" stroke="url(#paint6_linear_1_2)"/>
-    <g filter="url(#filter2_dd_1_2)">
-        <path fill-rule="evenodd" clip-rule="evenodd" d="M297.091 421.017C297.091 413.285 303.359 407.017 311.091 407.017H711.669C719.401 407.017 725.669 413.285 725.669 421.017V607.306C725.669 615.038 719.401 621.306 711.669 621.306H311.091C303.359 621.306 297.091 615.038 297.091 607.306V421.017ZM332.805 447.732C332.805 444.97 335.044 442.732 337.805 442.732H363.52C366.282 442.732 368.52 444.97 368.52 447.732V544.877C368.52 547.638 366.282 549.877 363.52 549.877H337.805C335.044 549.877 332.805 547.638 332.805 544.877V447.732ZM409.235 442.732C406.474 442.732 404.235 444.97 404.235 447.732V544.877C404.235 547.638 406.474 549.877 409.235 549.877H434.95C437.711 549.877 439.95 547.638 439.95 544.877V447.732C439.95 444.97 437.711 442.732 434.95 442.732H409.235ZM475.665 447.732C475.665 444.97 477.904 442.732 480.665 442.732H506.38C509.141 442.732 511.38 444.97 511.38 447.732V544.877C511.38 547.638 509.141 549.877 506.38 549.877H480.665C477.904 549.877 475.665 547.638 475.665 544.877V447.732ZM552.266 442.571C549.504 442.571 547.266 444.809 547.266 447.571V544.716C547.266 547.477 549.504 549.716 552.266 549.716H577.981C580.742 549.716 582.981 547.477 582.981 544.716V447.571C582.981 444.809 580.742 442.571 577.981 442.571H552.266Z" fill="url(#paint7_linear_1_2)"/>
-    </g>
-    <path d="M297.091 585.592H725.669V609.306C725.669 615.934 720.297 621.306 713.669 621.306H309.091C302.463 621.306 297.091 615.934 297.091 609.306V585.592Z" fill="#472EA8"/>
-    <defs>
-        <filter id="filter0_d_1_2" x="189" y="194.416" width="645" height="642.167" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-            <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-            <feOffset dy="4"/>
-            <feGaussianBlur stdDeviation="2"/>
-            <feComposite in2="hardAlpha" operator="out"/>
-            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
-            <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_2"/>
-            <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_2" result="shape"/>
-        </filter>
-        <filter id="filter1_i_1_2" x="225" y="227" width="573" height="568.5" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-            <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-            <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
-            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-            <feOffset/>
-            <feGaussianBlur stdDeviation="8"/>
-            <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
-            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0"/>
-            <feBlend mode="normal" in2="shape" result="effect1_innerShadow_1_2"/>
-        </filter>
-        <filter id="filter2_dd_1_2" x="286.091" y="392.017" width="450.579" height="237.289" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-            <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-            <feOffset dy="-4"/>
-            <feGaussianBlur stdDeviation="5.5"/>
-            <feComposite in2="hardAlpha" operator="out"/>
-            <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.14 0"/>
-            <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_2"/>
-            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-            <feOffset dy="4"/>
-            <feGaussianBlur stdDeviation="2"/>
-            <feComposite in2="hardAlpha" operator="out"/>
-            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
-            <feBlend mode="normal" in2="effect1_dropShadow_1_2" result="effect2_dropShadow_1_2"/>
-            <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_1_2" result="shape"/>
-        </filter>
-        <linearGradient id="paint0_linear_1_2" x1="512" y1="100" x2="512" y2="924" gradientUnits="userSpaceOnUse">
-            <stop stop-color="#2E114A"/>
-            <stop offset="0.943398" stop-color="#07051B"/>
-        </linearGradient>
-        <linearGradient id="paint1_linear_1_2" x1="511.5" y1="210.416" x2="511.5" y2="812.584" gradientUnits="userSpaceOnUse">
-            <stop stop-color="#2E114A"/>
-            <stop offset="0.943398" stop-color="#07051B"/>
-        </linearGradient>
-        <linearGradient id="paint2_linear_1_2" x1="271.391" y1="814" x2="271.391" y2="209" gradientUnits="userSpaceOnUse">
-            <stop stop-opacity="0.73"/>
-            <stop offset="1" stop-color="#F1F1F1" stop-opacity="0.94"/>
-        </linearGradient>
-        <linearGradient id="paint3_linear_1_2" x1="172.133" y1="251.539" x2="814" y2="814" gradientUnits="userSpaceOnUse">
-            <stop stop-color="#6AD2FA"/>
-            <stop offset="0.494792" stop-color="#7669FA"/>
-            <stop offset="0.744792" stop-color="#8850E4"/>
-            <stop offset="1" stop-color="#CE0EBB"/>
-        </linearGradient>
-        <linearGradient id="paint4_linear_1_2" x1="284.297" y1="792" x2="284.297" y2="227" gradientUnits="userSpaceOnUse">
-            <stop stop-opacity="0.73"/>
-            <stop offset="1" stop-color="#F1F1F1" stop-opacity="0.94"/>
-        </linearGradient>
-        <linearGradient id="paint5_linear_1_2" x1="513.915" y1="230" x2="513.915" y2="395.12" gradientUnits="userSpaceOnUse">
-            <stop stop-color="#621EA6" stop-opacity="0.89"/>
-            <stop offset="1" stop-color="#CCCAD1" stop-opacity="0"/>
-        </linearGradient>
-        <linearGradient id="paint6_linear_1_2" x1="512.464" y1="585.234" x2="512.464" y2="586.234" gradientUnits="userSpaceOnUse">
-            <stop stop-opacity="0"/>
-            <stop offset="0.229167" stop-opacity="0.37"/>
-            <stop offset="0.645833" stop-opacity="0.046875"/>
-            <stop offset="1" stop-opacity="0"/>
-        </linearGradient>
-        <linearGradient id="paint7_linear_1_2" x1="511.38" y1="407.017" x2="511.38" y2="621.306" gradientUnits="userSpaceOnUse">
-            <stop stop-color="#E9E9E9"/>
-            <stop offset="1" stop-color="#A59ADE"/>
-        </linearGradient>
-    </defs>
-</svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 25.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 880.0772095 165"
+   style="enable-background:new 0 0 880.0772095 165;"
+   xml:space="preserve"
+   sodipodi:docname="podman-desktop.svg"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs19"><linearGradient
+     inkscape:collect="always"
+     xlink:href="#paint0_linear_612_1773"
+     id="linearGradient36577"
+     gradientUnits="userSpaceOnUse"
+     gradientTransform="translate(26.120365,19.854609)"
+     x1="200"
+     y1="33.416401"
+     x2="200"
+     y2="350.58401" /><linearGradient
+     id="paint0_linear_612_1773"
+     x1="200"
+     y1="33.416401"
+     x2="200"
+     y2="350.58401"
+     gradientUnits="userSpaceOnUse"
+     gradientTransform="translate(26.120365,19.854609)"><stop
+       stop-color="#2E114A"
+       id="stop29716" /><stop
+       offset="0.943398"
+       stop-color="#07051B"
+       id="stop29718" /></linearGradient><filter
+     id="filter0_d_612_1773"
+     x="26"
+     y="23.416401"
+     width="348"
+     height="345.16699"
+     filterUnits="userSpaceOnUse"
+     color-interpolation-filters="sRGB"><feFlood
+       flood-opacity="0"
+       result="BackgroundImageFix"
+       id="feFlood29653" /><feColorMatrix
+       in="SourceAlpha"
+       type="matrix"
+       values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+       result="hardAlpha"
+       id="feColorMatrix29655" /><feOffset
+       dy="4"
+       id="feOffset29657" /><feGaussianBlur
+       stdDeviation="2"
+       id="feGaussianBlur29659" /><feComposite
+       in2="hardAlpha"
+       operator="out"
+       id="feComposite29661" /><feColorMatrix
+       type="matrix"
+       values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"
+       id="feColorMatrix29663" /><feBlend
+       mode="normal"
+       in2="BackgroundImageFix"
+       result="effect1_dropShadow_612_1773"
+       id="feBlend29665" /><feBlend
+       mode="normal"
+       in="SourceGraphic"
+       in2="effect1_dropShadow_612_1773"
+       result="shape"
+       id="feBlend29667" /></filter><linearGradient
+     inkscape:collect="always"
+     xlink:href="#paint1_linear_612_1773"
+     id="linearGradient36579"
+     gradientUnits="userSpaceOnUse"
+     x1="73"
+     y1="352"
+     x2="73"
+     y2="32" /><linearGradient
+     id="paint1_linear_612_1773"
+     x1="73"
+     y1="352"
+     x2="73"
+     y2="32"
+     gradientUnits="userSpaceOnUse"><stop
+       stop-opacity="0.73"
+       id="stop29721" /><stop
+       offset="1"
+       stop-color="#F1F1F1"
+       stop-opacity="0.94"
+       id="stop29723" /></linearGradient><linearGradient
+     inkscape:collect="always"
+     xlink:href="#paint2_linear_612_1773"
+     id="linearGradient36581"
+     gradientUnits="userSpaceOnUse"
+     x1="20.5"
+     y1="54.5"
+     x2="360"
+     y2="352" /><linearGradient
+     id="paint2_linear_612_1773"
+     x1="20.5"
+     y1="54.5"
+     x2="360"
+     y2="352"
+     gradientUnits="userSpaceOnUse"><stop
+       stop-color="#6AD2FA"
+       id="stop29726" /><stop
+       offset="0.494792"
+       stop-color="#7669FA"
+       id="stop29728" /><stop
+       offset="0.744792"
+       stop-color="#8850E4"
+       id="stop29730" /><stop
+       offset="1"
+       stop-color="#CE0EBB"
+       id="stop29732" /></linearGradient><filter
+     id="filter1_i_612_1773"
+     x="50"
+     y="44"
+     width="300"
+     height="296"
+     filterUnits="userSpaceOnUse"
+     color-interpolation-filters="sRGB"><feFlood
+       flood-opacity="0"
+       result="BackgroundImageFix"
+       id="feFlood29670" /><feBlend
+       mode="normal"
+       in="SourceGraphic"
+       in2="BackgroundImageFix"
+       result="shape"
+       id="feBlend29672" /><feColorMatrix
+       in="SourceAlpha"
+       type="matrix"
+       values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+       result="hardAlpha"
+       id="feColorMatrix29674" /><feOffset
+       id="feOffset29676" /><feGaussianBlur
+       stdDeviation="3.5"
+       id="feGaussianBlur29678" /><feComposite
+       in2="hardAlpha"
+       operator="arithmetic"
+       k2="-1"
+       k3="1"
+       id="feComposite29680"
+       k1="0"
+       k4="0" /><feColorMatrix
+       type="matrix"
+       values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0"
+       id="feColorMatrix29682" /><feBlend
+       mode="normal"
+       in2="shape"
+       result="effect1_innerShadow_612_1773"
+       id="feBlend29684" /></filter><linearGradient
+     inkscape:collect="always"
+     xlink:href="#paint3_linear_612_1773"
+     id="linearGradient36583"
+     gradientUnits="userSpaceOnUse"
+     x1="80.9375"
+     y1="340"
+     x2="80.9375"
+     y2="44" /><linearGradient
+     id="paint3_linear_612_1773"
+     x1="80.9375"
+     y1="340"
+     x2="80.9375"
+     y2="44"
+     gradientUnits="userSpaceOnUse"><stop
+       stop-opacity="0.73"
+       id="stop29735" /><stop
+       offset="1"
+       stop-color="#F1F1F1"
+       stop-opacity="0.94"
+       id="stop29737" /></linearGradient><linearGradient
+     inkscape:collect="always"
+     xlink:href="#paint4_linear_612_1773"
+     id="linearGradient36585"
+     gradientUnits="userSpaceOnUse"
+     gradientTransform="translate(26.120365,19.854609)"
+     x1="201"
+     y1="44"
+     x2="201"
+     y2="130" /><linearGradient
+     id="paint4_linear_612_1773"
+     x1="201"
+     y1="44"
+     x2="201"
+     y2="130"
+     gradientUnits="userSpaceOnUse"
+     gradientTransform="translate(26.120365,19.854609)"><stop
+       stop-color="#621EA6"
+       stop-opacity="0.89"
+       id="stop29740" /><stop
+       offset="1"
+       stop-color="#CCCAD1"
+       stop-opacity="0"
+       id="stop29742" /></linearGradient><linearGradient
+     inkscape:collect="always"
+     xlink:href="#paint5_linear_612_1773"
+     id="linearGradient36587"
+     gradientUnits="userSpaceOnUse"
+     gradientTransform="translate(26.120365,19.854609)"
+     x1="201"
+     y1="44"
+     x2="201"
+     y2="194" /><linearGradient
+     id="paint5_linear_612_1773"
+     x1="201"
+     y1="44"
+     x2="201"
+     y2="194"
+     gradientUnits="userSpaceOnUse"
+     gradientTransform="translate(26.120365,19.854609)"><stop
+       stop-opacity="0"
+       id="stop29745" /><stop
+       offset="0.229167"
+       stop-opacity="0.37"
+       id="stop29747" /><stop
+       offset="0.645833"
+       stop-color="#010101"
+       stop-opacity="0.046875"
+       id="stop29749" /><stop
+       offset="1"
+       stop-opacity="0"
+       id="stop29751" /></linearGradient><linearGradient
+     inkscape:collect="always"
+     xlink:href="#paint6_linear_612_1773"
+     id="linearGradient36589"
+     gradientUnits="userSpaceOnUse"
+     gradientTransform="translate(26.120365,19.854609)"
+     x1="200.50999"
+     y1="231"
+     x2="200.50999"
+     y2="232" /><linearGradient
+     id="paint6_linear_612_1773"
+     x1="200.50999"
+     y1="231"
+     x2="200.50999"
+     y2="232"
+     gradientUnits="userSpaceOnUse"
+     gradientTransform="translate(26.120365,19.854609)"><stop
+       stop-opacity="0"
+       id="stop29754" /><stop
+       offset="0.229167"
+       stop-opacity="0.37"
+       id="stop29756" /><stop
+       offset="0.645833"
+       stop-opacity="0.046875"
+       id="stop29758" /><stop
+       offset="1"
+       stop-opacity="0"
+       id="stop29760" /></linearGradient><filter
+     id="filter2_dd_612_1773"
+     x="75.593399"
+     y="121.736"
+     width="248.686"
+     height="136.343"
+     filterUnits="userSpaceOnUse"
+     color-interpolation-filters="sRGB"><feFlood
+       flood-opacity="0"
+       result="BackgroundImageFix"
+       id="feFlood29687" /><feColorMatrix
+       in="SourceAlpha"
+       type="matrix"
+       values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+       result="hardAlpha"
+       id="feColorMatrix29689" /><feOffset
+       dy="-4"
+       id="feOffset29691" /><feGaussianBlur
+       stdDeviation="5.5"
+       id="feGaussianBlur29693" /><feComposite
+       in2="hardAlpha"
+       operator="out"
+       id="feComposite29695" /><feColorMatrix
+       type="matrix"
+       values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.14 0"
+       id="feColorMatrix29697" /><feBlend
+       mode="normal"
+       in2="BackgroundImageFix"
+       result="effect1_dropShadow_612_1773"
+       id="feBlend29699" /><feColorMatrix
+       in="SourceAlpha"
+       type="matrix"
+       values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+       result="hardAlpha"
+       id="feColorMatrix29701" /><feOffset
+       dy="4"
+       id="feOffset29703" /><feGaussianBlur
+       stdDeviation="2"
+       id="feGaussianBlur29705" /><feComposite
+       in2="hardAlpha"
+       operator="out"
+       id="feComposite29707" /><feColorMatrix
+       type="matrix"
+       values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"
+       id="feColorMatrix29709" /><feBlend
+       mode="normal"
+       in2="effect1_dropShadow_612_1773"
+       result="effect2_dropShadow_612_1773"
+       id="feBlend29711" /><feBlend
+       mode="normal"
+       in="SourceGraphic"
+       in2="effect2_dropShadow_612_1773"
+       result="shape"
+       id="feBlend29713" /></filter><linearGradient
+     inkscape:collect="always"
+     xlink:href="#paint7_linear_612_1773"
+     id="linearGradient36591"
+     gradientUnits="userSpaceOnUse"
+     x1="199.937"
+     y1="136.73599"
+     x2="199.937"
+     y2="250.07899" /><linearGradient
+     id="paint7_linear_612_1773"
+     x1="199.937"
+     y1="136.73599"
+     x2="199.937"
+     y2="250.07899"
+     gradientUnits="userSpaceOnUse"><stop
+       stop-color="#E9E9E9"
+       id="stop29763" /><stop
+       offset="1"
+       stop-color="#A59ADE"
+       id="stop29765" /></linearGradient></defs><sodipodi:namedview
+   id="namedview19"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="0.78176652"
+   inkscape:cx="440.66865"
+   inkscape:cy="83.145029"
+   inkscape:window-width="1920"
+   inkscape:window-height="1131"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />&#10;<style
+   type="text/css"
+   id="style1">&#10;	.st0{fill:#A453B9;}&#10;	.st1{fill:rgb(0, 117, 168);}&#10;	.st2{fill:rgb(89, 89, 91);}&#10;	.st3{fill:#D13306;}&#10;	.st4{fill:#004D93;}&#10;	.st5{fill:#0081BE;}&#10;	.st6{fill:#1167F1;}&#10;	.st7{fill:#FFC400;}&#10;	.st8{fill:#FF7A3D;}&#10;	.st9{fill:#00A580;}&#10;	.st10{fill:#53C3D0;}&#10;	.st11{fill:#671C4C;}&#10;	.st12{fill:#00E3C2;}&#10;	.st13{fill:#BC2A46;}&#10;	.st14{fill:#FF192E;}&#10;	.st15{fill:#00B056;}&#10;  @media screen and (prefers-color-scheme: dark) {&#10;    .st2{fill:rgb(89, 89, 91);}&#10;  }&#10;</style>&#10;    &#10;<g
+   id="g19"
+   transform="translate(-2.6180315,78.020364)"><g
+     id="g36442"
+     transform="matrix(0.39842579,0,0,0.39639535,0.2466745,-81.084086)"
+     style="stroke-width:1.36534"><path
+       fill-rule="evenodd"
+       clip-rule="evenodd"
+       d="m 231.48737,54.537909 c -3.379,-1.6892 -7.355,-1.6892 -10.734,0 L 72.753765,128.53761 c -4.0654,2.033 -6.6334,6.188 -6.6334,10.733 v 145.168 c 0,4.545 2.568,8.7 6.6334,10.733 l 147.999605,74 c 3.379,1.689 7.355,1.689 10.734,0 l 148,-74 c 4.065,-2.033 6.633,-6.188 6.633,-10.733 v -145.168 c 0,-4.545 -2.568,-8.7 -6.633,-10.733 z"
+       fill="url(#paint0_linear_612_1773)"
+       id="path29631"
+       style="fill:url(#linearGradient36577);stroke-width:1.36534" /><g
+       filter="url(#filter0_d_612_1773)"
+       id="g29637"
+       transform="translate(26.120365,19.854609)"
+       style="stroke-width:1.36534"><path
+         d="m 194.633,34.6833 c 3.379,-1.6892 7.355,-1.6892 10.734,0 l 148,73.9997 c 4.065,2.033 6.633,6.188 6.633,10.733 v 145.168 c 0,4.545 -2.568,8.7 -6.633,10.733 l -148,74 c -3.379,1.689 -7.355,1.689 -10.734,0 l -147.9996,-74 C 42.568,273.284 40,269.129 40,264.584 V 119.416 c 0,-4.545 2.568,-8.7 6.6334,-10.733 z"
+         fill="url(#paint1_linear_612_1773)"
+         fill-opacity="0.2"
+         shape-rendering="crispEdges"
+         id="path29633"
+         style="fill:url(#linearGradient36579);stroke-width:1.36534" /><path
+         style="color:#000000;fill:url(#linearGradient36581);stroke-width:1.36534;stroke-linecap:square;stroke-linejoin:round;shape-rendering:crispEdges"
+         d="m 200,23.419922 c -3.37291,0 -6.74522,0.772299 -9.83789,2.318359 a 10.001,10.001 0 0 0 -0.002,0 l -147.998051,74 a 10.001,10.001 0 0 0 -0.002,0 C 34.726497,103.45566 30,111.10425 30,119.41602 v 145.16796 c 0,8.31177 4.726497,15.96036 12.160156,19.67774 a 10.001,10.001 0 0 0 0.002,0 l 147.998054,74 a 10.001,10.001 0 0 0 0.002,0 c 6.18521,3.09169 13.49057,3.09169 19.67578,0 a 10.001,10.001 0 0 0 0.002,0 l 148,-74 C 365.27309,280.54418 370,272.89575 370,264.58398 V 119.41602 c 0,-8.31177 -4.72691,-15.9602 -12.16016,-19.677739 l -148,-74 a 10.001,10.001 0 0 0 -0.002,0 C 206.74522,24.192221 203.37291,23.419922 200,23.419922 Z m -0.89453,20.207031 c 0.57265,-0.286276 1.21641,-0.286276 1.78906,0 l 148,73.999997 c 0.69675,0.34846 1.10547,1.01084 1.10547,1.78907 v 145.16796 c 0,0.77823 -0.40872,1.44061 -1.10547,1.78907 l -147.99805,74 c -0.57216,0.28599 -1.21869,0.28537 -1.79101,0 h -0.002 l -147.998051,-74 C 50.408336,266.02443 50,265.36221 50,264.58398 V 119.41602 c 0,-0.77823 0.408336,-1.44045 1.105469,-1.78907 z"
+         id="path29635" /></g><g
+       filter="url(#filter1_i_612_1773)"
+       id="g29641"
+       transform="translate(26.120365,19.854609)"
+       style="stroke-width:1.36534"><path
+         d="m 200,44 150,74 V 266 L 200,340 50,266 V 118 Z"
+         fill="url(#paint3_linear_612_1773)"
+         fill-opacity="0.2"
+         id="path29639"
+         style="fill:url(#linearGradient36583);stroke-width:1.36534" /></g><path
+       d="m 226.12037,63.854609 -149,74.000001 152,76 146,-76 z"
+       fill="url(#paint4_linear_612_1773)"
+       fill-opacity="0.3"
+       stroke="url(#paint5_linear_612_1773)"
+       id="path29643"
+       style="fill:url(#linearGradient36585);stroke:url(#linearGradient36587);stroke-width:1.36534" /><path
+       d="m 112.62037,250.85461 h 226.5"
+       stroke="url(#paint6_linear_612_1773)"
+       id="path29645"
+       style="stroke:url(#linearGradient36589);stroke-width:1.36534" /><g
+       filter="url(#filter2_dd_612_1773)"
+       id="g29649"
+       transform="translate(26.120365,19.854609)"
+       style="stroke-width:1.36534"><path
+         fill-rule="evenodd"
+         clip-rule="evenodd"
+         d="m 86.5934,150.736 c 0,-7.732 6.268,-14 13.9996,-14 H 299.28 c 7.732,0 14,6.268 14,14 v 85.343 c 0,7.732 -6.268,14 -14,14 H 100.593 c -7.7316,0 -13.9996,-6.268 -13.9996,-14 z m 18.8906,9.891 c 0,-2.762 2.238,-5 5,-5 h 8.89 c 2.762,0 5,2.238 5,5 v 46.671 c 0,2.762 -2.238,5 -5,5 h -8.89 c -2.762,0 -5,-2.238 -5,-5 z m 42.781,-5 c -2.762,0 -5,2.238 -5,5 v 46.671 c 0,2.762 2.238,5 5,5 h 8.89 c 2.762,0 5,-2.238 5,-5 v -46.671 c 0,-2.762 -2.238,-5 -5,-5 z m 32.781,5 c 0,-2.762 2.239,-5 5,-5 h 8.891 c 2.761,0 5,2.238 5,5 v 46.671 c 0,2.762 -2.239,5 -5,5 h -8.891 c -2.761,0 -5,-2.238 -5,-5 z m 42.871,-5.085 c -2.761,0 -5,2.238 -5,5 v 46.671 c 0,2.762 2.239,5 5,5 h 8.891 c 2.761,0 5,-2.238 5,-5 v -46.671 c 0,-2.762 -2.239,-5 -5,-5 z"
+         fill="url(#paint7_linear_612_1773)"
+         id="path29647"
+         style="fill:url(#linearGradient36591);stroke-width:1.36534" /></g><path
+       d="m 112.71377,251.04361 h 226.6866 v 6.89 c 0,6.628 -5.373,12 -12,12 h -202.6866 c -6.6274,0 -12,-5.372 -12,-12 z"
+       fill="#472ea8"
+       id="path29651"
+       style="stroke-width:1.36534" /></g><g
+     id="g3222"
+     transform="matrix(2.183325,0,0,2.1721983,1118.116,439.82149)"
+     style="fill:#8b5cf6;fill-opacity:1;stroke-width:1.36534"><g
+       aria-label="podman"
+       id="g3913"
+       style="font-size:37.592px;line-height:22.5552px;letter-spacing:0px;word-spacing:0px;fill:#8b5cf6;fill-opacity:1;stroke-width:0.361244px"
+       transform="translate(-52.791558,-117.62208)"><path
+         d="m -358.34296,-93.074374 c -2.93217,0 -5.48843,1.12776 -7.10488,3.345688 v -3.157728 h -3.45847 v 27.216608 h 3.60883 v -10.300208 c 1.65405,2.142744 4.13512,3.232912 6.95452,3.232912 5.82676,0 10.07466,-4.059936 10.07466,-10.187432 0,-6.089904 -4.2479,-10.14984 -10.07466,-10.14984 z m -0.30073,17.179544 c -3.79679,0 -6.69138,-2.781808 -6.69138,-7.029704 0,-4.210304 2.89459,-6.992112 6.69138,-6.992112 3.83438,0 6.72897,2.781808 6.72897,6.992112 0,4.247896 -2.89459,7.029704 -6.72897,7.029704 z"
+         style="font-weight:500;font-family:Montserrat;-inkscape-font-specification:'Montserrat Medium';letter-spacing:-2.11667px;fill:#8b5cf6;fill-opacity:1;stroke-width:0.361244px"
+         id="path3901" /><path
+         d="m -335.33997,-72.737102 c 5.97712,0 10.3378,-4.247896 10.3378,-10.187432 0,-5.939536 -4.36068,-10.14984 -10.3378,-10.14984 -5.97713,0 -10.3754,4.210304 -10.3754,10.14984 0,5.939536 4.39827,10.187432 10.3754,10.187432 z m 0,-3.157728 c -3.83439,0 -6.72897,-2.781808 -6.72897,-7.029704 0,-4.247896 2.89458,-6.992112 6.72897,-6.992112 3.83438,0 6.69137,2.744216 6.69137,6.992112 0,4.247896 -2.85699,7.029704 -6.69137,7.029704 z"
+         style="font-weight:500;font-family:Montserrat;-inkscape-font-specification:'Montserrat Medium';letter-spacing:-2.11667px;fill:#8b5cf6;fill-opacity:1;stroke-width:0.361244px"
+         id="path3903" /><path
+         d="m -305.4201,-89.879054 c -1.65405,-2.142744 -4.13512,-3.19532 -6.95452,-3.19532 -5.82676,0 -10.07465,4.059936 -10.07465,10.14984 0,6.089904 4.24789,10.187432 10.07465,10.187432 2.93218,0 5.48843,-1.12776 7.10489,-3.38328 v 3.157728 h 3.45846 v -27.893266 h -3.60883 z m -6.65378,13.984224 c -3.83439,0 -6.72897,-2.781808 -6.72897,-7.029704 0,-4.247896 2.89458,-6.992112 6.72897,-6.992112 3.79679,0 6.69137,2.744216 6.69137,6.992112 0,4.247896 -2.89458,7.029704 -6.69137,7.029704 z"
+         style="font-weight:500;font-family:Montserrat;-inkscape-font-specification:'Montserrat Medium';letter-spacing:-2.11667px;fill:#8b5cf6;fill-opacity:1;stroke-width:0.361244px"
+         id="path3905" /><path
+         d="m -272.16273,-93.074374 c -3.38328,0 -6.16509,1.428496 -7.66877,3.684016 -1.31572,-2.481072 -3.87197,-3.684016 -6.91692,-3.684016 -3.00736,0 -5.45084,1.12776 -6.87934,3.157728 v -2.969768 h -3.45846 v 19.92376 h 3.60883 V -83.22527 c 0,-4.32308 2.36829,-6.616192 5.97713,-6.616192 3.2705,0 5.1501,1.917192 5.1501,5.82676 v 11.052048 h 3.60883 V -83.22527 c 0,-4.32308 2.3683,-6.616192 5.97713,-6.616192 3.2705,0 5.1501,1.917192 5.1501,5.82676 v 11.052048 h 3.60884 v -11.46556 c 0,-5.864352 -3.3081,-8.64616 -8.15747,-8.64616 z"
+         style="font-weight:500;font-family:Montserrat;-inkscape-font-specification:'Montserrat Medium';letter-spacing:-2.11667px;fill:#8b5cf6;fill-opacity:1;stroke-width:0.361244px"
+         id="path3907" /><path
+         d="m -252.21292,-93.074374 c -3.19532,0 -6.16509,0.902208 -8.23265,2.556256 l 1.50368,2.706624 c 1.54128,-1.31572 3.94716,-2.142744 6.31546,-2.142744 3.57124,0 5.33806,1.766824 5.33806,4.811776 v 0.714248 h -5.71398 c -5.93954,0 -8.0071,2.63144 -8.0071,5.82676 0,3.458464 2.857,5.864352 7.36804,5.864352 3.12013,0 5.33806,-1.052576 6.541,-2.856992 v 2.63144 h 3.42088 v -12.02944 c 0,-5.45084 -3.08255,-8.08228 -8.53339,-8.08228 z m -0.82702,17.555464 c -2.74422,0 -4.39827,-1.240536 -4.39827,-3.232912 0,-1.69164 1.01499,-3.082544 4.58623,-3.082544 h 5.56361 v 2.781808 c -0.9022,2.293112 -3.04495,3.533648 -5.75157,3.533648 z"
+         style="font-weight:500;font-family:Montserrat;-inkscape-font-specification:'Montserrat Medium';letter-spacing:-2.11667px;fill:#8b5cf6;fill-opacity:1;stroke-width:0.361244px"
+         id="path3909" /><path
+         d="m -228.46632,-93.074374 c -3.15773,0 -5.71398,1.165352 -7.18007,3.19532 v -3.00736 h -3.45846 v 19.92376 h 3.60883 V -83.22527 c 0,-4.32308 2.48107,-6.616192 6.31545,-6.616192 3.42088,0 5.37566,1.917192 5.37566,5.82676 v 11.052048 h 3.60883 v -11.46556 c 0,-5.864352 -3.42087,-8.64616 -8.27024,-8.64616 z"
+         style="font-weight:500;font-family:Montserrat;-inkscape-font-specification:'Montserrat Medium';letter-spacing:-2.11667px;fill:#8b5cf6;fill-opacity:1;stroke-width:0.361244px"
+         id="path3911" /></g></g><path
+     style="font-size:81.5719px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Normal';letter-spacing:0px;word-spacing:0px;fill:#472ea8;fill-opacity:0.960784;stroke-width:0.736683px"
+     d="m 575.77794,-8.8878452 c -3.58916,-5.5468888 -9.46234,-8.4834778 -16.31438,-8.4834778 -12.23578,0 -21.37184,8.8097654 -21.37184,21.7796974 0,12.9699316 9.13606,21.8612686 21.37184,21.8612686 7.09676,0 13.05151,-3.099732 16.5591,-8.891337 v 8.483478 h 5.54689 v -60.526349 h -5.79161 z M 559.95299,21.130614 c -9.13605,0 -15.98809,-6.688896 -15.98809,-16.7222396 0,-10.0333436 6.85204,-16.7222394 15.98809,-16.7222394 9.05448,0 15.90652,6.6888958 15.90652,16.7222394 0,10.0333436 -6.85204,16.7222396 -15.90652,16.7222396 z M 635.16224,4.4083744 c 0,-12.8883601 -8.72819,-21.7796974 -20.80083,-21.7796974 -12.07264,0 -20.96398,9.0544811 -20.96398,21.7796974 0,12.7252166 9.13605,21.8612686 22.51384,21.8612686 6.77047,0 12.72522,-2.447157 16.5591,-7.015183 l -3.26288,-3.752307 c -3.26287,3.752307 -7.91247,5.628461 -13.13307,5.628461 -9.38077,0 -16.23281,-5.954749 -16.88539,-14.9276578 h 35.89164 c 0,-0.6525752 0.0816,-1.3051504 0.0816,-1.7945818 z M 614.36141,-12.395437 c 8.4019,0 14.5198,5.8731769 15.25394,14.2750826 h -30.42632 c 0.73415,-8.4019057 6.85204,-14.2750826 15.17238,-14.2750826 z m 44.1304,38.66508 c 11.17535,0 17.70111,-4.812742 17.70111,-12.235784 0,-16.4775241 -27.81602,-7.7493309 -27.81602,-19.3325406 0,-4.078595 3.42602,-7.0967554 11.17535,-7.0967554 4.40488,0 8.89134,1.060435 12.64364,3.6707356 l 2.52873,-4.6495986 c -3.58916,-2.447157 -9.62548,-3.997023 -15.17237,-3.997023 -10.93064,0 -16.96696,5.220602 -16.96696,12.2357852 0,16.9669548 27.81602,8.1571899 27.81602,19.3325398 0,4.241739 -3.34445,7.015184 -11.50164,7.015184 -6.03632,0 -11.82792,-2.12087 -15.25394,-4.812742 l -2.6103,4.568026 c 3.50759,3.01816 10.35963,5.302173 17.45638,5.302173 z M 727.17537,25.861784 707.10869,0.49292326 725.46236,-17.045035 h -7.17832 L 692.67046,6.3661 v -41.030665 h -5.7916 v 60.526349 h 5.7916 V 13.625999 l 10.11492,-9.2991965 17.29324,21.5349815 z m 29.28431,-6.770468 c -1.63144,1.468295 -3.99702,2.202442 -6.36261,2.202442 -4.81274,0 -7.42304,-2.773445 -7.42304,-7.830903 v -25.613576 h 13.0515 v -4.894314 h -13.0515 v -9.380769 h -5.79161 v 9.380769 h -7.66776 v 4.894314 h 7.66776 v 25.939864 c 0,7.912474 4.48646,12.4805 12.56208,12.4805 3.34444,0 6.77046,-0.978862 9.05448,-3.01816 z m 28.55024,7.178327 c 12.56208,0 21.7797,-9.136052 21.7797,-21.8612686 0,-12.7252163 -9.21762,-21.7796974 -21.7797,-21.7796974 -12.56207,0 -21.86127,9.0544811 -21.86127,21.7796974 0,12.7252166 9.2992,21.8612686 21.86127,21.8612686 z m 0,-5.139029 c -9.13605,0 -15.98809,-6.688896 -15.98809,-16.7222396 0,-10.0333436 6.85204,-16.7222394 15.98809,-16.7222394 9.13606,0 15.90652,6.6888958 15.90652,16.7222394 0,10.0333436 -6.77046,16.7222396 -15.90652,16.7222396 z m 55.71367,-38.501937 c -7.09675,0 -13.0515,3.099732 -16.55909,8.8097654 v -8.4834774 h -5.54689 v 58.731767 h 5.79161 V 17.786166 c 3.58916,5.546889 9.46234,8.483477 16.31437,8.483477 12.23579,0 21.37184,-8.809765 21.37184,-21.8612686 0,-12.969932 -9.13605,-21.7796974 -21.37184,-21.7796974 z m -0.40785,38.501937 c -9.13606,0 -15.9881,-6.688896 -15.9881,-16.7222396 0,-9.9517717 6.85204,-16.7222394 15.9881,-16.7222394 9.05448,0 15.98809,6.7704677 15.98809,16.7222394 0,10.0333436 -6.93361,16.7222396 -15.98809,16.7222396 z"
+     id="text36363"
+     transform="scale(1.0025578,0.99744872)"
+     aria-label="desktop" /></g></svg>


### PR DESCRIPTION
Logo previously only included the logomark and not the logotype. This version includes the logotype so the name of the app is apparent.