### PR TITLE
limactl: make `--tty` to be a global flag

### DIFF
--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -16,7 +16,6 @@ import (
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/lima-vm/lima/pkg/yqutil"
-	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -29,8 +28,6 @@ func newEditCommand() *cobra.Command {
 		RunE:              editAction,
 		ValidArgsFunction: editBashComplete,
 	}
-	// TODO: "survey" does not support using cygwin terminal on windows yet
-	editCommand.Flags().Bool("tty", isatty.IsTerminal(os.Stdout.Fd()), "enable TUI interactions such as opening an editor, defaults to true when stdout is a terminal")
 	editflags.RegisterEdit(editCommand)
 	return editCommand
 }

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -58,6 +58,8 @@ func newApp() *cobra.Command {
 	}
 	rootCmd.PersistentFlags().String("log-level", "", "Set the logging level [trace, debug, info, warn, error]")
 	rootCmd.PersistentFlags().Bool("debug", false, "debug mode")
+	// TODO: "survey" does not support using cygwin terminal on windows yet
+	rootCmd.PersistentFlags().Bool("tty", isatty.IsTerminal(os.Stdout.Fd()), "Enable TUI interactions such as opening an editor. Defaults to true when stdout is a terminal. Set to false for automation.")
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		l, _ := cmd.Flags().GetString("log-level")
 		if l != "" {

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -24,15 +24,12 @@ import (
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/lima-vm/lima/pkg/templatestore"
 	"github.com/lima-vm/lima/pkg/yqutil"
-	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 func registerCreateFlags(cmd *cobra.Command, commentPrefix string) {
 	flags := cmd.Flags()
-	// TODO: "survey" does not support using cygwin terminal on windows yet
-	flags.Bool("tty", isatty.IsTerminal(os.Stdout.Fd()), commentPrefix+"enable TUI interactions such as opening an editor, defaults to true when stdout is a terminal")
 	flags.String("name", "", commentPrefix+"override the instance name")
 	flags.Bool("list-templates", false, commentPrefix+"list available templates and exit")
 	editflags.RegisterCreate(cmd, commentPrefix)

--- a/hack/test-port-forwarding.pl
+++ b/hack/test-port-forwarding.pl
@@ -6,7 +6,7 @@
 # running to perform the tests:
 #
 # ./hack/test-port-forwarding.pl templates/default.yaml
-# limactl start --tty=false templates/default.yaml
+# limactl --tty=false start templates/default.yaml
 # git restore templates/default.yaml
 # ./hack/test-port-forwarding.pl default
 #

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -17,7 +17,7 @@ INFO "Validating \"$FILE\""
 limactl validate "$FILE"
 
 # --cpus=1 is needed for running vz on GHA: https://github.com/lima-vm/lima/pull/1511#issuecomment-1574937888
-LIMACTL_CREATE=(limactl create --tty=false --cpus=1 --memory=1)
+LIMACTL_CREATE=(limactl --tty=false create --cpus=1 --memory=1)
 
 CONTAINER_ENGINE="nerdctl"
 


### PR DESCRIPTION
`limactl start --tty=false` can be now `limactl --tty=false start` .

The previous form continues to work too.

Fix #1861