### PR TITLE
Generic/External internal driver for all OS

### DIFF
--- a/cmd/limactl/main_ext.go
+++ b/cmd/limactl/main_ext.go
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+// Import ext driver to register it in the registry on all platforms.
+import _ "github.com/lima-vm/lima/v2/pkg/driver/ext"

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -245,6 +245,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		inst.Dir,
 		*inst.Config.User.Name,
 		*inst.Config.SSH.LoadDotSSHPubKeys,
+		*inst.Config.SSH.Address,
 		*inst.Config.SSH.ForwardAgent,
 		*inst.Config.SSH.ForwardX11,
 		*inst.Config.SSH.ForwardX11Trusted)

--- a/cmd/limactl/show-ssh.go
+++ b/cmd/limactl/show-ssh.go
@@ -103,13 +103,14 @@ func showSSHAction(cmd *cobra.Command, args []string) error {
 		inst.Dir,
 		*inst.Config.User.Name,
 		*inst.Config.SSH.LoadDotSSHPubKeys,
+		*inst.Config.SSH.Address,
 		*inst.Config.SSH.ForwardAgent,
 		*inst.Config.SSH.ForwardX11,
 		*inst.Config.SSH.ForwardX11Trusted)
 	if err != nil {
 		return err
 	}
-	opts = append(opts, "Hostname=127.0.0.1")
+	opts = append(opts, fmt.Sprintf("Hostname=%s", inst.SSHAddress))
 	opts = append(opts, fmt.Sprintf("Port=%d", inst.SSHLocalPort))
 	return sshutil.Format(w, "ssh", instName, format, opts)
 }

