### PR TITLE
 Use VZ by default for new instances on macOS >= 13.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,7 @@ jobs:
 
   integration:
     name: Integration tests
+    # on macOS 12, the default vmType is QEMU
     runs-on: macos-12
     timeout-minutes: 120
     steps:
@@ -405,13 +406,14 @@ jobs:
 
   vz:
     name: "vz"
+    # on macOS 13, the default vmType is VZ
     runs-on: macos-13
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
         template:
-        - experimental/vz.yaml
+        - default.yaml
         - fedora.yaml
     steps:
     - uses: actions/checkout@v4
@@ -438,8 +440,6 @@ jobs:
     - name: Uninstall qemu
       run: brew uninstall --ignore-dependencies --force qemu
     - name: Test
-      env:
-        LIMACTL_CREATE_ARGS: "--vm-type vz --mount-type virtiofs --rosetta --network vzNAT"
       run: ./hack/test-templates.sh templates/${{ matrix.template }}
     - if: failure()
       uses: ./.github/actions/upload_failure_logs_if_exists

--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -196,7 +196,7 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool) ([]string, error) {
 				return fmt.Sprintf(".rosetta.enabled = %v | .rosetta.binfmt = %v", b, b), nil
 			},
 			false,
-			true,
+			false,
 		},
 		{"set", d("%s"), false, false},
 		{

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -8,7 +8,7 @@
 # VM type: "qemu", "vz" (on macOS 13 and later), or "default".
 # The vmType can be specified only on creating the instance.
 # The vmType of existing instances cannot be changed.
-# 🟢 Builtin default: "qemu"
+# 🟢 Builtin default: "vz" (on macOS 13.5 and later), "qemu" (on others)
 vmType: null
 
 # OS: "Linux".

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -281,7 +281,7 @@ rosetta:
 timezone: null
 
 firmware:
-  # Use legacy BIOS instead of UEFI. Ignored for aarch64.
+  # Use legacy BIOS instead of UEFI. Ignored for aarch64 and vz.
   # 🟢 Builtin default: false
   legacyBIOS: null
 #  # Override UEFI images

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -99,7 +99,7 @@ mounts:
   writable: true
 
 # Mount type for above mounts, such as "reverse-sshfs" (from sshocker), "9p" (EXPERIMENTAL, from QEMU’s virtio-9p-pci, aka virtfs),
-# or "virtiofs" (EXPERIMENTAL, needs `vmType: vz`)
+# or "virtiofs" (EXPERIMENTAL, needs `vmType: vz`; will graduate from experimental in Lima v1.0)
 # 🟢 Builtin default: "reverse-sshfs" (for QEMU), "virtiofs" (for vz)
 mountType: null
 
@@ -267,7 +267,7 @@ cpuType:
   # x86_64: "qemu64" # (or "host,-pdpe1gb" when running on x86_64 host)
 
 rosetta:
-  # Enable Rosetta for Linux (EXPERIMENTAL).
+  # Enable Rosetta for Linux (EXPERIMENTAL; will graduate from experimental in Lima v1.0).
   # Hint: try `softwareupdate --install-rosetta` if Lima gets stuck at `Installing rosetta...`
   # 🟢 Builtin default: false
   enabled: null
@@ -343,7 +343,7 @@ networks:
 
 
 # The "vzNAT" IP address is accessible from the host, but not from other guests.
-# Needs `vmType: vz` (EXPERIMENTAL).
+# Needs `vmType: vz` (EXPERIMENTAL; will graduate from experimental in Lima v1.0).
 # - vzNAT: true
 
 # Port forwarding rules. Forwarding between ports 22 and ssh.localPort cannot be overridden.

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -5,7 +5,7 @@
 # Default values in this YAML file are specified by `null` instead of Lima's "builtin default" values,
 # so they can be overridden by the $LIMA_HOME/_config/default.yaml mechanism documented at the end of this file.
 
-# VM type: "qemu" or "vz" (on macOS 13 and later).
+# VM type: "qemu", "vz" (on macOS 13 and later), or "default".
 # The vmType can be specified only on creating the instance.
 # The vmType of existing instances cannot be changed.
 # 🟢 Builtin default: "qemu"

--- a/examples/experimental/vz.yaml
+++ b/examples/experimental/vz.yaml
@@ -1,3 +1,11 @@
+# ⚠️ ⚠️ ⚠️ `template://experimental/vz` will be removed in Lima v1.0,
+# as vz will graduate from experimental and will be the default vmType.
+#
+# For Lima v1.0 and later, use the following command instead:
+# ```
+# limactl create template://default
+# ```
+
 # A template to run ubuntu using vmType: vz instead of qemu (Default)
 # This template requires Lima v0.14.0 or later and macOS 13.
 vmType: "vz"

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -447,9 +447,6 @@ func warnExperimental(y *LimaYAML) {
 	if *y.MountType == VIRTIOFS && runtime.GOOS == "linux" {
 		logrus.Warn("`mountType: virtiofs` on Linux is experimental")
 	}
-	if *y.VMType == VZ {
-		logrus.Warn("`vmType: vz` is experimental")
-	}
 	if *y.Arch == RISCV64 {
 		logrus.Warn("`arch: riscv64` is experimental")
 	}

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -80,7 +80,7 @@ func (l *LimaVzDriver) Validate() error {
 		return fmt.Errorf("field `mountType` must be %q or %q for VZ driver , got %q", limayaml.REVSSHFS, limayaml.VIRTIOFS, *l.Yaml.MountType)
 	}
 	if *l.Yaml.Firmware.LegacyBIOS {
-		return fmt.Errorf("`firmware.legacyBIOS` configuration is not supported for VZ driver")
+		logrus.Warnf("vmType %s: ignoring `firmware.legacyBIOS`", *l.Yaml.VMType)
 	}
 	for _, f := range l.Yaml.Firmware.Images {
 		switch f.VMType {

--- a/website/content/en/docs/config/multi-arch/_index.md
+++ b/website/content/en/docs/config/multi-arch/_index.md
@@ -63,7 +63,7 @@ See also https://github.com/containerd/nerdctl/blob/master/docs/multi-platform.m
 ## [Fast mode 2 (Rosetta): Intel containers on ARM VM on ARM Host](#fast-mode-2)
 
 > **Warning**
-> "vz" mode, including support for Rosetta, is experimental
+> "vz" mode, including support for Rosetta, is experimental (will graduate from experimental in Lima v1.0)
 
 | ⚡ Requirement | Lima >= 0.14, macOS >= 13.0, ARM |
 |-------------------|----------------------------------|

--- a/website/content/en/docs/config/network/_index.md
+++ b/website/content/en/docs/config/network/_index.md
@@ -180,7 +180,7 @@ networks:
 ### vzNAT
 
 > **Warning**
-> "vz" mode is experimental
+> "vz" mode is experimental (will graduate from experimental in Lima v1.0)
 
 | ⚡ Requirement | Lima >= 0.14, macOS >= 13.0 |
 |-------------------|-----------------------------|

--- a/website/content/en/docs/config/vmtype/_index.md
+++ b/website/content/en/docs/config/vmtype/_index.md
@@ -22,9 +22,12 @@ flowchart
   intel_on_arm --  "No" --> vz["VZ"]
 ```
 
+The default vmType is QEMU in Lima prior to v1.0.
+Starting with Lima v1.0, Lima will use VZ by default on macOS (>= 13.5) for new instances,
+unless the config is incompatible with VZ. (e.g., legacyBIOS or 9p is enabled)
+
 ## QEMU
 "qemu" option makes use of QEMU to run guest operating system. 
-This option is used by default if "vmType" is not set.
 
 ## VZ
 > **Warning**

--- a/website/content/en/docs/config/vmtype/_index.md
+++ b/website/content/en/docs/config/vmtype/_index.md
@@ -28,7 +28,7 @@ This option is used by default if "vmType" is not set.
 
 ## VZ
 > **Warning**
-> "vz" mode is experimental
+> "vz" mode is experimental (will graduate from experimental in Lima v1.0)
 
 | ⚡ Requirement | Lima >= 0.14, macOS >= 13.0 |
 |-------------------|-----------------------------|

--- a/website/content/en/docs/releases/experimental/_index.md
+++ b/website/content/en/docs/releases/experimental/_index.md
@@ -9,6 +9,7 @@ The following features are experimental and subject to change:
 - `mountType: 9p`
 - `mountType: virtiofs` on Linux
 - `vmType: vz` and relevant configurations (`mountType: virtiofs`, `rosetta`, `[]networks.vzNAT`)
+  (will graduate from experimental in Lima v1.0)
 - `vmType: wsl2` and relevant configurations (`mountType: wsl2`)
 - `arch: riscv64`
 - `video.display: vnc` and relevant configuration (`video.vnc.display`)


### PR DESCRIPTION
VZ is now the default type for new instances >= 13.5, unless the config is incompatible with vz (e.g., `firmware.legacyBIOS=true`, `mountType=9p`).
    
Existing instances will continue to use QEMU by default, unless `vz-identifier` is present in the instance directory.
    
Run `limactl start` with `--debug` to see how the vmType is resolved.