### PR TITLE
Set secontext for bind volumes in selinux enabled distros

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
     - 'release/**'
   pull_request:
 
+env:
+  LIMACTL_CREATE_ARGS: ""
+
 jobs:
   lints:
     name: "Lints"
@@ -399,6 +402,12 @@ jobs:
     name: "vz"
     runs-on: macos-13
     timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        template:
+        - experimental/vz.yaml
+        - fedora.yaml
     steps:
     - uses: actions/checkout@v4
       with:
@@ -411,14 +420,16 @@ jobs:
       with:
         path: ~/Library/Caches/lima/download
         # hashFiles do not seem to support symlinks
-        key: ${{ runner.os }}-${{ hashFiles('examples/experimental/vz.yaml') }}
+        key: ${{ runner.os }}-${{ hashFiles('examples/*.yaml') }}
     - name: Make
       run: make
     - name: Install
       run: make install
     - name: Install test dependencies
-      run: brew install bash coreutils
+      run: brew install bash coreutils jq
     - name: Uninstall qemu
       run: brew uninstall --ignore-dependencies --force qemu
     - name: Test
-      run: ./hack/test-templates.sh templates/experimental/vz.yaml
+      env:
+        LIMACTL_CREATE_ARGS: "--vm-type vz --mount-type virtiofs --rosetta --network vzNAT"
+      run: ./hack/test-templates.sh templates/${{ matrix.template }}

--- a/hack/test-selinux.sh
+++ b/hack/test-selinux.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+scriptdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.inc.sh
+source "${scriptdir}/common.inc.sh"
+
+if [ "$#" -ne 1 ]; then
+	ERROR "Usage: $0 NAME"
+	exit 1
+fi
+
+NAME="$1"
+expected="context=system_u:object_r:container_file_t:s0"
+#Skip Rosetta checks for x86 GHA mac runners
+if [[ "$(uname)" == "Darwin" && "$(arch)" == "arm64" ]]; then
+	INFO "Testing secontext is set for rosetta mounts"
+	got=$(limactl shell "$NAME" mount | grep "rosetta" | awk '{print $6}')
+	INFO "secontext rosetta: expected=${expected}, got=${got}"
+	if [[ $got != *$expected* ]]; then
+		ERROR "secontext for rosetta mount is not set or Invalid"
+		exit 1
+	fi
+fi
+INFO "Testing secontext is set for bind mounts"
+INFO "Checking in mounts"
+got=$(limactl shell "$NAME" mount | grep "$HOME" | awk '{print $6}')
+INFO "secontext ${HOME}: expected=${expected}, got=${got}"
+if [[ $got != *$expected* ]]; then
+	ERROR "secontext for \"$HOME\" dir is not set or Invalid"
+	exit 1
+fi
+got=$(limactl shell "$NAME" mount | grep "/tmp/lima" | awk '{print $6}')
+INFO "secontext /tmp/lima: expected=${expected}, got=${got}"
+if [[ $got != *$expected* ]]; then
+	ERROR 'secontext for "/tmp/lima" dir is not set or Invalid'
+	exit 1
+fi
+INFO "Checking in fstab file"
+expected='context="system_u:object_r:container_file_t:s0"'
+got=$(limactl shell "$NAME" cat /etc/fstab | grep "$HOME" | awk '{print $4}')
+INFO "secontext ${HOME}: expected=${expected}, got=${got}"
+if [[ $got != *$expected* ]]; then
+	ERROR "secontext for \"$HOME\" dir is not set or Invalid"
+	exit 1
+fi
+got=$(limactl shell "$NAME" cat /etc/fstab | grep "/tmp/lima" | awk '{print $4}')
+INFO "secontext /tmp/lima: expected=${expected}, got=${got}"
+if [[ $got != *$expected* ]]; then
+	ERROR 'secontext for "/tmp/lima" dir is not set or Invalid'
+	exit 1
+fi

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -109,7 +109,8 @@ if [[ -n ${CHECKS["disk"]} ]]; then
 fi
 
 set -x
-"${LIMACTL_CREATE[@]}" "$FILE"
+# shellcheck disable=SC2086
+"${LIMACTL_CREATE[@]}" ${LIMACTL_CREATE_ARGS} "$FILE"
 set +x
 
 INFO "Starting \"$NAME\""
@@ -223,7 +224,7 @@ if [[ -n ${CHECKS["port-forwards"]} ]]; then
 	if [ "${NAME}" = "debian" ]; then
 		limactl shell "$NAME" sudo apt-get install -y netcat-openbsd
 	fi
-	if [ "${NAME}" = "fedora" ]; then
+	if [ "${NAME}" == "fedora" ]; then
 		limactl shell "$NAME" sudo dnf install -y nc
 	fi
 	if [ "${NAME}" = "opensuse" ]; then
@@ -387,6 +388,10 @@ if [[ -n ${CHECKS["snapshot-offline"]} ]]; then
 	limactl snapshot apply "$NAME" --tag snap2
 	limactl snapshot delete "$NAME" --tag snap2
 	limactl start "$NAME"
+fi
+
+if [[ $NAME == "fedora" && "$(limactl ls --json "$NAME" | jq -r .vmType)" == "vz" ]]; then
+	"${scriptdir}"/test-selinux.sh "$NAME"
 fi
 
 INFO "Stopping \"$NAME\""

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-lima-mounts.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-lima-mounts.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+# Check if mount type is virtiofs and vm type as vz
+if ! [[ ${LIMA_CIDATA_VMTYPE} == "vz" && ${LIMA_CIDATA_MOUNTTYPE} == "virtiofs" ]]; then
+	exit 0
+fi
+
+# Update fstab entries and unmount/remount the volumes with secontext options
+# when selinux is enabled in kernel
+if [ -d /sys/fs/selinux ]; then
+	# shellcheck disable=SC2013
+	for line in $(grep -n virtiofs </etc/fstab | cut -d':' -f1); do
+		OPTIONS=$(awk -v line="$line" 'NR==line {print $4}' /etc/fstab)
+		if [[ ${OPTIONS} != *"context"* ]]; then
+			sed -i -e "$line""s/comment=cloudconfig/comment=cloudconfig,context=\"system_u:object_r:container_file_t:s0\"/g" /etc/fstab
+			TAG=$(awk -v line="$line" 'NR==line {print $1}' /etc/fstab)
+			MOUNT_POINT=$(awk -v line="$line" 'NR==line {print $2}' /etc/fstab)
+			OPTIONS=$(awk -v line="$line" 'NR==line {print $4}' /etc/fstab)
+			umount "${TAG}"
+			mount -t virtiofs "${TAG}" "${MOUNT_POINT}" -o "${OPTIONS}"
+		fi
+	done
+fi


### PR DESCRIPTION
Fixes #1882
Signed-off-by: T K Chandra Hasan <t.k.chandra.hasan@ibm.com>

The approach taken here is, once the mounts are created using the parameters in user-data, we would be unmounting the existing mounts and remounting with secontext options for selinux enabled distros. It would update the /etc/fstab file also. The context type we have taken here is container_file_t, as it would be easier to mount those directories inside the container.