### PR TITLE
.golangci.yml: enable and fix nolintlint, bodyclose, gosimple

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,7 @@ linters:
   # - prealloc
   - typecheck
   # - asciicheck
-  # - bodyclose
+  - bodyclose
   # - dogsled
   # - dupl
   # - errcheck
@@ -58,14 +58,14 @@ linters:
   # - gomodguard
   # - goprintffuncname
   # - gosec (gas)
-  # - gosimple (megacheck)
+  - gosimple
   # - interfacer
   # - lll
   # - maligned
   # - nestif
   # - nlreturn
   # - noctx
-  # - nolintlint
+  - nolintlint
   # - rowserrcheck
   # - scopelint
   # - sqlclosecheck

--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -85,7 +85,7 @@ func editAction(cmd *cobra.Command, args []string) error {
 		logrus.Info("Aborting, as requested by saving the file with empty content")
 		return nil
 	}
-	if bytes.Compare(yBytes, yContent) == 0 {
+	if bytes.Equal(yBytes, yContent) {
 		logrus.Info("Aborting, no changes made to the instance")
 		return nil
 	}

--- a/pkg/osutil/osutil_linux.go
+++ b/pkg/osutil/osutil_linux.go
@@ -11,7 +11,7 @@ const UnixPathMax = 108
 // Stat is a selection of syscall.Stat_t
 type Stat struct {
 	Uid uint32 //nolint:revive
-	Gid uint32 //nolint:revive
+	Gid uint32
 }
 
 func SysStat(fi fs.FileInfo) (Stat, bool) {

--- a/pkg/osutil/osutil_others.go
+++ b/pkg/osutil/osutil_others.go
@@ -14,7 +14,7 @@ const UnixPathMax = 104
 // Stat is a selection of syscall.Stat_t
 type Stat struct {
 	Uid uint32 //nolint:revive
-	Gid uint32 //nolint:revive
+	Gid uint32
 }
 
 func SysStat(fi fs.FileInfo) (Stat, bool) {

--- a/pkg/osutil/osutil_windows.go
+++ b/pkg/osutil/osutil_windows.go
@@ -14,7 +14,7 @@ const UnixPathMax = 108
 // Stat is a selection of syscall.Stat_t
 type Stat struct {
 	Uid uint32 //nolint:revive
-	Gid uint32 //nolint:revive
+	Gid uint32
 }
 
 func SysStat(_ fs.FileInfo) (Stat, bool) {

--- a/pkg/osutil/user.go
+++ b/pkg/osutil/user.go
@@ -18,13 +18,13 @@ type User struct {
 	User  string
 	Uid   uint32 //nolint:revive
 	Group string
-	Gid   uint32 //nolint:revive
+	Gid   uint32
 	Home  string
 }
 
 type Group struct {
 	Name string
-	Gid  uint32 //nolint:revive
+	Gid  uint32
 }
 
 var users map[string]User
@@ -77,7 +77,7 @@ func LookupGroup(name string) (Group, error) {
 const (
 	fallbackUser = "lima"
 	fallbackUid  = 1000 //nolint:revive
-	fallbackGid  = 1000 //nolint:revive
+	fallbackGid  = 1000
 )
 
 var cache struct {


### PR DESCRIPTION
This PR modifies golangci-lint's config and enables few useful linters: `bodyclose`, `nolintlint`, `gosimple`. And fixes appeared lint issues:

```
cmd/limactl/edit.go:88:5: S1004: should use bytes.Equal(yBytes, yContent) instead (gosimple)
        if bytes.Compare(yBytes, yContent) == 0 {
           ^
pkg/osutil/user.go:21:15: directive `//nolint:revive` is unused for linter "revive" (nolintlint)
        Gid   uint32 //nolint:revive
                     ^
pkg/osutil/user.go:27:14: directive `//nolint:revive` is unused for linter "revive" (nolintlint)
        Gid  uint32 //nolint:revive
                    ^
```