### PR TITLE
Optimize the upgrade comparison by storing nerdctl version

### DIFF
--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -30,6 +30,7 @@ func newHostagentCommand() *cobra.Command {
 	hostagentCommand.Flags().String("socket", "", "hostagent socket")
 	hostagentCommand.Flags().Bool("run-gui", false, "run gui synchronously within hostagent")
 	hostagentCommand.Flags().String("nerdctl-archive", "", "local file path (not URL) of nerdctl-full-VERSION-GOOS-GOARCH.tar.gz")
+	hostagentCommand.Flags().String("nerdctl-version", "", "just version (i.e. VERSION) of nerdctl-full-VERSION-GOOS-GOARCH.tar.gz")
 	return hostagentCommand
 }
 
@@ -79,8 +80,15 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	nerdctlVersion, err := cmd.Flags().GetString("nerdctl-version")
+	if err != nil {
+		return err
+	}
 	if nerdctlArchive != "" {
 		opts = append(opts, hostagent.WithNerdctlArchive(nerdctlArchive))
+	}
+	if nerdctlVersion != "" {
+		opts = append(opts, hostagent.WithNerdctlVersion(nerdctlVersion))
 	}
 	ha, err := hostagent.New(instName, stdout, sigintCh, opts...)
 	if err != nil {

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -181,6 +181,7 @@ containerd:
 #  - location: "~/Downloads/nerdctl-full-X.Y.Z-linux-amd64.tar.gz"
 #    arch: "x86_64"
 #    digest: "sha256:..."
+#    version: "X.Y.Z"
 
 # Provisioning scripts need to be idempotent because they might be called
 # multiple times, e.g. when the host VM is being restarted.

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -110,7 +110,7 @@ func setupEnv(y *limayaml.LimaYAML, args TemplateArgs) (map[string]string, error
 	return env, nil
 }
 
-func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort, tcpDNSLocalPort int, nerdctlArchive string, vsockPort int) error {
+func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort, tcpDNSLocalPort int, nerdctlArchive string, nerdctlVersion string, vsockPort int) error {
 	if err := limayaml.Validate(*y, false); err != nil {
 		return err
 	}
@@ -355,6 +355,12 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 			// ISO9660 requires len(Path) <= 30
 			Path:   "nerdctl-full.tgz",
 			Reader: nftgzR,
+		})
+	}
+	if nerdctlVersion != "" {
+		layout = append(layout, iso9660util.Entry{
+			Path:   "nerdctl-version.txt",
+			Reader: strings.NewReader("nerdctl version " + nerdctlVersion + "\n"),
 		})
 	}
 

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -59,6 +59,7 @@ type HostAgent struct {
 
 type options struct {
 	nerdctlArchive string // local path, not URL
+	nerdctlVersion string
 }
 
 type Opt func(*options) error
@@ -66,6 +67,13 @@ type Opt func(*options) error
 func WithNerdctlArchive(s string) Opt {
 	return func(o *options) error {
 		o.nerdctlArchive = s
+		return nil
+	}
+}
+
+func WithNerdctlVersion(s string) Opt {
+	return func(o *options) error {
+		o.nerdctlVersion = s
 		return nil
 	}
 }
@@ -125,7 +133,7 @@ func New(instName string, stdout io.Writer, sigintCh chan os.Signal, opts ...Opt
 		vSockPort = port
 	}
 
-	if err := cidata.GenerateISO9660(inst.Dir, instName, y, udpDNSLocalPort, tcpDNSLocalPort, o.nerdctlArchive, vSockPort); err != nil {
+	if err := cidata.GenerateISO9660(inst.Dir, instName, y, udpDNSLocalPort, tcpDNSLocalPort, o.nerdctlArchive, o.nerdctlVersion, vSockPort); err != nil {
 		return nil, err
 	}
 

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -37,21 +37,27 @@ const (
 	DefaultVirtiofsQueueSize int = 1024
 )
 
-func defaultContainerdArchives() []File {
+func defaultContainerdArchives() []Archive {
 	const nerdctlVersion = "1.6.2"
 	location := func(goos string, goarch string) string {
 		return "https://github.com/containerd/nerdctl/releases/download/v" + nerdctlVersion + "/nerdctl-full-" + nerdctlVersion + "-" + goos + "-" + goarch + ".tar.gz"
 	}
-	return []File{
+	return []Archive{
 		{
-			Location: location("linux", "amd64"),
-			Arch:     X8664,
-			Digest:   "sha256:37678f27ad341a7c568c5064f62bcbe90cddec56e65f5d684edf8ca955c3e6a4",
+			File: File{
+				Location: location("linux", "amd64"),
+				Arch:     X8664,
+				Digest:   "sha256:37678f27ad341a7c568c5064f62bcbe90cddec56e65f5d684edf8ca955c3e6a4",
+			},
+			Version: nerdctlVersion,
 		},
 		{
-			Location: location("linux", "arm64"),
-			Arch:     AARCH64,
-			Digest:   "sha256:ea30ab544c057e3a0457194ecd273ffbce58067de534bdfaffe4edf3a4da6357",
+			File: File{
+				Location: location("linux", "arm64"),
+				Arch:     AARCH64,
+				Digest:   "sha256:ea30ab544c057e3a0457194ecd273ffbce58067de534bdfaffe4edf3a4da6357",
+			},
+			Version: nerdctlVersion,
 		},
 		// No arm-v7
 		// No riscv64

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -286,8 +286,12 @@ func TestFillDefault(t *testing.T) {
 		Containerd: Containerd{
 			System: pointer.Bool(true),
 			User:   pointer.Bool(false),
-			Archives: []File{
-				{Location: "/tmp/nerdctl.tgz"},
+			Archives: []Archive{
+				{
+					File: File{
+						Location: "/tmp/nerdctl.tgz",
+					},
+				},
 			},
 		},
 		SSH: SSH{
@@ -465,11 +469,14 @@ func TestFillDefault(t *testing.T) {
 		Containerd: Containerd{
 			System: pointer.Bool(true),
 			User:   pointer.Bool(false),
-			Archives: []File{
+			Archives: []Archive{
 				{
-					Arch:     arch,
-					Location: "/tmp/nerdctl.tgz",
-					Digest:   "$DIGEST",
+					File: File{
+						Arch:     arch,
+						Location: "/tmp/nerdctl.tgz",
+						Digest:   "$DIGEST",
+					},
+					Version: "1.0.0",
 				},
 			},
 		},

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -75,6 +75,11 @@ type File struct {
 	Digest   digest.Digest `yaml:"digest,omitempty" json:"digest,omitempty"`
 }
 
+type Archive struct {
+	File
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+}
+
 type Kernel struct {
 	File    `yaml:",inline"`
 	Cmdline string `yaml:"cmdline,omitempty" json:"cmdline,omitempty"`
@@ -173,9 +178,9 @@ type Provision struct {
 }
 
 type Containerd struct {
-	System   *bool  `yaml:"system,omitempty" json:"system,omitempty"`     // default: false
-	User     *bool  `yaml:"user,omitempty" json:"user,omitempty"`         // default: true
-	Archives []File `yaml:"archives,omitempty" json:"archives,omitempty"` // default: see defaultContainerdArchives
+	System   *bool     `yaml:"system,omitempty" json:"system,omitempty"`     // default: false
+	User     *bool     `yaml:"user,omitempty" json:"user,omitempty"`         // default: true
+	Archives []Archive `yaml:"archives,omitempty" json:"archives,omitempty"` // default: see defaultContainerdArchives
 }
 
 type ProbeMode = string

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -175,6 +175,9 @@ func Start(ctx context.Context, inst *store.Instance) error {
 	if prepared.NerdctlArchiveCache != "" {
 		args = append(args, "--nerdctl-archive", prepared.NerdctlArchiveCache)
 	}
+	if prepared.NerdctlArchiveVersion != "" {
+		args = append(args, "--nerdctl-version", prepared.NerdctlArchiveVersion)
+	}
 	args = append(args, inst.Name)
 	haCmd := exec.CommandContext(ctx, self, args...)
 	haCmd.SysProcAttr = SysProcAttr

--- a/website/content/en/docs/dev/Internals/_index.md
+++ b/website/content/en/docs/dev/Internals/_index.md
@@ -138,6 +138,7 @@ The directory contains the following files:
 - `lima.env`: The `LIMA_CIDATA_*` environment variables (see below) available during `boot.sh` processing
 - `lima-guestagent`: Lima guest agent binary
 - `nerdctl-full.tgz`: [`nerdctl-full-<VERSION>-<OS>-<ARCH>.tar.gz`](https://github.com/containerd/nerdctl/releases)
+- `nerdctl-version.txt`: `"nerdctl version <VERSION>"`(`nerdctl --version` output)
 - `boot.sh`: Boot script
 - `boot/*`: Boot script modules
 - `util/*`: Utility command scripts, executed in the boot script modules


### PR DESCRIPTION
Store the version in the containerd archives:

```json
[
  {
    "location": "https://github.com/containerd/nerdctl/releases/download/v1.6.2/nerdctl-full-1.6.2-linux-amd64.tar.gz",
    "arch": "x86_64",
    "digest": "sha256:37678f27ad341a7c568c5064f62bcbe90cddec56e65f5d684edf8ca955c3e6a4",
    "version": "1.6.2"
  },
  {
    "location": "https://github.com/containerd/nerdctl/releases/download/v1.6.2/nerdctl-full-1.6.2-linux-arm64.tar.gz",
    "arch": "aarch64",
    "digest": "sha256:ea30ab544c057e3a0457194ecd273ffbce58067de534bdfaffe4edf3a4da6357",
    "version": "1.6.2"
  }
]
```

Then we can compare it with the `nerdctl --version` later, to see if it has changed.

Pass it as a separate flag, since it is not apparent from the cache file name (sha2)...