### PR TITLE
Don't download files that are already cached

### DIFF
--- a/pkg/fileutils/download.go
+++ b/pkg/fileutils/download.go
@@ -41,6 +41,17 @@ func DownloadFile(dest string, f limayaml.File, decompress bool, description str
 	return res.CachePath, nil
 }
 
+// CachedFile checks if a file is in the cache, validating the digest if it is available. Returns path in cache.
+func CachedFile(f limayaml.File) (string, error) {
+	res, err := downloader.Cached(f.Location,
+		downloader.WithCache(),
+		downloader.WithExpectedDigest(f.Digest))
+	if err != nil {
+		return "", fmt.Errorf("cache did not contain %q: %w", f.Location, err)
+	}
+	return res.CachePath, nil
+}
+
 // Errors compose multiple into a single error.
 // Errors filters out ErrSkipped.
 func Errors(errs []error) error {


### PR DESCRIPTION
The nerdctl(-full) archive has already been downloaded to the cache (during `create`),
so don't log downloading it again (during `start`) - unless file is missing or digest fails.

Don't use files for different arch, or check for local files that are not available in the cache.
Refactor common methods out from the longer functions, so that they can be reused.

Closes #1875

Edit: it wasn't _actually_ downloading the file again, just spamming the INFO log about it