### PR TITLE
limactl,guestagent: Remove global variables

### DIFF
--- a/cmd/lima-guestagent/daemon_linux.go
+++ b/cmd/lima-guestagent/daemon_linux.go
@@ -28,12 +28,6 @@ func newDaemonCommand() *cobra.Command {
 	return daemonCommand
 }
 
-var (
-	vSockPort = 0
-
-	virtioPort = "/dev/virtio-ports/" + filenames.VirtioPort
-)
-
 func daemonAction(cmd *cobra.Command, _ []string) error {
 	tick, err := cmd.Flags().GetDuration("tick")
 	if err != nil {
@@ -43,6 +37,7 @@ func daemonAction(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	vSockPort := 0
 	if vSockPortOverride != 0 {
 		vSockPort = vSockPortOverride
 	}
@@ -74,6 +69,7 @@ func daemonAction(cmd *cobra.Command, _ []string) error {
 	srv := &http.Server{Handler: r}
 
 	var l net.Listener
+	virtioPort := "/dev/virtio-ports/" + filenames.VirtioPort
 	if _, err := os.Stat(virtioPort); err == nil {
 		qemuL, err := serialport.Listen(virtioPort)
 		if err != nil {

--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var copyHelp = `Copy files between host and guest
+const copyHelp = `Copy files between host and guest
 
 Prefix guest filenames with the instance name and a colon.
 

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -21,7 +21,7 @@ import (
 // in place of the 'ssh' executable.
 const envShellSSH = "SSH"
 
-var shellHelp = `Execute shell in Lima
+const shellHelp = `Execute shell in Lima
 
 lima command is provided as an alias for limactl shell $LIMA_INSTANCE. $LIMA_INSTANCE defaults to "` + DefaultInstanceName + `".
 


### PR DESCRIPTION
This PR removes unnecessary global variables in `cmd` packages.