### PR TITLE
CI: release: use ubuntu-20.04 for Linux binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,8 @@ jobs:
         name: artifacts-darwin
         path: _artifacts/
   release:
-    runs-on: ubuntu-22.04
+    # An old release of Ubuntu is chosen for glibc compatibility
+    runs-on: ubuntu-20.04
     needs: artifacts-darwin
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
Use an old release of Ubuntu for better glibc compatibility