--- a/cmd/limactl/tunnel.go
+++ b/cmd/limactl/tunnel.go
@@ -95,6 +95,7 @@ func tunnelAction(cmd *cobra.Command, args []string) error {
 		inst.Dir,
 		*inst.Config.User.Name,
 		*inst.Config.SSH.LoadDotSSHPubKeys,
+		*inst.Config.SSH.Address,
 		*inst.Config.SSH.ForwardAgent,
 		*inst.Config.SSH.ForwardX11,
 		*inst.Config.SSH.ForwardX11Trusted)

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -38,7 +38,8 @@ import (
 )
 
 var netLookupIP = func(host string) []net.IP {
-	ips, err := net.LookupIP(host)
+	ctx := context.Background()
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
 	if err != nil {
 		logrus.Debugf("net.LookupIP %s: %s", host, err)
 		return nil

--- a/pkg/driver/ext/errors.go
+++ b/pkg/driver/ext/errors.go
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ext
+
+import "errors"
+
+var errUnimplemented = errors.New("unimplemented")

--- a/pkg/driver/ext/ext_driver.go
+++ b/pkg/driver/ext/ext_driver.go
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ext
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"slices"
+
+	"github.com/lima-vm/lima/v2/pkg/driver"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/ptr"
+)
+
+type LimaExtDriver struct {
+	Instance *limatype.Instance
+}
+
+var _ driver.Driver = (*LimaExtDriver)(nil)
+
+func New() *LimaExtDriver {
+	return &LimaExtDriver{}
+}
+
+func (l *LimaExtDriver) Configure(inst *limatype.Instance) *driver.ConfiguredDriver {
+	l.Instance = inst
+
+	return &driver.ConfiguredDriver{
+		Driver: l,
+	}
+}
+
+func (l *LimaExtDriver) Validate(ctx context.Context) error {
+	return validateConfig(ctx, l.Instance.Config)
+}
+
+func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
+	if cfg == nil {
+		return errors.New("configuration is nil")
+	}
+	if err := validateMountType(cfg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Helper method for mount type validation.
+func validateMountType(cfg *limatype.LimaYAML) error {
+	if cfg.MountTypesUnsupported != nil && cfg.MountType != nil && slices.Contains(cfg.MountTypesUnsupported, *cfg.MountType) {
+		return fmt.Errorf("mount type %q is explicitly unsupported", *cfg.MountType)
+	}
+
+	return nil
+}
+
+func (l *LimaExtDriver) FillConfig(_ context.Context, cfg *limatype.LimaYAML, _ string) error {
+	if cfg.VMType == nil {
+		cfg.VMType = ptr.Of(limatype.EXT)
+	}
+
+	if cfg.MountType == nil || *cfg.MountType == "" || *cfg.MountType == "default" {
+		cfg.MountType = ptr.Of(limatype.REVSSHFS)
+	}
+
+	mountTypesUnsupported := make(map[string]struct{})
+	mountTypesUnsupported[limatype.NINEP] = struct{}{}
+	mountTypesUnsupported[limatype.VIRTIOFS] = struct{}{}
+
+	if _, ok := mountTypesUnsupported[*cfg.MountType]; ok {
+		return fmt.Errorf("mount type %q is explicitly unsupported", *cfg.MountType)
+	}
+
+	return nil
+}
+
+func (l *LimaExtDriver) Start(_ context.Context) (chan error, error) {
+	errCh := make(chan error)
+
+	return errCh, nil
+}
+
+func (l *LimaExtDriver) BootScripts() (map[string][]byte, error) {
+	return nil, nil
+}
+
+func (l *LimaExtDriver) RunGUI() error {
+	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "ext", *l.Instance.Config.Video.Display)
+}
+
+func (l *LimaExtDriver) Stop(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaExtDriver) GuestAgentConn(_ context.Context) (net.Conn, string, error) {
+	return nil, "", nil
+}
+
+func (l *LimaExtDriver) Info() driver.Info {
+	var info driver.Info
+	info.Name = "ext"
+	if l.Instance != nil && l.Instance.Dir != "" {
+		info.InstanceDir = l.Instance.Dir
+	}
+
+	info.Features = driver.DriverFeatures{
+		DynamicSSHAddress:    false,
+		SkipSocketForwarding: false,
+		CanRunGUI:            false,
+	}
+	return info
+}
+
+func (l *LimaExtDriver) SSHAddress(_ context.Context) (string, error) {
+	return l.Instance.SSHAddress, nil
+}
+
+func (l *LimaExtDriver) InspectStatus(_ context.Context, _ *limatype.Instance) string {
+	return ""
+}
+
+func (l *LimaExtDriver) Create(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaExtDriver) Delete(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaExtDriver) CreateDisk(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaExtDriver) Register(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaExtDriver) Unregister(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaExtDriver) ChangeDisplayPassword(_ context.Context, _ string) error {
+	return nil
+}
+
+func (l *LimaExtDriver) DisplayConnection(_ context.Context) (string, error) {
+	return "", nil
+}
+
+func (l *LimaExtDriver) CreateSnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaExtDriver) ApplySnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaExtDriver) DeleteSnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaExtDriver) ListSnapshots(_ context.Context) (string, error) {
+	return "", errUnimplemented
+}
+
+func (l *LimaExtDriver) ForwardGuestAgent() bool {
+	// If driver is not providing, use host agent
+	return true
+}
+
+func (l *LimaExtDriver) AdditionalSetupForSSH(_ context.Context) error {
+	return nil
+}

--- a/pkg/driver/ext/register.go
+++ b/pkg/driver/ext/register.go
@@ -1,0 +1,12 @@
+//go:build !external_ext
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ext
+
+import "github.com/lima-vm/lima/v2/pkg/registry"
+
+func init() {
+	registry.Register(New())
+}

