### PR TITLE
limactl: move `--set`, `--network`, and `--video` out of experimental

### DIFF
--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -175,7 +175,7 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool) ([]string, error) {
 				return expr, nil
 			},
 			false,
-			true},
+			false},
 		{"rosetta",
 			func(_ *flag.Flag) (string, error) {
 				b, err := flags.GetBool("rosetta")
@@ -186,7 +186,7 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool) ([]string, error) {
 			},
 			false,
 			true},
-		{"set", d("%s"), false, true},
+		{"set", d("%s"), false, false},
 		{"video",
 			func(_ *flag.Flag) (string, error) {
 				b, err := flags.GetBool("video")
@@ -199,7 +199,7 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool) ([]string, error) {
 				return ".video.display = \"none\"", nil
 			},
 			false,
-			true},
+			false},
 		{"arch", d(".arch = %q"), true, false},
 		{"containerd",
 			func(_ *flag.Flag) (string, error) {

--- a/website/content/en/docs/Releases/Experimental/_index.md
+++ b/website/content/en/docs/Releases/Experimental/_index.md
@@ -18,7 +18,4 @@ The following features are experimental and subject to change:
 
 The following commands are experimental and subject to change:
 
-- `limactl (create|start|edit) --set=<YQ EXPRESSION>`
-- `limactl (create|start|edit) --network=<NETWORK>`
-- `limactl (create|start|edit) --video=<BOOL>`
 - `limactl snapshot *`


### PR DESCRIPTION
The following flags are no longer marked as experimental:

- `limactl (create|start|edit) --set=<YQ EXPRESSION>`
- `limactl (create|start|edit) --network=<NETWORK>`
- `limactl (create|start|edit) --video=<BOOL>`