### PR TITLE
Add Gentoo as an experimental distribution

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,7 @@ Distro:
 - [`ubuntu`](./ubuntu.yaml): Ubuntu (same as `default.yaml` but without extra YAML lines)
 - [`ubuntu-lts`](./ubuntu-lts.yaml): Ubuntu LTS (same as `ubuntu.yaml` but pinned to an LTS version)
 - [`deprecated/centos-7`](./deprecated/centos-7.yaml): [deprecated] CentOS Linux 7
+- [`experimental/gentoo`](./experimental/gentoo.yaml): [experimental] Gentoo
 - [`experimental/opensuse-tumbleweed`](./experimental/opensuse-tumbleweed.yaml): [experimental] openSUSE Tumbleweed
 
 Container engines:

--- a/examples/experimental/gentoo.yaml
+++ b/examples/experimental/gentoo.yaml
@@ -1,0 +1,15 @@
+vmType: "qemu"
+images:
+- location: "https://distfiles.gentoo.org/experimental/amd64/openstack/gentoo-openstack-amd64-default-latest.qcow2"
+  arch: "x86_64"
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+mountType: "9p"
+
+# The built-in containerd installer does not support Gentoo currently.
+containerd:
+  system: false
+  user: false


### PR DESCRIPTION
Requested by user:
* #1934

Not sure what you would actually _use_ it for, it doesn't support systemd with the openstack image.

And you would have to build sshfs and containerd from source, including all their dependencies...

----

https://wiki.gentoo.org/wiki/Handbook:AMD64

```console
$ sudo -Ss
# cd

# emerge-webrsync
# eselect profile set default/linux/amd64/17.1
```

> The arm and arm64 architectures are supported by the Gentoo project but do not yet have Handbooks at their disposal due to too many variations in SoCs. It is simply not practical for the Handbook project to maintain a cohesive set of installation instructions.

> Equally, the riscv architecture is supported, however there is no separate Handbook for it (yet)

```yaml
arch: "armv7l"
arch: "aarch64"
arch: "riscv64"
```
