### PR TITLE
docs: fix typo in 'GitHub'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,7 +169,7 @@ jobs:
       # jq:        required by test-templates.sh to determine download URL for nerdctl
       run: |
         set -x
-        # Github runners seem to have lima installed by brew already; we don't want/need it
+        # GitHub runners seem to have lima installed by brew already; we don't want/need it
         time brew uninstall --ignore-dependencies lima colima
         time brew install qemu bash coreutils curl jq
     - name: "Show cache"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Lima roadmap
 
-Instead of using a static text file, Lima uses the `roadmap` label on Github issues to designate features or bug fixes that we plan to implement.
+Instead of using a static text file, Lima uses the `roadmap` label on GitHub issues to designate features or bug fixes that we plan to implement.
 
 Issues are tagged with the `roadmap` label when at least one maintainer or contributor has declared intent to work on or help with the implementation.
 

--- a/hack/test-port-forwarding.pl
+++ b/hack/test-port-forwarding.pl
@@ -27,7 +27,7 @@ my $addr = scalar gethostbyname(hostname());
 my $ipv4 = length $addr ? inet_ntoa($addr) : "127.0.0.1";
 my $ipv6 = ""; # todo
 
-# macOS Github runners seem to use "localhost" as the hostname
+# macOS GitHub runners seem to use "localhost" as the hostname
 if ($ipv4 eq "127.0.0.1" && $Config{osname} eq "darwin") {
     $ipv4 = qx(system_profiler SPNetworkDataType -json | jq -r 'first(.SPNetworkDataType[] | select(.ip_address) | .ip_address) | first');
     chomp $ipv4;

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -182,7 +182,7 @@ enable = false
   enable = true
 
 [[menus.main]]
-  name = "Github"
+  name = "GitHub"
   url = "https://github.com/lima-vm/lima"
   pre = '<i class="fab fa-github"></i>'
 


### PR DESCRIPTION
This PR renames `Github` to `GitHub` (see this [page](https://github.com/logos)).