### PR TITLE
templates: rocky-9: use HTTPS URL

### DIFF
--- a/examples/rocky-9.yaml
+++ b/examples/rocky-9.yaml
@@ -4,7 +4,7 @@ images:
 - location: "https://dl.rockylinux.org/pub/rocky/9.2/images/x86_64/Rocky-9-GenericCloud-Base-9.2-20230513.0.x86_64.qcow2"
   arch: "x86_64"
   digest: "sha256:50510f98abe1b20a548102a05a9be83153b0bf634fc502d5c8d1f508f6de1430"
-- location: "http://dl.rockylinux.org/pub/rocky/9.2/images/aarch64/Rocky-9-GenericCloud-Base-9.2-20230513.0.aarch64.qcow2"
+- location: "https://dl.rockylinux.org/pub/rocky/9.2/images/aarch64/Rocky-9-GenericCloud-Base-9.2-20230513.0.aarch64.qcow2"
   arch: "aarch64"
   digest: "sha256:eb7752c0be359007ad470e43b0d8c921e31d3ad7d4bcec9b6a2b18a8d17c05d8"
 mounts:


### PR DESCRIPTION
I believe the switch to an HTTP URL in 0f050f97c74297e4e7d94c27b86d181c78a4ef3c (#1550) was a mistake.
