### PR TITLE
Enable errcheck linter; fix lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,7 @@ linters:
   # - dogsled
   # - dupl
   - dupword
-  # - errcheck
+  - errcheck
   # - errorlint
   # - exhaustive
   # - exhaustivestruct

--- a/cmd/limactl/disk.go
+++ b/cmd/limactl/disk.go
@@ -51,7 +51,7 @@ $ limactl disk create DISK --size SIZE [--format qcow2]
 		RunE:  diskCreateAction,
 	}
 	diskCreateCommand.Flags().String("size", "", "configure the disk size")
-	diskCreateCommand.MarkFlagRequired("size")
+	_ = diskCreateCommand.MarkFlagRequired("size")
 	diskCreateCommand.Flags().String("format", "qcow2", "specify the disk format")
 	return diskCreateCommand
 }

--- a/cmd/limactl/gendoc.go
+++ b/cmd/limactl/gendoc.go
@@ -61,10 +61,11 @@ func gendocAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if output != "" && prefix != "" {
-		replaceAll(dir, output, prefix)
+		if err := replaceAll(dir, output, prefix); err != nil {
+			return err
+		}
 	}
-	replaceAll(dir, homeDir, "~")
-	return nil
+	return replaceAll(dir, homeDir, "~")
 }
 
 func genMan(cmd *cobra.Command, dir string) error {

--- a/pkg/guestagent/kubernetesservice/kubernetesservice.go
+++ b/pkg/guestagent/kubernetesservice/kubernetesservice.go
@@ -56,7 +56,7 @@ func (s *ServiceWatcher) getServiceInformer() cache.SharedIndexInformer {
 func (s *ServiceWatcher) Start() {
 	const retryInterval = 10 * time.Second
 	const pollImmediately = false
-	wait.PollUntilContextCancel(context.TODO(), retryInterval, pollImmediately, func(ctx context.Context) (done bool, err error) {
+	_ = wait.PollUntilContextCancel(context.TODO(), retryInterval, pollImmediately, func(ctx context.Context) (done bool, err error) {
 		kubeClient, err := tryGetKubeClient()
 		if err != nil {
 			logrus.Tracef("failed to get kube client: %v, will retry in %v", err, retryInterval)

--- a/pkg/guestagent/kubernetesservice/kubernetesservice_test.go
+++ b/pkg/guestagent/kubernetesservice/kubernetesservice_test.go
@@ -27,9 +27,10 @@ func TestGetPorts(t *testing.T) {
 	serviceCreatedCh := make(chan struct{}, 1)
 	kubeClient, informerFactory := newFakeKubeClient()
 	serviceInformer := informerFactory.Core().V1().Services().Informer()
-	serviceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := serviceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) { serviceCreatedCh <- struct{}{} },
 	})
+	assert.NilError(t, err)
 	informerFactory.Start(ctx.Done())
 	serviceWatcher := NewServiceWatcher()
 	serviceWatcher.setServiceInformer(serviceInformer)
@@ -41,7 +42,7 @@ func TestGetPorts(t *testing.T) {
 	}
 	cases := []testCase{
 		{
-			name: "nodePort serivce",
+			name: "nodePort service",
 			service: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "nodeport"},
 				Spec: corev1.ServiceSpec{

--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -325,7 +325,7 @@ func (l *LimaQemuDriver) shutdownQEMU(ctx context.Context, timeout time.Duration
 	select {
 	case qWaitErr := <-qWaitCh:
 		logrus.WithError(qWaitErr).Info("QEMU has exited")
-		l.removeVNCFiles()
+		_ = l.removeVNCFiles()
 		return errors.Join(qWaitErr, l.killVhosts())
 	case <-deadline:
 	}
@@ -346,7 +346,7 @@ func (l *LimaQemuDriver) killQEMU(_ context.Context, _ time.Duration, qCmd *exec
 	}
 	qemuPIDPath := filepath.Join(l.Instance.Dir, filenames.PIDFile(*l.Yaml.VMType))
 	_ = os.RemoveAll(qemuPIDPath)
-	l.removeVNCFiles()
+	_ = l.removeVNCFiles()
 	return errors.Join(qWaitErr, l.killVhosts())
 }
 

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -263,7 +263,7 @@ func watchHostAgentEvents(ctx context.Context, inst *store.Instance, haStdoutPat
 			} else {
 				logrus.Infof("READY. Run `%s` to open the shell.", LimactlShellCmd(inst.Name))
 			}
-			ShowMessage(inst)
+			_ = ShowMessage(inst)
 			err = nil
 			return true
 		}

--- a/pkg/store/instance_test.go
+++ b/pkg/store/instance_test.go
@@ -65,7 +65,8 @@ var tableTwo = "NAME    STATUS     SSH            VMTYPE    ARCH       CPUS    M
 func TestPrintInstanceTable(t *testing.T) {
 	var buf bytes.Buffer
 	instances := []*Instance{&instance}
-	PrintInstances(&buf, instances, "table", nil)
+	err := PrintInstances(&buf, instances, "table", nil)
+	assert.NilError(t, err)
 	assert.Equal(t, table, buf.String())
 }
 
@@ -74,7 +75,8 @@ func TestPrintInstanceTableEmu(t *testing.T) {
 	instance1 := instance
 	instance1.Arch = "unknown"
 	instances := []*Instance{&instance1}
-	PrintInstances(&buf, instances, "table", nil)
+	err := PrintInstances(&buf, instances, "table", nil)
+	assert.NilError(t, err)
 	assert.Equal(t, tableEmu, buf.String())
 }
 
@@ -85,7 +87,8 @@ func TestPrintInstanceTableHome(t *testing.T) {
 	instance1 := instance
 	instance1.Dir = filepath.Join(u.HomeDir, "dir")
 	instances := []*Instance{&instance1}
-	PrintInstances(&buf, instances, "table", nil)
+	err = PrintInstances(&buf, instances, "table", nil)
+	assert.NilError(t, err)
 	assert.Equal(t, tableHome, buf.String())
 }
 
@@ -93,7 +96,8 @@ func TestPrintInstanceTable60(t *testing.T) {
 	var buf bytes.Buffer
 	instances := []*Instance{&instance}
 	options := PrintOptions{TerminalWidth: 60}
-	PrintInstances(&buf, instances, "table", &options)
+	err := PrintInstances(&buf, instances, "table", &options)
+	assert.NilError(t, err)
 	assert.Equal(t, table60, buf.String())
 }
 
@@ -101,7 +105,8 @@ func TestPrintInstanceTable80SameArch(t *testing.T) {
 	var buf bytes.Buffer
 	instances := []*Instance{&instance}
 	options := PrintOptions{TerminalWidth: 80}
-	PrintInstances(&buf, instances, "table", &options)
+	err := PrintInstances(&buf, instances, "table", &options)
+	assert.NilError(t, err)
 	assert.Equal(t, table80i, buf.String())
 }
 
@@ -111,7 +116,8 @@ func TestPrintInstanceTable80DiffArch(t *testing.T) {
 	instance1.Arch = limayaml.NewArch("unknown")
 	instances := []*Instance{&instance1}
 	options := PrintOptions{TerminalWidth: 80}
-	PrintInstances(&buf, instances, "table", &options)
+	err := PrintInstances(&buf, instances, "table", &options)
+	assert.NilError(t, err)
 	assert.Equal(t, table80d, buf.String())
 }
 
@@ -119,7 +125,8 @@ func TestPrintInstanceTable100(t *testing.T) {
 	var buf bytes.Buffer
 	instances := []*Instance{&instance}
 	options := PrintOptions{TerminalWidth: 100}
-	PrintInstances(&buf, instances, "table", &options)
+	err := PrintInstances(&buf, instances, "table", &options)
+	assert.NilError(t, err)
 	assert.Equal(t, table100, buf.String())
 }
 
@@ -127,7 +134,8 @@ func TestPrintInstanceTableAll(t *testing.T) {
 	var buf bytes.Buffer
 	instances := []*Instance{&instance}
 	options := PrintOptions{TerminalWidth: 40, AllFields: true}
-	PrintInstances(&buf, instances, "table", &options)
+	err := PrintInstances(&buf, instances, "table", &options)
+	assert.NilError(t, err)
 	assert.Equal(t, tableAll, buf.String())
 }
 
@@ -143,6 +151,7 @@ func TestPrintInstanceTableTwo(t *testing.T) {
 	instance2.Arch = limayaml.AARCH64
 	instances := []*Instance{&instance1, &instance2}
 	options := PrintOptions{TerminalWidth: 80}
-	PrintInstances(&buf, instances, "table", &options)
+	err := PrintInstances(&buf, instances, "table", &options)
+	assert.NilError(t, err)
 	assert.Equal(t, tableTwo, buf.String())
 }

--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -104,7 +104,7 @@ func startVM(ctx context.Context, driver *driver.BaseDriver) (*virtualMachineWra
 					wrapper.mu.Lock()
 					wrapper.stopped = true
 					wrapper.mu.Unlock()
-					usernetClient.UnExposeSSH(driver.SSHLocalPort)
+					_ = usernetClient.UnExposeSSH(driver.SSHLocalPort)
 					errCh <- errors.New("vz driver state stopped")
 				default:
 					logrus.Debugf("[VZ] - vm state change: %q", newState)


### PR DESCRIPTION
This PR adds `errcheck` to `golangci-lint` config. `errcheck` is useful for detecting code paths when a developer forgets to check for an `err`.

Also, fixes the following lint issues:
```sh
❯ golangci-lint run
pkg/store/instance_test.go:68:16: Error return value is not checked (errcheck)
        PrintInstances(&buf, instances, "table", nil)
                      ^
pkg/store/instance_test.go:77:16: Error return value is not checked (errcheck)
        PrintInstances(&buf, instances, "table", nil)
                      ^
pkg/store/instance_test.go:88:16: Error return value is not checked (errcheck)
        PrintInstances(&buf, instances, "table", nil)
                      ^
pkg/store/instance_test.go:96:16: Error return value is not checked (errcheck)
        PrintInstances(&buf, instances, "table", &options)
                      ^
pkg/store/instance_test.go:104:16: Error return value is not checked (errcheck)
        PrintInstances(&buf, instances, "table", &options)
                      ^
pkg/store/instance_test.go:114:16: Error return value is not checked (errcheck)
        PrintInstances(&buf, instances, "table", &options)
                      ^
pkg/store/instance_test.go:122:16: Error return value is not checked (errcheck)
        PrintInstances(&buf, instances, "table", &options)
                      ^
pkg/store/instance_test.go:130:16: Error return value is not checked (errcheck)
        PrintInstances(&buf, instances, "table", &options)
                      ^
pkg/store/instance_test.go:146:16: Error return value is not checked (errcheck)
        PrintInstances(&buf, instances, "table", &options)
                      ^
pkg/vz/vm_darwin.go:107:31: Error return value of `usernetClient.UnExposeSSH` is not checked (errcheck)
                                        usernetClient.UnExposeSSH(driver.SSHLocalPort)
                                                                 ^
pkg/qemu/qemu_driver.go:328:19: Error return value of `l.removeVNCFiles` is not checked (errcheck)
                l.removeVNCFiles()
                                ^
pkg/qemu/qemu_driver.go:349:18: Error return value of `l.removeVNCFiles` is not checked (errcheck)
        l.removeVNCFiles()
                        ^
pkg/start/start.go:266:15: Error return value is not checked (errcheck)
                        ShowMessage(inst)
                                   ^
cmd/limactl/disk.go:54:36: Error return value of `diskCreateCommand.MarkFlagRequired` is not checked (errcheck)
        diskCreateCommand.MarkFlagRequired("size")
                                          ^
cmd/limactl/gendoc.go:64:13: Error return value is not checked (errcheck)
                replaceAll(dir, output, prefix)
                          ^
cmd/limactl/gendoc.go:66:12: Error return value is not checked (errcheck)
        replaceAll(dir, homeDir, "~")
                  ^
pkg/guestagent/kubernetesservice/kubernetesservice.go:59:29: Error return value of `wait.PollUntilContextCancel` is not checked (errcheck)
        wait.PollUntilContextCancel(context.TODO(), retryInterval, pollImmediately, func(ctx context.Context) (done bool, err error) {
                                   ^
pkg/guestagent/kubernetesservice/kubernetesservice_test.go:30:33: Error return value of `serviceInformer.AddEventHandler` is not checked (errcheck)
        serviceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
                                       ^
```