### PR TITLE
networks/usernet: remove github.com/apparentlymart/go-cidr dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Code-Hex/vz/v3 v3.1.0
 	github.com/alessio/shellescape v1.4.2
-	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/balajiv113/fd v0.0.0-20230330094840-143eec500f3e
 	github.com/cheggaaa/pb/v3 v3.1.4
 	github.com/containerd/containerd v1.7.8
@@ -48,14 +47,13 @@ require (
 	k8s.io/client-go v0.28.3
 )
 
-require google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
-
 require (
 	github.com/Code-Hex/go-infinity-channel v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.1
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/a8m/envsubst v1.4.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.0 // indirect
+	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/digitalocean/go-libvirt v0.0.0-20220804181439-8648fbde413e // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
@@ -114,6 +112,7 @@ require (
 	golang.org/x/tools v0.13.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
 	google.golang.org/grpc v1.58.3 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/djherbis/times.v1 v1.3.0 // indirect

--- a/pkg/networks/usernet/config.go
+++ b/pkg/networks/usernet/config.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"path/filepath"
 
-	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
@@ -86,12 +85,12 @@ func Subnet(name string) (net.IP, error) {
 
 // GatewayIP returns the 2nd IP for the given subnet
 func GatewayIP(subnet net.IP) string {
-	return cidr.Inc(cidr.Inc(subnet)).String()
+	return incIP(incIP(subnet)).String()
 }
 
 // DNSIP returns the 3rd IP for the given subnet
 func DNSIP(subnet net.IP) string {
-	return cidr.Inc(cidr.Inc(cidr.Inc(subnet))).String()
+	return incIP(incIP(incIP(subnet))).String()
 }
 
 // Leases returns a leases file based on network name.

--- a/pkg/networks/usernet/ip.go
+++ b/pkg/networks/usernet/ip.go
@@ -1,0 +1,20 @@
+package usernet
+
+import "net"
+
+// incIP increments IP address by 1.
+func incIP(ip net.IP) net.IP {
+	in := ip
+	if v4 := ip.To4(); v4 != nil {
+		in = v4
+	}
+	res := make([]byte, len(in))
+	copy(res, in)
+	for j := len(res) - 1; j >= 0; j-- {
+		res[j]++
+		if res[j] > 0 {
+			return res
+		}
+	}
+	return res
+}

--- a/pkg/networks/usernet/ip_test.go
+++ b/pkg/networks/usernet/ip_test.go
@@ -1,0 +1,35 @@
+package usernet
+
+import (
+	"net"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestIncIP(t *testing.T) {
+	cases := []struct {
+		ip   string
+		want string
+	}{
+		{ip: "0.0.0.0", want: "0.0.0.1"},
+		{ip: "10.0.0.0", want: "10.0.0.1"},
+		{ip: "192.168.1.1", want: "192.168.1.2"},
+		{ip: "9.255.255.255", want: "10.0.0.0"},
+		{ip: "255.255.255.255", want: "0.0.0.0"},
+		{ip: "::", want: "::1"},
+		{ip: "::1", want: "::2"},
+		{ip: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", want: "::"},
+		{ip: "2001:0db8::1", want: "2001:0db8::2"},
+		{ip: "2001:db8:c001:ba00::", want: "2001:db8:c001:ba00::1"},
+		{ip: "2001:0db8:85a3:0000:0000:8a2e:0370:7334", want: "2001:0db8:85a3:0000:0000:8a2e:0370:7335"},
+	}
+	for _, c := range cases {
+		t.Run(c.ip, func(t *testing.T) {
+			input := net.ParseIP(c.ip)
+			want := net.ParseIP(c.want)
+			got := incIP(input)
+			assert.Assert(t, got.Equal(want))
+		})
+	}
+}


### PR DESCRIPTION
This PR adds `incIP` function for increasing IP by 1. This allows the removal of the direct dependency [`github.com/apparentlymart/go-cidr`](https://github.com/apparentlymart/go-cidr) (the package even without a README).

Because ["A little copying is better than a little dependency"](https://go-proverbs.github.io/).