### PR TITLE
pkg/limayaml: replace github.com/xorcare/pointer with ptr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
-	github.com/xorcare/pointer v1.2.2
 	golang.org/x/sync v0.4.0
 	golang.org/x/sys v0.13.0
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,6 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/u-root/uio v0.0.0-20210528114334-82958018845c h1:BFvcl34IGnw8yvJi8hlqLFo9EshRInwWBs2M5fGWzQA=
 github.com/u-root/uio v0.0.0-20210528114334-82958018845c/go.mod h1:LpEX5FO/cB+WF4TYGY1V5qktpaZLkKkSegbr0V4eYXA=
-github.com/xorcare/pointer v1.2.2 h1:zjD77b5DTehClND4MK+9dDE0DcpFIZisAJ/+yVJvKYA=
-github.com/xorcare/pointer v1.2.2/go.mod h1:azsKh7oVwYB7C1o8P284fG8MvtErX/F5/dqXiaj71ak=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/pkg/cidata/cidata_test.go
+++ b/pkg/cidata/cidata_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/lima-vm/lima/pkg/networks"
+	"github.com/lima-vm/lima/pkg/ptr"
 
 	"github.com/lima-vm/lima/pkg/limayaml"
-	"github.com/xorcare/pointer"
 	"gotest.tools/v3/assert"
 )
 
@@ -46,7 +46,7 @@ func TestSetupEnv(t *testing.T) {
 			envKey := "http_proxy"
 			envValue := httpProxy.String()
 			templateArgs := TemplateArgs{SlirpGateway: networks.SlirpGateway}
-			envs, err := setupEnv(&limayaml.LimaYAML{PropagateProxyEnv: pointer.Bool(false), Env: map[string]string{envKey: envValue}}, templateArgs)
+			envs, err := setupEnv(&limayaml.LimaYAML{PropagateProxyEnv: ptr.Of(false), Env: map[string]string{envKey: envValue}}, templateArgs)
 			assert.NilError(t, err)
 			assert.Equal(t, envs[envKey], strings.ReplaceAll(envValue, httpProxy.Hostname(), networks.SlirpGateway))
 		})
@@ -57,7 +57,7 @@ func TestSetupInvalidEnv(t *testing.T) {
 	envKey := "http_proxy"
 	envValue := "://localhost:8080"
 	templateArgs := TemplateArgs{SlirpGateway: networks.SlirpGateway}
-	envs, err := setupEnv(&limayaml.LimaYAML{PropagateProxyEnv: pointer.Bool(false), Env: map[string]string{envKey: envValue}}, templateArgs)
+	envs, err := setupEnv(&limayaml.LimaYAML{PropagateProxyEnv: ptr.Of(false), Env: map[string]string{envKey: envValue}}, templateArgs)
 	assert.NilError(t, err)
 	assert.Equal(t, envs[envKey], envValue)
 }

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/lima-vm/lima/pkg/networks"
+	"github.com/lima-vm/lima/pkg/ptr"
 	"github.com/pbnjay/memory"
 
 	"github.com/lima-vm/lima/pkg/guestagent/api"
@@ -20,7 +21,6 @@ import (
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/sirupsen/logrus"
-	"github.com/xorcare/pointer"
 
 	"golang.org/x/sys/cpu"
 )
@@ -133,21 +133,21 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 	if o.VMType != nil {
 		y.VMType = o.VMType
 	}
-	y.VMType = pointer.String(ResolveVMType(y.VMType))
+	y.VMType = ptr.Of(ResolveVMType(y.VMType))
 	if y.OS == nil {
 		y.OS = d.OS
 	}
 	if o.OS != nil {
 		y.OS = o.OS
 	}
-	y.OS = pointer.String(ResolveOS(y.OS))
+	y.OS = ptr.Of(ResolveOS(y.OS))
 	if y.Arch == nil {
 		y.Arch = d.Arch
 	}
 	if o.Arch != nil {
 		y.Arch = o.Arch
 	}
-	y.Arch = pointer.String(ResolveArch(y.Arch))
+	y.Arch = ptr.Of(ResolveArch(y.Arch))
 
 	y.Images = append(append(o.Images, y.Images...), d.Images...)
 	for i := range y.Images {
@@ -218,7 +218,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.CPUs = o.CPUs
 	}
 	if y.CPUs == nil || *y.CPUs == 0 {
-		y.CPUs = pointer.Int(defaultCPUs())
+		y.CPUs = ptr.Of(defaultCPUs())
 	}
 
 	if y.Memory == nil {
@@ -228,7 +228,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.Memory = o.Memory
 	}
 	if y.Memory == nil || *y.Memory == "" {
-		y.Memory = pointer.String(defaultMemoryAsString())
+		y.Memory = ptr.Of(defaultMemoryAsString())
 	}
 
 	if y.Disk == nil {
@@ -238,7 +238,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.Disk = o.Disk
 	}
 	if y.Disk == nil || *y.Disk == "" {
-		y.Disk = pointer.String(defaultDiskSizeAsString())
+		y.Disk = ptr.Of(defaultDiskSizeAsString())
 	}
 
 	y.AdditionalDisks = append(append(o.AdditionalDisks, y.AdditionalDisks...), d.AdditionalDisks...)
