### PR TITLE
CI: upgrade test: bump up the old Lima (v0.10.0→v0.15.1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -372,7 +372,7 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
-        oldver: ["v0.10.0"]
+        oldver: ["v0.15.1"]
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
v0.10.0 (Apr 25, 2022) is too old to test upgradability. Bump up to v0.15.1 (Apr 16, 2023).

- https://github.com/lima-vm/lima/releases/tag/v0.10.0
- https://github.com/lima-vm/lima/releases/tag/v0.15.1