### PR TITLE
fix usb-bus for qemu 6

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -786,8 +786,8 @@ func Cmdline(cfg Config) (string, []string, error) {
 			args = append(args, "-device", "virtio-"+input+"-pci")
 		} else { // kernel panic with virtio and old versions of QEMU
 			args = append(args, "-vga", "none", "-device", "ramfb")
-			args = append(args, "-device", "usb-kbd,bus=usb-bus.0")
-			args = append(args, "-device", "usb-"+input+",bus=usb-bus.0")
+			args = append(args, "-device", "usb-kbd,bus=usb-bus")
+			args = append(args, "-device", "usb-"+input+",bus=usb-bus")
 		}
 		args = append(args, "-device", "qemu-xhci,id=usb-bus")
 	}


### PR DESCRIPTION
Lima does not start in qemu 6.2.0_1. Problem with USB forwarding to a virtual machine.

Logs:
```
time="2023-11-22T14:33:50+03:00" level=info msg="Terminal is not available, proceeding without opening an editor"
time="2023-11-22T14:33:50+03:00" level=debug msg="Evaluating yq expression: \"\""
time="2023-11-22T14:33:50+03:00" level=debug msg="Make sure \"user-v2\" network is running"
time="2023-11-22T14:33:50+03:00" level=debug msg="Make sure usernet network is started"
time="2023-11-22T14:33:50+03:00" level=debug msg="Starting usernet network: [limactl usernet -p <some-user>.lima/_networks/user-v2/usernet_user-v2.pid -e <some-user>.lima/_networks/user-v2/user-v2_ep.sock --listen-qemu <some-user>.lima/_networks/user-v2/user-v2_qemu.sock --listen <some-user>.lima/_networks/user-v2/user-v2_fd.sock --subnet 192.168.104.0/24 --leases 192.168.104.2=5a:94:ef:e4:0c:dd]"
time="2023-11-22T14:33:50+03:00" level=debug msg="Make sure \"shared\" network is stopped"
time="2023-11-22T14:33:50+03:00" level=debug msg="Make sure \"bridged\" network is stopped"
time="2023-11-22T14:33:50+03:00" level=debug msg="Make sure \"host\" network is stopped"
time="2023-11-22T14:33:50+03:00" level=debug msg="Executed [codesign --verify /opt/homebrew/bin/qemu-system-aarch64]: out=\"\"" error="<nil>"
time="2023-11-22T14:33:50+03:00" level=debug msg="Executed [codesign --display --entitlements - --xml /opt/homebrew/bin/qemu-system-aarch64]: out=\"Executable=/opt/homebrew/Cellar/qemu/6.2.0_1/bin/qemu-system-aarch64\\n<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?><!DOCTYPE plist PUBLIC \\\"-//Apple//DTD PLIST 1.0//EN\\\" \\\"https://www.apple.com/DTDs/PropertyList-1.0.dtd\\\"><plist version=\\\"1.0\\\"><dict><key>com.apple.security.hypervisor</key><true/></dict></plist>\\n\"" error="<nil>"
time="2023-11-22T14:33:50+03:00" level=info msg="QEMU binary \"/opt/homebrew/bin/qemu-system-aarch64\" seems properly signed with the \"com.apple.security.hypervisor\" entitlement"
time="2023-11-22T14:33:50+03:00" level=info msg="Attempting to download the image" arch=aarch64 digest="sha256:b009b7b83bcf287b269ba8ceaeb67338c047c8daa3f0deb159bd6f9b1e6b2fc7" location="https://artifactory.msk.test.ru/artifactory/tools/lima/ubuntu_22.04-test-arm64-2.img"
time="2023-11-22T14:33:50+03:00" level=debug msg="file \"<some-user>.lima/test/basedisk\" is cached as \"<some-user>Library/Caches/lima/download/by-url-sha256/81d1ac751d57c2d9d970dd8be7790988167ae54cd897d5be457c4e6947ab9f2e/data\""
time="2023-11-22T14:33:50+03:00" level=debug msg="Comparing digest \"sha256:b009b7b83bcf287b269ba8ceaeb67338c047c8daa3f0deb159bd6f9b1e6b2fc7\" with the cached digest file \"<some-user>Library/Caches/lima/download/by-url-sha256/81d1ac751d57c2d9d970dd8be7790988167ae54cd897d5be457c4e6947ab9f2e/sha256.digest\", not computing the actual digest of \"<some-user>Library/Caches/lima/download/by-url-sha256/81d1ac751d57c2d9d970dd8be7790988167ae54cd897d5be457c4e6947ab9f2e/data\""
time="2023-11-22T14:33:50+03:00" level=debug msg="res.ValidatedDigest=true"
time="2023-11-22T14:33:50+03:00" level=info msg="Using cache \"<some-user>Library/Caches/lima/download/by-url-sha256/81d1ac751d57c2d9d970dd8be7790988167ae54cd897d5be457c4e6947ab9f2e/data\""
time="2023-11-22T14:33:50+03:00" level=debug msg="[hostagent] Creating iso file <some-user>.lima/test/cidata.iso"
time="2023-11-22T14:33:50+03:00" level=debug msg="[hostagent] Using /var/folders/4k/b_mc9zg14kx9hhbw3nvz9xfr0000gn/T/diskfs_iso3537355661 as workspace"
time="2023-11-22T14:33:50+03:00" level=debug msg="[hostagent] Failed to detect CPU features. Assuming that AES acceleration is available on this Apple silicon."
time="2023-11-22T14:33:50+03:00" level=debug msg="[hostagent] OpenSSH version 9.0.1 detected"
time="2023-11-22T14:33:50+03:00" level=debug msg="[hostagent] AES accelerator seems available, prioritizing aes128-gcm@openssh.com and aes256-gcm@openssh.com"
time="2023-11-22T14:33:50+03:00" level=info msg="[hostagent] hostagent socket created at <some-user>.lima/test/ha.sock"
time="2023-11-22T14:33:50+03:00" level=debug msg="[hostagent] QEMU version 6.2.0 detected"
time="2023-11-22T14:33:50+03:00" level=debug msg="[hostagent] firmware candidates = [<some-user>.local/share/qemu/edk2-aarch64-code.fd /opt/homebrew/share/qemu/edk2-aarch64-code.fd /usr/share/AAVMF/AAVMF_CODE.fd /usr/share/qemu-efi-aarch64/QEMU_EFI.fd]"
time="2023-11-22T14:33:50+03:00" level=info msg="[hostagent] Starting QEMU (hint: to watch the boot progress, see \"<some-user>.lima/test/serial*.log\")"
time="2023-11-22T14:33:50+03:00" level=debug msg="[hostagent] qCmd.Args: [/opt/homebrew/bin/qemu-system-aarch64 -m 9216 -cpu host -machine virt,accel=hvf,highmem=off -smp 5,sockets=1,cores=5,threads=1 -drive if=pflash,format=raw,readonly=on,file=/opt/homebrew/share/qemu/edk2-aarch64-code.fd -boot order=c,splash-time=0,menu=on -drive file=<some-user>.lima/test/diffdisk,if=virtio,discard=on -drive id=cdrom0,if=none,format=raw,readonly=on,file=<some-user>.lima/test/cidata.iso -device virtio-scsi-pci,id=scsi0 -device scsi-cd,bus=scsi0.0,drive=cdrom0 -netdev socket,id=net0,fd=3 -device virtio-net-pci,netdev=net0,mac=52:55:55:c9:a9:ce -device virtio-rng-pci -display none -vga none -device ramfb -device usb-kbd,bus=usb-bus.0 -device usb-mouse,bus=usb-bus.0 -device qemu-xhci,id=usb-bus -parallel none -chardev socket,id=char-serial,path=<some-user>.lima/test/serial.sock,server=on,wait=off,logfile=<some-user>.lima/test/serial.log -serial chardev:char-serial -chardev socket,id=char-serial-pci,path=<some-user>.lima/test/serialp.sock,server=on,wait=off,logfile=<some-user>.lima/test/serialp.log -device pci-serial,chardev=char-serial-pci -chardev socket,id=char-serial-virtio,path=<some-user>.lima/test/serialv.sock,server=on,wait=off,logfile=<some-user>.lima/test/serialv.log -device virtio-serial-pci,id=virtio-serial0,max_ports=1 -device virtconsole,chardev=char-serial-virtio,id=console0 -chardev socket,id=char-qmp,path=<some-user>.lima/test/qmp.sock,server=on,wait=off -qmp chardev:char-qmp -name lima-test -pidfile <some-user>.lima/test/qemu.pid]"
time="2023-11-22T14:33:50+03:00" level=debug msg="received an event" event="{2023-11-22 14:33:50.926411 +0300 MSK {false false false [] 52941}}"
time="2023-11-22T14:33:50+03:00" level=info msg="SSH Local Port: 52941"
time="2023-11-22T14:33:50+03:00" level=info msg="[hostagent] Waiting for the essential requirement 1 of 5: \"ssh\""
time="2023-11-22T14:33:50+03:00" level=debug msg="[hostagent] executing script \"ssh\""
time="2023-11-22T14:33:50+03:00" level=debug msg="[hostagent] executing ssh for script \"ssh\": /usr/bin/ssh [ssh -F /dev/null -o IdentityFile=\"<some-user>.lima/_config/user\" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NoHostAuthenticationForLocalhost=yes -o GSSAPIAuthentication=no -o PreferredAuthentications=publickey -o Compression=no -o BatchMode=yes -o IdentitiesOnly=yes -o Ciphers=\"^aes128-gcm@openssh.com,aes256-gcm@openssh.com\" -o User=<some-user> -o ControlMaster=auto -o ControlPath=\"<some-user>.lima/test/ssh.sock\" -o ControlPersist=yes -p 52941 127.0.0.1 -- /bin/bash]"
time="2023-11-22T14:33:50+03:00" level=debug msg="[hostagent] stdout=\"\", stderr=\"ssh: connect to host 127.0.0.1 port 52941: Connection refused\\r\\n\", err=failed to execute script \"ssh\": stdout=\"\", stderr=\"ssh: connect to host 127.0.0.1 port 52941: Connection refused\\r\\n\": exit status 255"
time="2023-11-22T14:33:50+03:00" level=debug msg="[hostagent] qemu[stderr]: qemu-system-aarch64: -device usb-kbd,bus=usb-bus.0: Bus 'usb-bus.0' not found"
time="2023-11-22T14:33:50+03:00" level=info msg="[hostagent] Driver stopped due to error: \"exit status 1\""
time="2023-11-22T14:33:50+03:00" level=info msg="[hostagent] Shutting down the host agent"
time="2023-11-22T14:33:50+03:00" level=debug msg="[hostagent] shutting down the SSH master"
time="2023-11-22T14:33:50+03:00" level=debug msg="[hostagent] executing ssh for exiting the master: /usr/bin/ssh [ssh -F /dev/null -o IdentityFile=\"<some-user>.lima/_config/user\" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NoHostAuthenticationForLocalhost=yes -o GSSAPIAuthentication=no -o PreferredAuthentications=publickey -o Compression=no -o BatchMode=yes -o IdentitiesOnly=yes -o Ciphers=\"^aes128-gcm@openssh.com,aes256-gcm@openssh.com\" -o User=<some-user> -o ControlMaster=auto -o ControlPath=\"<some-user>.lima/test/ssh.sock\" -o ControlPersist=yes -O exit -p 52941 127.0.0.1]"
time="2023-11-22T14:33:50+03:00" level=warning msg="[hostagent] failed to exit SSH master"
time="2023-11-22T14:33:50+03:00" level=info msg="[hostagent] Shutting down QEMU with ACPI"
time="2023-11-22T14:33:50+03:00" level=warning msg="[hostagent] Failed to remove SSH binding for port 52941"
time="2023-11-22T14:33:51+03:00" level=warning msg="[hostagent] failed to open the QMP socket \"<some-user>.lima/test/qmp.sock\", forcibly killing QEMU"
time="2023-11-22T14:33:51+03:00" level=info msg="[hostagent] QEMU has already exited"
time="2023-11-22T14:33:51+03:00" level=debug msg="received an event" event="{2023-11-22 14:33:51.01017 +0300 MSK {false false true [] 0}}"
time="2023-11-22T14:33:51+03:00" level=fatal msg="exiting, status={Running:false Degraded:false Exiting:true Errors:[] SSHLocalPort:0} (hint: see \"<some-user>.lima/test/ha.stderr.log\")"
```