@@ -250,7 +250,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.Audio.Device = o.Audio.Device
 	}
 	if y.Audio.Device == nil {
-		y.Audio.Device = pointer.String("")
+		y.Audio.Device = ptr.Of("")
 	}
 
 	if y.Video.Display == nil {
@@ -260,7 +260,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.Video.Display = o.Video.Display
 	}
 	if y.Video.Display == nil || *y.Video.Display == "" {
-		y.Video.Display = pointer.String("none")
+		y.Video.Display = ptr.Of("none")
 	}
 
 	if y.Video.VNC.Display == nil {
@@ -270,7 +270,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.Video.VNC.Display = o.Video.VNC.Display
 	}
 	if (y.Video.VNC.Display == nil || *y.Video.VNC.Display == "") && *y.VMType == QEMU {
-		y.Video.VNC.Display = pointer.String("127.0.0.1:0,to=9")
+		y.Video.VNC.Display = ptr.Of("127.0.0.1:0,to=9")
 	}
 
 	if y.Firmware.LegacyBIOS == nil {
@@ -280,7 +280,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.Firmware.LegacyBIOS = o.Firmware.LegacyBIOS
 	}
 	if y.Firmware.LegacyBIOS == nil {
-		y.Firmware.LegacyBIOS = pointer.Bool(false)
+		y.Firmware.LegacyBIOS = ptr.Of(false)
 	}
 
 	if y.SSH.LocalPort == nil {
@@ -291,7 +291,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 	}
 	if y.SSH.LocalPort == nil {
 		// y.SSH.LocalPort value is not filled here (filled by the hostagent)
-		y.SSH.LocalPort = pointer.Int(0)
+		y.SSH.LocalPort = ptr.Of(0)
 	}
 	if y.SSH.LoadDotSSHPubKeys == nil {
 		y.SSH.LoadDotSSHPubKeys = d.SSH.LoadDotSSHPubKeys
@@ -300,7 +300,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.SSH.LoadDotSSHPubKeys = o.SSH.LoadDotSSHPubKeys
 	}
 	if y.SSH.LoadDotSSHPubKeys == nil {
-		y.SSH.LoadDotSSHPubKeys = pointer.Bool(true)
+		y.SSH.LoadDotSSHPubKeys = ptr.Of(true)
 	}
 
 	if y.SSH.ForwardAgent == nil {
@@ -310,7 +310,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.SSH.ForwardAgent = o.SSH.ForwardAgent
 	}
 	if y.SSH.ForwardAgent == nil {
-		y.SSH.ForwardAgent = pointer.Bool(false)
+		y.SSH.ForwardAgent = ptr.Of(false)
 	}
 
 	if y.SSH.ForwardX11 == nil {
@@ -320,7 +320,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.SSH.ForwardX11 = o.SSH.ForwardX11
 	}
 	if y.SSH.ForwardX11 == nil {
-		y.SSH.ForwardX11 = pointer.Bool(false)
+		y.SSH.ForwardX11 = ptr.Of(false)
 	}
 
 	if y.SSH.ForwardX11Trusted == nil {
@@ -330,7 +330,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.SSH.ForwardX11Trusted = o.SSH.ForwardX11Trusted
 	}
 	if y.SSH.ForwardX11Trusted == nil {
-		y.SSH.ForwardX11Trusted = pointer.Bool(false)
+		y.SSH.ForwardX11Trusted = ptr.Of(false)
 	}
 
 	hosts := make(map[string]string)
@@ -353,7 +353,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 			provision.Mode = ProvisionModeSystem
 		}
 		if provision.Mode == ProvisionModeDependency && provision.SkipDefaultDependencyResolution == nil {
-			provision.SkipDefaultDependencyResolution = pointer.Bool(false)
+			provision.SkipDefaultDependencyResolution = ptr.Of(false)
 		}
 	}
 
@@ -364,7 +364,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.GuestInstallPrefix = o.GuestInstallPrefix
 	}
 	if y.GuestInstallPrefix == nil {
-		y.GuestInstallPrefix = pointer.String(defaultGuestInstallPrefix())
+		y.GuestInstallPrefix = ptr.Of(defaultGuestInstallPrefix())
 	}
 
 	if y.Containerd.System == nil {
@@ -374,7 +374,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.Containerd.System = o.Containerd.System
 	}
 	if y.Containerd.System == nil {
-		y.Containerd.System = pointer.Bool(false)
+		y.Containerd.System = ptr.Of(false)
 	}
 	if y.Containerd.User == nil {
 		y.Containerd.User = d.Containerd.User
@@ -383,7 +383,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.Containerd.User = o.Containerd.User
 	}
 	if y.Containerd.User == nil {
-		y.Containerd.User = pointer.Bool(true)
+		y.Containerd.User = ptr.Of(true)
 	}
 
 	y.Containerd.Archives = append(append(o.Containerd.Archives, y.Containerd.Archives...), d.Containerd.Archives...)