--- a/pkg/hostagent/events/events.go
+++ b/pkg/hostagent/events/events.go
@@ -16,7 +16,8 @@ type Status struct {
 
 	Errors []string `json:"errors,omitempty"`
 
-	SSHLocalPort int `json:"sshLocalPort,omitempty"`
+	SSHIPAddress string `json:"sshIPAddress,omitempty"`
+	SSHLocalPort int    `json:"sshLocalPort,omitempty"`
 
 	// Cloud-init progress information
 	CloudInitProgress *CloudInitProgress `json:"cloudInitProgress,omitempty"`

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -176,8 +176,10 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 	if err := cidata.GenerateCloudConfig(ctx, inst.Dir, instName, inst.Config); err != nil {
 		return nil, err
 	}
-	if err := cidata.GenerateISO9660(ctx, limaDriver, inst.Dir, instName, inst.Config, udpDNSLocalPort, tcpDNSLocalPort, o.guestAgentBinary, o.nerdctlArchive, vSockPort, virtioPort, noCloudInit, rosettaEnabled, rosettaBinFmt); err != nil {
-		return nil, err
+	if *inst.Config.VMType != limatype.EXT {
+		if err := cidata.GenerateISO9660(ctx, limaDriver, inst.Dir, instName, inst.Config, udpDNSLocalPort, tcpDNSLocalPort, o.guestAgentBinary, o.nerdctlArchive, vSockPort, virtioPort, noCloudInit, rosettaEnabled, rosettaBinFmt); err != nil {
+			return nil, err
+		}
 	}
 
 	sshExe, err := sshutil.NewSSHExe()

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -588,6 +588,12 @@ sudo chown -R "${USER}" /run/host-services`
 		})
 	}
 
+	if *a.instConfig.VMType == limatype.EXT {
+		if err := a.runProvisionScripts(); err != nil {
+			return err
+		}
+	}
+
 	staticPortForwards := a.separateStaticPortForwards()
 	a.addStaticPortForwardsFromList(ctx, staticPortForwards)
 

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -138,7 +138,7 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 	}
 
 	// inst.Config is loaded with FillDefault() already, so no need to care about nil pointers.
-	sshLocalPort, err := determineSSHLocalPort(*inst.Config.SSH.LocalPort, instName, limaVersion)
+	sshLocalPort, err := determineSSHLocalPort(*inst.Config.SSH.Address, *inst.Config.SSH.LocalPort, instName, limaVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -190,6 +190,7 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 		inst.Dir,
 		*inst.Config.User.Name,
 		*inst.Config.SSH.LoadDotSSHPubKeys,
+		*inst.Config.SSH.Address,
 		*inst.Config.SSH.ForwardAgent,
 		*inst.Config.SSH.ForwardX11,
 		*inst.Config.SSH.ForwardX11Trusted)
@@ -291,12 +292,15 @@ func writeSSHConfigFile(sshPath, instName, instDir, instSSHAddress string, sshLo
 	return os.WriteFile(fileName, b.Bytes(), 0o600)
 }
 
-func determineSSHLocalPort(confLocalPort int, instName, limaVersion string) (int, error) {
+func determineSSHLocalPort(confSSHAddress string, confLocalPort int, instName, limaVersion string) (int, error) {
 	if confLocalPort > 0 {
 		return confLocalPort, nil
 	}
 	if confLocalPort < 0 {
 		return 0, fmt.Errorf("invalid ssh local port %d", confLocalPort)
+	}
+	if confLocalPort == 0 && confSSHAddress != "127.0.0.1" {
+		return 22, nil
 	}
 	if versionutil.LessThan(limaVersion, "2.0.0") && instName == "default" {
 		// use hard-coded value for "default" instance, for backward compatibility
@@ -450,8 +454,22 @@ func (a *HostAgent) Run(ctx context.Context) error {
 	return a.startRoutinesAndWait(ctx, errCh)
 }
 
+func getIP(address string) string {
+	ip := net.ParseIP(address)
+	if ip != nil {
+		return address
+	}
+	ctx := context.Background()
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", address)
+	if err == nil && len(ips) > 0 {
+		return ips[0].String()
+	}
+	return address
+}
+
 func (a *HostAgent) startRoutinesAndWait(ctx context.Context, errCh <-chan error) error {
 	stBase := events.Status{
+		SSHIPAddress: getIP(a.instSSHAddress),
 		SSHLocalPort: a.sshLocalPort,
 	}
 	stBooting := stBase

--- a/pkg/hostagent/provision.go
+++ b/pkg/hostagent/provision.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hostagent
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/lima-vm/sshocker/pkg/ssh"
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+)
+
+func (a *HostAgent) runProvisionScripts() error {
+	var errs []error
+
+	for i, f := range a.instConfig.Provision {
+		switch f.Mode {
+		case limatype.ProvisionModeSystem, limatype.ProvisionModeUser:
+			logrus.Infof("Running %s provision %d of %d", f.Mode, i+1, len(a.instConfig.Provision))
+			err := a.waitForProvision(
+				provision{
+					description: fmt.Sprintf("provision.%s/%08d", f.Mode, i),
+					sudo:        f.Mode == limatype.ProvisionModeSystem,
+					script:      *f.Script,
+				})
+			if err != nil {
+				errs = append(errs, err)
+			}
+		case limatype.ProvisionModeDependency, limatype.ProvisionModeBoot:
+			logrus.Infof("Skipping %s provision %d of %d", f.Mode, i+1, len(a.instConfig.Provision))
+			continue
+		default:
+			return fmt.Errorf("unknown provision mode %q", f.Mode)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (a *HostAgent) waitForProvision(p provision) error {
+	if p.sudo {
+		return a.waitForSystemProvision(p)
+	}
+	return a.waitForUserProvision(p)
+}
+
+func (a *HostAgent) waitForSystemProvision(p provision) error {
+	logrus.Debugf("executing script %q", p.description)
+	stdout, stderr, err := sudoExecuteScript(a.instSSHAddress, a.sshLocalPort, a.sshConfig, p.script, p.description)
+	logrus.Debugf("stdout=%q, stderr=%q, err=%v", stdout, stderr, err)
+	if err != nil {
+		return fmt.Errorf("stdout=%q, stderr=%q: %w", stdout, stderr, err)
+	}
+	return nil
+}
+
+func (a *HostAgent) waitForUserProvision(p provision) error {
+	logrus.Debugf("executing script %q", p.description)
+	stdout, stderr, err := ssh.ExecuteScript(a.instSSHAddress, a.sshLocalPort, a.sshConfig, p.script, p.description)
+	logrus.Debugf("stdout=%q, stderr=%q, err=%v", stdout, stderr, err)
+	if err != nil {
+		return fmt.Errorf("stdout=%q, stderr=%q: %w", stdout, stderr, err)
+	}
+	return nil
+}
+
+type provision struct {
+	description string
+	script      string
+	sudo        bool
+}

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -163,23 +163,25 @@ true
 		req = append(req, startControlMasterReq)
 		return req
 	}
-	req = append(req,
-		requirement{
-			description: "user session is ready for ssh",
-			script: `#!/bin/bash
+	if *a.instConfig.VMType != limatype.EXT {
+		req = append(req,
+			requirement{
+				description: "user session is ready for ssh",
+				script: `#!/bin/bash
 set -eux -o pipefail
 if ! timeout 30s bash -c "until sudo diff -q /run/lima-ssh-ready /mnt/lima-cidata/meta-data 2>/dev/null; do sleep 3; done"; then
 	echo >&2 "not ready to start persistent ssh session"
 	exit 1
 fi
 `,
-			debugHint: `The boot sequence will terminate any existing user session after updating
+				debugHint: `The boot sequence will terminate any existing user session after updating
 /etc/environment to make sure the session includes the new values.
 Terminating the session will break the persistent SSH tunnel, so
 it must not be created until the session reset is done.
 `,
-			noMaster: true,
-		})
+				noMaster: true,
+			})
+	}
 
 	if *a.instConfig.MountType == limatype.REVSSHFS && len(a.instConfig.Mounts) > 0 {
 		req = append(req, requirement{
@@ -263,20 +265,22 @@ Also see "/var/log/cloud-init-output.log" in the guest.
 
 func (a *HostAgent) finalRequirements() []requirement {
 	req := make([]requirement, 0)
-	req = append(req,
-		requirement{
-			description: "boot scripts must have finished",
-			script: `#!/bin/bash
+	if *a.instConfig.VMType != limatype.EXT {
+		req = append(req,
+			requirement{
+				description: "boot scripts must have finished",
+				script: `#!/bin/bash
 set -eux -o pipefail
 if ! timeout 30s bash -c "until sudo diff -q /run/lima-boot-done /mnt/lima-cidata/meta-data 2>/dev/null; do sleep 3; done"; then
 	echo >&2 "boot scripts have not finished"
 	exit 1
 fi
 `,
-			debugHint: `All boot scripts, provisioning scripts, and readiness probes must
+				debugHint: `All boot scripts, provisioning scripts, and readiness probes must
 finish before the instance is considered "ready".
 Check "/var/log/cloud-init-output.log" in the guest to see where the process is blocked!
 `,
-		})
+			})
+	}
 	return req
 }

--- a/pkg/hostagent/sudo.go
+++ b/pkg/hostagent/sudo.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hostagent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/lima-vm/sshocker/pkg/ssh"
+	"github.com/sirupsen/logrus"
+)
+
+// sudoExecuteScript executes the given script (as root) on the remote host via stdin.
+// Returns stdout and stderr.
+//
+// scriptName is used only for readability of error strings.
+func sudoExecuteScript(host string, port int, c *ssh.SSHConfig, script, scriptName string) (stdout, stderr string, err error) {
+	if c == nil {
+		return "", "", errors.New("got nil SSHConfig")
+	}
+	interpreter, err := ssh.ParseScriptInterpreter(script)
+	if err != nil {
+		return "", "", err
+	}
+	sshBinary := c.Binary()
+	sshArgs := c.Args()
+	if port != 0 {
+		sshArgs = append(sshArgs, "-p", strconv.Itoa(port))
+	}
+	sshArgs = append(sshArgs, host, "--", "sudo", interpreter)
+	sshCmd := exec.CommandContext(context.TODO(), sshBinary, sshArgs...)
+	sshCmd.Stdin = strings.NewReader(script)
+	var buf bytes.Buffer
+	sshCmd.Stderr = &buf
+	logrus.Debugf("executing ssh for script %q: %s %v", scriptName, sshCmd.Path, sshCmd.Args)
+	out, err := sshCmd.Output()
+	if err != nil {
+		return string(out), buf.String(), fmt.Errorf("failed to execute script %q: stdout=%q, stderr=%q: %w", scriptName, string(out), buf.String(), err)
+	}
+	return string(out), buf.String(), nil
+}

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -105,7 +105,7 @@ func Prepare(ctx context.Context, inst *limatype.Instance, guestAgent string) (*
 			ensuredBaseDisk = true
 			break
 		}
-		if !ensuredBaseDisk {
+		if !ensuredBaseDisk && *inst.Config.VMType != limatype.EXT {
 			return nil, fileutils.Errors(errs)
 		}
 	}
@@ -117,6 +117,11 @@ func Prepare(ctx context.Context, inst *limatype.Instance, guestAgent string) (*
 	// Ensure diffDisk size matches the store
 	if err := prepareDiffDisk(ctx, inst); err != nil {
 		return nil, err
+	}
+
+	if *inst.Config.VMType == limatype.EXT {
+		// Created externally
+		created = true
 	}
 
 	nerdctlArchiveCache, err := cacheutil.EnsureNerdctlArchiveCache(ctx, inst.Config, created)

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -297,7 +297,13 @@ func watchHostAgentEvents(ctx context.Context, inst *limatype.Instance, haStdout
 
 	onEvent := func(ev hostagentevents.Event) bool {
 		if !printedSSHLocalPort && ev.Status.SSHLocalPort != 0 {
-			logrus.Infof("SSH Local Port: %d", ev.Status.SSHLocalPort)
+			if ev.Status.SSHIPAddress == "127.0.0.1" {
+				logrus.Infof("SSH Local Port: %d", ev.Status.SSHLocalPort)
+			} else if ev.Status.SSHLocalPort == 22 {
+				logrus.Infof("SSH IP Address: %s", ev.Status.SSHIPAddress)
+			} else {
+				logrus.Infof("SSH IP Address: %s Port: %d", ev.Status.SSHIPAddress, ev.Status.SSHLocalPort)
+			}
 			printedSSHLocalPort = true
 
 			// Update the instance's SSH port

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -93,13 +93,14 @@ const (
 	QEMU VMType = "qemu"
 	VZ   VMType = "vz"
 	WSL2 VMType = "wsl2"
+	EXT  VMType = "ext"
 )
 
 var (
 	OSTypes    = []OS{LINUX}
 	ArchTypes  = []Arch{X8664, AARCH64, ARMV7L, PPC64LE, RISCV64, S390X}
 	MountTypes = []MountType{REVSSHFS, NINEP, VIRTIOFS, WSLMount}
-	VMTypes    = []VMType{QEMU, VZ, WSL2}
+	VMTypes    = []VMType{QEMU, VZ, WSL2, EXT}
 )
 
 type User struct {

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -189,7 +189,8 @@ type Virtiofs struct {
 }
 
 type SSH struct {
-	LocalPort *int `yaml:"localPort,omitempty" json:"localPort,omitempty" jsonschema:"nullable"`
+	Address   *string `yaml:"address,omitempty" json:"address,omitempty" jsonschema:"nullable"`
+	LocalPort *int    `yaml:"localPort,omitempty" json:"localPort,omitempty" jsonschema:"nullable"`
 
 	// LoadDotSSHPubKeys loads ~/.ssh/*.pub in addition to $LIMA_HOME/_config/user.pub .
 	LoadDotSSHPubKeys *bool `yaml:"loadDotSSHPubKeys,omitempty" json:"loadDotSSHPubKeys,omitempty" jsonschema:"nullable"` // default: false

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -325,6 +325,16 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 		y.TimeZone = ptr.Of(hostTimeZone())
 	}
 
+	if y.SSH.Address == nil {
+		y.SSH.Address = d.SSH.Address
+	}
+	if o.SSH.Address != nil {
+		y.SSH.Address = o.SSH.Address
+	}
+	if y.SSH.Address == nil {
+		y.SSH.Address = ptr.Of("127.0.0.1")
+	}
+
 	if y.SSH.LocalPort == nil {
 		y.SSH.LocalPort = d.SSH.LocalPort
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -88,6 +88,7 @@ func TestFillDefault(t *testing.T) {
 			Archives: defaultContainerdArchives(),
 		},
 		SSH: limatype.SSH{
+			Address:           ptr.Of("127.0.0.1"),
 			LocalPort:         ptr.Of(0),
 			LoadDotSSHPubKeys: ptr.Of(false),
 			ForwardAgent:      ptr.Of(false),
@@ -330,6 +331,7 @@ func TestFillDefault(t *testing.T) {
 			},
 		},
 		SSH: limatype.SSH{
+			Address:           ptr.Of("0.0.0.0"),
 			LocalPort:         ptr.Of(888),
 			LoadDotSSHPubKeys: ptr.Of(false),
 			ForwardAgent:      ptr.Of(true),
@@ -526,6 +528,7 @@ func TestFillDefault(t *testing.T) {
 			},
 		},
 		SSH: limatype.SSH{
+			Address:           ptr.Of("127.0.1.1"),
 			LocalPort:         ptr.Of(4433),
 			LoadDotSSHPubKeys: ptr.Of(true),
 			ForwardAgent:      ptr.Of(true),

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -583,9 +583,22 @@ func validateParamIsUsed(y *limatype.LimaYAML) error {
 	return nil
 }
 
+func lookupIP(host string) error {
+	if strings.HasSuffix(host, ".local") {
+		// allow offline or slow mDNS
+		return nil
+	}
+	ctx := context.Background()
+	_, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+	return err
+}
+
 func validateHost(field, host string) error {
-	if net.ParseIP(host) == nil {
-		return fmt.Errorf("field `%s` must be IP", field)
+	if net.ParseIP(host) != nil {
+		return nil
+	}
+	if err := lookupIP(host); err != nil {
+		return fmt.Errorf("field `%s` must be IP: %w", field, err)
 	}
 	return nil
 }

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -143,6 +143,11 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		}
 	}
 
+	if y.SSH.Address != nil {
+		if err := validateHost("ssh.address", *y.SSH.Address); err != nil {
+			return err
+		}
+	}
 	if *y.SSH.LocalPort != 0 {
 		if err := validatePort("ssh.localPort", *y.SSH.LocalPort); err != nil {
 			errs = errors.Join(errs, err)
@@ -571,6 +576,13 @@ func validateParamIsUsed(y *limatype.LimaYAML) error {
 		if !keyIsUsed {
 			return fmt.Errorf("field `param` key %q is not used in any provision, probe, copyToHost, or portForward", key)
 		}
+	}
+	return nil
+}
+
+func validateHost(field, host string) error {
+	if net.ParseIP(host) == nil {
+		return fmt.Errorf("field `%s` must be IP", field)
 	}
 	return nil
 }

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -181,12 +182,20 @@ var sshInfo struct {
 	openSSH openSSHInfo
 }
 
+func IsLocalhost(address string) bool {
+	ip := net.ParseIP(address)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
+}
+
 // CommonOpts returns ssh option key-value pairs like {"IdentityFile=/path/to/id_foo"}.
 // The result may contain different values with the same key.
 //
 // The result always contains the IdentityFile option.
 // The result never contains the Port option.
-func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, error) {
+func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH, localhost bool) ([]string, error) {
 	configDir, err := dirnames.LimaConfigDir()
 	if err != nil {
 		return nil, err
@@ -240,13 +249,19 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 		}
 	}
 
+	if localhost {
+		opts = append(opts,
+			"StrictHostKeyChecking=no",
+			"UserKnownHostsFile=/dev/null",
+			"BatchMode=yes",
+		)
+	}
+
 	opts = append(opts,
-		"StrictHostKeyChecking=no",
-		"UserKnownHostsFile=/dev/null",
 		"NoHostAuthenticationForLocalhost=yes",
 		"PreferredAuthentications=publickey",
 		"Compression=no",
-		"BatchMode=yes",
+		"PasswordAuthentication=no",
 		"IdentitiesOnly=yes",
 	)
 
@@ -333,12 +348,12 @@ func IsControlMasterExisting(instDir string) bool {
 }
 
 // SSHOpts adds the following options to CommonOptions: User, ControlMaster, ControlPath, ControlPersist.
-func SSHOpts(ctx context.Context, sshExe SSHExe, instDir, username string, useDotSSH, forwardAgent, forwardX11, forwardX11Trusted bool) ([]string, error) {
+func SSHOpts(ctx context.Context, sshExe SSHExe, instDir, username string, useDotSSH bool, hostAddress string, forwardAgent, forwardX11, forwardX11Trusted bool) ([]string, error) {
 	controlSock := filepath.Join(instDir, filenames.SSHSock)
 	if len(controlSock) >= osutil.UnixPathMax {
 		return nil, fmt.Errorf("socket path %q is too long: >= UNIX_PATH_MAX=%d", controlSock, osutil.UnixPathMax)
 	}
-	opts, err := CommonOpts(ctx, sshExe, useDotSSH)
+	opts, err := CommonOpts(ctx, sshExe, useDotSSH, IsLocalhost(hostAddress))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -18,6 +18,10 @@ func TestDefaultPubKeys(t *testing.T) {
 	}
 }
 
+func TestIsLocalhost(t *testing.T) {
+	assert.Equal(t, IsLocalhost("127.0.0.1"), true)
+}
+
 func TestParseOpenSSHVersion(t *testing.T) {
 	assert.Check(t, ParseOpenSSHVersion([]byte("OpenSSH_8.4p1 Ubuntu")).Equal(
 		semver.Version{Major: 8, Minor: 4, Patch: 1, PreRelease: "", Metadata: ""}))

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -59,7 +59,7 @@ func Inspect(ctx context.Context, instName string) (*limatype.Instance, error) {
 	inst.Config = y
 	inst.Arch = *y.Arch
 	inst.VMType = *y.VMType
-	inst.SSHAddress = "127.0.0.1"
+	inst.SSHAddress = *y.SSH.Address
 	inst.SSHLocalPort = *y.SSH.LocalPort // maybe 0
 	inst.SSHConfigFile = filepath.Join(instDir, filenames.SSHConfig)
 	inst.HostAgentPID, err = ReadPIDFile(filepath.Join(instDir, filenames.HostAgentPID))

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -171,6 +171,14 @@ func inspectStatusWithPIDFiles(instDir string, inst *limatype.Instance, y *limat
 		inst.Status = limatype.StatusBroken
 		inst.Errors = append(inst.Errors, err)
 	}
+	if *y.VMType == limatype.EXT {
+		if inst.HostAgentPID > 0 {
+			inst.Status = limatype.StatusRunning
+		} else if inst.HostAgentPID == 0 {
+			inst.Status = limatype.StatusStopped
+		}
+		return
+	}
 
 	if inst.Status == limatype.StatusUnknown {
 		switch {

--- a/templates/README.md
+++ b/templates/README.md
@@ -43,6 +43,9 @@ Distro:
 Alternative package managers:
 - [`linuxbrew.yaml`](./linuxbrew.yaml): [Homebrew](https://brew.sh) on Linux (Ubuntu)
 
+External:
+- [`experimental/ext`](./experimental/ext.yaml): [experimental] External Raspberry Pi Zero
+
 Container engines:
 - [`apptainer`](./apptainer.yaml): Apptainer
 - [`apptainer-rootful`](./apptainer-rootful.yaml): Apptainer (rootful)

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -117,6 +117,9 @@ additionalDisks:
 #   fsType: "ext4"
 
 ssh:
+  # Address for the host.
+  # 🟢 Builtin default: "127.0.0.1" (localhost)
+  address: null
   # A localhost port of the host. Forwarded to port 22 of the guest.
   # 🟢 Builtin default: 0 (automatically assigned to a free port)
   localPort: null

--- a/templates/experimental/raspberrypi.yaml
+++ b/templates/experimental/raspberrypi.yaml
@@ -1,0 +1,14 @@
+vmType: ext
+
+arch: "aarch64"
+cpus: 4
+memory: 512MiB
+disk: 32GiB
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+
+ssh:
+  address: raspberrypi.local

--- a/website/content/en/docs/config/vmtype/ext.md
+++ b/website/content/en/docs/config/vmtype/ext.md
@@ -1,0 +1,11 @@
+---
+title: EXT
+weight: 3
+---
+
+> **Warning**
+> "ext" mode is experimental
+
+"ext" option makes use of an external machine, either a virtual machine or a physical machine.
+
+It is accessed using an address (for SSH), the keys are supposed to be set up for it already.


### PR DESCRIPTION
Similar to the docker-machine "generic" driver, bring your own virtual machine (or physical server)

Not so useful in itself, but not so bad when made into a real driver or wrapped with helper scripts...

```
NAME          STATUS     SSH                   VMTYPE    ARCH      CPUS    MEMORY    DISK      DIR
beaglebone    Running    192.168.7.2:22        ext       armv7l    1       512MiB    4GiB      ~/.lima/beaglebone
core          Stopped    127.0.0.1:0           qemu      x86_64    1       1GiB      100GiB    ~/.lima/core
```

```yaml
vmType: ext

arch: "armv7l"
cpus: 1
memory: 512MiB
disk: 4GiB

# We do not have arm-v7 binaries of containerd
containerd:
  system: false
  user: false

ssh:
  address: 192.168.7.2
```


Requires:

* https://github.com/lima-vm/lima/pull/2006

----

Installed lima-guestagent, and nerdctl from tarballs/binaries.

```
$ _output/bin/limactl shell beaglebone nerdctl version
Client:
 Version:	v1.7.0
 OS/Arch:	linux/arm
 Git commit:	e674fe7ba6e49f12e88cd9c6c442e7ea5232502c
 buildctl:
  Version:	v0.12.3
  GitCommit:	438f47256f0decd64cc96084e22d3357da494c27

Server:
 containerd:
  Version:	v1.7.6
  GitCommit:	091922f03c2762540fd057fba91260237ff86acb
 runc:
  Version:	1.1.9
  GitCommit:	v1.1.9-0-gccaecfc
```

`limactl guest-install beaglebone`

* #2028
----

Hardware

https://www.beagleboard.org/boards/beaglebone-black

You could also use a Raspberry Pi Zero*, or a cloud droplet.

\* need the Zero 2, for arm-v7 (previous model was arm-v6)

https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/

Discussion

* https://github.com/lima-vm/lima/discussions/2029