The reason is `qemu-system-aarch64: -device usb-kbd,bus=usb-bus.0: Bus 'usb-bus.0' not found"`.
Command `qemu-system-aarch64 -device help | grep usb` shows next
```
name "usb-host", bus usb-bus
name "usb-hub", bus usb-bus
name "ich9-usb-ehci1", bus PCI
name "ich9-usb-ehci2", bus PCI
name "ich9-usb-uhci1", bus PCI
name "ich9-usb-uhci2", bus PCI
name "ich9-usb-uhci3", bus PCI
name "ich9-usb-uhci4", bus PCI
name "ich9-usb-uhci5", bus PCI
name "ich9-usb-uhci6", bus PCI
name "nec-usb-xhci", bus PCI
name "piix3-usb-uhci", bus PCI
name "piix4-usb-uhci", bus PCI
name "usb-ehci", bus PCI
name "usb-bot", bus usb-bus
name "usb-mtp", bus usb-bus, desc "USB Media Transfer Protocol device"
name "usb-storage", bus usb-bus
name "usb-uas", bus usb-bus
name "usb-net", bus usb-bus
name "usb-braille", bus usb-bus
name "usb-ccid", bus usb-bus, desc "CCID Rev 1.1 smartcard reader"
name "usb-kbd", bus usb-bus
name "usb-mouse", bus usb-bus
name "usb-serial", bus usb-bus
name "usb-tablet", bus usb-bus
name "usb-wacom-tablet", bus usb-bus, desc "QEMU PenPartner Tablet"
name "usb-audio", bus usb-bus
```

It means that the bus name is "usb-bus" and not "usb-bus.0".

I tested it on my M1 Mac with qemu `6.2.0_1` and `8.1.2` and got the same results.