@@ -427,7 +427,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.HostResolver.Enabled = o.HostResolver.Enabled
 	}
 	if y.HostResolver.Enabled == nil {
-		y.HostResolver.Enabled = pointer.Bool(true)
+		y.HostResolver.Enabled = ptr.Of(true)
 	}
 
 	if y.HostResolver.IPv6 == nil {
@@ -437,7 +437,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.HostResolver.IPv6 = o.HostResolver.IPv6
 	}
 	if y.HostResolver.IPv6 == nil {
-		y.HostResolver.IPv6 = pointer.Bool(false)
+		y.HostResolver.IPv6 = ptr.Of(false)
 	}
 
 	if y.PropagateProxyEnv == nil {
@@ -447,7 +447,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.PropagateProxyEnv = o.PropagateProxyEnv
 	}
 	if y.PropagateProxyEnv == nil {
-		y.PropagateProxyEnv = pointer.Bool(true)
+		y.PropagateProxyEnv = ptr.Of(true)
 	}
 
 	networks := make([]Network, 0, len(d.Networks)+len(y.Networks)+len(o.Networks))
@@ -519,9 +519,9 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 	}
 	if y.MountType == nil || *y.MountType == "" {
 		if *y.VMType == VZ {
-			y.MountType = pointer.String(VIRTIOFS)
+			y.MountType = ptr.Of(VIRTIOFS)
 		} else {
-			y.MountType = pointer.String(REVSSHFS)
+			y.MountType = ptr.Of(REVSSHFS)
 		}
 	}
 
@@ -571,34 +571,34 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 	for i := range y.Mounts {
 		mount := &y.Mounts[i]
 		if mount.SSHFS.Cache == nil {
-			mount.SSHFS.Cache = pointer.Bool(true)
+			mount.SSHFS.Cache = ptr.Of(true)
 		}
 		if mount.SSHFS.FollowSymlinks == nil {
-			mount.SSHFS.FollowSymlinks = pointer.Bool(false)
+			mount.SSHFS.FollowSymlinks = ptr.Of(false)
 		}
 		if mount.SSHFS.SFTPDriver == nil {
-			mount.SSHFS.SFTPDriver = pointer.String("")
+			mount.SSHFS.SFTPDriver = ptr.Of("")
 		}
 		if mount.NineP.SecurityModel == nil {
-			mounts[i].NineP.SecurityModel = pointer.String(Default9pSecurityModel)
+			mounts[i].NineP.SecurityModel = ptr.Of(Default9pSecurityModel)
 		}
 		if mount.NineP.ProtocolVersion == nil {
-			mounts[i].NineP.ProtocolVersion = pointer.String(Default9pProtocolVersion)
+			mounts[i].NineP.ProtocolVersion = ptr.Of(Default9pProtocolVersion)
 		}
 		if mount.NineP.Msize == nil {
-			mounts[i].NineP.Msize = pointer.String(Default9pMsize)
+			mounts[i].NineP.Msize = ptr.Of(Default9pMsize)
 		}
 		if mount.Virtiofs.QueueSize == nil && *y.VMType == QEMU && *y.MountType == VIRTIOFS {
-			mounts[i].Virtiofs.QueueSize = pointer.Int(DefaultVirtiofsQueueSize)
+			mounts[i].Virtiofs.QueueSize = ptr.Of(DefaultVirtiofsQueueSize)
 		}
 		if mount.Writable == nil {
-			mount.Writable = pointer.Bool(false)
+			mount.Writable = ptr.Of(false)
 		}
 		if mount.NineP.Cache == nil {
 			if *mount.Writable {
-				mounts[i].NineP.Cache = pointer.String(Default9pCacheForRW)
+				mounts[i].NineP.Cache = ptr.Of(Default9pCacheForRW)
 			} else {
-				mounts[i].NineP.Cache = pointer.String(Default9pCacheForRO)
+				mounts[i].NineP.Cache = ptr.Of(Default9pCacheForRO)
 			}
 		}
 		if mount.MountPoint == "" {
@@ -633,7 +633,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.CACertificates.RemoveDefaults = o.CACertificates.RemoveDefaults
 	}
 	if y.CACertificates.RemoveDefaults == nil {
-		y.CACertificates.RemoveDefaults = pointer.Bool(false)
+		y.CACertificates.RemoveDefaults = ptr.Of(false)
 	}
 
 	caFiles := unique(append(append(d.CACertificates.Files, y.CACertificates.Files...), o.CACertificates.Files...))
@@ -650,10 +650,10 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 			y.Rosetta.Enabled = o.Rosetta.Enabled
 		}
 		if y.Rosetta.Enabled == nil {
-			y.Rosetta.Enabled = pointer.Bool(false)
+			y.Rosetta.Enabled = ptr.Of(false)
 		}
 	} else {
-		y.Rosetta.Enabled = pointer.Bool(false)
+		y.Rosetta.Enabled = ptr.Of(false)
 	}
 
 	if y.Rosetta.BinFmt == nil {
@@ -663,7 +663,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.Rosetta.BinFmt = o.Rosetta.BinFmt
 	}
 	if y.Rosetta.BinFmt == nil {
-		y.Rosetta.BinFmt = pointer.Bool(false)
+		y.Rosetta.BinFmt = ptr.Of(false)
 	}
 
 	if y.Plain == nil {
@@ -673,7 +673,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.Plain = o.Plain
 	}
 	if y.Plain == nil {
-		y.Plain = pointer.Bool(false)
+		y.Plain = ptr.Of(false)
 	}
 
 	fixUpForPlainMode(y)
