### PR TITLE
textutil,dns: enable and fix dupword lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,7 @@ linters:
   - bodyclose
   # - dogsled
   # - dupl
+  - dupword
   # - errcheck
   # - errorlint
   # - exhaustive

--- a/pkg/hostagent/dns/dns.go
+++ b/pkg/hostagent/dns/dns.go
@@ -68,7 +68,7 @@ func (s *Server) Shutdown() {
 }
 
 func newStaticClientConfig(ips []string) (*dns.ClientConfig, error) {
-	logrus.Tracef("newStaticClientConfig creating config for the the following IPs: %v", ips)
+	logrus.Tracef("newStaticClientConfig creating config for the following IPs: %v", ips)
 	s := ``
 	for _, ip := range ips {
 		s += fmt.Sprintf("nameserver %s\n", ip)

--- a/pkg/textutil/textutil.go
+++ b/pkg/textutil/textutil.go
@@ -77,7 +77,7 @@ var TemplateFuncMap = template.FuncMap{
 	},
 	"indent": func(a ...interface{}) (string, error) {
 		if len(a) == 0 {
-			return "", errors.New("function takes at at least one string argument")
+			return "", errors.New("function takes at least one string argument")
 		}
 		if len(a) > 2 {
 			return "", errors.New("function takes at most 2 arguments")
@@ -97,7 +97,7 @@ var TemplateFuncMap = template.FuncMap{
 	},
 	"missing": func(a ...interface{}) (string, error) {
 		if len(a) == 0 {
-			return "", errors.New("function takes at at least one string argument")
+			return "", errors.New("function takes at least one string argument")
 		}
 		if len(a) > 2 {
 			return "", errors.New("function takes at most 2 arguments")


### PR DESCRIPTION
This PR enables `dupword` and fixes the following lint issues:
```sh
❯ golangci-lint run
pkg/hostagent/dns/dns.go:71:16: Duplicate words (the) found (dupword)
        logrus.Tracef("newStaticClientConfig creating config for the the following IPs: %v", ips)
                      ^
pkg/textutil/textutil.go:80:26: Duplicate words (at) found (dupword)
                        return "", errors.New("function takes at at least one string argument")
                                              ^
pkg/textutil/textutil.go:100:26: Duplicate words (at) found (dupword)
                        return "", errors.New("function takes at at least one string argument")
                                              ^
```