### PR TITLE
Fix website github links

### DIFF
--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -110,7 +110,7 @@ version = "master"
 #url_latest_version = "https://lima-vm.io"
 
 # Specify a value here if your content directory is not in your repo's root directory
-# github_subdir = ""
+github_subdir = "website"
 
 # Uncomment this if your GitHub repo does not have "main" as the default branch,
 # or specify a new value if you want to reference another branch in your GitHub links


### PR DESCRIPTION
This PR fixes #1914 .
It needs to specify `github_subdir` parameter. ([Doc](https://www.docsy.dev/docs/adding-content/repository-links/#github_subdir-optional))

#### Build result
<img width="1070" alt="image" src="https://github.com/lima-vm/lima/assets/38242129/d2343eca-76e0-4c44-9474-e3707f10132c">
