### PR TITLE
pkg: remove outdated or unnecessary build tags

### DIFF
--- a/pkg/guestagent/api/client/client_others.go
+++ b/pkg/guestagent/api/client/client_others.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package client
 

--- a/pkg/guestagent/api/client/client_windows.go
+++ b/pkg/guestagent/api/client/client_windows.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 package client
 
 import (

--- a/pkg/hostagent/port_others.go
+++ b/pkg/hostagent/port_others.go
@@ -1,5 +1,4 @@
 //go:build !darwin && !windows
-// +build !darwin,!windows
 
 package hostagent
 

--- a/pkg/hostagent/port_windows.go
+++ b/pkg/hostagent/port_windows.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 package hostagent
 
 import (

--- a/pkg/httpclientutil/httpclientutil_others.go
+++ b/pkg/httpclientutil/httpclientutil_others.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package httpclientutil
 

--- a/pkg/httpclientutil/httpclientutil_windows.go
+++ b/pkg/httpclientutil/httpclientutil_windows.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 package httpclientutil
 
 import (

--- a/pkg/lockutil/lockutil_unix.go
+++ b/pkg/lockutil/lockutil_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // From https://github.com/containerd/nerdctl/blob/v0.13.0/pkg/lockutil/lockutil_unix.go
 /*

--- a/pkg/osutil/dns_others.go
+++ b/pkg/osutil/dns_others.go
@@ -1,5 +1,4 @@
 //go:build !darwin
-// +build !darwin
 
 package osutil
 

--- a/pkg/osutil/osutil_others.go
+++ b/pkg/osutil/osutil_others.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows
-// +build !linux,!windows
 
 package osutil
 

--- a/pkg/osutil/rosetta_others.go
+++ b/pkg/osutil/rosetta_others.go
@@ -1,5 +1,4 @@
 //go:build !darwin
-// +build !darwin
 
 package osutil
 

--- a/pkg/start/ha_cmd_opts_others.go
+++ b/pkg/start/ha_cmd_opts_others.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package start
 

--- a/pkg/store/instance_unix.go
+++ b/pkg/store/instance_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package store
 

--- a/pkg/vz/errors_darwin.go
+++ b/pkg/vz/errors_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin && !no_vz
-// +build darwin,!no_vz
 
 package vz
 

--- a/pkg/vz/network_darwin.go
+++ b/pkg/vz/network_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin && !no_vz
-// +build darwin,!no_vz
 
 package vz
 

--- a/pkg/vz/rosetta_directory_share.go
+++ b/pkg/vz/rosetta_directory_share.go
@@ -1,5 +1,4 @@
 //go:build darwin && !arm64 && !no_vz
-// +build darwin,!arm64,!no_vz
 
 package vz
 

--- a/pkg/vz/rosetta_directory_share_arm64.go
+++ b/pkg/vz/rosetta_directory_share_arm64.go
@@ -1,5 +1,4 @@
 //go:build darwin && arm64 && !no_vz
-// +build darwin,arm64,!no_vz
 
 package vz
 

--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin && !no_vz
-// +build darwin,!no_vz
 
 package vz
 

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin && !no_vz
-// +build darwin,!no_vz
 
 package vz
 

--- a/pkg/vz/vz_driver_others.go
+++ b/pkg/vz/vz_driver_others.go
@@ -1,5 +1,4 @@
 //go:build !darwin || no_vz
-// +build !darwin no_vz
 
 package vz
 

--- a/pkg/windows/process_windows.go
+++ b/pkg/windows/process_windows.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 package windows
 
 import (

--- a/pkg/windows/registry_windows.go
+++ b/pkg/windows/registry_windows.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 package windows
 
 import (

--- a/pkg/windows/wsl_util_windows.go
+++ b/pkg/windows/wsl_util_windows.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 package windows
 
 import (

--- a/pkg/wsl2/vm_windows.go
+++ b/pkg/wsl2/vm_windows.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 package wsl2
 
 import (

--- a/pkg/wsl2/wsl_driver_others.go
+++ b/pkg/wsl2/wsl_driver_others.go
@@ -1,5 +1,4 @@
 //go:build !windows || no_wsl
-// +build !windows no_wsl
 
 package wsl2
 

--- a/pkg/wsl2/wsl_driver_windows.go
+++ b/pkg/wsl2/wsl_driver_windows.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 package wsl2
 
 import (


### PR DESCRIPTION
This PR removes outdated `// +build` comments because the minimum supported version is Go 20. This achieved by running the command:
```
go fix -fix buildtag ./...
```