### PR TITLE
Enable gocritic linter and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@
 ---
 run:
   concurrency: 6
-  deadline: 5m
 linters:
   disable-all: true
   enable:
@@ -47,7 +46,7 @@ linters:
   # - gochecknoinits
   # - gocognit
   # - goconst
-  # - gocritic
+  - gocritic
   # - gocyclo
   # - godot
   # - godox
@@ -83,76 +82,29 @@ linters:
   # - wsl
 linters-settings:
   gocritic:
-    enabled-checks:
-    # Diagnostic
-    - appendAssign
-    - argOrder
-    - badCond
-    - caseOrder
-    - codegenComment
-    - commentedOutCode
-    - deprecatedComment
-    - dupArg
-    - dupBranchBody
-    - dupCase
-    - dupSubExpr
-    - exitAfterDefer
-    - flagDeref
-    - flagName
-    - nilValReturn
-    - offBy1
-    - sloppyReassign
-    - weakCond
-    - octalLiteral
-
-    # Performance
+    # See "Tags" section in https://github.com/go-critic/go-critic#usage
+    enabled-tags:
+    - diagnostic
+    - performance
+    - style
+    - opinionated
+    - experimental
+    disabled-checks:
     - appendCombine
-    - equalFold
-    - hugeParam
-    - indexAlloc
-    - rangeExprCopy
-    - rangeValCopy
-
-    # Style
-    - assignOp
-    - boolExprSimplify
-    - captLocal
-    - commentFormatting
-    - commentedOutImport
-    - defaultCaseOrder
-    - docStub
-    - elseif
-    - emptyFallthrough
-    - emptyStringTest
-    - hexLiteral
-    - ifElseChain
-    - methodExprCall
-    - regexpMust
-    - singleCaseSwitch
-    - sloppyLen
-    - stringXbytes
-    - switchTrue
-    - typeAssertChain
-    - typeSwitchVar
-    - underef
+    - sloppyReassign
     - unlabelStmt
-    - unlambda
-    - unslice
-    - valSwap
-    - wrapperFunc
-    - yodaStyleExpr
-
-    # Opinionated
-    - builtinShadow
+    - rangeValCopy
+    - hugeParam
     - importShadow
-    - initClause
-    - nestingReduce
-    - paramTypeCombine
-    - ptrToRefParam
-    - typeUnparen
-    - unnamedResult
-    - unnecessaryBlock
+    - ifElseChain
+    - sprintfQuotedString
+    - builtinShadow
+    - filepathJoin
 issues:
+  # Maximum issues count per one linter.
+  max-issues-per-linter: 0
+  # Maximum count of issues with the same text.
+  max-same-issues: 0
   exclude-rules:
   # Allow using Uid, Gid in pkg/osutil.
   - path: "pkg/osutil/"

--- a/cmd/limactl/gendoc.go
+++ b/cmd/limactl/gendoc.go
@@ -117,7 +117,7 @@ weight: 3
 }
 
 // replaceAll replaces all occurrences of new with old, for all files in dir
