### PR TITLE
feat: propagate host timezone to guest

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -1,6 +1,10 @@
 #cloud-config
 # vim:syntax=yaml
 
+{{- if .Timezone }}
+timezone: {{.Timezone}}
+{{- end }}
+
 growpart:
   mode: auto
   devices: ['/']

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -82,6 +82,7 @@ type TemplateArgs struct {
 	VMType                          string
 	VSockPort                       int
 	Plain                           bool
+	Timezone                        string
 }
 
 func ValidateTemplateArgs(args TemplateArgs) error {


### PR DESCRIPTION
This PR closes #1921, propagates host timezone to guest VM.

This doesn't work for template://alpine for it doesn't have pre-installed tzdata. And this PR doesn't use timedatectl because some distros might not be using systemd.