### PR TITLE
limactl create: don't override user-specified name

### DIFF
--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -425,9 +425,11 @@ func chooseNextCreatorState(st *creatorState, yq string) (*creatorState, error) 
 				return st, fmt.Errorf("invalid answer %d for %d entries", ansEx, len(templates))
 			}
 			yamlPath := templates[ansEx].Location
-			st.instName, err = guessarg.InstNameFromYAMLPath(yamlPath)
-			if err != nil {
-				return nil, err
+			if st.instName == "" {
+				st.instName, err = guessarg.InstNameFromYAMLPath(yamlPath)
+				if err != nil {
+					return nil, err
+				}
 			}
 			st.yBytes, err = os.ReadFile(yamlPath)
 			if err != nil {


### PR DESCRIPTION
Currently, when creating a new instance, the instance name specified by the user via `--name` gets discarded when a template is chosen later; the template name is used instead:

```console
$ ./_output/bin/limactl create --name test
? Creating an instance "test" Choose another template (docker, podman, archlinux, fedora, ...)
? Choose a template ubuntu-lts
? Creating an instance "ubuntu-lts" Proceed with the current configuration
[output truncated...]
INFO[0005] Run `limactl start ubuntu-lts` to start the instance.
```

Fix that by only setting the instance name to the template name when it's not already set. After this change:

```console
$ ./_output/bin/limactl create --name test
? Creating an instance "test" Choose another template (docker, podman, archlinux, fedora, ...)
? Choose a template ubuntu-lts
? Creating an instance "test" Proceed with the current configuration
[output truncated...]
INFO[0005] Run `limactl start test` to start the instance.
```
