### PR TITLE
Preserve LIMA_CIDATA_* variables when running a user provision script

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.sh
@@ -66,7 +66,7 @@ if [ -d "${LIMA_CIDATA_MNT}"/provision.user ]; then
 		cp "$f" "${USER_SCRIPT}"
 		chown "${LIMA_CIDATA_USER}" "${USER_SCRIPT}"
 		chmod 755 "${USER_SCRIPT}"
-		if ! sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "${USER_SCRIPT}"; then
+		if ! sudo -Eiu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "${USER_SCRIPT}"; then
 			WARNING "Failed to execute $f (as user ${LIMA_CIDATA_USER})"
 			CODE=1
 		fi

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.sh
@@ -66,7 +66,7 @@ if [ -d "${LIMA_CIDATA_MNT}"/provision.user ]; then
 		cp "$f" "${USER_SCRIPT}"
 		chown "${LIMA_CIDATA_USER}" "${USER_SCRIPT}"
 		chmod 755 "${USER_SCRIPT}"
-		if ! sudo -Esu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "${USER_SCRIPT}"; then
+		if ! sudo -HEsu "${LIMA_CIDATA_USER}" -D "${LIMA_CIDATA_HOME}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "${USER_SCRIPT}"; then
 			WARNING "Failed to execute $f (as user ${LIMA_CIDATA_USER})"
 			CODE=1
 		fi

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.sh
@@ -66,7 +66,7 @@ if [ -d "${LIMA_CIDATA_MNT}"/provision.user ]; then
 		cp "$f" "${USER_SCRIPT}"
 		chown "${LIMA_CIDATA_USER}" "${USER_SCRIPT}"
 		chmod 755 "${USER_SCRIPT}"
-		if ! sudo -Eiu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "${USER_SCRIPT}"; then
+		if ! sudo -Esu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "${USER_SCRIPT}"; then
 			WARNING "Failed to execute $f (as user ${LIMA_CIDATA_USER})"
 			CODE=1
 		fi

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.sh
@@ -66,7 +66,7 @@ if [ -d "${LIMA_CIDATA_MNT}"/provision.user ]; then
 		cp "$f" "${USER_SCRIPT}"
 		chown "${LIMA_CIDATA_USER}" "${USER_SCRIPT}"
 		chmod 755 "${USER_SCRIPT}"
-		if ! sudo -HEsu "${LIMA_CIDATA_USER}" -D "${LIMA_CIDATA_HOME}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "${USER_SCRIPT}"; then
+		if ! sudo -HEsu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "${USER_SCRIPT}"; then
 			WARNING "Failed to execute $f (as user ${LIMA_CIDATA_USER})"
 			CODE=1
 		fi


### PR DESCRIPTION
### Description

[Lima's environment vars](https://github.com/lima-vm/lima/blob/master/pkg/cidata/cidata.TEMPLATE.d/lima.env) are not accessible from a user mode provision script like this:

```yaml
provision:
- mode: user
  script: |
    #!/bin/sh
    ln -s $LIMA_CIDATA_HOSTHOME_MOUNTPOINT/.conan ~/.conan
```

The above script creates a wrong link since the `LIMA_CIDATA_HOSTHOME_MOUNTPOINT` variable isn't visible from the script:
```
# ls -la ~
total 20
drwxr-xr-x    4 zzzzz    zzzzz         4096 Dec  4 15:01 .
drwxr-xr-x    3 root     root          4096 Dec  2 00:02 ..
-rw-------    1 zzzzz    zzzzz          234 Dec  4 11:58 .ash_history
lrwxrwxrwx    1 zzzzz    zzzzz            7 Dec  4 15:01 .conan -> /.conan
drwxr-xr-x    3 zzzzz    zzzzz         4096 Dec  4 11:54 .config
drwx------    2 zzzzz    zzzzz         4096 Dec  2 00:02 .ssh
```

To preserve LIMA_CIDATA_* variables in a user script the `sudo` command shall use `-E` option which preserves all environment variables.