-func replaceAll(dir string, old, new string) error {
+func replaceAll(dir, old, new string) error {
 	logrus.Infof("Replacing %q with %q", old, new)
 	return filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
@@ -133,7 +133,7 @@ func replaceAll(dir string, old, new string) error {
 		if err != nil {
 			return err
 		}
-		out := bytes.Replace(in, []byte(old), []byte(new), -1)
+		out := bytes.ReplaceAll(in, []byte(old), []byte(new))
 		err = os.WriteFile(path, out, 0o644)
 		if err != nil {
 			return err

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -437,10 +437,11 @@ func writeCIDataDir(rootPath string, layout []iso9660util.Entry) error {
 		if err != nil {
 			return err
 		}
-		defer f.Close()
 		if _, err := io.Copy(f, e.Reader); err != nil {
+			_ = f.Close()
 			return err
 		}
+		_ = f.Close()
 	}
 
 	return nil

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -291,7 +291,7 @@ func Cached(remote string, opts ...Opt) (*Result, error) {
 // cacheDirectoryPath returns the cache subdirectory path.
 // - "url" file contains the url
 // - "data" file contains the data
-func cacheDirectoryPath(cacheDir string, remote string) string {
+func cacheDirectoryPath(cacheDir, remote string) string {
 	return filepath.Join(cacheDir, "download", "by-url-sha256", fmt.Sprintf("%x", sha256.Sum256([]byte(remote))))
 }
 
@@ -380,7 +380,7 @@ func Decompressor(ext string) ([]string, bool) {
 	return []string{program, "-d"}, true
 }
 
-func decompressLocal(dst, src, ext string, description string) error {
+func decompressLocal(dst, src, ext, description string) error {
 	command, found := Decompressor(ext)
 	if !found {
 		return fmt.Errorf("decompressLocal: unknown extension %s", ext)
@@ -472,7 +472,7 @@ func validateLocalFileDigest(localPath string, expectedDigest digest.Digest) err
 	return nil
 }
 
-func downloadHTTP(localPath, url string, description string, expectedDigest digest.Digest) error {
+func downloadHTTP(localPath, url, description string, expectedDigest digest.Digest) error {
 	if localPath == "" {
 		return fmt.Errorf("downloadHTTP: got empty localPath")
 	}

--- a/pkg/executil/command.go
+++ b/pkg/executil/command.go
@@ -16,6 +16,8 @@ type options struct {
 type Opt func(*options) error
 
 // WithContext runs the command with CommandContext.
+//
+//nolint:gocritic // consider `ctx' to be of non-pointer type
 func WithContext(ctx *context.Context) Opt {
 	return func(o *options) error {
 		o.ctx = ctx

--- a/pkg/guestagent/guestagent_linux.go
+++ b/pkg/guestagent/guestagent_linux.go
@@ -121,8 +121,7 @@ func (a *agent) setWorthCheckingIPTablesRoutine(auditClient *libaudit.AuditClien
 			logrus.Error(err)
 			continue
 		}
-		switch msg.Type {
-		case auparse.AUDIT_NETFILTER_CFG:
+		if msg.Type == auparse.AUDIT_NETFILTER_CFG {
 			a.worthCheckingIPTablesMu.Lock()
 			logrus.Debug("setWorthCheckingIPTablesRoutine(): setting to true")
 			a.worthCheckingIPTables = true

--- a/pkg/guestagent/procnettcp/procnettcp_linux.go
+++ b/pkg/guestagent/procnettcp/procnettcp_linux.go
@@ -20,11 +20,12 @@ func ParseFiles() ([]Entry, error) {
 			}
 			return res, err
 		}
-		defer r.Close()
 		parsed, err := Parse(r, kind)
 		if err != nil {
+			_ = r.Close()
 			return res, err
 		}
+		_ = r.Close()
 		res = append(res, parsed...)
 	}
 	return res, nil

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -665,7 +665,7 @@ func executeSSH(ctx context.Context, sshConfig *ssh.SSHConfig, port int, command
 	return nil
 }
 
-func forwardSSH(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote string, verb string, reverse bool) error {
+func forwardSSH(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote, verb string, reverse bool) error {
 	args := sshConfig.Args()
 	args = append(args,
 		"-T",
@@ -732,7 +732,7 @@ func forwardSSH(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, 
 				}
 			} else {
 				logrus.WithError(err).Warnf("Failed to set up forward from %q (guest) to %q (host)", remote, local)
-				if removeErr := os.RemoveAll(local); err != nil {
+				if removeErr := os.RemoveAll(local); removeErr != nil {
 					logrus.WithError(removeErr).Warnf("Failed to clean up %q (host) after forwarding failed", local)
 				}
 			}

--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -47,10 +47,10 @@ func (a *HostAgent) setupMount(m limayaml.Mount) (*mount, error) {
 	// NOTE: allow_other requires "user_allow_other" in /etc/fuse.conf
 	sshfsOptions := "allow_other"
 	if !*m.SSHFS.Cache {
-		sshfsOptions = sshfsOptions + ",cache=no"
+		sshfsOptions += ",cache=no"
 	}
 	if *m.SSHFS.FollowSymlinks {
-		sshfsOptions = sshfsOptions + ",follow_symlinks"
+		sshfsOptions += ",follow_symlinks"
 	}
 	logrus.Infof("Mounting %q on %q", location, mountPoint)
 

--- a/pkg/hostagent/port.go
+++ b/pkg/hostagent/port.go
@@ -42,7 +42,7 @@ func hostAddress(rule limayaml.PortForward, guest api.IPPort) string {
 	return host.String()
 }
 
-func (pf *portForwarder) forwardingAddresses(guest api.IPPort, localUnixIP net.IP) (string, string) {
+func (pf *portForwarder) forwardingAddresses(guest api.IPPort, localUnixIP net.IP) (hostAddr, guestAddr string) {
 	if pf.vmType == limayaml.WSL2 {
 		guest.IP = localUnixIP
 		host := api.IPPort{

--- a/pkg/hostagent/port_darwin.go
+++ b/pkg/hostagent/port_darwin.go
@@ -16,7 +16,7 @@ import (
 )
 
 // forwardTCP is not thread-safe
-func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote string, verb string) error {
+func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote, verb string) error {
 	if strings.HasPrefix(local, "/") {
 		return forwardSSH(ctx, sshConfig, port, local, remote, verb, false)
 	}

--- a/pkg/hostagent/port_others.go
+++ b/pkg/hostagent/port_others.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lima-vm/sshocker/pkg/ssh"
 )
 
-func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote string, verb string) error {
+func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote, verb string) error {
 	return forwardSSH(ctx, sshConfig, port, local, remote, verb, false)
 }
 

--- a/pkg/hostagent/port_windows.go
+++ b/pkg/hostagent/port_windows.go
@@ -7,7 +7,7 @@ import (
 	"github.com/lima-vm/sshocker/pkg/ssh"
 )
 
-func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote string, verb string) error {
+func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote, verb string) error {
 	return forwardSSH(ctx, sshConfig, port, local, remote, verb, false)
 }
 

--- a/pkg/httpclientutil/httpclientutil.go
+++ b/pkg/httpclientutil/httpclientutil.go
@@ -17,7 +17,7 @@ import (
 
 // Get calls HTTP GET and verifies that the status code is 2XX .
 func Get(ctx context.Context, c *http.Client, url string) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -708,7 +708,7 @@ func executeGuestTemplate(format string) (bytes.Buffer, error) {
 	return bytes.Buffer{}, err
 }
 
-func executeHostTemplate(format string, instDir string) (bytes.Buffer, error) {
+func executeHostTemplate(format, instDir string) (bytes.Buffer, error) {
 	tmpl, err := template.New("").Parse(format)
 	if err == nil {
 		user, _ := osutil.LimaUser(false)

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -421,16 +421,16 @@ func TestFillDefault(t *testing.T) {
 
 	expect = y
 
-	expect.Provision = append(y.Provision, d.Provision...)
-	expect.Probes = append(y.Probes, d.Probes...)
-	expect.PortForwards = append(y.PortForwards, d.PortForwards...)
-	expect.CopyToHost = append(y.CopyToHost, d.CopyToHost...)
-	expect.Containerd.Archives = append(y.Containerd.Archives, d.Containerd.Archives...)
-	expect.AdditionalDisks = append(y.AdditionalDisks, d.AdditionalDisks...)
+	expect.Provision = append(append([]Provision{}, y.Provision...), d.Provision...)
+	expect.Probes = append(append([]Probe{}, y.Probes...), d.Probes...)
+	expect.PortForwards = append(append([]PortForward{}, y.PortForwards...), d.PortForwards...)
+	expect.CopyToHost = append(append([]CopyToHost{}, y.CopyToHost...), d.CopyToHost...)
+	expect.Containerd.Archives = append(append([]File{}, y.Containerd.Archives...), d.Containerd.Archives...)
+	expect.AdditionalDisks = append(append([]Disk{}, y.AdditionalDisks...), d.AdditionalDisks...)
 
 	// Mounts and Networks start with lowest priority first, so higher priority entries can overwrite
-	expect.Mounts = append(d.Mounts, y.Mounts...)
-	expect.Networks = append(d.Networks, y.Networks...)
+	expect.Mounts = append(append([]Mount{}, d.Mounts...), y.Mounts...)
+	expect.Networks = append(append([]Network{}, d.Networks...), y.Networks...)
 
 	expect.HostResolver.Hosts["default"] = d.HostResolver.Hosts["default"]
 
@@ -585,7 +585,7 @@ func TestFillDefault(t *testing.T) {
 	expect.HostResolver.Hosts["MY.Host"] = d.HostResolver.Hosts["host.lima.internal"]
 
 	// o.Mounts just makes d.Mounts[0] writable because the Location matches
-	expect.Mounts = append(d.Mounts, y.Mounts...)
+	expect.Mounts = append(append([]Mount{}, d.Mounts...), y.Mounts...)
 	expect.Mounts[0].Writable = ptr.Of(true)
 	expect.Mounts[0].SSHFS.Cache = ptr.Of(false)
 	expect.Mounts[0].SSHFS.FollowSymlinks = ptr.Of(true)

--- a/pkg/networks/commands.go
+++ b/pkg/networks/commands.go
@@ -75,7 +75,7 @@ func (config *YAML) Sock(name string) string {
 
 // VDESock returns a vde socket.
 //
-// Deprecated. Use Sock.
+// Deprecated: Use Sock.
 func (config *YAML) VDESock(name string) string {
 	return filepath.Join(config.Paths.VarRun, fmt.Sprintf("%s.ctl", name))
 }

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -175,7 +175,7 @@ func Usernet(name string) (bool, error) {
 
 // VDESock returns a vde socket.
 //
-// Deprecated. Use Sock.
+// Deprecated: Use Sock.
 func VDESock(name string) (string, error) {
 	loadCache()
 	if cache.err != nil {

--- a/pkg/networks/usernet/config.go
+++ b/pkg/networks/usernet/config.go
@@ -29,7 +29,7 @@ func Sock(name string, sockType SockType) (string, error) {
 }
 
 // SockWithDirectory return a usernet socket based on dir, name and sockType
-func SockWithDirectory(dir string, name string, sockType SockType) (string, error) {
+func SockWithDirectory(dir, name string, sockType SockType) (string, error) {
 	if name == "" {
 		name = "default"
 	}
@@ -108,7 +108,7 @@ func Leases(name string) (string, error) {
 	return sockPath, nil
 }
 
-func netmaskToCidr(baseIP net.IP, netMask net.IP) (net.IP, *net.IPNet, error) {
+func netmaskToCidr(baseIP, netMask net.IP) (net.IP, *net.IPNet, error) {
 	size, _ := net.IPMask(netMask.To4()).Size()
 	return net.ParseCIDR(fmt.Sprintf("%s/%d", baseIP.String(), size))
 }

--- a/pkg/networks/usernet/dnshosts/dnshosts_test.go
+++ b/pkg/networks/usernet/dnshosts/dnshosts_test.go
@@ -194,8 +194,8 @@ func Test_extractZones(t *testing.T) {
 }
 
 var (
-	_ sort.Interface = (recordSorter)(nil)
-	_ sort.Interface = (zoneSorter)(nil)
+	_ sort.Interface = recordSorter(nil)
+	_ sort.Interface = zoneSorter(nil)
 )
 
 type recordSorter []types.Record
@@ -206,12 +206,12 @@ func (r recordSorter) Len() int {
 }
 
 // Less implements sort.Interface
-func (r recordSorter) Less(i int, j int) bool {
+func (r recordSorter) Less(i, j int) bool {
 	return r[i].Name < r[j].Name
 }
 
 // Swap implements sort.Interface
-func (r recordSorter) Swap(i int, j int) {
+func (r recordSorter) Swap(i, j int) {
 	r[i], r[j] = r[j], r[i]
 }
 
@@ -223,11 +223,11 @@ func (z zoneSorter) Len() int {
 }
 
 // Less implements sort.Interface
-func (z zoneSorter) Less(i int, j int) bool {
+func (z zoneSorter) Less(i, j int) bool {
 	return z[i].Name < z[j].Name
 }
 
 // Swap implements sort.Interface
-func (z zoneSorter) Swap(i int, j int) {
+func (z zoneSorter) Swap(i, j int) {
 	z[i], z[j] = z[j], z[i]
 }

--- a/pkg/networks/usernet/gvproxy_test.go
+++ b/pkg/networks/usernet/gvproxy_test.go
@@ -33,12 +33,12 @@ nameserver 8.8.8.8`)
 	})
 }
 
-func createResolveFile(t *testing.T, file string, content string) {
+func createResolveFile(t *testing.T, file, content string) {
 	f, err := os.Create(file)
 	assert.NilError(t, err)
 	t.Cleanup(func() { _ = f.Close() })
 	writer := bufio.NewWriter(f)
-	_, err = writer.Write([]byte(content))
+	_, err = writer.WriteString(content)
 	assert.NilError(t, err)
 	err = writer.Flush()
 	assert.NilError(t, err)

--- a/pkg/qemu/entitlementutil/entitlementutil.go
+++ b/pkg/qemu/entitlementutil/entitlementutil.go
@@ -49,7 +49,7 @@ func Sign(qExe string) error {
     <true/>
   </dict>
 </plist>`
-	if _, err = ent.Write([]byte(entXML)); err != nil {
+	if _, err = ent.WriteString(entXML); err != nil {
 		return fmt.Errorf("Failed to write to a temporary file %q for signing QEMU binary: %w", entName, err)
 	}
 	ent.Close()
@@ -68,7 +68,7 @@ func Sign(qExe string) error {
 // The result can be used *ONLY* for controlling hint messages.
 // DO NOT change the behavior of Lima depending on this result.
 //
-//nolint:revive
+//nolint:revive // underscores in this function name intentionally added
 func isColimaWrapper__useThisFunctionOnlyForPrintingHints__(qExe string) bool {
 	return strings.Contains(qExe, "/.colima/_wrapper/")
 }

--- a/pkg/qemu/imgutil/imgutil.go
+++ b/pkg/qemu/imgutil/imgutil.go
@@ -79,7 +79,7 @@ type Info struct {
 	Children              []InfoChild         `json:"children,omitempty"`                // since QEMU 8.0
 }
 
-func ConvertToRaw(source string, dest string) error {
+func ConvertToRaw(source, dest string) error {
 	var stdout, stderr bytes.Buffer
 	cmd := exec.Command("qemu-img", "convert", "-O", "raw", source, dest)
 	cmd.Stdout = &stdout

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -222,7 +222,7 @@ func CommonOpts(useDotSSH bool) ([]string, error) {
 }
 
 // SSHOpts adds the following options to CommonOptions: User, ControlMaster, ControlPath, ControlPersist
-func SSHOpts(instDir string, useDotSSH, forwardAgent bool, forwardX11 bool, forwardX11Trusted bool) ([]string, error) {
+func SSHOpts(instDir string, useDotSSH, forwardAgent, forwardX11, forwardX11Trusted bool) ([]string, error) {
 	controlSock := filepath.Join(instDir, filenames.SSHSock)
 	if len(controlSock) >= osutil.UnixPathMax {
 		return nil, fmt.Errorf("socket path %q is too long: >= UNIX_PATH_MAX=%d", controlSock, osutil.UnixPathMax)

--- a/pkg/store/disk.go
+++ b/pkg/store/disk.go
@@ -60,7 +60,7 @@ func InspectDisk(diskName string) (*Disk, error) {
 
 // inspectDisk attempts to inspect the disk size and format by itself,
 // and falls back to inspectDiskWithQemuImg on an error.
-func inspectDisk(fName string) (int64, string, error) {
+func inspectDisk(fName string) (size int64, format string, _ error) {
 	f, err := os.Open(fName)
 	if err != nil {
 		return inspectDiskWithQemuImg(fName)
@@ -79,7 +79,7 @@ func inspectDisk(fName string) (int64, string, error) {
 }
 
 // inspectDiskSizeWithQemuImg invokes `qemu-img` binary to inspect the disk size and format.
-func inspectDiskWithQemuImg(fName string) (int64, string, error) {
+func inspectDiskWithQemuImg(fName string) (size int64, format string, _ error) {
 	info, err := imgutil.GetInfo(fName)
 	if err != nil {
 		return -1, "", err

--- a/pkg/textutil/textutil.go
+++ b/pkg/textutil/textutil.go
@@ -25,7 +25,7 @@ func ExecuteTemplate(tmpl string, args interface{}) ([]byte, error) {
 }
 
 // PrefixString adds prefix to beginning of each line
-func PrefixString(prefix string, text string) string {
+func PrefixString(prefix, text string) string {
 	result := []string{}
 	for _, line := range strings.Split(text, "\n") {
 		if line == "" {
@@ -44,12 +44,12 @@ func IndentString(size int, text string) string {
 }
 
 // TrimString removes characters from beginning and end
-func TrimString(cutset string, text string) string {
+func TrimString(cutset, text string) string {
 	return strings.Trim(text, cutset)
 }
 
 // MissingString returns message if the text is empty
-func MissingString(message string, text string) string {
+func MissingString(message, text string) string {
 	if text == "" {
 		return message
 	}

--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -690,7 +690,7 @@ func getEFI(driver *driver.BaseDriver) (*vz.EFIVariableStore, error) {
 	return vz.NewEFIVariableStore(efi)
 }
 
-func createSockPair() (*os.File, *os.File, error) {
+func createSockPair() (server, client *os.File, _ error) {
 	pairs, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_DGRAM, 0)
 	if err != nil {
 		return nil, nil, err
@@ -710,8 +710,8 @@ func createSockPair() (*os.File, *os.File, error) {
 	if err = syscall.SetsockoptInt(clientFD, syscall.SOL_SOCKET, syscall.SO_RCVBUF, 4*1024*1024); err != nil {
 		return nil, nil, err
 	}
-	server := os.NewFile(uintptr(serverFD), "server")
-	client := os.NewFile(uintptr(clientFD), "client")
+	server = os.NewFile(uintptr(serverFD), "server")
+	client = os.NewFile(uintptr(clientFD), "client")
 	runtime.SetFinalizer(server, func(file *os.File) {
 		logrus.Debugf("Server network file GC'ed")
 	})


### PR DESCRIPTION
This PR enables `gocritic` linter. Also, fixes or disables `gocritic` issues.

The full log of running `golangci-lint`:
```sh
❯ golangci-lint run
pkg/qemu/entitlementutil/entitlementutil.go:52:14: preferStringWriter: ent.WriteString(entXML) should be preferred to the ent.Write([]byte(entXML)) (gocritic)
        if _, err = ent.Write([]byte(entXML)); err != nil {
                    ^
pkg/qemu/entitlementutil/entitlementutil.go:65:1: whyNoLint: include an explanation for nolint directive (gocritic)
// isColimaWrapper__useThisFunctionOnlyForPrintingHints returns true
^
pkg/executil/command.go:19:18: ptrToRefParam: consider `ctx' to be of non-pointer type (gocritic)
func WithContext(ctx *context.Context) Opt {
                 ^
pkg/networks/usernet/dnshosts/dnshosts_test.go:209:1: paramTypeCombine: func(i int, j int) bool could be replaced with func(i, j int) bool (gocritic)
func (r recordSorter) Less(i int, j int) bool {
^
pkg/networks/usernet/dnshosts/dnshosts_test.go:214:1: paramTypeCombine: func(i int, j int) could be replaced with func(i, j int) (gocritic)
func (r recordSorter) Swap(i int, j int) {
^
pkg/networks/usernet/dnshosts/dnshosts_test.go:226:1: paramTypeCombine: func(i int, j int) bool could be replaced with func(i, j int) bool (gocritic)
func (z zoneSorter) Less(i int, j int) bool {
^
pkg/networks/usernet/dnshosts/dnshosts_test.go:231:1: paramTypeCombine: func(i int, j int) could be replaced with func(i, j int) (gocritic)
func (z zoneSorter) Swap(i int, j int) {
^
pkg/networks/usernet/dnshosts/dnshosts_test.go:197:21: typeUnparen: could simplify (recordSorter) to recordSorter (gocritic)
        _ sort.Interface = (recordSorter)(nil)
                           ^
pkg/networks/usernet/dnshosts/dnshosts_test.go:198:21: typeUnparen: could simplify (zoneSorter) to zoneSorter (gocritic)
        _ sort.Interface = (zoneSorter)(nil)
                           ^
pkg/qemu/imgutil/imgutil.go:82:1: paramTypeCombine: func(source string, dest string) error could be replaced with func(source, dest string) error (gocritic)
func ConvertToRaw(source string, dest string) error {
^
pkg/textutil/textutil.go:28:1: paramTypeCombine: func(prefix string, text string) string could be replaced with func(prefix, text string) string (gocritic)
func PrefixString(prefix string, text string) string {
^
pkg/textutil/textutil.go:47:1: paramTypeCombine: func(cutset string, text string) string could be replaced with func(cutset, text string) string (gocritic)
func TrimString(cutset string, text string) string {
^
pkg/textutil/textutil.go:52:1: paramTypeCombine: func(message string, text string) string could be replaced with func(message, text string) string (gocritic)
func MissingString(message string, text string) string {
^
pkg/sshutil/sshutil.go:225:1: paramTypeCombine: func(instDir string, useDotSSH, forwardAgent bool, forwardX11 bool, forwardX11Trusted bool) ([]string, error) could be replaced with func(instDir string, useDotSSH, forwardAgent, forwardX11, forwardX11Trusted bool) ([]string, error) (gocritic)
func SSHOpts(instDir string, useDotSSH, forwardAgent bool, forwardX11 bool, forwardX11Trusted bool) ([]string, error) {
^
pkg/networks/commands.go:78:1: deprecatedComment: the proper format is `Deprecated: <text>` (gocritic)
// Deprecated. Use Sock.
^
pkg/networks/config.go:178:1: deprecatedComment: the proper format is `Deprecated: <text>` (gocritic)
// Deprecated. Use Sock.
^
pkg/downloader/downloader.go:294:1: paramTypeCombine: func(cacheDir string, remote string) string could be replaced with func(cacheDir, remote string) string (gocritic)
func cacheDirectoryPath(cacheDir string, remote string) string {
^
pkg/downloader/downloader.go:383:1: paramTypeCombine: func(dst, src, ext string, description string) error could be replaced with func(dst, src, ext, description string) error (gocritic)
func decompressLocal(dst, src, ext string, description string) error {
^
pkg/downloader/downloader.go:475:1: paramTypeCombine: func(localPath, url string, description string, expectedDigest digest.Digest) error could be replaced with func(localPath, url, description string, expectedDigest digest.Digest) error (gocritic)
func downloadHTTP(localPath, url string, description string, expectedDigest digest.Digest) error {
^
pkg/limayaml/defaults.go:711:1: paramTypeCombine: func(format string, instDir string) (bytes.Buffer, error) could be replaced with func(format, instDir string) (bytes.Buffer, error) (gocritic)
func executeHostTemplate(format string, instDir string) (bytes.Buffer, error) {
^
pkg/limayaml/defaults_test.go:424:21: appendAssign: append result not assigned to the same slice (gocritic)
        expect.Provision = append(y.Provision, d.Provision...)
                           ^
pkg/limayaml/defaults_test.go:425:18: appendAssign: append result not assigned to the same slice (gocritic)
        expect.Probes = append(y.Probes, d.Probes...)
                        ^
pkg/limayaml/defaults_test.go:426:24: appendAssign: append result not assigned to the same slice (gocritic)
        expect.PortForwards = append(y.PortForwards, d.PortForwards...)
                              ^
pkg/limayaml/defaults_test.go:427:22: appendAssign: append result not assigned to the same slice (gocritic)
        expect.CopyToHost = append(y.CopyToHost, d.CopyToHost...)
                            ^
pkg/limayaml/defaults_test.go:428:31: appendAssign: append result not assigned to the same slice (gocritic)
        expect.Containerd.Archives = append(y.Containerd.Archives, d.Containerd.Archives...)
                                     ^
pkg/limayaml/defaults_test.go:429:27: appendAssign: append result not assigned to the same slice (gocritic)
        expect.AdditionalDisks = append(y.AdditionalDisks, d.AdditionalDisks...)
                                 ^
pkg/limayaml/defaults_test.go:432:18: appendAssign: append result not assigned to the same slice (gocritic)
        expect.Mounts = append(d.Mounts, y.Mounts...)
                        ^
pkg/limayaml/defaults_test.go:433:20: appendAssign: append result not assigned to the same slice (gocritic)
        expect.Networks = append(d.Networks, y.Networks...)
                          ^
pkg/limayaml/defaults_test.go:588:18: appendAssign: append result not assigned to the same slice (gocritic)
        expect.Mounts = append(d.Mounts, y.Mounts...)
                        ^
pkg/store/disk.go:63:1: unnamedResult: consider giving a name to these results (gocritic)
func inspectDisk(fName string) (int64, string, error) {
^
pkg/store/disk.go:82:1: unnamedResult: consider giving a name to these results (gocritic)
func inspectDiskWithQemuImg(fName string) (int64, string, error) {
^
pkg/networks/usernet/config.go:32:1: paramTypeCombine: func(dir string, name string, sockType SockType) (string, error) could be replaced with func(dir, name string, sockType SockType) (string, error) (gocritic)
func SockWithDirectory(dir string, name string, sockType SockType) (string, error) {
^
pkg/networks/usernet/config.go:111:1: paramTypeCombine: func(baseIP net.IP, netMask net.IP) (net.IP, *net.IPNet, error) could be replaced with func(baseIP, netMask net.IP) (net.IP, *net.IPNet, error) (gocritic)
func netmaskToCidr(baseIP net.IP, netMask net.IP) (net.IP, *net.IPNet, error) {
^
pkg/networks/usernet/gvproxy_test.go:36:1: paramTypeCombine: func(t *testing.T, file string, content string) could be replaced with func(t *testing.T, file, content string) (gocritic)
func createResolveFile(t *testing.T, file string, content string) {
^
pkg/networks/usernet/gvproxy_test.go:41:11: preferStringWriter: writer.WriteString(content) should be preferred to the writer.Write([]byte(content)) (gocritic)
        _, err = writer.Write([]byte(content))
                 ^
pkg/cidata/cidata.go:440:3: deferInLoop: Possible resource leak, 'defer' is called in the 'for' loop (gocritic)
                defer f.Close()
                ^
pkg/qemu/qemu.go:160:1: paramTypeCombine: func(cfg Config, cmd string, tag string) (string, error) could be replaced with func(cfg Config, cmd, tag string) (string, error) (gocritic)
func sendHmpCommand(cfg Config, cmd string, tag string) (string, error) {
^
pkg/qemu/qemu.go:316:1: paramTypeCombine: func(exe string, machine string) (*features, error) could be replaced with func(exe, machine string) (*features, error) (gocritic)
func inspectFeatures(exe string, machine string) (*features, error) {
^
pkg/qemu/qemu.go:465:1: unnamedResult: consider giving a name to these results (gocritic)
func Cmdline(cfg Config) (string, []string, error) {
^
pkg/qemu/qemu.go:1018:1: unnamedResult: consider giving a name to these results (gocritic)
func Exe(arch limayaml.Arch) (string, []string, error) {
^
pkg/vz/vm_darwin.go:693:1: unnamedResult: consider giving a name to these results (gocritic)
func createSockPair() (*os.File, *os.File, error) {
^
pkg/hostagent/hostagent.go:668:1: paramTypeCombine: func(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote string, verb string, reverse bool) error could be replaced with func(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote, verb string, reverse bool) error (gocritic)
func forwardSSH(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote string, verb string, reverse bool) error {
^
pkg/hostagent/hostagent.go:735:8: uncheckedInlineErr: removeErr error is unchecked, maybe intended to check it instead of err (gocritic)
                                if removeErr := os.RemoveAll(local); err != nil {
                                   ^
pkg/hostagent/mount.go:50:3: assignOp: replace `sshfsOptions = sshfsOptions + ",cache=no"` with `sshfsOptions += ",cache=no"` (gocritic)
                sshfsOptions = sshfsOptions + ",cache=no"
                ^
pkg/hostagent/mount.go:53:3: assignOp: replace `sshfsOptions = sshfsOptions + ",follow_symlinks"` with `sshfsOptions += ",follow_symlinks"` (gocritic)
                sshfsOptions = sshfsOptions + ",follow_symlinks"
                ^
pkg/hostagent/port.go:45:1: unnamedResult: consider giving a name to these results (gocritic)
func (pf *portForwarder) forwardingAddresses(guest api.IPPort, localUnixIP net.IP) (string, string) {
^
pkg/hostagent/port_darwin.go:19:1: paramTypeCombine: func(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote string, verb string) error could be replaced with func(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote, verb string) error (gocritic)
func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote string, verb string) error {
^
cmd/limactl/gendoc.go:120:1: paramTypeCombine: func(dir string, old, new string) error could be replaced with func(dir, old, new string) error (gocritic)
func replaceAll(dir string, old, new string) error {
^
cmd/limactl/gendoc.go:136:10: wrapperFunc: use bytes.ReplaceAll method in `bytes.Replace(in, []byte(old), []byte(new), -1)` (gocritic)
                out := bytes.Replace(in, []byte(old), []byte(new), -1)
                       ^
```