### PR TITLE
hostagent: increase nofile limit

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -288,6 +288,7 @@ func (a *HostAgent) Run(ctx context.Context) error {
 		}
 		a.emitEvent(ctx, exitingEv)
 	}()
+	adjustNofileRlimit()
 
 	firstUsernetIndex := limayaml.FirstUsernetIndex(a.y)
 	if firstUsernetIndex == -1 && *a.y.HostResolver.Enabled {

--- a/pkg/hostagent/hostagent_unix.go
+++ b/pkg/hostagent/hostagent_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package hostagent
+
+import (
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Default nofile limit is too low on some system.
+// For example in the macOS standard terminal is 256.
+// It means that there are only ~240 connections available from the host to the vm.
+// That function increases the nofile limit for child processes, especially the ssh process
+//
+// More about limits in go: https://go.dev/issue/46279
+func adjustNofileRlimit() {
+	var limit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
+		logrus.WithError(err).Debug("failed to get RLIMIT_NOFILE")
+	} else if limit.Cur != limit.Max {
+		limit.Cur = limit.Max
+		err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit)
+		if err != nil {
+			logrus.WithError(err).Debugf("failed to set RLIMIT_NOFILE (%+v)", limit)
+		}
+	}
+}

--- a/pkg/hostagent/hostagent_windows.go
+++ b/pkg/hostagent/hostagent_windows.go
@@ -1,0 +1,5 @@
+//go:build windows
+
+package hostagent
+
+func adjustNofileRlimit() {}


### PR DESCRIPTION
Default nofile limit in the standard terminal in macOS is 256. You can see it with `ulimit -n`.

So when I tried to open over 240 connections to 127.0.0.1, the ssh process crashed. 

Default limit is too low for a vm that can run many applications. 

I suggest to use the same approach as in golang - setting an increased limit for the lima needs.

PR relates on all types of networks, but only for the macOS.

I understand that users can increase the limit themselves using `ulimit -n <N>`. But the regular user expects to get a working environment without exploring such low-level features.