### PR TITLE
Enable gofumpt, whitespace linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,7 @@ linters:
   # - godot
   # - godox
   # - goerr113
-  # - gofumpt
+  - gofumpt
   # - goheader
   # - golint
   # - gomnd
@@ -77,7 +77,7 @@ linters:
   # - unconvert
   # - unparam
   - unused
-  # - whitespace
+  - whitespace
   # - wrapcheck
   # - wsl
 linters-settings:

--- a/cmd/lima-guestagent/daemon_linux.go
+++ b/cmd/lima-guestagent/daemon_linux.go
@@ -80,7 +80,7 @@ func daemonAction(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return err
 		}
-		if err := os.Chmod(socket, 0777); err != nil {
+		if err := os.Chmod(socket, 0o777); err != nil {
 			return err
 		}
 		l = socketL

--- a/cmd/lima-guestagent/install_systemd_linux.go
+++ b/cmd/lima-guestagent/install_systemd_linux.go
@@ -15,7 +15,7 @@ import (
 )
 
 func newInstallSystemdCommand() *cobra.Command {
-	var installSystemdCommand = &cobra.Command{
+	installSystemdCommand := &cobra.Command{
 		Use:   "install-systemd",
 		Short: "install a systemd unit (user)",
 		RunE:  installSystemdAction,
@@ -38,11 +38,11 @@ func installSystemdAction(cmd *cobra.Command, _ []string) error {
 		logrus.Infof("File %q already exists, overwriting", unitPath)
 	} else {
 		unitDir := filepath.Dir(unitPath)
-		if err := os.MkdirAll(unitDir, 0755); err != nil {
+		if err := os.MkdirAll(unitDir, 0o755); err != nil {
 			return err
 		}
 	}
-	if err := os.WriteFile(unitPath, unit, 0644); err != nil {
+	if err := os.WriteFile(unitPath, unit, 0o644); err != nil {
 		return err
 	}
 	logrus.Infof("Written file %q", unitPath)

--- a/cmd/lima-guestagent/main_linux.go
+++ b/cmd/lima-guestagent/main_linux.go
@@ -15,7 +15,7 @@ func main() {
 }
 
 func newApp() *cobra.Command {
-	var rootCmd = &cobra.Command{
+	rootCmd := &cobra.Command{
 		Use:     "lima-guestagent",
 		Short:   "Do not launch manually",
 		Version: strings.TrimPrefix(version.Version, "v"),

--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -23,7 +23,7 @@ Example: limactl copy default:/etc/os-release .
 `
 
 func newCopyCommand() *cobra.Command {
-	var copyCommand = &cobra.Command{
+	copyCommand := &cobra.Command{
 		Use:     "copy SOURCE ... TARGET",
 		Aliases: []string{"cp"},
 		Short:   "Copy files between host and guest",

--- a/cmd/limactl/debug.go
+++ b/cmd/limactl/debug.go
@@ -21,7 +21,7 @@ func newDebugCommand() *cobra.Command {
 }
 
 func newDebugDNSCommand() *cobra.Command {
-	var cmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "dns UDPPORT [TCPPORT]",
 		Short: "Debug built-in DNS",
 		Long:  "DO NOT USE! THE COMMAND SYNTAX IS SUBJECT TO CHANGE!",

--- a/cmd/limactl/delete.go
+++ b/cmd/limactl/delete.go
@@ -14,7 +14,7 @@ import (
 )
 
 func newDeleteCommand() *cobra.Command {
-	var deleteCommand = &cobra.Command{
+	deleteCommand := &cobra.Command{
 		Use:               "delete INSTANCE [INSTANCE, ...]",
 		Aliases:           []string{"remove", "rm"},
 		Short:             "Delete an instance of Lima.",

--- a/cmd/limactl/disk.go
+++ b/cmd/limactl/disk.go
@@ -16,7 +16,7 @@ import (
 )
 
 func newDiskCommand() *cobra.Command {
-	var diskCommand = &cobra.Command{
+	diskCommand := &cobra.Command{
 		Use:   "disk",
 		Short: "Lima disk management",
 		Example: `  Create a disk:
@@ -40,7 +40,7 @@ func newDiskCommand() *cobra.Command {
 }
 
 func newDiskCreateCommand() *cobra.Command {
-	var diskCreateCommand = &cobra.Command{
+	diskCreateCommand := &cobra.Command{
 		Use: "create DISK",
 		Example: `
 To create a new disk:
@@ -92,7 +92,7 @@ func diskCreateAction(cmd *cobra.Command, args []string) error {
 
 	logrus.Infof("Creating %s disk %q with size %s", format, name, units.BytesSize(float64(diskSize)))
 
-	if err := os.MkdirAll(diskDir, 0700); err != nil {
+	if err := os.MkdirAll(diskDir, 0o700); err != nil {
 		return err
 	}
 
@@ -104,7 +104,7 @@ func diskCreateAction(cmd *cobra.Command, args []string) error {
 }
 
 func newDiskListCommand() *cobra.Command {
-	var diskListCommand = &cobra.Command{
+	diskListCommand := &cobra.Command{
 		Use: "list",
 		Example: `
 To list existing disks:
@@ -190,7 +190,7 @@ func diskListAction(cmd *cobra.Command, args []string) error {
 }
 
 func newDiskDeleteCommand() *cobra.Command {
-	var diskDeleteCommand = &cobra.Command{
+	diskDeleteCommand := &cobra.Command{
 		Use: "delete DISK [DISK, ...]",
 		Example: `
 To delete a disk:
@@ -279,7 +279,7 @@ func forceDeleteCommand(diskName string) string {
 }
 
 func newDiskUnlockCommand() *cobra.Command {
-	var diskUnlockCommand = &cobra.Command{
+	diskUnlockCommand := &cobra.Command{
 		Use: "unlock DISK [DISK, ...]",
 		Example: `
 Emergency recovery! If an instance is force stopped, it may leave a disk locked while not actually using it.

--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -21,7 +21,7 @@ import (
 )
 
 func newEditCommand() *cobra.Command {
-	var editCommand = &cobra.Command{
+	editCommand := &cobra.Command{
 		Use:               "edit INSTANCE",
 		Short:             "Edit an instance of Lima",
 		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
@@ -95,13 +95,13 @@ func editAction(cmd *cobra.Command, args []string) error {
 	}
 	if err := limayaml.Validate(*y, true); err != nil {
 		rejectedYAML := "lima.REJECTED.yaml"
-		if writeErr := os.WriteFile(rejectedYAML, yBytes, 0644); writeErr != nil {
+		if writeErr := os.WriteFile(rejectedYAML, yBytes, 0o644); writeErr != nil {
 			return fmt.Errorf("the YAML is invalid, attempted to save the buffer as %q but failed: %v: %w", rejectedYAML, writeErr, err)
 		}
 		// TODO: may need to support editing the rejected YAML
 		return fmt.Errorf("the YAML is invalid, saved the buffer as %q: %w", rejectedYAML, err)
 	}
-	if err := os.WriteFile(filePath, yBytes, 0644); err != nil {
+	if err := os.WriteFile(filePath, yBytes, 0o644); err != nil {
 		return err
 	}
 	logrus.Infof("Instance %q configuration edited", instName)

--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -109,7 +109,8 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool) ([]string, error) {
 	d := defaultExprFunc
 	defs := []def{
 		{"cpus", d(".cpus = %s"), false, false},
-		{"dns",
+		{
+			"dns",
 			func(_ *flag.Flag) (string, error) {
 				ipSlice, err := flags.GetIPSlice("dns")
 				if err != nil {
@@ -127,9 +128,11 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool) ([]string, error) {
 				return expr, nil
 			},
 			false,
-			false},
+			false,
+		},
 		{"memory", d(".memory = \"%sGiB\""), false, false},
-		{"mount",
+		{
+			"mount",
 			func(_ *flag.Flag) (string, error) {
 				ss, err := flags.GetStringSlice("mount")
 				if err != nil {
@@ -148,10 +151,12 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool) ([]string, error) {
 				return expr, nil
 			},
 			false,
-			false},
+			false,
+		},
 		{"mount-type", d(".mountType = %q"), false, false},
 		{"mount-writable", d(".mounts[].writable = %s"), false, false},
-		{"network",
+		{
+			"network",
 			func(_ *flag.Flag) (string, error) {
 				ss, err := flags.GetStringSlice("network")
 				if err != nil {
@@ -177,8 +182,10 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool) ([]string, error) {
 				return expr, nil
 			},
 			false,
-			false},
-		{"rosetta",
+			false,
+		},
+		{
+			"rosetta",
 			func(_ *flag.Flag) (string, error) {
 				b, err := flags.GetBool("rosetta")
 				if err != nil {
@@ -187,9 +194,11 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool) ([]string, error) {
 				return fmt.Sprintf(".rosetta.enabled = %v | .rosetta.binfmt = %v", b, b), nil
 			},
 			false,
-			true},
+			true,
+		},
 		{"set", d("%s"), false, false},
-		{"video",
+		{
+			"video",
 			func(_ *flag.Flag) (string, error) {
 				b, err := flags.GetBool("video")
 				if err != nil {
@@ -201,9 +210,11 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool) ([]string, error) {
 				return ".video.display = \"none\"", nil
 			},
 			false,
-			false},
+			false,
+		},
 		{"arch", d(".arch = %q"), true, false},
-		{"containerd",
+		{
+			"containerd",
 			func(_ *flag.Flag) (string, error) {
 				s, err := flags.GetString("containerd")
 				if err != nil {
@@ -223,8 +234,8 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool) ([]string, error) {
 				}
 			},
 			true,
-			false},
-
+			false,
+		},
 		{"disk", d(".disk= \"%sGiB\""), true, false},
 		{"vm-type", d(".vmType = %q"), true, false},
 		{"plain", d(".plain = %s"), true, false},

--- a/cmd/limactl/factory-reset.go
+++ b/cmd/limactl/factory-reset.go
@@ -12,7 +12,7 @@ import (
 )
 
 func newFactoryResetCommand() *cobra.Command {
-	var resetCommand = &cobra.Command{
+	resetCommand := &cobra.Command{
 		Use:               "factory-reset INSTANCE",
 		Short:             "Factory reset an instance of Lima",
 		Args:              WrapArgsError(cobra.MaximumNArgs(1)),

--- a/cmd/limactl/gendoc.go
+++ b/cmd/limactl/gendoc.go
@@ -86,7 +86,7 @@ and $LIMA_WORKDIR.
 **limactl**(1)
 `
 	out := md2man.Render([]byte(md))
-	if err := os.WriteFile(filePath, out, 0644); err != nil {
+	if err := os.WriteFile(filePath, out, 0o644); err != nil {
 		return err
 	}
 	// limactl(1)
@@ -99,7 +99,7 @@ and $LIMA_WORKDIR.
 
 func genDocsy(cmd *cobra.Command, dir string) error {
 	return doc.GenMarkdownTreeCustom(cmd.Root(), dir, func(s string) string {
-		//Replace limactl_completion_bash to completion bash for docsy title
+		// Replace limactl_completion_bash to completion bash for docsy title
 		name := filepath.Base(s)
 		name = strings.ReplaceAll(name, "limactl_", "")
 		name = strings.ReplaceAll(name, "_", " ")
@@ -110,7 +110,7 @@ weight: 3
 ---
 `, name)
 	}, func(s string) string {
-		//Use ../ for move one folder up for docsy
+		// Use ../ for move one folder up for docsy
 		return "../" + strings.TrimSuffix(s, filepath.Ext(s))
 	})
 }
@@ -133,7 +133,7 @@ func replaceAll(dir string, old, new string) error {
 			return err
 		}
 		out := bytes.Replace(in, []byte(old), []byte(new), -1)
-		err = os.WriteFile(path, out, 0644)
+		err = os.WriteFile(path, out, 0o644)
 		if err != nil {
 			return err
 		}

--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -19,7 +19,7 @@ import (
 )
 
 func newHostagentCommand() *cobra.Command {
-	var hostagentCommand = &cobra.Command{
+	hostagentCommand := &cobra.Command{
 		Use:    "hostagent INSTANCE",
 		Short:  "run hostagent",
 		Args:   WrapArgsError(cobra.ExactArgs(1)),
@@ -42,7 +42,7 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 		if _, err := os.Stat(pidfile); !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("pidfile %q already exists", pidfile)
 		}
-		if err := os.WriteFile(pidfile, []byte(strconv.Itoa(os.Getpid())+"\n"), 0644); err != nil {
+		if err := os.WriteFile(pidfile, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
 			return err
 		}
 		defer os.RemoveAll(pidfile)
@@ -62,7 +62,7 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if runGUI {
-		//Without this the call to vz.RunGUI fails. Adding it here, as this has to be called before the vz cgo loads.
+		// Without this the call to vz.RunGUI fails. Adding it here, as this has to be called before the vz cgo loads.
 		runtime.LockOSThread()
 		defer runtime.UnlockOSThread()
 	}

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -35,7 +35,7 @@ func newApp() *cobra.Command {
 		templatesDir = filepath.Join(prefixDir, "share/lima/templates")
 	}
 
-	var rootCmd = &cobra.Command{
+	rootCmd := &cobra.Command{
 		Use:     "limactl",
 		Short:   "Lima: Linux virtual machines",
 		Version: strings.TrimPrefix(version.Version, "v"),

--- a/cmd/limactl/protect.go
+++ b/cmd/limactl/protect.go
@@ -10,7 +10,7 @@ import (
 )
 
 func newProtectCommand() *cobra.Command {
-	var protectCommand = &cobra.Command{
+	protectCommand := &cobra.Command{
 		Use:   "protect INSTANCE [INSTANCE, ...]",
 		Short: "Protect an instance to prohibit accidental removal",
 		Long: `Protect an instance to prohibit accidental removal via the 'limactl delete' command.

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -32,7 +32,7 @@ Hint: try --debug to show the detailed logs, if it seems hanging (mostly due to 
 `
 
 func newShellCommand() *cobra.Command {
-	var shellCmd = &cobra.Command{
+	shellCmd := &cobra.Command{
 		Use:               "shell [flags] INSTANCE [COMMAND...]",
 		Short:             "Execute shell in Lima",
 		Long:              shellHelp,

--- a/cmd/limactl/show_ssh.go
+++ b/cmd/limactl/show_ssh.go
@@ -49,7 +49,7 @@ func newShowSSHCommand() *cobra.Command {
 	if s, err := dirnames.LimaDir(); err == nil {
 		limaHome = s
 	}
-	var shellCmd = &cobra.Command{
+	shellCmd := &cobra.Command{
 		Use:   "show-ssh [flags] INSTANCE",
 		Short: "Show the ssh command line (DEPRECATED; use `ssh -F` instead)",
 		Long: fmt.Sprintf(`Show the ssh command line (DEPRECATED)

--- a/cmd/limactl/snapshot.go
+++ b/cmd/limactl/snapshot.go
@@ -12,7 +12,7 @@ import (
 )
 
 func newSnapshotCommand() *cobra.Command {
-	var snapshotCmd = &cobra.Command{
+	snapshotCmd := &cobra.Command{
 		Use:   "snapshot",
 		Short: "Manage instance snapshots",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -28,7 +28,7 @@ func newSnapshotCommand() *cobra.Command {
 }
 
 func newSnapshotCreateCommand() *cobra.Command {
-	var createCmd = &cobra.Command{
+	createCmd := &cobra.Command{
 		Use:               "create INSTANCE",
 		Aliases:           []string{"save"},
 		Short:             "Create (save) a snapshot",
@@ -63,7 +63,7 @@ func snapshotCreateAction(cmd *cobra.Command, args []string) error {
 }
 
 func newSnapshotDeleteCommand() *cobra.Command {
-	var deleteCmd = &cobra.Command{
+	deleteCmd := &cobra.Command{
 		Use:               "delete INSTANCE",
 		Aliases:           []string{"del"},
 		Short:             "Delete (del) a snapshot",
@@ -98,7 +98,7 @@ func snapshotDeleteAction(cmd *cobra.Command, args []string) error {
 }
 
 func newSnapshotApplyCommand() *cobra.Command {
-	var applyCmd = &cobra.Command{
+	applyCmd := &cobra.Command{
 		Use:               "apply INSTANCE",
 		Aliases:           []string{"load"},
 		Short:             "Apply (load) a snapshot",
@@ -133,7 +133,7 @@ func snapshotApplyAction(cmd *cobra.Command, args []string) error {
 }
 
 func newSnapshotListCommand() *cobra.Command {
-	var listCmd = &cobra.Command{
+	listCmd := &cobra.Command{
 		Use:               "list INSTANCE",
 		Aliases:           []string{"ls"},
 		Short:             "List existing snapshots",

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -37,7 +37,7 @@ func registerCreateFlags(cmd *cobra.Command, commentPrefix string) {
 }
 
 func newCreateCommand() *cobra.Command {
-	var createCommand = &cobra.Command{
+	createCommand := &cobra.Command{
 		Use: "create FILE.yaml|URL",
 		Example: `
 To create an instance "default" from the default Ubuntu template:
@@ -74,7 +74,7 @@ $ cat template.yaml | limactl create --name=local -
 }
 
 func newStartCommand() *cobra.Command {
-	var startCommand = &cobra.Command{
+	startCommand := &cobra.Command{
 		Use: "start NAME|FILE.yaml|URL",
 		Example: `
 To create an instance "default" (if not created yet) from the default Ubuntu template, and start it:
@@ -282,7 +282,7 @@ func applyYQExpressionToExistingInstance(inst *store.Instance, yq string) (*stor
 	if err != nil {
 		return nil, err
 	}
-	if err := os.WriteFile(filePath, yBytes, 0644); err != nil {
+	if err := os.WriteFile(filePath, yBytes, 0o644); err != nil {
 		return nil, err
 	}
 	// Reload
@@ -322,15 +322,15 @@ func createInstance(ctx context.Context, st *creatorState, saveBrokenEditorBuffe
 			return nil, err
 		}
 		rejectedYAML := "lima.REJECTED.yaml"
-		if writeErr := os.WriteFile(rejectedYAML, st.yBytes, 0644); writeErr != nil {
+		if writeErr := os.WriteFile(rejectedYAML, st.yBytes, 0o644); writeErr != nil {
 			return nil, fmt.Errorf("the YAML is invalid, attempted to save the buffer as %q but failed: %v: %w", rejectedYAML, writeErr, err)
 		}
 		return nil, fmt.Errorf("the YAML is invalid, saved the buffer as %q: %w", rejectedYAML, err)
 	}
-	if err := os.MkdirAll(instDir, 0700); err != nil {
+	if err := os.MkdirAll(instDir, 0o700); err != nil {
 		return nil, err
 	}
-	if err := os.WriteFile(filePath, st.yBytes, 0644); err != nil {
+	if err := os.WriteFile(filePath, st.yBytes, 0o644); err != nil {
 		return nil, err
 	}
 

--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -19,7 +19,7 @@ import (
 )
 
 func newStopCommand() *cobra.Command {
-	var stopCmd = &cobra.Command{
+	stopCmd := &cobra.Command{
 		Use:               "stop INSTANCE",
 		Short:             "Stop an instance",
 		Args:              WrapArgsError(cobra.MaximumNArgs(1)),

--- a/cmd/limactl/unprotect.go
+++ b/cmd/limactl/unprotect.go
@@ -10,7 +10,7 @@ import (
 )
 
 func newUnprotectCommand() *cobra.Command {
-	var unprotectCommand = &cobra.Command{
+	unprotectCommand := &cobra.Command{
 		Use:               "unprotect INSTANCE [INSTANCE, ...]",
 		Short:             "Unprotect an instance",
 		Args:              WrapArgsError(cobra.MinimumNArgs(1)),

--- a/cmd/limactl/usernet.go
+++ b/cmd/limactl/usernet.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newUsernetCommand() *cobra.Command {
-	var hostagentCommand = &cobra.Command{
+	hostagentCommand := &cobra.Command{
 		Use:    "usernet",
 		Short:  "run usernet",
 		Args:   cobra.ExactArgs(0),
@@ -37,7 +37,7 @@ func usernetAction(cmd *cobra.Command, _ []string) error {
 		if _, err := os.Stat(pidfile); !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("pidfile %q already exists", pidfile)
 		}
-		if err := os.WriteFile(pidfile, []byte(strconv.Itoa(os.Getpid())+"\n"), 0644); err != nil {
+		if err := os.WriteFile(pidfile, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
 			return err
 		}
 		defer os.RemoveAll(pidfile)

--- a/cmd/limactl/validate.go
+++ b/cmd/limactl/validate.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newValidateCommand() *cobra.Command {
-	var validateCommand = &cobra.Command{
+	validateCommand := &cobra.Command{
 		Use:   "validate FILE.yaml [FILE.yaml, ...]",
 		Short: "Validate YAML files",
 		Args:  WrapArgsError(cobra.MinimumNArgs(1)),

--- a/pkg/bicopy/bicopy.go
+++ b/pkg/bicopy/bicopy.go
@@ -36,7 +36,7 @@ func Bicopy(x, y io.ReadWriter, quit <-chan struct{}) {
 		CloseWrite() error
 	}
 	var wg sync.WaitGroup
-	var broker = func(to, from io.ReadWriter) {
+	broker := func(to, from io.ReadWriter) {
 		if _, err := io.Copy(to, from); err != nil {
 			logrus.WithError(err).Debug("failed to call io.Copy")
 		}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -428,11 +428,11 @@ func writeCIDataDir(rootPath string, layout []iso9660util.Entry) error {
 
 	for _, e := range layout {
 		if dir := path.Dir(e.Path); dir != "" && dir != "/" {
-			if err := os.MkdirAll(filepath.Join(rootPath, dir), 0700); err != nil {
+			if err := os.MkdirAll(filepath.Join(rootPath, dir), 0o700); err != nil {
 				return err
 			}
 		}
-		f, err := os.OpenFile(filepath.Join(rootPath, e.Path), os.O_CREATE|os.O_RDWR, 0700)
+		f, err := os.OpenFile(filepath.Join(rootPath, e.Path), os.O_CREATE|os.O_RDWR, 0o700)
 		if err != nil {
 			return err
 		}

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -155,7 +155,7 @@ func Download(local, remote string, opts ...Opt) (*Result, error) {
 		}
 
 		localPathDir := filepath.Dir(localPath)
-		if err := os.MkdirAll(localPathDir, 0755); err != nil {
+		if err := os.MkdirAll(localPathDir, 0o755); err != nil {
 			return nil, err
 		}
 	}
@@ -215,11 +215,11 @@ func Download(local, remote string, opts ...Opt) (*Result, error) {
 	if err := os.RemoveAll(shad); err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(shad, 0700); err != nil {
+	if err := os.MkdirAll(shad, 0o700); err != nil {
 		return nil, err
 	}
 	shadURL := filepath.Join(shad, "url")
-	if err := os.WriteFile(shadURL, []byte(remote), 0644); err != nil {
+	if err := os.WriteFile(shadURL, []byte(remote), 0o644); err != nil {
 		return nil, err
 	}
 	if err := downloadHTTP(shadData, remote, o.description, o.expectedDigest); err != nil {
@@ -230,7 +230,7 @@ func Download(local, remote string, opts ...Opt) (*Result, error) {
 		return nil, err
 	}
 	if shadDigest != "" && o.expectedDigest != "" {
-		if err := os.WriteFile(shadDigest, []byte(o.expectedDigest.String()), 0644); err != nil {
+		if err := os.WriteFile(shadDigest, []byte(o.expectedDigest.String()), 0o644); err != nil {
 			return nil, err
 		}
 	}
@@ -404,7 +404,7 @@ func decompressLocal(dst, src, ext string, description string) error {
 		return err
 	}
 	defer in.Close()
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY, 0644)
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
 	}

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -130,7 +130,7 @@ func TestDownloadLocal(t *testing.T) {
 		localTestFile := filepath.Join(t.TempDir(), "some-file")
 		testDownloadFileContents := []byte("TestDownloadLocal")
 
-		assert.NilError(t, os.WriteFile(localTestFile, testDownloadFileContents, 0644))
+		assert.NilError(t, os.WriteFile(localTestFile, testDownloadFileContents, 0o644))
 		testLocalFileURL := "file://" + localTestFile
 		wrongDigest := digest.Digest(emptyFileDigest)
 
@@ -158,7 +158,6 @@ func TestDownloadLocal(t *testing.T) {
 }
 
 func TestDownloadCompressed(t *testing.T) {
-
 	if runtime.GOOS == "windows" {
 		// FIXME: `assertion failed: error is not nil: exec: "gzip": executable file not found in %PATH%`
 		t.Skip("Skipping on windows")
@@ -168,7 +167,7 @@ func TestDownloadCompressed(t *testing.T) {
 		localPath := filepath.Join(t.TempDir(), t.Name())
 		localFile := filepath.Join(t.TempDir(), "test-file")
 		testDownloadCompressedContents := []byte("TestDownloadCompressed")
-		assert.NilError(t, os.WriteFile(localFile, testDownloadCompressedContents, 0644))
+		assert.NilError(t, os.WriteFile(localFile, testDownloadCompressedContents, 0o644))
 		assert.NilError(t, exec.Command("gzip", localFile).Run())
 		localFile += ".gz"
 		testLocalFileURL := "file://" + localFile

--- a/pkg/editutil/editorcmd/editorcmd.go
+++ b/pkg/editutil/editorcmd/editorcmd.go
@@ -25,7 +25,7 @@ import (
 // Detect detects a text editor command.
 // Returns an empty string when no editor is found.
 func Detect() string {
-	var candidates = []string{
+	candidates := []string{
 		os.Getenv("VISUAL"),
 		os.Getenv("EDITOR"),
 		"editor",

--- a/pkg/guestagent/api/api.go
+++ b/pkg/guestagent/api/api.go
@@ -6,9 +6,7 @@ import (
 	"time"
 )
 
-var (
-	IPv4loopback1 = net.IPv4(127, 0, 0, 1)
-)
+var IPv4loopback1 = net.IPv4(127, 0, 0, 1)
 
 type IPPort struct {
 	IP   net.IP `json:"ip"`

--- a/pkg/guestagent/iptables/iptables_test.go
+++ b/pkg/guestagent/iptables/iptables_test.go
@@ -67,7 +67,6 @@ const data = `# Warning: iptables-legacy tables present, use iptables-legacy to 
 `
 
 func TestParsePortsFromRules(t *testing.T) {
-
 	// Turn the string into individual lines
 	rules := strings.Split(data, "\n")
 	if len(rules) > 0 && rules[len(rules)-1] == "" {

--- a/pkg/hostagent/dns/dns_test.go
+++ b/pkg/hostagent/dns/dns_test.go
@@ -15,12 +15,9 @@ import (
 	"gotest.tools/v3/assert/cmp"
 )
 
-var (
-	dnsResult *dns.Msg
-)
+var dnsResult *dns.Msg
 
 func TestDNSRecords(t *testing.T) {
-
 	srv, _ := mockdns.NewServerWithLogger(map[string]mockdns.Zone{
 		"onerecord.com.": {
 			TXT: []string{"My txt record"},
@@ -120,8 +117,7 @@ func TestDNSRecords(t *testing.T) {
 	})
 }
 
-type TestResponseWriter struct {
-}
+type TestResponseWriter struct{}
 
 // LocalAddr returns the net.Addr of the server
 func (r TestResponseWriter) LocalAddr() net.Addr {
@@ -168,6 +164,7 @@ type TestAddr struct{}
 func (r TestAddr) Network() string {
 	return ""
 }
+
 func (r TestAddr) String() string {
 	return ""
 }

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -197,7 +197,7 @@ func writeSSHConfigFile(inst *store.Instance, instSSHAddress string, sshLocalPor
 		return err
 	}
 	fileName := filepath.Join(inst.Dir, filenames.SSHConfig)
-	return os.WriteFile(fileName, b.Bytes(), 0600)
+	return os.WriteFile(fileName, b.Bytes(), 0o600)
 }
 
 func determineSSHLocalPort(y *limayaml.LimaYAML, instName string) (int, error) {
@@ -344,7 +344,7 @@ func (a *HostAgent) Run(ctx context.Context) error {
 		if err := a.driver.ChangeDisplayPassword(ctx, vncpasswd); err != nil {
 			return err
 		}
-		if err := os.WriteFile(vncpwdfile, []byte(vncpasswd), 0600); err != nil {
+		if err := os.WriteFile(vncpwdfile, []byte(vncpasswd), 0o600); err != nil {
 			return err
 		}
 		if strings.Contains(vncoptions, "to=") {
@@ -360,7 +360,7 @@ func (a *HostAgent) Run(ctx context.Context) error {
 			vncdisplay = net.JoinHostPort(vnchost, vncnum)
 		}
 		vncfile := filepath.Join(a.instDir, filenames.VNCDisplayFile)
-		if err := os.WriteFile(vncfile, []byte(vncdisplay), 0600); err != nil {
+		if err := os.WriteFile(vncfile, []byte(vncdisplay), 0o600); err != nil {
 			return err
 		}
 		vncurl := "vnc://" + net.JoinHostPort(vnchost, vncport)
@@ -679,7 +679,7 @@ func forwardSSH(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, 
 					logrus.WithError(err).Warnf("Failed to clean up %q (host) before setting up forwarding", local)
 				}
 			}
-			if err := os.MkdirAll(filepath.Dir(local), 0750); err != nil {
+			if err := os.MkdirAll(filepath.Dir(local), 0o750); err != nil {
 				return fmt.Errorf("can't create directory for local socket %q: %w", local, err)
 			}
 		case verbCancel:
@@ -733,7 +733,7 @@ func copyToHost(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, 
 		remote,
 	)
 	logrus.Infof("Copying config from %s to %s", remote, local)
-	if err := os.MkdirAll(filepath.Dir(local), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(local), 0o700); err != nil {
 		return fmt.Errorf("can't create directory for local file %q: %w", local, err)
 	}
 	cmd := exec.CommandContext(ctx, sshConfig.Binary(), args...)
@@ -741,7 +741,7 @@ func copyToHost(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, 
 	if err != nil {
 		return fmt.Errorf("failed to run %v: %q: %w", cmd.Args, string(out), err)
 	}
-	if err := os.WriteFile(local, out, 0600); err != nil {
+	if err := os.WriteFile(local, out, 0o600); err != nil {
 		return fmt.Errorf("can't write to local file %q: %w", local, err)
 	}
 	return nil

--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -41,7 +41,7 @@ func (a *HostAgent) setupMount(m limayaml.Mount) (*mount, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(location, 0755); err != nil {
+	if err := os.MkdirAll(location, 0o755); err != nil {
 		return nil, err
 	}
 	// NOTE: allow_other requires "user_allow_other" in /etc/fuse.conf

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -119,7 +119,6 @@ fi
 `,
 			debugHint: `Append "user_allow_other" to /etc/fuse.conf (/etc/fuse3.conf) in the guest`,
 		})
-
 	}
 	if a.guestAgentProto == guestagentclient.VSOCK {
 		req = append(req, requirement{

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -41,10 +41,12 @@ type LimaYAML struct {
 	Plain             *bool          `yaml:"plain,omitempty" json:"plain,omitempty"`
 }
 
-type OS = string
-type Arch = string
-type MountType = string
-type VMType = string
+type (
+	OS        = string
+	Arch      = string
+	MountType = string
+	VMType    = string
+)
 
 const (
 	LINUX OS = "Linux"

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -1,6 +1,7 @@
 package limayaml
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -8,8 +9,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-
-	"errors"
 
 	"github.com/docker/go-units"
 	"github.com/lima-vm/lima/pkg/localpathutil"

--- a/pkg/lockutil/lockutil_windows.go
+++ b/pkg/lockutil/lockutil_windows.go
@@ -34,7 +34,7 @@ var (
 )
 
 func WithDirLock(dir string, fn func() error) error {
-	dirFile, err := os.OpenFile(dir+".lock", os.O_CREATE, 0644)
+	dirFile, err := os.OpenFile(dir+".lock", os.O_CREATE, 0o644)
 	if err != nil {
 		return err
 	}

--- a/pkg/nativeimgutil/nativeimgutil.go
+++ b/pkg/nativeimgutil/nativeimgutil.go
@@ -109,7 +109,7 @@ func convertRawToRaw(source, dest string, size *int64) error {
 	}
 	if size != nil {
 		logrus.Infof("Expanding to %s", units.BytesSize(float64(*size)))
-		destF, err := os.OpenFile(dest, os.O_RDWR, 0644)
+		destF, err := os.OpenFile(dest, os.O_RDWR, 0o644)
 		if err != nil {
 			return err
 		}

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -112,7 +112,7 @@ func loadCache() {
 				return
 			}
 			configDir := filepath.Dir(configFile)
-			cache.err = os.MkdirAll(configDir, 0755)
+			cache.err = os.MkdirAll(configDir, 0o755)
 			if cache.err != nil {
 				cache.err = fmt.Errorf("could not create %q directory: %w", configDir, cache.err)
 				return
@@ -122,7 +122,7 @@ func loadCache() {
 			if cache.err != nil {
 				return
 			}
-			cache.err = os.WriteFile(configFile, defaultConfig, 0644)
+			cache.err = os.WriteFile(configFile, defaultConfig, 0o644)
 			if cache.err != nil {
 				return
 			}

--- a/pkg/networks/reconcile/reconcile.go
+++ b/pkg/networks/reconcile/reconcile.go
@@ -100,7 +100,7 @@ func makeVarRun(config *networks.YAML) error {
 	if err != nil {
 		return err
 	}
-	if fi.Mode()&020 == 0 || stat.Gid != daemon.Gid {
+	if fi.Mode()&0o20 == 0 || stat.Gid != daemon.Gid {
 		return fmt.Errorf("%q doesn't seem to be writable by the daemon (gid:%d) group",
 			config.Paths.VarRun, daemon.Gid)
 	}
@@ -115,7 +115,7 @@ func startDaemon(ctx context.Context, config *networks.YAML, name, daemon string
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(networksDir, 0755); err != nil {
+	if err := os.MkdirAll(networksDir, 0o755); err != nil {
 		return err
 	}
 	user, err := config.User(daemon)
@@ -174,7 +174,7 @@ func validateConfig(config *networks.YAML) error {
 func startNetwork(ctx context.Context, config *networks.YAML, name string) error {
 	logrus.Debugf("Make sure %q network is running", name)
 
-	//Handle usernet first without sudo requirements
+	// Handle usernet first without sudo requirements
 	isUsernet, err := config.Usernet(name)
 	if err != nil {
 		return err
@@ -220,7 +220,7 @@ func startNetwork(ctx context.Context, config *networks.YAML, name string) error
 
 func stopNetwork(config *networks.YAML, name string) error {
 	logrus.Debugf("Make sure %q network is stopped", name)
-	//Handle usernet first without sudo requirements
+	// Handle usernet first without sudo requirements
 	isUsernet, err := config.Usernet(name)
 	if err != nil {
 		return err

--- a/pkg/networks/usernet/client.go
+++ b/pkg/networks/usernet/client.go
@@ -35,7 +35,7 @@ func (c *Client) ConfigureDriver(driver *driver.BaseDriver) error {
 	if err != nil {
 		return err
 	}
-	var hosts = driver.Yaml.HostResolver.Hosts
+	hosts := driver.Yaml.HostResolver.Hosts
 	hosts[fmt.Sprintf("lima-%s.internal", driver.Instance.Name)] = ipAddress
 	err = c.AddDNSHosts(hosts)
 	return err

--- a/pkg/networks/usernet/config_test.go
+++ b/pkg/networks/usernet/config_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestUsernetConfig(t *testing.T) {
-
 	t.Run("verify dns ip", func(t *testing.T) {
 		subnet, _, err := net.ParseCIDR(networks.SlirpNetwork)
 		assert.NilError(t, err)

--- a/pkg/networks/usernet/dnshosts/dnshosts_test.go
+++ b/pkg/networks/usernet/dnshosts/dnshosts_test.go
@@ -193,8 +193,10 @@ func Test_extractZones(t *testing.T) {
 	}
 }
 
-var _ sort.Interface = (recordSorter)(nil)
-var _ sort.Interface = (zoneSorter)(nil)
+var (
+	_ sort.Interface = (recordSorter)(nil)
+	_ sort.Interface = (zoneSorter)(nil)
+)
 
 type recordSorter []types.Record
 

--- a/pkg/networks/usernet/gvproxy.go
+++ b/pkg/networks/usernet/gvproxy.go
@@ -33,9 +33,7 @@ type GVisorNetstackOpts struct {
 	DefaultLeases map[string]string
 }
 
-var (
-	opts *GVisorNetstackOpts
-)
+var opts *GVisorNetstackOpts
 
 const gatewayMacAddr = "5a:94:ef:e4:0c:dd"
 
@@ -146,7 +144,6 @@ func listenQEMU(ctx context.Context, vn *virtualnetwork.VirtualNetwork) error {
 				continue
 			}
 		}
-
 	}()
 
 	return nil

--- a/pkg/networks/usernet/recoincile.go
+++ b/pkg/networks/usernet/recoincile.go
@@ -27,9 +27,9 @@ func Start(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
-	//usernet files contents are stored under {LIMA_HOME}/_networks/user-v2/<pid, fdsock, endpointsock, logs>
+	// usernet files contents are stored under {LIMA_HOME}/_networks/user-v2/<pid, fdsock, endpointsock, logs>
 	usernetDir := path.Join(networksDir, name)
-	if err := os.MkdirAll(usernetDir, 0755); err != nil {
+	if err := os.MkdirAll(usernetDir, 0o755); err != nil {
 		return err
 	}
 
@@ -70,11 +70,13 @@ func Start(ctx context.Context, name string) error {
 				return err
 			}
 			leasesString := mapToCliString(leases)
-			args := []string{"usernet", "-p", pidFile,
+			args := []string{
+				"usernet", "-p", pidFile,
 				"-e", endpointSock,
 				"--listen-qemu", qemuSock,
 				"--listen", fdSock,
-				"--subnet", subnet.String()}
+				"--subnet", subnet.String(),
+			}
 			if leasesString != "" {
 				args = append(args, "--leases", leasesString)
 			}

--- a/pkg/networks/validate.go
+++ b/pkg/networks/validate.go
@@ -142,18 +142,18 @@ func validatePath(path string, allowDaemonGroupWritable bool) error {
 		if err != nil {
 			return err
 		}
-		if fi.Mode()&020 != 0 && stat.Gid != root.Gid && stat.Gid != uint32(adminGid) && stat.Gid != daemon.Gid {
+		if fi.Mode()&0o20 != 0 && stat.Gid != root.Gid && stat.Gid != uint32(adminGid) && stat.Gid != daemon.Gid {
 			return fmt.Errorf(`%s %q is group-writable and group %d is not one of [wheel, admin, daemon]`,
 				file, path, stat.Gid)
 		}
-		if fi.Mode().IsDir() && fi.Mode()&1 == 0 && (fi.Mode()&0010 == 0 || stat.Gid != daemon.Gid) {
+		if fi.Mode().IsDir() && fi.Mode()&1 == 0 && (fi.Mode()&0o010 == 0 || stat.Gid != daemon.Gid) {
 			return fmt.Errorf(`%s %q is not executable by the %q (gid: %d)" group`, file, path, daemon.User, daemon.Gid)
 		}
-	} else if fi.Mode()&020 != 0 && stat.Gid != root.Gid && stat.Gid != uint32(adminGid) {
+	} else if fi.Mode()&0o20 != 0 && stat.Gid != root.Gid && stat.Gid != uint32(adminGid) {
 		return fmt.Errorf(`%s %q is group-writable and group %d is not one of [wheel, admin]`,
 			file, path, stat.Gid)
 	}
-	if fi.Mode()&002 != 0 {
+	if fi.Mode()&0o02 != 0 {
 		return fmt.Errorf("%s %q is world-writable", file, path)
 	}
 	if path != "/" {

--- a/pkg/osutil/user.go
+++ b/pkg/osutil/user.go
@@ -27,8 +27,10 @@ type Group struct {
 	Gid  uint32
 }
 
-var users map[string]User
-var groups map[string]Group
+var (
+	users  map[string]User
+	groups map[string]Group
+)
 
 // regexUsername matches user and group names to be valid for `useradd`.
 // `useradd` allows names with a trailing '$', but it feels prudent to map those

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -70,7 +70,7 @@ func EnsureDisk(cfg Config) error {
 					continue
 				}
 				if f.Kernel.Cmdline != "" {
-					if err := os.WriteFile(kernelCmdline, []byte(f.Kernel.Cmdline), 0644); err != nil {
+					if err := os.WriteFile(kernelCmdline, []byte(f.Kernel.Cmdline), 0o644); err != nil {
 						errs[i] = err
 						continue
 					}
@@ -660,7 +660,7 @@ func Cmdline(cfg Config) (string, []string, error) {
 	}
 
 	// Network
-	//Configure default usernetwork with limayaml.MACAddress(driver.Instance.Dir) for eth0 interface
+	// Configure default usernetwork with limayaml.MACAddress(driver.Instance.Dir) for eth0 interface
 	firstUsernetIndex := limayaml.FirstUsernetIndex(y)
 	if firstUsernetIndex == -1 {
 		args = append(args, "-netdev", fmt.Sprintf("user,id=net0,net=%s,dhcpstart=%s,hostfwd=tcp:127.0.0.1:%d-:22",
@@ -682,7 +682,7 @@ func Cmdline(cfg Config) (string, []string, error) {
 				return "", nil, err
 			}
 
-			//Handle usernet connections
+			// Handle usernet connections
 			isUsernet, err := nwCfg.Usernet(nw.Lima)
 			if err != nil {
 				return "", nil, err
@@ -867,7 +867,7 @@ func Cmdline(cfg Config) (string, []string, error) {
 			if err != nil {
 				return "", nil, err
 			}
-			if err := os.MkdirAll(location, 0755); err != nil {
+			if err := os.MkdirAll(location, 0o755); err != nil {
 				return "", nil, err
 			}
 

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -59,7 +59,7 @@ func DefaultPubKeys(loadDotSSH bool) ([]PubKey, error) {
 		if !errors.Is(err, os.ErrNotExist) {
 			return nil, err
 		}
-		if err := os.MkdirAll(configDir, 0700); err != nil {
+		if err := os.MkdirAll(configDir, 0o700); err != nil {
 			return nil, fmt.Errorf("could not create %q directory: %w", configDir, err)
 		}
 		if err := lockutil.WithDirLock(configDir, func() error {
@@ -304,20 +304,20 @@ func detectValidPublicKey(content string) bool {
 	if strings.ContainsRune(content, '\n') {
 		return false
 	}
-	var spaced = strings.SplitN(content, " ", 3)
+	spaced := strings.SplitN(content, " ", 3)
 	if len(spaced) < 2 {
 		return false
 	}
-	var algo, base64Key = spaced[0], spaced[1]
-	var decodedKey, err = base64.StdEncoding.DecodeString(base64Key)
+	algo, base64Key := spaced[0], spaced[1]
+	decodedKey, err := base64.StdEncoding.DecodeString(base64Key)
 	if err != nil || len(decodedKey) < 4 {
 		return false
 	}
-	var sigLength = binary.BigEndian.Uint32(decodedKey)
+	sigLength := binary.BigEndian.Uint32(decodedKey)
 	if uint32(len(decodedKey)) < sigLength {
 		return false
 	}
-	var sigFormat = string(decodedKey[4 : 4+sigLength])
+	sigFormat := string(decodedKey[4 : 4+sigLength])
 	return algo == sigFormat
 }
 

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -376,7 +376,6 @@ func PrintInstances(w io.Writer, instances []*Instance, format string, options *
 				)
 			}
 			fmt.Fprint(w, "\n")
-
 		}
 		return w.Flush()
 	default:
@@ -407,7 +406,7 @@ func (inst *Instance) Protect() error {
 	protected := filepath.Join(inst.Dir, filenames.Protected)
 	// TODO: Do an equivalent of `chmod +a "everyone deny delete,delete_child,file_inherit,directory_inherit"`
 	// https://github.com/lima-vm/lima/issues/1595
-	if err := os.WriteFile(protected, nil, 0400); err != nil {
+	if err := os.WriteFile(protected, nil, 0o400); err != nil {
 		return err
 	}
 	inst.Protected = true

--- a/pkg/store/instance_test.go
+++ b/pkg/store/instance_test.go
@@ -14,9 +14,11 @@ import (
 
 const separator = string(filepath.Separator)
 
-var vmtype = limayaml.QEMU
-var goarch = limayaml.NewArch(runtime.GOARCH)
-var space = strings.Repeat(" ", len(goarch)-4)
+var (
+	vmtype = limayaml.QEMU
+	goarch = limayaml.NewArch(runtime.GOARCH)
+	space  = strings.Repeat(" ", len(goarch)-4)
+)
 
 var instance = Instance{
 	Name:       "foo",

--- a/pkg/textutil/textutil_test.go
+++ b/pkg/textutil/textutil_test.go
@@ -12,6 +12,7 @@ func TestPrefixString(t *testing.T) {
 	assert.Equal(t, "- foo", PrefixString("- ", "foo"))
 	assert.Equal(t, "- foo\n- bar\n", PrefixString("- ", "foo\nbar\n"))
 }
+
 func TestIndentString(t *testing.T) {
 	assert.Equal(t, "  foo", IndentString(2, "foo"))
 	assert.Equal(t, "  foo\n  bar\n", IndentString(2, "foo\nbar\n"))

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,6 +1,4 @@
 package version
 
-var (
-	// Version is filled on compilation time
-	Version = "<unknown>"
-)
+// Version is filled on compilation time
+var Version = "<unknown>"

--- a/pkg/vz/network_darwin.go
+++ b/pkg/vz/network_darwin.go
@@ -102,9 +102,11 @@ func (v *QEMUPacketConn) Write(b []byte) (n int, err error) {
 	}
 	return write, nil
 }
+
 func (v *QEMUPacketConn) Close() error {
 	return v.unixConn.Close()
 }
+
 func (v *QEMUPacketConn) LocalAddr() net.Addr {
 	return v.unixConn.LocalAddr()
 }

--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -67,7 +67,7 @@ func startVM(ctx context.Context, driver *driver.BaseDriver) (*virtualMachineWra
 		}
 	}()
 	go func() {
-		//Handle errors via errCh and handle stop vm during context close
+		// Handle errors via errCh and handle stop vm during context close
 		defer func() {
 			for i := range vmNetworkFiles {
 				vmNetworkFiles[i].Close()
@@ -89,7 +89,7 @@ func startVM(ctx context.Context, driver *driver.BaseDriver) (*virtualMachineWra
 						logrus.Errorf("pidfile %q already exists", pidFile)
 						errCh <- err
 					}
-					if err := os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())+"\n"), 0644); err != nil {
+					if err := os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
 						logrus.Errorf("error writing to pid fil %q", pidFile)
 						errCh <- err
 					}
@@ -120,7 +120,7 @@ func startVM(ctx context.Context, driver *driver.BaseDriver) (*virtualMachineWra
 func startUsernet(ctx context.Context, driver *driver.BaseDriver) (*usernet.Client, error) {
 	firstUsernetIndex := limayaml.FirstUsernetIndex(driver.Yaml)
 	if firstUsernetIndex == -1 {
-		//Start a in-process gvisor-tap-vsock
+		// Start a in-process gvisor-tap-vsock
 		endpointSock, err := usernet.SockWithDirectory(driver.Instance.Dir, "", usernet.EndpointSock)
 		if err != nil {
 			return nil, err
@@ -279,10 +279,10 @@ func newVirtioNetworkDeviceConfiguration(attachment vz.NetworkDeviceAttachment, 
 func attachNetwork(driver *driver.BaseDriver, vmConfig *vz.VirtualMachineConfiguration) error {
 	var configurations []*vz.VirtioNetworkDeviceConfiguration
 
-	//Configure default usernetwork with limayaml.MACAddress(driver.Instance.Dir) for eth0 interface
+	// Configure default usernetwork with limayaml.MACAddress(driver.Instance.Dir) for eth0 interface
 	firstUsernetIndex := limayaml.FirstUsernetIndex(driver.Yaml)
 	if firstUsernetIndex == -1 {
-		//slirp network using gvisor netstack
+		// slirp network using gvisor netstack
 		vzSock, err := usernet.SockWithDirectory(driver.Instance.Dir, "", usernet.FDSock)
 		if err != nil {
 			return err
@@ -527,7 +527,7 @@ func attachFolderMounts(driver *driver.BaseDriver, vmConfig *vz.VirtualMachineCo
 				return err
 			}
 			if _, err := os.Stat(expandedPath); errors.Is(err, os.ErrNotExist) {
-				err := os.MkdirAll(expandedPath, 0750)
+				err := os.MkdirAll(expandedPath, 0o750)
 				if err != nil {
 					return err
 				}
@@ -667,7 +667,7 @@ func getMachineIdentifier(driver *driver.BaseDriver) (*vz.GenericMachineIdentifi
 		if err != nil {
 			return nil, err
 		}
-		err = os.WriteFile(identifier, machineIdentifier.DataRepresentation(), 0666)
+		err = os.WriteFile(identifier, machineIdentifier.DataRepresentation(), 0o666)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -35,7 +35,7 @@ func New(driver *driver.BaseDriver) *LimaVzDriver {
 }
 
 func (l *LimaVzDriver) Validate() error {
-	//Calling NewEFIBootLoader to do required version check for latest APIs
+	// Calling NewEFIBootLoader to do required version check for latest APIs
 	_, err := vz.NewEFIBootLoader()
 	if errors.Is(err, vz.ErrUnsupportedOSVersion) {
 		return fmt.Errorf("VZ driver requires macOS 13 or higher to run")

--- a/pkg/windows/registry_windows.go
+++ b/pkg/windows/registry_windows.go
@@ -114,7 +114,6 @@ func GetDistroID(name string) (string, error) {
 	defer rootKey.Close()
 
 	keys, err := rootKey.ReadSubKeyNames(-1)
-
 	if err != nil {
 		return "", fmt.Errorf("failed to read subkey names for %s: %w", wslDistroInfoPrefix, err)
 	}

--- a/pkg/yqutil/yqutil.go
+++ b/pkg/yqutil/yqutil.go
@@ -64,7 +64,6 @@ func EvaluateExpression(expression string, content []byte) ([]byte, error) {
 	}
 
 	return out.Bytes(), nil
-
 }
 
 func Join(yqExprs []string) string {


### PR DESCRIPTION
This PR enables [`gofumpt`](https://github.com/mvdan/gofumpt), `whitespace` linters that check code formatting.

Also, fixes appeared issues (by running `gofumpt -w .`):
```
❯ golangci-lint run
pkg/cidata/cidata.go:431: File is not `gofumpt`-ed (gofumpt)
                        if err := os.MkdirAll(filepath.Join(rootPath, dir), 0700); err != nil {
pkg/cidata/cidata.go:435: File is not `gofumpt`-ed (gofumpt)
                f, err := os.OpenFile(filepath.Join(rootPath, e.Path), os.O_CREATE|os.O_RDWR, 0700)
pkg/hostagent/hostagent.go:200: File is not `gofumpt`-ed (gofumpt)
        return os.WriteFile(fileName, b.Bytes(), 0600)
pkg/hostagent/hostagent.go:347: File is not `gofumpt`-ed (gofumpt)
                if err := os.WriteFile(vncpwdfile, []byte(vncpasswd), 0600); err != nil {
pkg/hostagent/hostagent.go:363: File is not `gofumpt`-ed (gofumpt)
                if err := os.WriteFile(vncfile, []byte(vncdisplay), 0600); err != nil {
pkg/hostagent/hostagent.go:682: File is not `gofumpt`-ed (gofumpt)
                        if err := os.MkdirAll(filepath.Dir(local), 0750); err != nil {
pkg/hostagent/hostagent.go:736: File is not `gofumpt`-ed (gofumpt)
        if err := os.MkdirAll(filepath.Dir(local), 0700); err != nil {
pkg/hostagent/hostagent.go:744: File is not `gofumpt`-ed (gofumpt)
        if err := os.WriteFile(local, out, 0600); err != nil {
pkg/hostagent/mount.go:44: File is not `gofumpt`-ed (gofumpt)
        if err := os.MkdirAll(location, 0755); err != nil {
pkg/hostagent/requirements.go:122: unnecessary trailing newline (whitespace)

        }
cmd/limactl/editflags/editflags.go:112: File is not `gofumpt`-ed (gofumpt)
                {"dns",
cmd/limactl/editflags/editflags.go:130: File is not `gofumpt`-ed (gofumpt)
                        false},
cmd/limactl/editflags/editflags.go:132: File is not `gofumpt`-ed (gofumpt)
                {"mount",
cmd/limactl/editflags/editflags.go:151: File is not `gofumpt`-ed (gofumpt)
                        false},
cmd/limactl/editflags/editflags.go:154: File is not `gofumpt`-ed (gofumpt)
                {"network",
cmd/limactl/editflags/editflags.go:180: File is not `gofumpt`-ed (gofumpt)
                        false},
                {"rosetta",
cmd/limactl/editflags/editflags.go:190: File is not `gofumpt`-ed (gofumpt)
                        true},
cmd/limactl/editflags/editflags.go:192: File is not `gofumpt`-ed (gofumpt)
                {"video",
cmd/limactl/editflags/editflags.go:204: File is not `gofumpt`-ed (gofumpt)
                        false},
cmd/limactl/editflags/editflags.go:206: File is not `gofumpt`-ed (gofumpt)
                {"containerd",
cmd/limactl/editflags/editflags.go:226: File is not `gofumpt`-ed (gofumpt)
                        false},
pkg/networks/usernet/dnshosts/dnshosts_test.go:196: File is not `gofumpt`-ed (gofumpt)
var _ sort.Interface = (recordSorter)(nil)
var _ sort.Interface = (zoneSorter)(nil)
pkg/version/version.go:3: File is not `gofumpt`-ed (gofumpt)
var (
        // Version is filled on compilation time
        Version = "<unknown>"
)
pkg/guestagent/iptables/iptables_test.go:70: File is not `gofumpt`-ed (gofumpt)

pkg/guestagent/iptables/iptables_test.go:69: unnecessary leading newline (whitespace)
func TestParsePortsFromRules(t *testing.T) {

pkg/limayaml/limayaml.go:44: File is not `gofumpt`-ed (gofumpt)
type OS = string
type Arch = string
type MountType = string
type VMType = string
pkg/limayaml/validate.go:3: File is not `gofumpt`-ed (gofumpt)
import (
pkg/limayaml/validate.go:11: File is not `gofumpt`-ed (gofumpt)

        "errors"
pkg/networks/reconcile/reconcile.go:103: File is not `gofumpt`-ed (gofumpt)
        if fi.Mode()&020 == 0 || stat.Gid != daemon.Gid {
pkg/networks/reconcile/reconcile.go:118: File is not `gofumpt`-ed (gofumpt)
        if err := os.MkdirAll(networksDir, 0755); err != nil {
pkg/networks/reconcile/reconcile.go:177: File is not `gofumpt`-ed (gofumpt)
        //Handle usernet first without sudo requirements
pkg/networks/reconcile/reconcile.go:223: File is not `gofumpt`-ed (gofumpt)
        //Handle usernet first without sudo requirements
pkg/networks/config.go:115: File is not `gofumpt`-ed (gofumpt)
                        cache.err = os.MkdirAll(configDir, 0755)
pkg/networks/config.go:125: File is not `gofumpt`-ed (gofumpt)
                        cache.err = os.WriteFile(configFile, defaultConfig, 0644)
pkg/networks/validate.go:145: File is not `gofumpt`-ed (gofumpt)
                if fi.Mode()&020 != 0 && stat.Gid != root.Gid && stat.Gid != uint32(adminGid) && stat.Gid != daemon.Gid {
pkg/networks/validate.go:149: File is not `gofumpt`-ed (gofumpt)
                if fi.Mode().IsDir() && fi.Mode()&1 == 0 && (fi.Mode()&0010 == 0 || stat.Gid != daemon.Gid) {
pkg/networks/validate.go:152: File is not `gofumpt`-ed (gofumpt)
        } else if fi.Mode()&020 != 0 && stat.Gid != root.Gid && stat.Gid != uint32(adminGid) {
pkg/networks/validate.go:156: File is not `gofumpt`-ed (gofumpt)
        if fi.Mode()&002 != 0 {
pkg/osutil/user.go:30: File is not `gofumpt`-ed (gofumpt)
var users map[string]User
var groups map[string]Group
pkg/qemu/qemu.go:73: File is not `gofumpt`-ed (gofumpt)
                                        if err := os.WriteFile(kernelCmdline, []byte(f.Kernel.Cmdline), 0644); err != nil {
pkg/qemu/qemu.go:663: File is not `gofumpt`-ed (gofumpt)
        //Configure default usernetwork with limayaml.MACAddress(driver.Instance.Dir) for eth0 interface
pkg/qemu/qemu.go:685: File is not `gofumpt`-ed (gofumpt)
                        //Handle usernet connections
pkg/qemu/qemu.go:870: File is not `gofumpt`-ed (gofumpt)
                        if err := os.MkdirAll(location, 0755); err != nil {
cmd/limactl/copy.go:26: File is not `gofumpt`-ed (gofumpt)
        var copyCommand = &cobra.Command{
cmd/limactl/debug.go:24: File is not `gofumpt`-ed (gofumpt)
        var cmd = &cobra.Command{
cmd/limactl/delete.go:17: File is not `gofumpt`-ed (gofumpt)
        var deleteCommand = &cobra.Command{
cmd/limactl/disk.go:19: File is not `gofumpt`-ed (gofumpt)
        var diskCommand = &cobra.Command{
cmd/limactl/disk.go:43: File is not `gofumpt`-ed (gofumpt)
        var diskCreateCommand = &cobra.Command{
cmd/limactl/disk.go:95: File is not `gofumpt`-ed (gofumpt)
        if err := os.MkdirAll(diskDir, 0700); err != nil {
cmd/limactl/disk.go:107: File is not `gofumpt`-ed (gofumpt)
        var diskListCommand = &cobra.Command{
cmd/limactl/disk.go:193: File is not `gofumpt`-ed (gofumpt)
        var diskDeleteCommand = &cobra.Command{
cmd/limactl/disk.go:282: File is not `gofumpt`-ed (gofumpt)
        var diskUnlockCommand = &cobra.Command{
cmd/limactl/edit.go:24: File is not `gofumpt`-ed (gofumpt)
        var editCommand = &cobra.Command{
cmd/limactl/edit.go:98: File is not `gofumpt`-ed (gofumpt)
                if writeErr := os.WriteFile(rejectedYAML, yBytes, 0644); writeErr != nil {
cmd/limactl/edit.go:104: File is not `gofumpt`-ed (gofumpt)
        if err := os.WriteFile(filePath, yBytes, 0644); err != nil {
cmd/limactl/factory-reset.go:15: File is not `gofumpt`-ed (gofumpt)
        var resetCommand = &cobra.Command{
cmd/limactl/gendoc.go:89: File is not `gofumpt`-ed (gofumpt)
        if err := os.WriteFile(filePath, out, 0644); err != nil {
cmd/limactl/gendoc.go:102: File is not `gofumpt`-ed (gofumpt)
                //Replace limactl_completion_bash to completion bash for docsy title
cmd/limactl/gendoc.go:113: File is not `gofumpt`-ed (gofumpt)
                //Use ../ for move one folder up for docsy
cmd/limactl/gendoc.go:136: File is not `gofumpt`-ed (gofumpt)
                err = os.WriteFile(path, out, 0644)
cmd/limactl/hostagent.go:22: File is not `gofumpt`-ed (gofumpt)
        var hostagentCommand = &cobra.Command{
cmd/limactl/hostagent.go:45: File is not `gofumpt`-ed (gofumpt)
                if err := os.WriteFile(pidfile, []byte(strconv.Itoa(os.Getpid())+"\n"), 0644); err != nil {
cmd/limactl/hostagent.go:65: File is not `gofumpt`-ed (gofumpt)
                //Without this the call to vz.RunGUI fails. Adding it here, as this has to be called before the vz cgo loads.
cmd/limactl/main.go:38: File is not `gofumpt`-ed (gofumpt)
        var rootCmd = &cobra.Command{
cmd/limactl/protect.go:13: File is not `gofumpt`-ed (gofumpt)
        var protectCommand = &cobra.Command{
cmd/limactl/shell.go:35: File is not `gofumpt`-ed (gofumpt)
        var shellCmd = &cobra.Command{
cmd/limactl/show_ssh.go:52: File is not `gofumpt`-ed (gofumpt)
        var shellCmd = &cobra.Command{
cmd/limactl/snapshot.go:15: File is not `gofumpt`-ed (gofumpt)
        var snapshotCmd = &cobra.Command{
cmd/limactl/snapshot.go:31: File is not `gofumpt`-ed (gofumpt)
        var createCmd = &cobra.Command{
cmd/limactl/snapshot.go:66: File is not `gofumpt`-ed (gofumpt)
        var deleteCmd = &cobra.Command{
cmd/limactl/snapshot.go:101: File is not `gofumpt`-ed (gofumpt)
        var applyCmd = &cobra.Command{
cmd/limactl/snapshot.go:136: File is not `gofumpt`-ed (gofumpt)
        var listCmd = &cobra.Command{
cmd/limactl/start.go:40: File is not `gofumpt`-ed (gofumpt)
        var createCommand = &cobra.Command{
cmd/limactl/start.go:77: File is not `gofumpt`-ed (gofumpt)
        var startCommand = &cobra.Command{
cmd/limactl/start.go:285: File is not `gofumpt`-ed (gofumpt)
        if err := os.WriteFile(filePath, yBytes, 0644); err != nil {
cmd/limactl/start.go:325: File is not `gofumpt`-ed (gofumpt)
                if writeErr := os.WriteFile(rejectedYAML, st.yBytes, 0644); writeErr != nil {
cmd/limactl/start.go:330: File is not `gofumpt`-ed (gofumpt)
        if err := os.MkdirAll(instDir, 0700); err != nil {
                return nil, err
        }
        if err := os.WriteFile(filePath, st.yBytes, 0644); err != nil {
cmd/limactl/stop.go:22: File is not `gofumpt`-ed (gofumpt)
        var stopCmd = &cobra.Command{
cmd/limactl/unprotect.go:13: File is not `gofumpt`-ed (gofumpt)
        var unprotectCommand = &cobra.Command{
cmd/limactl/usernet.go:14: File is not `gofumpt`-ed (gofumpt)
        var hostagentCommand = &cobra.Command{
cmd/limactl/usernet.go:40: File is not `gofumpt`-ed (gofumpt)
                if err := os.WriteFile(pidfile, []byte(strconv.Itoa(os.Getpid())+"\n"), 0644); err != nil {
cmd/limactl/validate.go:14: File is not `gofumpt`-ed (gofumpt)
        var validateCommand = &cobra.Command{
pkg/store/instance.go:410: File is not `gofumpt`-ed (gofumpt)
        if err := os.WriteFile(protected, nil, 0400); err != nil {
pkg/store/instance_test.go:17: File is not `gofumpt`-ed (gofumpt)
var vmtype = limayaml.QEMU
var goarch = limayaml.NewArch(runtime.GOARCH)
var space = strings.Repeat(" ", len(goarch)-4)
pkg/store/instance.go:379: unnecessary trailing newline (whitespace)

                }
pkg/nativeimgutil/nativeimgutil.go:112: File is not `gofumpt`-ed (gofumpt)
                destF, err := os.OpenFile(dest, os.O_RDWR, 0644)
pkg/networks/usernet/client.go:38: File is not `gofumpt`-ed (gofumpt)
        var hosts = driver.Yaml.HostResolver.Hosts
pkg/networks/usernet/gvproxy.go:36: File is not `gofumpt`-ed (gofumpt)
var (
        opts *GVisorNetstackOpts
)
pkg/networks/usernet/gvproxy.go:149: File is not `gofumpt`-ed (gofumpt)

pkg/networks/usernet/recoincile.go:30: File is not `gofumpt`-ed (gofumpt)
        //usernet files contents are stored under {LIMA_HOME}/_networks/user-v2/<pid, fdsock, endpointsock, logs>
pkg/networks/usernet/recoincile.go:32: File is not `gofumpt`-ed (gofumpt)
        if err := os.MkdirAll(usernetDir, 0755); err != nil {
pkg/networks/usernet/recoincile.go:73: File is not `gofumpt`-ed (gofumpt)
                        args := []string{"usernet", "-p", pidFile,
pkg/networks/usernet/recoincile.go:77: File is not `gofumpt`-ed (gofumpt)
                                "--subnet", subnet.String()}
pkg/networks/usernet/config_test.go:12: File is not `gofumpt`-ed (gofumpt)

pkg/networks/usernet/config_test.go:11: unnecessary leading newline (whitespace)
func TestUsernetConfig(t *testing.T) {

pkg/bicopy/bicopy.go:39: File is not `gofumpt`-ed (gofumpt)
        var broker = func(to, from io.ReadWriter) {
pkg/sshutil/sshutil.go:62: File is not `gofumpt`-ed (gofumpt)
                if err := os.MkdirAll(configDir, 0700); err != nil {
pkg/sshutil/sshutil.go:307: File is not `gofumpt`-ed (gofumpt)
        var spaced = strings.SplitN(content, " ", 3)
pkg/sshutil/sshutil.go:311: File is not `gofumpt`-ed (gofumpt)
        var algo, base64Key = spaced[0], spaced[1]
        var decodedKey, err = base64.StdEncoding.DecodeString(base64Key)
pkg/sshutil/sshutil.go:316: File is not `gofumpt`-ed (gofumpt)
        var sigLength = binary.BigEndian.Uint32(decodedKey)
pkg/sshutil/sshutil.go:320: File is not `gofumpt`-ed (gofumpt)
        var sigFormat = string(decodedKey[4 : 4+sigLength])
pkg/guestagent/api/api.go:9: File is not `gofumpt`-ed (gofumpt)
var (
        IPv4loopback1 = net.IPv4(127, 0, 0, 1)
)
pkg/textutil/textutil_test.go:14: File is not `gofumpt`-ed (gofumpt)
}
pkg/hostagent/dns/dns_test.go:18: File is not `gofumpt`-ed (gofumpt)
var (
        dnsResult *dns.Msg
)
pkg/hostagent/dns/dns_test.go:23: File is not `gofumpt`-ed (gofumpt)

pkg/hostagent/dns/dns_test.go:123: File is not `gofumpt`-ed (gofumpt)
type TestResponseWriter struct {
}
pkg/hostagent/dns/dns_test.go:170: File is not `gofumpt`-ed (gofumpt)
}
pkg/hostagent/dns/dns_test.go:22: unnecessary leading newline (whitespace)
func TestDNSRecords(t *testing.T) {

pkg/editutil/editorcmd/editorcmd.go:28: File is not `gofumpt`-ed (gofumpt)
        var candidates = []string{
pkg/downloader/downloader.go:158: File is not `gofumpt`-ed (gofumpt)
                if err := os.MkdirAll(localPathDir, 0755); err != nil {
pkg/downloader/downloader.go:218: File is not `gofumpt`-ed (gofumpt)
        if err := os.MkdirAll(shad, 0700); err != nil {
pkg/downloader/downloader.go:222: File is not `gofumpt`-ed (gofumpt)
        if err := os.WriteFile(shadURL, []byte(remote), 0644); err != nil {
pkg/downloader/downloader.go:233: File is not `gofumpt`-ed (gofumpt)
                if err := os.WriteFile(shadDigest, []byte(o.expectedDigest.String()), 0644); err != nil {
pkg/downloader/downloader.go:407: File is not `gofumpt`-ed (gofumpt)
        out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY, 0644)
pkg/downloader/downloader_test.go:133: File is not `gofumpt`-ed (gofumpt)
                assert.NilError(t, os.WriteFile(localTestFile, testDownloadFileContents, 0644))
pkg/downloader/downloader_test.go:161: File is not `gofumpt`-ed (gofumpt)

pkg/downloader/downloader_test.go:171: File is not `gofumpt`-ed (gofumpt)
                assert.NilError(t, os.WriteFile(localFile, testDownloadCompressedContents, 0644))
pkg/downloader/downloader_test.go:160: unnecessary leading newline (whitespace)
func TestDownloadCompressed(t *testing.T) {

pkg/vz/network_darwin.go:104: File is not `gofumpt`-ed (gofumpt)
}
pkg/vz/network_darwin.go:107: File is not `gofumpt`-ed (gofumpt)
}
pkg/vz/vm_darwin.go:70: File is not `gofumpt`-ed (gofumpt)
                //Handle errors via errCh and handle stop vm during context close
pkg/vz/vm_darwin.go:92: File is not `gofumpt`-ed (gofumpt)
                                        if err := os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())+"\n"), 0644); err != nil {
pkg/vz/vm_darwin.go:123: File is not `gofumpt`-ed (gofumpt)
                //Start a in-process gvisor-tap-vsock
pkg/vz/vm_darwin.go:282: File is not `gofumpt`-ed (gofumpt)
        //Configure default usernetwork with limayaml.MACAddress(driver.Instance.Dir) for eth0 interface
pkg/vz/vm_darwin.go:285: File is not `gofumpt`-ed (gofumpt)
                //slirp network using gvisor netstack
pkg/vz/vm_darwin.go:530: File is not `gofumpt`-ed (gofumpt)
                                err := os.MkdirAll(expandedPath, 0750)
pkg/vz/vm_darwin.go:670: File is not `gofumpt`-ed (gofumpt)
                err = os.WriteFile(identifier, machineIdentifier.DataRepresentation(), 0666)
pkg/vz/vz_driver_darwin.go:38: File is not `gofumpt`-ed (gofumpt)
        //Calling NewEFIBootLoader to do required version check for latest APIs
pkg/yqutil/yqutil.go:67: File is not `gofumpt`-ed (gofumpt)
```