### PR TITLE
docs: socketfilterfw needs sudo

### DIFF
--- a/website/content/en/docs/Config/Network/_index.md
+++ b/website/content/en/docs/Config/Network/_index.md
@@ -168,8 +168,8 @@ and will stop automatically once the last instance has stopped. Daemon logs will
 The IP address is automatically assigned by macOS's bootpd.
 If the IP address is not assigned, try the following commands:
 ```bash
-/usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/libexec/bootpd
-/usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/bootpd
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/libexec/bootpd
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/bootpd
 ```
 
 #### Unmanaged

--- a/website/content/en/docs/faq/_index.md
+++ b/website/content/en/docs/faq/_index.md
@@ -181,8 +181,8 @@ For more details, see [Documentation/Networking](https://wiki.qemu.org/Documenta
 #### "IP address is not assigined for vmnet networks"
 Try the following commands:
 ```bash
-/usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/libexec/bootpd
-/usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/bootpd
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/libexec/bootpd
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/bootpd
 ```
 
 ### Filesystem sharing


### PR DESCRIPTION
It is reported that the following commands fix the issue #1259:
```
sudo /usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/libexec/bootpd
sudo /usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/bootpd
```