### PR TITLE
Add MountWritable for setting writable default

### DIFF
--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -48,7 +48,7 @@ func registerEdit(cmd *cobra.Command, commentPrefix string) {
 		return []string{"reverse-sshfs", "9p", "virtiofs"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
-	flags.Bool("mount-writable", false, commentPrefix+"make all mounts writable")
+	flags.Bool("mount-writable", false, commentPrefix+"make mounts writable by default")
 
 	flags.StringSlice("network", nil, commentPrefix+"additional networks, e.g., \"vzNAT\" or \"lima:shared\" to assign vmnet IP")
 	_ = cmd.RegisterFlagCompletionFunc("network", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -148,7 +148,7 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool) ([]string, error) {
 			false,
 			false},
 		{"mount-type", d(".mountType = %q"), false, false},
-		{"mount-writable", d(".mounts[].writable = %s"), false, false},
+		{"mount-writable", d(".mountWritable = %s"), false, false},
 		{"network",
 			func(_ *flag.Flag) (string, error) {
 				ss, err := flags.GetStringSlice("network")

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -51,7 +51,7 @@ disk: null
 
 # Expose host directories to the guest, the mount point might be accessible from all UIDs in the guest
 # 🟢 Builtin default: null (Mount nothing)
-# 🔵 This file: Mount the home as read-only, /tmp/lima as writable
+# 🔵 This file: Mount the home as default, /tmp/lima as writable
 mounts:
 - location: "~"
   # Configure the mountPoint inside the guest.
@@ -59,7 +59,8 @@ mounts:
   mountPoint: null
   # CAUTION: `writable` SHOULD be false for the home directory.
   # Setting `writable` to true is possible, but untested and dangerous.
-  # 🟢 Builtin default: false
+  # 🟢 Builtin default: see `mountWritable`
+  # 🔵 This file: null (only for the home)
   writable: null
   sshfs:
     # Enabling the SSHFS cache will increase performance of the mounted filesystem, at
@@ -94,7 +95,7 @@ mounts:
     # 🟢 Builtin default: "fscache" for non-writable mounts, "mmap" for writable mounts
     cache: null
 - location: "/tmp/lima"
-  # 🟢 Builtin default: false
+  # 🟢 Builtin default: see `mountWritable`
   # 🔵 This file: true (only for "/tmp/lima")
   writable: true
 
@@ -102,6 +103,11 @@ mounts:
 # or "virtiofs" (EXPERIMENTAL, needs `vmType: vz`)
 # 🟢 Builtin default: "reverse-sshfs" (for QEMU), "virtiofs" (for vz)
 mountType: null
+
+# Mount writable default for above mounts, true for read-write and false for read-only
+# (in this file the default writable is only used for the home, but not for "/tmp/lima").
+# 🟢 Builtin default: false
+mountWritable: null
 
 # Lima disks to attach to the instance. The disks will be accessible from inside the
 # instance, labeled by name. (e.g. if the disk is named "data", it will be labeled

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -26,6 +26,9 @@ import (
 )
 
 const (
+	// DefaultMountWritable is false for the home directory
+	DefaultMountWritable bool = false
+
 	// Default9pSecurityModel is "none" for supporting symlinks
 	// https://gitlab.com/qemu-project/qemu/-/issues/173
 	Default9pSecurityModel   string = "none"
@@ -524,6 +527,15 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 			y.MountType = pointer.String(REVSSHFS)
 		}
 	}
+	if y.MountWritable == nil {
+		y.MountWritable = d.MountWritable
+	}
+	if o.MountWritable != nil {
+		y.MountWritable = o.MountWritable
+	}
+	if y.MountWritable == nil {
+		y.MountWritable = pointer.Bool(DefaultMountWritable)
+	}
 
 	// Combine all mounts; highest priority entry determines writable status.
 	// Only works for exact matches; does not normalize case or resolve symlinks.
@@ -592,7 +604,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 			mounts[i].Virtiofs.QueueSize = pointer.Int(DefaultVirtiofsQueueSize)
 		}
 		if mount.Writable == nil {
-			mount.Writable = pointer.Bool(false)
+			mount.Writable = y.MountWritable
 		}
 		if mount.NineP.Cache == nil {
 			if *mount.Writable {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -143,7 +143,8 @@ func TestFillDefault(t *testing.T) {
 		Mounts: []Mount{
 			{Location: "/tmp"},
 		},
-		MountType: pointer.String(NINEP),
+		MountType:     pointer.String(NINEP),
+		MountWritable: pointer.Bool(false),
 		Provision: []Provision{
 			{Script: "#!/bin/true"},
 		},
@@ -189,7 +190,7 @@ func TestFillDefault(t *testing.T) {
 
 	expect.Mounts = y.Mounts
 	expect.Mounts[0].MountPoint = expect.Mounts[0].Location
-	expect.Mounts[0].Writable = pointer.Bool(false)
+	expect.Mounts[0].Writable = pointer.Bool(DefaultMountWritable)
 	expect.Mounts[0].SSHFS.Cache = pointer.Bool(true)
 	expect.Mounts[0].SSHFS.FollowSymlinks = pointer.Bool(false)
 	expect.Mounts[0].SSHFS.SFTPDriver = pointer.String("")
@@ -198,9 +199,9 @@ func TestFillDefault(t *testing.T) {
 	expect.Mounts[0].NineP.Msize = pointer.String(Default9pMsize)
 	expect.Mounts[0].NineP.Cache = pointer.String(Default9pCacheForRO)
 	expect.Mounts[0].Virtiofs.QueueSize = pointer.Int(DefaultVirtiofsQueueSize)
-	// Only missing Mounts field is Writable, and the default value is also the null value: false
 
 	expect.MountType = pointer.String(NINEP)
+	expect.MountWritable = pointer.Bool(false)
 
 	expect.Provision = y.Provision
 	expect.Provision[0].Mode = ProvisionModeSystem
@@ -323,6 +324,8 @@ func TestFillDefault(t *testing.T) {
 				Writable: pointer.Bool(false),
 			},
 		},
+		MountType:     nil, // set by VMType
+		MountWritable: pointer.Bool(true),
 		Provision: []Provision{
 			{
 				Script: "#!/bin/true",
@@ -377,6 +380,7 @@ func TestFillDefault(t *testing.T) {
 	// Also verify that archive arch is filled in
 	expect.Containerd.Archives[0].Arch = *d.Arch
 	expect.Mounts[0].MountPoint = expect.Mounts[0].Location
+	expect.Mounts[0].Writable = pointer.Bool(DefaultMountWritable)
 	expect.Mounts[0].SSHFS.Cache = pointer.Bool(true)
 	expect.Mounts[0].SSHFS.FollowSymlinks = pointer.Bool(false)
 	expect.Mounts[0].SSHFS.SFTPDriver = pointer.String("")
@@ -389,6 +393,7 @@ func TestFillDefault(t *testing.T) {
 		"default": d.HostResolver.Hosts["default"],
 	}
 	expect.MountType = pointer.String(VIRTIOFS)
+	expect.MountWritable = pointer.Bool(true)
 	expect.CACertificates.RemoveDefaults = pointer.Bool(true)
 	expect.CACertificates.Certs = []string{
 		"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT\n-----END CERTIFICATE-----\n",
@@ -594,6 +599,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Mounts[0].Virtiofs.QueueSize = pointer.Int(2048)
 
 	expect.MountType = pointer.String(NINEP)
+	expect.MountWritable = pointer.Bool(false)
 
 	// o.Networks[1] is overriding the d.Networks[0].Lima entry for the "def0" interface
 	expect.Networks = append(append(d.Networks, y.Networks...), o.Networks[0])

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -18,6 +18,7 @@ type LimaYAML struct {
 	AdditionalDisks    []Disk          `yaml:"additionalDisks,omitempty" json:"additionalDisks,omitempty"`
 	Mounts             []Mount         `yaml:"mounts,omitempty" json:"mounts,omitempty"`
 	MountType          *MountType      `yaml:"mountType,omitempty" json:"mountType,omitempty"`
+	MountWritable      *bool           `yaml:"mountWritable,omitempty" json:"mountWritable,omitempty"`
 	SSH                SSH             `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
 	Firmware           Firmware        `yaml:"firmware,omitempty" json:"firmware,omitempty"`
 	Audio              Audio           `yaml:"audio,omitempty" json:"audio,omitempty"`


### PR DESCRIPTION
Previously setting --mount-writable=false would turn off the writable for "/tmp/lima", which was undocumented.

Make it a global config, so that it is easy to change in the future (and easy to revert in local config, too)

Issue #1872

Note: this does not _change_ the default (it is still false), it just makes it _possible_ to change (in one place)