### PR TITLE
pkg/osutil: refactor LimaUser and LimaGroup functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -151,3 +151,8 @@ linters-settings:
     - typeUnparen
     - unnamedResult
     - unnecessaryBlock
+issues:
+  exclude-rules:
+  # Allow using Uid, Gid in pkg/osutil.
+  - path: "pkg/osutil/"
+    text: "uid"

--- a/pkg/osutil/osutil_linux.go
+++ b/pkg/osutil/osutil_linux.go
@@ -10,7 +10,7 @@ const UnixPathMax = 108
 
 // Stat is a selection of syscall.Stat_t
 type Stat struct {
-	Uid uint32 //nolint:revive
+	Uid uint32
 	Gid uint32
 }
 

--- a/pkg/osutil/osutil_others.go
+++ b/pkg/osutil/osutil_others.go
@@ -13,7 +13,7 @@ const UnixPathMax = 104
 
 // Stat is a selection of syscall.Stat_t
 type Stat struct {
-	Uid uint32 //nolint:revive
+	Uid uint32
 	Gid uint32
 }
 

--- a/pkg/osutil/osutil_windows.go
+++ b/pkg/osutil/osutil_windows.go
@@ -13,7 +13,7 @@ const UnixPathMax = 108
 
 // Stat is a selection of syscall.Stat_t
 type Stat struct {
-	Uid uint32 //nolint:revive
+	Uid uint32
 	Gid uint32
 }
 

--- a/pkg/osutil/user_test.go
+++ b/pkg/osutil/user_test.go
@@ -2,7 +2,6 @@ package osutil
 
 import (
 	"path"
-	"regexp"
 	"strconv"
 	"testing"
 
@@ -15,8 +14,7 @@ func TestLimaUserWarn(t *testing.T) {
 }
 
 func validUsername(username string) bool {
-	validName := "^[a-z_][a-z0-9_-]*$"
-	return regexp.MustCompile(validName).Match([]byte(username))
+	return regexUsername.MatchString(username)
 }
 
 func TestLimaUsername(t *testing.T) {


### PR DESCRIPTION
This PR refactors the function `osutil.LimaUser` and `osutil.LimaGroup`:

- compile three regexps only once;
- replace `.Match([]byte(...` with `.MatchString(...`;
- remove duplicated regexp for matching username;
- replace regexp for matching uid/gid with the new function `parseUidGid`;
- replace `strconv.ParseUint` with `parseUidGid`;
- add function for converting `uid/gid` to string.