### PR TITLE
ci: add WSL2 CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,9 +73,35 @@ jobs:
 
   windows:
     name: "Windows tests"
-    runs-on: windows-2022
+    runs-on: windows-2022-8-cores
     timeout-minutes: 30
     steps:
+    - name: Enable WSL2
+      run: |
+        wsl --set-default-version 2
+        # Manually install the latest kernel from MSI
+        Invoke-WebRequest -Uri "https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi" -OutFile "wsl_update_x64.msi"
+        $pwd = (pwd).Path
+        Start-Process msiexec.exe -Wait -ArgumentList "/I $pwd\wsl_update_x64.msi /quiet"
+        wsl --update
+        wsl --status
+        wsl --list --online
+    - name: Install WSL2 distro
+      timeout-minutes: 3
+      run: |
+        # FIXME: At least one distro has to be installed here,
+        # otherwise `wsl --list --verbose` (called from Lima) fails:
+        # https://github.com/lima-vm/lima/pull/1826#issuecomment-1729993334
+        # The distro image itself is not consumed by Lima.
+        # ------------------------------------------------------------------
+        # Ubuntu-22.04:    gets stuck in some infinite loop during adduser
+        # OracleLinux_9_1: almostly silently fails, and just prints "Usage: adduser [options] LOGIN"
+        wsl --install -d openSUSE-Leap-15.5
+        wsl --list --verbose
+    - name: Set gitconfig
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
@@ -86,6 +112,19 @@ jobs:
       run: go test -v ./...
     - name: Make
       run: make
+    - name: Smoke test
+      # Make sure the path is set properly and then run limactl
+      run: |
+        $env:Path = 'C:\Program Files\Git\usr\bin;' + $env:Path
+        Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $env:Path
+        .\_output\bin\limactl.exe start template://experimental/wsl2
+      # TODO: run the full integration tests
+    - name: Debug
+      if: always()
+      run: type C:\Users\runneradmin\.lima\wsl2\ha.stdout.log
+    - name: Debug
+      if: always()
+      run: type C:\Users\runneradmin\.lima\wsl2\ha.stderr.log
 
   integration:
     name: Integration tests

--- a/examples/experimental/wsl2.yaml
+++ b/examples/experimental/wsl2.yaml
@@ -4,9 +4,9 @@ vmType: wsl2
 
 images:
 # Source: https://github.com/runfinch/finch-core/blob/main/Dockerfile
-- location: "https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1690920103.tar.zst"
+- location: "https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1694791577.tar.gz"
   arch: "x86_64"
-  digest: "sha256:53f2e329b8da0f6a25e025d1f6cc262ae228402ba615ad095739b2f0ec6babc9"
+  digest: "sha256:2d4d2e7386450899c6d0587fd0db21afadb31d974fa744aa9365c883935c5341"
 
 mountType: wsl2
 

--- a/pkg/wsl2/lima-init.TEMPLATE
+++ b/pkg/wsl2/lima-init.TEMPLATE
@@ -1,5 +1,6 @@
-set -eu; \
-export LOG_FILE=/var/log/lima-init.log; \
-exec > >(tee \$LOG_FILE) 2>&1; \
-export LIMA_CIDATA_MNT="$(/usr/bin/wslpath '{{.CIDataPath}}')"; \
-exec "\$LIMA_CIDATA_MNT/boot.sh";
+#!/bin/bash
+set -eu
+export LOG_FILE=/var/log/lima-init.log
+exec > >(tee $LOG_FILE) 2>&1
+export LIMA_CIDATA_MNT="$(/usr/bin/wslpath '{{.CIDataPath}}')"
+exec "$LIMA_CIDATA_MNT/boot.sh"


### PR DESCRIPTION
Picking up where #1826 left off

According to [these docs](https://github.com/actions/runner-images/blob/win22/20230903.2/images/win/Windows2022-Readme.md), Windows runners should have Git for Windows pre-installed, meaning `tar.exe` and `gzip.exe` should be in the path already.

Let's see if just changing the rootfs from zstd to gz compression gets us any further, and iterate from there.

Closes #1781.