### PR TITLE
Disk resize command

### DIFF
--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -301,6 +301,11 @@ if [[ -n ${CHECKS["restart"]} ]]; then
 	limactl stop "$NAME"
 	sleep 3
 
+	if [[ -n ${CHECKS["disk"]} ]]; then
+		INFO "Resize disk and verify that partition and fs size are increased"
+		limactl disk resize data --size 11G
+	fi
+
 	export ftp_proxy=my.proxy:8021
 	INFO "Restarting \"$NAME\""
 	limactl start "$NAME"
@@ -323,6 +328,10 @@ if [[ -n ${CHECKS["restart"]} ]]; then
 	if [[ -n ${CHECKS["disk"]} ]]; then
 		if ! limactl shell "$NAME" sh -c 'test -f /mnt/lima-data/sweet-disk'; then
 			ERROR "Disk does not persist across restarts"
+			exit 1
+		fi
+		if ! limactl shell "$NAME" sh -c 'df -h /mnt/lima-data/ --output=size | grep -q 11G'; then
+			ERROR "Disk FS does not resized after restart"
 			exit 1
 		fi
 	fi

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -137,6 +137,17 @@ func CreateDataDisk(dir, format string, size int) error {
 	return nil
 }
 
+func ResizeDataDisk(dir, format string, size int) error {
+	dataDisk := filepath.Join(dir, filenames.DataDisk)
+
+	args := []string{"resize", "-f", format, dataDisk, strconv.Itoa(size)}
+	cmd := exec.Command("qemu-img", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to run %v: %q: %w", cmd.Args, string(out), err)
+	}
+	return nil
+}
+
 func newQmpClient(cfg Config) (*qmp.SocketMonitor, error) {
 	qmpSock := filepath.Join(cfg.InstanceDir, filenames.QMPSock)
 	qmpClient, err := qmp.NewSocketMonitor("unix", qmpSock, 5*time.Second)


### PR DESCRIPTION
The size of the created disk cannot be changed now. Even if the user resizes the disk using `qemu-img resize` he needs to run some commands in VM to grow the partition and resize the FS.

I added command `limactl disk resize` which can resize disk of a stopped vm using qemu-img.

Also I added parsing a format of an existing disk and render it in `limactl ls`

In cidata was added commands to resize the partition and the FS across all attached disks.

Shrinking of a disk is a danger operation, so i explicitly disallow it