### PR TITLE
fix: Windows ssh command quoting

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -138,8 +138,10 @@ func CommonOpts(useDotSSH bool) ([]string, error) {
 	var opts []string
 	if runtime.GOOS == "windows" {
 		privateKeyPath = ioutilx.CanonicalWindowsPath(privateKeyPath)
+		opts = []string{fmt.Sprintf(`IdentityFile='%s'`, privateKeyPath)}
+	} else {
+		opts = []string{fmt.Sprintf(`IdentityFile="%s"`, privateKeyPath)}
 	}
-	opts = []string{fmt.Sprintf(`IdentityFile="%s"`, privateKeyPath)}
 
 	// Append all private keys corresponding to ~/.ssh/*.pub to keep old instances working
 	// that had been created before lima started using an internal identity.
@@ -170,7 +172,11 @@ func CommonOpts(useDotSSH bool) ([]string, error) {
 				// Fail on permission-related and other path errors
 				return nil, err
 			}
-			opts = append(opts, "IdentityFile=\""+privateKeyPath+"\"")
+			if runtime.GOOS == "windows" {
+				opts = append(opts, fmt.Sprintf(`IdentityFile='%s'`, privateKeyPath))
+			} else {
+				opts = append(opts, fmt.Sprintf(`IdentityFile="%s"`, privateKeyPath))
+			}
 		}
 	}
 
@@ -229,10 +235,11 @@ func SSHOpts(instDir string, useDotSSH, forwardAgent bool, forwardX11 bool, forw
 	if err != nil {
 		return nil, err
 	}
+	controlPath := fmt.Sprintf(`ControlPath="%s"`, controlSock)
 	if runtime.GOOS == "windows" {
 		controlSock = ioutilx.CanonicalWindowsPath(controlSock)
+		controlPath = fmt.Sprintf(`ControlPath='%s'`, controlSock)
 	}
-	controlPath := fmt.Sprintf(`ControlPath="%s"`, controlSock)
 	opts = append(opts,
 		fmt.Sprintf("User=%s", u.Username), // guest and host have the same username, but we should specify the username explicitly (#85)
 		"ControlMaster=auto",


### PR DESCRIPTION
I thought I fixed this issue in #1825, but I must have tested it incorrectly, as the issue was still occurring in my latest test

Before:
```
{"level":"info","msg":"Waiting for the essential requirement 1 of 3: \"ssh\"","time":"2023-09-29T18:46:02Z"}
{"level":"debug","msg":"executing script \"ssh\"","time":"2023-09-29T18:46:02Z"}
{"level":"debug","msg":"executing ssh for script \"ssh\": C:\\Program Files\\Git\\usr\\bin\\ssh.exe [ssh -F /dev/null -o IdentityFile=\"C:/Users/Administrator/Code/finch space/_output/lima/data/_config/user\" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NoHostAuthenticationForLocalhost=yes -o GSSAPIAuthentication=no -o PreferredAuthentications=publickey -o Compression=no -o BatchMode=yes -o IdentitiesOnly=yes -o Ciphers=^aes128-gcm@openssh.com,aes256-gcm@openssh.com -o User=lima -o ControlMaster=auto -o ControlPath=\"C:/Users/Administrator/Code/finch space/_output/lima/data/finch/ssh.sock\" -o ControlPersist=yes -p 22 192.168.169.245 -- /bin/bash]","time":"2023-09-29T18:46:02Z"}
{"level":"debug","msg":"stdout=\"\", stderr=\"command-line line 0: invalid quotes\\r\\n\", err=failed to execute script \"ssh\": stdout=\"\", stderr=\"command-line line 0: invalid quotes\\r\\n\": exit status 255","time":"2023-09-29T18:46:02Z"}
```

After:
```
{"level":"info","msg":"The essential requirement 1 of 3 is satisfied","time":"2023-09-29T18:51:52Z"}
{"level":"info","msg":"Waiting for the essential requirement 2 of 3: \"user session is ready for ssh\"","time":"2023-09-29T18:51:52Z"}
{"level":"debug","msg":"executing script \"user session is ready for ssh\"","time":"2023-09-29T18:51:53Z"}
{"level":"debug","msg":"executing ssh for script \"user session is ready for ssh\": C:\\Program Files\\Git\\usr\\bin\\ssh.exe [ssh -F /dev/null -o IdentityFile='C:/Users/Administrator/Code/finch space/_output/lima/data/_config/user' -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NoHostAuthenticationForLocalhost=yes -o GSSAPIAuthentication=no -o PreferredAuthentications=publickey -o Compression=no -o BatchMode=yes -o IdentitiesOnly=yes -o Ciphers='^aes128-gcm@openssh.com,aes256-gcm@openssh.com' -o User=lima -o ControlMaster=auto -o ControlPath='C:/Users/Administrator/Code/finch space/_output/lima/data/finch/ssh.sock' -o ControlPersist=yes -p 22 192.168.169.245 -- /bin/bash]","time":"2023-09-29T18:51:53Z"}
```

I tried out the changes on macOS as well, and I didn't see any regressions. I'm not quite sure why Windows doesn't like the double quotes. Instead of figuring out the root cause, this is more of a workaround, but it doesn't seem to cause any issues