### PR TITLE
templates: Update Rocky Linux to 8.9 and 9.3

### DIFF
--- a/examples/rocky-8.yaml
+++ b/examples/rocky-8.yaml
@@ -4,12 +4,18 @@
 # EL9-based distros are known to work.
 
 images:
-- location: "https://dl.rockylinux.org/pub/rocky/8.8/images/x86_64/Rocky-8-GenericCloud-Base-8.8-20230518.0.x86_64.qcow2"
+- location: "https://dl.rockylinux.org/pub/rocky/8.9/images/x86_64/Rocky-8-GenericCloud-Base-8.9-20231119.0.x86_64.qcow2"
   arch: "x86_64"
-  digest: "sha256:086bf68f84c974cfcf533741c5be8752270df681a38f20423cf24b851d5edf77"
-- location: "https://dl.rockylinux.org/pub/rocky/8.8/images/aarch64/Rocky-8-GenericCloud-Base-8.8-20230518.0.aarch64.qcow2"
+  digest: "sha256:d17f15a7649dd064795306c114b90fc5062e7d5fefa9e9f0bd6b7ce1aeac3ae5"
+- location: "https://dl.rockylinux.org/pub/rocky/8.9/images/aarch64/Rocky-8-GenericCloud-Base-8.9-20231119.0.aarch64.qcow2"
   arch: "aarch64"
-  digest: "sha256:dcedb823982fab67094c6c8237b8c06e28cf5c4a7bfe7db43ff23c1b9347c746"
+  digest: "sha256:801c1afc27b8d200702193312c342f39f1418ed37f8501e6f07e9f707196df44"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://dl.rockylinux.org/pub/rocky/8/images/x86_64/Rocky-8-GenericCloud.latest.x86_64.qcow2"
+  arch: "x86_64"
+- location: "https://dl.rockylinux.org/pub/rocky/8/images/aarch64/Rocky-8-GenericCloud.latest.aarch64.qcow2"
+  arch: "aarch64"
 mounts:
 - location: "~"
 - location: "/tmp/lima"

--- a/examples/rocky-9.yaml
+++ b/examples/rocky-9.yaml
@@ -1,12 +1,18 @@
 # This template requires Lima v0.11.1 or later.
 
 images:
-- location: "https://dl.rockylinux.org/pub/rocky/9.2/images/x86_64/Rocky-9-GenericCloud-Base-9.2-20230513.0.x86_64.qcow2"
+- location: "https://dl.rockylinux.org/pub/rocky/9.3/images/x86_64/Rocky-9-GenericCloud-Base-9.3-20231113.0.x86_64.qcow2"
   arch: "x86_64"
-  digest: "sha256:50510f98abe1b20a548102a05a9be83153b0bf634fc502d5c8d1f508f6de1430"
-- location: "https://dl.rockylinux.org/pub/rocky/9.2/images/aarch64/Rocky-9-GenericCloud-Base-9.2-20230513.0.aarch64.qcow2"
+  digest: "sha256:7713278c37f29b0341b0a841ca3ec5c3724df86b4d97e7ee4a2a85def9b2e651"
+- location: "https://dl.rockylinux.org/pub/rocky/9.3/images/aarch64/Rocky-9-GenericCloud-Base-9.3-20231113.0.aarch64.qcow2"
   arch: "aarch64"
-  digest: "sha256:eb7752c0be359007ad470e43b0d8c921e31d3ad7d4bcec9b6a2b18a8d17c05d8"
+  digest: "sha256:1948a5e00786dbf3230335339cf96491659e17444f5d00dabac0f095a7354cc1"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2"
+  arch: "x86_64"
+- location: "https://dl.rockylinux.org/pub/rocky/9/images/aarch64/Rocky-9-GenericCloud.latest.aarch64.qcow2"
+  arch: "aarch64"
 mounts:
 - location: "~"
 - location: "/tmp/lima"


### PR DESCRIPTION
Update Rocky Linux templates to point at the recently updated images and provides fallback to unversioned image which should always be the most recent image available.