### PR TITLE
wsl2: temporarily remove docs

### DIFF
--- a/pkg/wsl2/wsl_driver_windows.go
+++ b/pkg/wsl2/wsl_driver_windows.go
@@ -100,6 +100,11 @@ func (l *LimaWslDriver) Validate() error {
 
 func (l *LimaWslDriver) Start(ctx context.Context) (chan error, error) {
 	logrus.Infof("Starting WSL VM")
+
+	// Keep this warning below, at least until we can get the driver to work on GHA Large Runner (windows-2022-8-cores).
+	// A failed attempt can be found at https://github.com/lima-vm/lima/pull/1826
+	logrus.Warnf("wsl2 driver is experimental and seems currently unstable. Help wanted to fix it.")
+
 	status, err := store.GetWslStatus(l.Instance.Name)
 	if err != nil {
 		return nil, err

--- a/website/content/en/docs/Config/Mount/_index.md
+++ b/website/content/en/docs/Config/Mount/_index.md
@@ -138,6 +138,8 @@ mounts:
 - For Linux, the "virtiofs" mount type requires the [Rust version of virtiofsd](https://gitlab.com/virtio-fs/virtiofsd).
   Using the version from QEMU (usually packaged as `qemu-virtiofsd`) will *not* work, as it requires root access to run.
 
+<!-- WSL2 driver seems currently unstable -->
+<!--
 ### wsl2
 > **Warning**
 > "wsl2" mode is experimental
@@ -165,3 +167,4 @@ mountType: "wsl2"
 #### Caveats
 - WSL2 file permissions may not work exactly as expected when accessing files that are natively on the Windows disk ([more info](https://github.com/MicrosoftDocs/WSL/blob/mattw-wsl2-explainer/WSL/file-permissions.md))
 - WSL2's disk sharing system uses a 9P protocol server, making the performance similar to [Lima's 9p](#9p) mode ([more info](https://github.com/MicrosoftDocs/WSL/blob/mattw-wsl2-explainer/WSL/wsl2-architecture.md#wsl-2-architectural-flow))
+-->

--- a/website/content/en/docs/Config/VMType/_index.md
+++ b/website/content/en/docs/Config/VMType/_index.md
@@ -13,8 +13,7 @@ The vmType of existing instances cannot be changed.
 See the following flowchart to choose the best vmType for you:
 ```mermaid
 flowchart
-  host{"Host OS"} -- "Windows" --> wsl2["WSL2"]
-  host -- "Linux" --> qemu["QEMU"]
+  host{"Host OS"} -- "Linux" --> qemu["QEMU"]
   host -- "macOS" --> intel_on_arm{"Need to run <br> Intel binaries <br> on ARM?"}
   intel_on_arm -- "Yes" --> just_elf{"Just need to <br> run Intel userspace (fast), <br> or entire Intel VM (slow)?"}
   just_elf -- "Userspace (fast)" --> vz
@@ -69,6 +68,8 @@ mountType: "virtiofs"
   https://github.com/lima-vm/lima/issues/1577#issuecomment-1565625668
   The issue is fixed in macOS 13.5.
 
+<!-- WSL2 driver seems currently unstable -->
+<!--
 ## WSL2
 > **Warning**
 > "wsl2" mode is experimental
@@ -110,3 +111,4 @@ containerd:
 - When running lima using "wsl2", `${LIMA_HOME}/<INSTANCE>/serial.log` will not contain kernel boot logs
 - WSL2 requires a `tar` formatted rootfs archive instead of a VM image
 - Windows doesn't ship with ssh.exe, gzip.exe, etc. which are used by Lima at various points. The easiest way around this is to run `winget install -e --id Git.MinGit` (winget is now built in to Windows as well), and add the resulting `C:\Program Files\Git\usr\bin\` directory to your path.
+-->


### PR DESCRIPTION
Temporarily remove the wsl2 docs, as the wsl2 driver does not seem to work. See PR #1826 for a failed attempt to get it work.