### PR TITLE
Update /mnt/data/etc/network/interfaces on each boot

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/04-persistent-data-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/04-persistent-data-volume.sh
@@ -27,6 +27,10 @@ if [ "$(awk '$2 == "/" {print $3}' /proc/mounts)" == "tmpfs" ]; then
 		fi
 		# Mount data volume
 		mount -t ext4 /dev/disk/by-label/data-volume /mnt/data
+		# Update /etc files that might have changed during this boot
+		cp /etc/network/interfaces /mnt/data/etc/network/
+		cp /etc/resolv.conf /mnt/data/etc/
+		# TODO there are probably others that should be updated as well
 	else
 		# Find an unpartitioned disk and create data-volume
 		DISKS=$(lsblk --list --noheadings --output name,type | awk '$2 == "disk" {print $1}')

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/50-alpine-fix.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/50-alpine-fix.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -eux
-
-# This script prepares Alpine for lima; there is nothing in here for other distros
-test -f /etc/alpine-release || exit 0
-
-# need to update /etc/resolv.conf
-rc-service networking restart


### PR DESCRIPTION
Otherwise it always reverts back to the first-boot settings once 04-persistent-data-volume.sh is done, and any further restarts of the networking service will revert to the old interfaces.

This problem was exposed by #1898. There are probably additional settings that might change `/etc` files on a reboot and need to be persisted, but I wanted to keep this PR small.

Similarly `/etc/resolv.conf` is generated by `udhcpc` (via `ifup`), but reverts back to the first-boot version after the bind-mount of the persistent data volume.

Restarting the networking service was just an expensive and indirect way to update `/etc/resolv.conf` by re-running `udhcpc` again.

Fixes https://github.com/rancher-sandbox/rancher-desktop/issues/6051