### PR TITLE
Change prompt color from lime to lime green

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/08-shell-prompt.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/08-shell-prompt.sh
@@ -7,7 +7,7 @@ if [ "${LIMA_CIDATA_NAME}" = "default" ] && command -v patch >/dev/null 2>&1 && 
 
 	! grep -q "^# Lima PS1" "${LIMA_CIDATA_HOME}/.bashrc" || exit 0
 
-	# Change the default shell prompt from "green" to "lime" (#BFFF00)
+	# Change the default shell prompt from "green" to "lime green" (#32CD32)
 
 	patch --forward -r - "${LIMA_CIDATA_HOME}/.bashrc" <<'EOF'
 @@ -37,7 +37,11 @@
@@ -23,23 +23,20 @@ if [ "${LIMA_CIDATA_NAME}" = "default" ] && command -v patch >/dev/null 2>&1 && 
  esac
  
  # uncomment for a colored prompt, if the terminal has the capability; turned
-@@ -56,8 +60,13 @@
+@@ -56,7 +60,12 @@
      fi
  fi
  
 -if [ "$color_prompt" = yes ]; then
--    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
-+# Lima PS1: set color to lime
++# Lima PS1: set color to lime green
 +if [ "$color_prompt" = true ]; then
-+    PS1='${debian_chroot:+($debian_chroot)}\[\033[38;2;192;255;0m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
++    PS1='${debian_chroot:+($debian_chroot)}\[\033[38;2;50;205;50m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
 +elif [ "$color_prompt" = 256 ]; then
-+    PS1='${debian_chroot:+($debian_chroot)}\[\033[38;5;154m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
++    PS1='${debian_chroot:+($debian_chroot)}\[\033[38;5;77m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
 +elif [ "$color_prompt" = yes ]; then
-+    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;92m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+     PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
  else
      PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
- fi
-fi
 EOF
 
 fi


### PR DESCRIPTION
This makes it more legible with light backgrounds, and changes the fallback color from "light green" back to regular "green".

The previous "lime" color had issues on light background, where "lime green" works on dark backgrounds and OK on light backgrounds.

Closes #485

Issue #1892 