### PR TITLE
Add vnc example with xorg desktop environment

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -53,6 +53,7 @@ Optional feature enablers:
 - [`experimental/riscv64`](./experimental/riscv64.yaml): [experimental] RISC-V
 - [`experimental/net-user-v2`](./experimental/net-user-v2.yaml): [experimental] user-v2 network
   to enable VM-to-VM communication without root privilege
+- [`experimental/vnc`](./experimental/vnc.yaml): [experimental] use vnc display and xorg server
 
 Lost+found:
 - ~`centos`~: Removed in Lima v0.8.0, as CentOS 8 reached [EOL](https://www.centos.org/centos-linux-eol/).

--- a/examples/experimental/vnc.yaml
+++ b/examples/experimental/vnc.yaml
@@ -1,0 +1,61 @@
+# A template to run ubuntu using display: vnc
+# This template requires Lima v0.15.0 or later.
+images:
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+- location: "https://cloud-images.ubuntu.com/releases/23.04/release-20230926/ubuntu-23.04-server-cloudimg-amd64.img"
+  arch: "x86_64"
+  digest: "sha256:1e35473cea5e1b827b91ad6ebb43b605a00d506c11f66c75076c424ae5372440"
+- location: "https://cloud-images.ubuntu.com/releases/23.04/release-20230926/ubuntu-23.04-server-cloudimg-arm64.img"
+  arch: "aarch64"
+  digest: "sha256:46d4f3874831fc28e0edcf24b86b6b8017e0492fa848d951cfa3c7b520b2d2fa"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/23.04/release/ubuntu-23.04-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/releases/23.04/release/ubuntu-23.04-server-cloudimg-arm64.img"
+  arch: "aarch64"
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+
+vmType: "qemu"
+video:
+  display: "vnc"
+
+provision:
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    command -v Xorg >/dev/null 2>&1 && exit 0
+    export DEBIAN_FRONTEND=noninteractive
+    # x-terminal-emulator x-session-manager x-window-manager
+    apt-get install -y xorg xterm openbox hsetroot tint2 slim
+    printf "auto_login yes\ndefault_user ${LIMA_CIDATA_USER}\n" >>/etc/slim.conf
+    # configure some nice lima green, set up panel and apps
+    printf "hsetroot -solid \"#32CD32\" &\ntint2 &\n" >>/etc/xdg/openbox/autostart
+    sed -i 's/Clearlooks/Clearlooks-Olive/' /etc/xdg/openbox/rc.xml # go for green
+    apt-get install -y --no-install-recommends dillo xfe # x-www-browser +explorer
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    systemctl set-default graphical.target
+    systemctl isolate graphical.target
+probes:
+- description: "Xorg to be installed"
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! timeout 30s bash -c "until command -v Xorg >/dev/null 2>&1; do sleep 3; done"; then
+      echo >&2 "Xorg is not installed yet"
+      exit 1
+    fi
+  hint: See "/var/log/cloud-init-output.log". in the guest
+message: |
+  Use a VNC viewer or noVNC, to connect to the display:
+
+  * VNC Display:    see <file://{{.Dir}}/vncdisplay>
+  * VNC Password:   see <file://{{.Dir}}/vncpassword>


### PR DESCRIPTION
Set automatic login using a simple login manager (slim), and basic xorg programs including xterm and openbox wm.

Add a panel and some programs for the applications menu, use tint2 instead of the removed fbpanel and basic apps.

![lima-vnc](https://github.com/lima-vm/lima/assets/10364051/ed18f0ac-21fe-4be8-a534-e2888fd3b254)

Also works with https://novnc.com/

And with  [lima-gui ](https://github.com/afbjorklund/lima-gui) "Display" button

----

* https://github.com/lima-vm/lima/discussions/1002
* https://github.com/lima-vm/lima/pull/1899