### PR TITLE
test: refactor asserts

### DIFF
--- a/pkg/cidata/cidata_test.go
+++ b/pkg/cidata/cidata_test.go
@@ -21,10 +21,7 @@ func TestSetupEnv(t *testing.T) {
 	netLookupIP = fakeLookupIP
 	urlMustParse := func(urlStr string) *url.URL {
 		u, err := url.Parse(urlStr)
-		if err != nil {
-			panic(err)
-		}
-
+		assert.NilError(t, err)
 		return u
 	}
 

--- a/pkg/networks/config_test.go
+++ b/pkg/networks/config_test.go
@@ -10,7 +10,7 @@ import (
 func TestFillDefault(t *testing.T) {
 	nwYaml := YAML{}
 	newYaml, err := fillDefaults(nwYaml)
-	assert.Check(t, err == nil)
+	assert.NilError(t, err)
 
 	userNet := newYaml.Networks[ModeUserV2]
 	assert.Equal(t, userNet.Mode, ModeUserV2)

--- a/pkg/networks/usernet/config_test.go
+++ b/pkg/networks/usernet/config_test.go
@@ -12,25 +12,19 @@ func TestUsernetConfig(t *testing.T) {
 
 	t.Run("verify dns ip", func(t *testing.T) {
 		subnet, _, err := net.ParseCIDR(networks.SlirpNetwork)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		assert.Equal(t, DNSIP(subnet), "192.168.5.3")
 	})
 
 	t.Run("verify gateway ip", func(t *testing.T) {
 		subnet, _, err := net.ParseCIDR(networks.SlirpNetwork)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		assert.Equal(t, GatewayIP(subnet), "192.168.5.2")
 	})
 
 	t.Run("verify subnet via config ip", func(t *testing.T) {
 		subnet, err := Subnet("user-v2")
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		assert.Equal(t, subnet.String(), "192.168.104.0")
 	})
 }

--- a/pkg/networks/usernet/gvproxy_test.go
+++ b/pkg/networks/usernet/gvproxy_test.go
@@ -35,17 +35,11 @@ nameserver 8.8.8.8`)
 
 func createResolveFile(t *testing.T, file string, content string) {
 	f, err := os.Create(file)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	t.Cleanup(func() { _ = f.Close() })
 	writer := bufio.NewWriter(f)
 	_, err = writer.Write([]byte(content))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	err = writer.Flush()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }


### PR DESCRIPTION
This PR refactors tests by replacing `if err != nil` with `assert.NilError(t, err)`.