### PR TITLE
k8s: wait for coredns deployment to be available

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -155,6 +155,11 @@ probes:
       echo >&2 "kubernetes cluster is not up and running yet"
       exit 1
     fi
+- description: "coredns deployment to be running"
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    sudo kubectl wait -n kube-system --timeout=180s --for=condition=available deploy coredns
 copyToHost:
 - guest: "/etc/kubernetes/admin.conf"
   host: "{{.Dir}}/copied-from-guest/kubeconfig.yaml"


### PR DESCRIPTION
Wait for flannel and coredns to be fully deployed, before announcing the cluster "ready"...

We don't need to do this for k3s, since there it is more integrated (and starts up faster too)

```
NAMESPACE      NAME                               READY   STATUS     RESTARTS   AGE   IP             NODE       NOMINATED NODE   READINESS GATES
kube-flannel   kube-flannel-ds-9szh5              0/1     Init:0/2   0          4s    192.168.5.15   lima-k8s   <none>           <none>
kube-system    coredns-5dd5756b68-pxl27           0/1     Pending    0          3s    <none>         <none>     <none>           <none>
kube-system    coredns-5dd5756b68-tzx9t           0/1     Pending    0          3s    <none>         <none>     <none>           <none>
kube-system    etcd-lima-k8s                      1/1     Running    0          17s   192.168.5.15   lima-k8s   <none>           <none>
kube-system    kube-apiserver-lima-k8s            1/1     Running    0          16s   192.168.5.15   lima-k8s   <none>           <none>
kube-system    kube-controller-manager-lima-k8s   1/1     Running    0          17s   192.168.5.15   lima-k8s   <none>           <none>
kube-system    kube-proxy-j8hfv                   1/1     Running    0          4s    192.168.5.15   lima-k8s   <none>           <none>
kube-system    kube-scheduler-lima-k8s            1/1     Running    0          16s   192.168.5.15   lima-k8s   <none>           <none>
```

Note: it doesn't _have_ to be flannel, but whatever CNI is being used (by default, that is flannel).