### PR TITLE
Register CopyToHost as a known property

### DIFF
--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -19,6 +19,39 @@ import (
 	"github.com/lima-vm/lima/pkg/reflectutil"
 )
 
+var knownYamlProperties = []string{
+	"AdditionalDisks",
+	"Arch",
+	"Audio",
+	"CACertificates",
+	"Containerd",
+	"CopyToHost",
+	"CPUs",
+	"CPUType",
+	"Disk",
+	"DNS",
+	"Env",
+	"Firmware",
+	"GuestInstallPrefix",
+	"HostResolver",
+	"Images",
+	"Memory",
+	"Message",
+	"Mounts",
+	"MountType",
+	"Networks",
+	"OS",
+	"Plain",
+	"PortForwards",
+	"Probes",
+	"PropagateProxyEnv",
+	"Provision",
+	"Rosetta",
+	"SSH",
+	"Video",
+	"VMType",
+}
+
 const Enabled = true
 
 type LimaVzDriver struct {
@@ -45,36 +78,7 @@ func (l *LimaVzDriver) Validate() error {
 	if *l.Yaml.Firmware.LegacyBIOS {
 		return fmt.Errorf("`firmware.legacyBIOS` configuration is not supported for VZ driver")
 	}
-	if unknown := reflectutil.UnknownNonEmptyFields(l.Yaml, "VMType",
-		"Arch",
-		"Images",
-		"CPUs",
-		"CPUType",
-		"Memory",
-		"Disk",
-		"Mounts",
-		"MountType",
-		"SSH",
-		"Firmware",
-		"Provision",
-		"Containerd",
-		"GuestInstallPrefix",
-		"Probes",
-		"PortForwards",
-		"Message",
-		"Networks",
-		"Env",
-		"DNS",
-		"HostResolver",
-		"PropagateProxyEnv",
-		"CACertificates",
-		"Rosetta",
-		"AdditionalDisks",
-		"Audio",
-		"Video",
-		"OS",
-		"Plain",
-	); len(unknown) > 0 {
+	if unknown := reflectutil.UnknownNonEmptyFields(l.Yaml, knownYamlProperties...); len(unknown) > 0 {
 		logrus.Warnf("vmType %s: ignoring %+v", *l.Yaml.VMType, unknown)
 	}
 

--- a/pkg/wsl2/wsl_driver_windows.go
+++ b/pkg/wsl2/wsl_driver_windows.go
@@ -14,6 +14,28 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var knownYamlProperties = []string{
+	"Arch",
+	"Containerd",
+	"CopyToHost",
+	"CPUType",
+	"Disk",
+	"DNS",
+	"Env",
+	"HostResolver",
+	"Images",
+	"Message",
+	"Mounts",
+	"MountType",
+	"Plain",
+	"PortForwards",
+	"Probes",
+	"PropagateProxyEnv",
+	"Provision",
+	"SSH",
+	"VMType",
+}
+
 const Enabled = true
 
 type LimaWslDriver struct {
@@ -31,25 +53,7 @@ func (l *LimaWslDriver) Validate() error {
 		return fmt.Errorf("field `mountType` must be %q for WSL2 driver, got %q", limayaml.WSLMount, *l.Yaml.MountType)
 	}
 	// TODO: revise this list for WSL2
-	if unknown := reflectutil.UnknownNonEmptyFields(l.Yaml, "VMType",
-		"Arch",
-		"Images",
-		"CPUType",
-		"Disk",
-		"Mounts",
-		"MountType",
-		"SSH",
-		"Provision",
-		"Containerd",
-		"Probes",
-		"PortForwards",
-		"Message",
-		"Env",
-		"DNS",
-		"HostResolver",
-		"PropagateProxyEnv",
-		"Plain",
-	); len(unknown) > 0 {
+	if unknown := reflectutil.UnknownNonEmptyFields(l.Yaml, knownYamlProperties...); len(unknown) > 0 {
 		logrus.Warnf("Ignoring: vmType %s: %+v", *l.Yaml.VMType, unknown)
 	}
 


### PR DESCRIPTION
This PR fixes #1932 .

`CopyToHost` is added in #1301 .