@@ -685,10 +685,10 @@ func fixUpForPlainMode(y *LimaYAML) {
 	}
 	y.Mounts = nil
 	y.PortForwards = nil
-	y.Containerd.System = pointer.Bool(false)
-	y.Containerd.User = pointer.Bool(false)
-	y.Rosetta.BinFmt = pointer.Bool(false)
-	y.Rosetta.Enabled = pointer.Bool(false)
+	y.Containerd.System = ptr.Of(false)
+	y.Containerd.User = ptr.Of(false)
+	y.Rosetta.BinFmt = ptr.Of(false)
+	y.Rosetta.Enabled = ptr.Of(false)
 }
 
 func executeGuestTemplate(format string) (bytes.Buffer, error) {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/lima-vm/lima/pkg/guestagent/api"
 	"github.com/lima-vm/lima/pkg/osutil"
+	"github.com/lima-vm/lima/pkg/ptr"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/xorcare/pointer"
 	"gotest.tools/v3/assert"
 )
 
@@ -60,52 +60,52 @@ func TestFillDefault(t *testing.T) {
 
 	// Builtin default values
 	builtin := LimaYAML{
-		VMType: pointer.String("qemu"),
-		OS:     pointer.String(LINUX),
-		Arch:   pointer.String(arch),
+		VMType: ptr.Of("qemu"),
+		OS:     ptr.Of(LINUX),
+		Arch:   ptr.Of(arch),
 		CPUType: map[Arch]string{
 			AARCH64: "cortex-a72",
 			ARMV7L:  "cortex-a7",
 			X8664:   "qemu64",
 			RISCV64: "rv64",
 		},
-		CPUs:               pointer.Int(defaultCPUs()),
-		Memory:             pointer.String(defaultMemoryAsString()),
-		Disk:               pointer.String(defaultDiskSizeAsString()),
-		GuestInstallPrefix: pointer.String(defaultGuestInstallPrefix()),
+		CPUs:               ptr.Of(defaultCPUs()),
+		Memory:             ptr.Of(defaultMemoryAsString()),
+		Disk:               ptr.Of(defaultDiskSizeAsString()),
+		GuestInstallPrefix: ptr.Of(defaultGuestInstallPrefix()),
 		Containerd: Containerd{
-			System:   pointer.Bool(false),
-			User:     pointer.Bool(true),
+			System:   ptr.Of(false),
+			User:     ptr.Of(true),
 			Archives: defaultContainerdArchives(),
 		},
 		SSH: SSH{
-			LocalPort:         pointer.Int(0),
-			LoadDotSSHPubKeys: pointer.Bool(true),
-			ForwardAgent:      pointer.Bool(false),
-			ForwardX11:        pointer.Bool(false),
-			ForwardX11Trusted: pointer.Bool(false),
+			LocalPort:         ptr.Of(0),
+			LoadDotSSHPubKeys: ptr.Of(true),
+			ForwardAgent:      ptr.Of(false),
+			ForwardX11:        ptr.Of(false),
+			ForwardX11Trusted: ptr.Of(false),
 		},
 		Firmware: Firmware{
-			LegacyBIOS: pointer.Bool(false),
+			LegacyBIOS: ptr.Of(false),
 		},
 		Audio: Audio{
-			Device: pointer.String(""),
+			Device: ptr.Of(""),
 		},
 		Video: Video{
-			Display: pointer.String("none"),
+			Display: ptr.Of("none"),
 			VNC: VNCOptions{
-				Display: pointer.String("127.0.0.1:0,to=9"),
+				Display: ptr.Of("127.0.0.1:0,to=9"),
 			},
 		},
 		HostResolver: HostResolver{
-			Enabled: pointer.Bool(true),
-			IPv6:    pointer.Bool(false),
+			Enabled: ptr.Of(true),
+			IPv6:    ptr.Of(false),
 		},
-		PropagateProxyEnv: pointer.Bool(true),
+		PropagateProxyEnv: ptr.Of(true),
 		CACertificates: CACertificates{
-			RemoveDefaults: pointer.Bool(false),
+			RemoveDefaults: ptr.Of(false),
 		},
-		Plain: pointer.Bool(false),
+		Plain: ptr.Of(false),
 	}
 	if IsAccelOS() {
 		if HasHostCPU() {
@@ -144,7 +144,7 @@ func TestFillDefault(t *testing.T) {
 		Mounts: []Mount{
 			{Location: "/tmp"},
 		},
-		MountType: pointer.String(NINEP),
+		MountType: ptr.Of(NINEP),
 		Provision: []Provision{
 			{Script: "#!/bin/true"},
 		},
@@ -190,18 +190,18 @@ func TestFillDefault(t *testing.T) {
 
 	expect.Mounts = y.Mounts
 	expect.Mounts[0].MountPoint = expect.Mounts[0].Location
-	expect.Mounts[0].Writable = pointer.Bool(false)
-	expect.Mounts[0].SSHFS.Cache = pointer.Bool(true)
-	expect.Mounts[0].SSHFS.FollowSymlinks = pointer.Bool(false)
-	expect.Mounts[0].SSHFS.SFTPDriver = pointer.String("")
-	expect.Mounts[0].NineP.SecurityModel = pointer.String(Default9pSecurityModel)
-	expect.Mounts[0].NineP.ProtocolVersion = pointer.String(Default9pProtocolVersion)
-	expect.Mounts[0].NineP.Msize = pointer.String(Default9pMsize)
-	expect.Mounts[0].NineP.Cache = pointer.String(Default9pCacheForRO)
-	expect.Mounts[0].Virtiofs.QueueSize = pointer.Int(DefaultVirtiofsQueueSize)
+	expect.Mounts[0].Writable = ptr.Of(false)
+	expect.Mounts[0].SSHFS.Cache = ptr.Of(true)
+	expect.Mounts[0].SSHFS.FollowSymlinks = ptr.Of(false)
+	expect.Mounts[0].SSHFS.SFTPDriver = ptr.Of("")
+	expect.Mounts[0].NineP.SecurityModel = ptr.Of(Default9pSecurityModel)
+	expect.Mounts[0].NineP.ProtocolVersion = ptr.Of(Default9pProtocolVersion)
+	expect.Mounts[0].NineP.Msize = ptr.Of(Default9pMsize)
+	expect.Mounts[0].NineP.Cache = ptr.Of(Default9pCacheForRO)
+	expect.Mounts[0].Virtiofs.QueueSize = ptr.Of(DefaultVirtiofsQueueSize)
 	// Only missing Mounts field is Writable, and the default value is also the null value: false
 
-	expect.MountType = pointer.String(NINEP)
+	expect.MountType = ptr.Of(NINEP)
 
 	expect.Provision = y.Provision
 	expect.Provision[0].Mode = ProvisionModeSystem
@@ -245,7 +245,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Env = y.Env
 
 	expect.CACertificates = CACertificates{
-		RemoveDefaults: pointer.Bool(false),
+		RemoveDefaults: ptr.Of(false),
 		Files:          []string{"ca.crt"},
 		Certs: []string{
 			"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT\n-----END CERTIFICATE-----\n",
@@ -253,8 +253,8 @@ func TestFillDefault(t *testing.T) {
 	}
 
 	expect.Rosetta = Rosetta{
-		Enabled: pointer.Bool(false),
-		BinFmt:  pointer.Bool(false),
+		Enabled: ptr.Of(false),
+		BinFmt:  ptr.Of(false),
 	}
 
 	FillDefault(&y, &LimaYAML{}, &LimaYAML{}, filePath)
@@ -267,61 +267,61 @@ func TestFillDefault(t *testing.T) {
 
 	// Choose values that are different from the "builtin" defaults
 	d = LimaYAML{
-		VMType: pointer.String("vz"),
-		OS:     pointer.String("unknown"),
-		Arch:   pointer.String("unknown"),
+		VMType: ptr.Of("vz"),
+		OS:     ptr.Of("unknown"),
+		Arch:   ptr.Of("unknown"),
 		CPUType: map[Arch]string{
 			AARCH64: "arm64",
 			ARMV7L:  "armhf",
 			X8664:   "amd64",
 			RISCV64: "riscv64",
 		},
-		CPUs:   pointer.Int(7),
-		Memory: pointer.String("5GiB"),
-		Disk:   pointer.String("105GiB"),
+		CPUs:   ptr.Of(7),
+		Memory: ptr.Of("5GiB"),
+		Disk:   ptr.Of("105GiB"),
 		AdditionalDisks: []Disk{
 			{Name: "data"},
 		},
-		GuestInstallPrefix: pointer.String("/opt"),
+		GuestInstallPrefix: ptr.Of("/opt"),
 		Containerd: Containerd{
-			System: pointer.Bool(true),
-			User:   pointer.Bool(false),
+			System: ptr.Of(true),
+			User:   ptr.Of(false),
 			Archives: []File{
 				{Location: "/tmp/nerdctl.tgz"},
 			},
 		},
 		SSH: SSH{
-			LocalPort:         pointer.Int(888),
-			LoadDotSSHPubKeys: pointer.Bool(false),
-			ForwardAgent:      pointer.Bool(true),
-			ForwardX11:        pointer.Bool(false),
-			ForwardX11Trusted: pointer.Bool(false),
+			LocalPort:         ptr.Of(888),
+			LoadDotSSHPubKeys: ptr.Of(false),
+			ForwardAgent:      ptr.Of(true),
+			ForwardX11:        ptr.Of(false),
+			ForwardX11Trusted: ptr.Of(false),
 		},
 		Firmware: Firmware{
-			LegacyBIOS: pointer.Bool(true),
+			LegacyBIOS: ptr.Of(true),
 		},
 		Audio: Audio{
-			Device: pointer.String("coreaudio"),
+			Device: ptr.Of("coreaudio"),
 		},
 		Video: Video{
-			Display: pointer.String("cocoa"),
+			Display: ptr.Of("cocoa"),
 			VNC: VNCOptions{
-				Display: pointer.String("none"),
+				Display: ptr.Of("none"),
 			},
 		},
 		HostResolver: HostResolver{
-			Enabled: pointer.Bool(false),
-			IPv6:    pointer.Bool(true),
+			Enabled: ptr.Of(false),
+			IPv6:    ptr.Of(true),
 			Hosts: map[string]string{
 				"default": "localhost",
 			},
 		},
-		PropagateProxyEnv: pointer.Bool(false),
+		PropagateProxyEnv: ptr.Of(false),
 
 		Mounts: []Mount{
 			{
 				Location: "/var/log",
-				Writable: pointer.Bool(false),
+				Writable: ptr.Of(false),
 			},
 		},
 		Provision: []Provision{
@@ -363,14 +363,14 @@ func TestFillDefault(t *testing.T) {
 			"TWO": "two",
 		},
 		CACertificates: CACertificates{
-			RemoveDefaults: pointer.Bool(true),
+			RemoveDefaults: ptr.Of(true),
 			Certs: []string{
 				"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT\n-----END CERTIFICATE-----\n",
 			},
 		},
 		Rosetta: Rosetta{
-			Enabled: pointer.Bool(true),
-			BinFmt:  pointer.Bool(true),
+			Enabled: ptr.Of(true),
+			BinFmt:  ptr.Of(true),
 		},
 	}
 
@@ -378,35 +378,35 @@ func TestFillDefault(t *testing.T) {
 	// Also verify that archive arch is filled in
 	expect.Containerd.Archives[0].Arch = *d.Arch
 	expect.Mounts[0].MountPoint = expect.Mounts[0].Location
-	expect.Mounts[0].SSHFS.Cache = pointer.Bool(true)
-	expect.Mounts[0].SSHFS.FollowSymlinks = pointer.Bool(false)
-	expect.Mounts[0].SSHFS.SFTPDriver = pointer.String("")
-	expect.Mounts[0].NineP.SecurityModel = pointer.String(Default9pSecurityModel)
-	expect.Mounts[0].NineP.ProtocolVersion = pointer.String(Default9pProtocolVersion)
-	expect.Mounts[0].NineP.Msize = pointer.String(Default9pMsize)
-	expect.Mounts[0].NineP.Cache = pointer.String(Default9pCacheForRO)
-	expect.Mounts[0].Virtiofs.QueueSize = pointer.Int(DefaultVirtiofsQueueSize)
+	expect.Mounts[0].SSHFS.Cache = ptr.Of(true)
+	expect.Mounts[0].SSHFS.FollowSymlinks = ptr.Of(false)
+	expect.Mounts[0].SSHFS.SFTPDriver = ptr.Of("")
+	expect.Mounts[0].NineP.SecurityModel = ptr.Of(Default9pSecurityModel)
+	expect.Mounts[0].NineP.ProtocolVersion = ptr.Of(Default9pProtocolVersion)
+	expect.Mounts[0].NineP.Msize = ptr.Of(Default9pMsize)
+	expect.Mounts[0].NineP.Cache = ptr.Of(Default9pCacheForRO)
+	expect.Mounts[0].Virtiofs.QueueSize = ptr.Of(DefaultVirtiofsQueueSize)
 	expect.HostResolver.Hosts = map[string]string{
 		"default": d.HostResolver.Hosts["default"],
 	}
-	expect.MountType = pointer.String(VIRTIOFS)
-	expect.CACertificates.RemoveDefaults = pointer.Bool(true)
+	expect.MountType = ptr.Of(VIRTIOFS)
+	expect.CACertificates.RemoveDefaults = ptr.Of(true)
 	expect.CACertificates.Certs = []string{
 		"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT\n-----END CERTIFICATE-----\n",
 	}
 
 	if runtime.GOOS == "darwin" && IsNativeArch(AARCH64) {
 		expect.Rosetta = Rosetta{
-			Enabled: pointer.Bool(true),
-			BinFmt:  pointer.Bool(true),
+			Enabled: ptr.Of(true),
+			BinFmt:  ptr.Of(true),
 		}
 	} else {
 		expect.Rosetta = Rosetta{
-			Enabled: pointer.Bool(false),
-			BinFmt:  pointer.Bool(true),
+			Enabled: ptr.Of(false),
+			BinFmt:  ptr.Of(true),
 		}
 	}
-	expect.Plain = pointer.Bool(false)
+	expect.Plain = ptr.Of(false)
 
 	y = LimaYAML{}
 	FillDefault(&y, &d, &LimaYAML{}, filePath)
@@ -446,25 +446,25 @@ func TestFillDefault(t *testing.T) {
 	// User-provided overrides should override user-provided config settings
 
 	o = LimaYAML{
-		VMType: pointer.String("qemu"),
-		OS:     pointer.String(LINUX),
-		Arch:   pointer.String(arch),
+		VMType: ptr.Of("qemu"),
+		OS:     ptr.Of(LINUX),
+		Arch:   ptr.Of(arch),
 		CPUType: map[Arch]string{
 			AARCH64: "uber-arm",
 			ARMV7L:  "armv8",
 			X8664:   "pentium",
 			RISCV64: "sifive-u54",
 		},
-		CPUs:   pointer.Int(12),
-		Memory: pointer.String("7GiB"),
-		Disk:   pointer.String("117GiB"),
+		CPUs:   ptr.Of(12),
+		Memory: ptr.Of("7GiB"),
+		Disk:   ptr.Of("117GiB"),
 		AdditionalDisks: []Disk{
 			{Name: "test"},
 		},
-		GuestInstallPrefix: pointer.String("/usr"),
+		GuestInstallPrefix: ptr.Of("/usr"),
 		Containerd: Containerd{
-			System: pointer.Bool(true),
-			User:   pointer.Bool(false),
+			System: ptr.Of(true),
+			User:   ptr.Of(false),
 			Archives: []File{
 				{
 					Arch:     arch,
@@ -474,49 +474,49 @@ func TestFillDefault(t *testing.T) {
 			},
 		},
 		SSH: SSH{
-			LocalPort:         pointer.Int(4433),
-			LoadDotSSHPubKeys: pointer.Bool(true),
-			ForwardAgent:      pointer.Bool(true),
-			ForwardX11:        pointer.Bool(false),
-			ForwardX11Trusted: pointer.Bool(false),
+			LocalPort:         ptr.Of(4433),
+			LoadDotSSHPubKeys: ptr.Of(true),
+			ForwardAgent:      ptr.Of(true),
+			ForwardX11:        ptr.Of(false),
+			ForwardX11Trusted: ptr.Of(false),
 		},
 		Firmware: Firmware{
-			LegacyBIOS: pointer.Bool(true),
+			LegacyBIOS: ptr.Of(true),
 		},
 		Audio: Audio{
-			Device: pointer.String("coreaudio"),
+			Device: ptr.Of("coreaudio"),
 		},
 		Video: Video{
-			Display: pointer.String("cocoa"),
+			Display: ptr.Of("cocoa"),
 			VNC: VNCOptions{
-				Display: pointer.String("none"),
+				Display: ptr.Of("none"),
 			},
 		},
 		HostResolver: HostResolver{
-			Enabled: pointer.Bool(false),
-			IPv6:    pointer.Bool(false),
+			Enabled: ptr.Of(false),
+			IPv6:    ptr.Of(false),
 			Hosts: map[string]string{
 				"override.": "underflow",
 			},
 		},
-		PropagateProxyEnv: pointer.Bool(false),
+		PropagateProxyEnv: ptr.Of(false),
 
 		Mounts: []Mount{
 			{
 				Location: "/var/log",
-				Writable: pointer.Bool(true),
+				Writable: ptr.Of(true),
 				SSHFS: SSHFS{
-					Cache:          pointer.Bool(false),
-					FollowSymlinks: pointer.Bool(true),
+					Cache:          ptr.Of(false),
+					FollowSymlinks: ptr.Of(true),
 				},
 				NineP: NineP{
-					SecurityModel:   pointer.String("mapped-file"),
-					ProtocolVersion: pointer.String("9p2000"),
-					Msize:           pointer.String("8KiB"),
-					Cache:           pointer.String("none"),
+					SecurityModel:   ptr.Of("mapped-file"),
+					ProtocolVersion: ptr.Of("9p2000"),
+					Msize:           ptr.Of("8KiB"),
+					Cache:           ptr.Of("none"),
 				},
 				Virtiofs: Virtiofs{
-					QueueSize: pointer.Int(2048),
+					QueueSize: ptr.Of(2048),
 				},
 			},
 		},
@@ -562,11 +562,11 @@ func TestFillDefault(t *testing.T) {
 			"THREE": "trois",
 		},
 		CACertificates: CACertificates{
-			RemoveDefaults: pointer.Bool(true),
+			RemoveDefaults: ptr.Of(true),
 		},
 		Rosetta: Rosetta{
-			Enabled: pointer.Bool(false),
-			BinFmt:  pointer.Bool(false),
+			Enabled: ptr.Of(false),
+			BinFmt:  ptr.Of(false),
 		},
 	}
 
@@ -586,16 +586,16 @@ func TestFillDefault(t *testing.T) {
 
 	// o.Mounts just makes d.Mounts[0] writable because the Location matches
 	expect.Mounts = append(d.Mounts, y.Mounts...)
-	expect.Mounts[0].Writable = pointer.Bool(true)
-	expect.Mounts[0].SSHFS.Cache = pointer.Bool(false)
-	expect.Mounts[0].SSHFS.FollowSymlinks = pointer.Bool(true)
-	expect.Mounts[0].NineP.SecurityModel = pointer.String("mapped-file")
-	expect.Mounts[0].NineP.ProtocolVersion = pointer.String("9p2000")
-	expect.Mounts[0].NineP.Msize = pointer.String("8KiB")
-	expect.Mounts[0].NineP.Cache = pointer.String("none")
-	expect.Mounts[0].Virtiofs.QueueSize = pointer.Int(2048)
+	expect.Mounts[0].Writable = ptr.Of(true)
+	expect.Mounts[0].SSHFS.Cache = ptr.Of(false)
+	expect.Mounts[0].SSHFS.FollowSymlinks = ptr.Of(true)
+	expect.Mounts[0].NineP.SecurityModel = ptr.Of("mapped-file")
+	expect.Mounts[0].NineP.ProtocolVersion = ptr.Of("9p2000")
+	expect.Mounts[0].NineP.Msize = ptr.Of("8KiB")
+	expect.Mounts[0].NineP.Cache = ptr.Of("none")
+	expect.Mounts[0].Virtiofs.QueueSize = ptr.Of(2048)
 
-	expect.MountType = pointer.String(NINEP)
+	expect.MountType = ptr.Of(NINEP)
 
 	// o.Networks[1] is overriding the d.Networks[0].Lima entry for the "def0" interface
 	expect.Networks = append(append(d.Networks, y.Networks...), o.Networks[0])
@@ -609,17 +609,17 @@ func TestFillDefault(t *testing.T) {
 	// ONE remains from filledDefaults.Env; the rest are set from o
 	expect.Env["ONE"] = y.Env["ONE"]
 
-	expect.CACertificates.RemoveDefaults = pointer.Bool(true)
+	expect.CACertificates.RemoveDefaults = ptr.Of(true)
 	expect.CACertificates.Files = []string{"ca.crt"}
 	expect.CACertificates.Certs = []string{
 		"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT\n-----END CERTIFICATE-----\n",
 	}
 
 	expect.Rosetta = Rosetta{
-		Enabled: pointer.Bool(false),
-		BinFmt:  pointer.Bool(false),
+		Enabled: ptr.Of(false),
+		BinFmt:  ptr.Of(false),
 	}
-	expect.Plain = pointer.Bool(false)
+	expect.Plain = ptr.Of(false)
 
 	FillDefault(&y, &d, &o, filePath)
 	assert.DeepEqual(t, &y, &expect, opts...)

--- a/pkg/ptr/ptr.go
+++ b/pkg/ptr/ptr.go
@@ -1,0 +1,7 @@
+// Package ptr holds utilities for taking pointer references to values.
+package ptr
+
+// Of returns pointer to value.
+func Of[T any](value T) *T {
+	return &value
+}

--- a/pkg/ptr/ptr_test.go
+++ b/pkg/ptr/ptr_test.go
@@ -1,0 +1,14 @@
+package ptr
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestOf(t *testing.T) {
+	assert.DeepEqual(t, bool(true), *Of(true))
+	assert.DeepEqual(t, int(10), *Of(10))
+	assert.DeepEqual(t, string(""), *Of(""))
+	assert.DeepEqual(t, string("value"), *Of("value"))
+}


### PR DESCRIPTION
This PR removes `github.com/xorcare/pointer` dependency. It's not worth to import the whole package for the one function. With generics we can write it in one line:
```go
func Of[T any](value T) *T {
	return &value
}
```