### PR TITLE
docs: replace deprecated `useHostResolver` with new `hostResolver.enabled`

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -428,7 +428,7 @@ hostResolver:
     # guest.name: 127.1.1.1
     # host.name: host.lima.internal
 
-# If useHostResolver is false, then the following rules apply for configuring dns:
+# If hostResolver.enabled is false, then the following rules apply for configuring dns:
 # Explicitly set DNS addresses for qemu user-mode networking. By default qemu picks *one*
 # nameserver from the host config and forwards all queries to this server. On macOS
 # Lima adds the nameservers configured for the first host interface in service order,

--- a/website/content/en/docs/Config/Network/_index.md
+++ b/website/content/en/docs/Config/Network/_index.md
@@ -35,7 +35,7 @@ The loopback addresses of the host is `192.168.5.2` and is accessible from the g
 
 The DNS.
 
-If `useHostResolver` in `lima.yaml` is true, then the hostagent is going to run a DNS server over tcp and udp - each on a separate randomly selected free port. This server does a local lookup using the native host resolver, so it will deal correctly with VPN configurations and split-DNS setups, as well as mDNS, local `/etc/hosts` etc. For this the hostagent has to be compiled with `CGO_ENABLED=1` as default Go resolver is [broken](https://github.com/golang/go/issues/12524).
+If `hostResolver.enabled` in `lima.yaml` is true, then the hostagent is going to run a DNS server over tcp and udp - each on a separate randomly selected free port. This server does a local lookup using the native host resolver, so it will deal correctly with VPN configurations and split-DNS setups, as well as mDNS, local `/etc/hosts` etc. For this the hostagent has to be compiled with `CGO_ENABLED=1` as default Go resolver is [broken](https://github.com/golang/go/issues/12524).
 
 These tcp and udp ports are then forwarded via iptables rules to `192.168.5.3:53`, overriding the DNS provided by QEMU via slirp.
 
@@ -55,7 +55,7 @@ DNS over tcp is rarely used. It is usually only used either when user explicitly
 
 During initial cloud-init bootstrap, `iptables` may not yet be installed. In that case the repo server is determined using the slirp DNS. After `iptables` has been installed, the forwarding rule is applied, switching over to the hostagent DNS.
 
-If `useHostResolver` is false, then DNS servers can be configured manually in `lima.yaml` via the `dns` setting. If that list is empty, then Lima will either use the slirp DNS (on Linux), or the nameservers from the first host interface in service order that has an assigned IPv4 address (on macOS).
+If `hostResolver.enabled` is false, then DNS servers can be configured manually in `lima.yaml` via the `dns` setting. If that list is empty, then Lima will either use the slirp DNS (on Linux), or the nameservers from the first host interface in service order that has an assigned IPv4 address (on macOS).
 
 ## VMNet networks
 


### PR DESCRIPTION
Update the doc according to: https://github.com/lima-vm/lima/blob/73200003a79cfe829caa2ee9cce7c68c99e33bcb/pkg/limayaml/limayaml.go#L37