### PR TITLE
qemu, aarch64: use EDK2 from "Firmware/edk2 20231213 patches" (needed for QEMU v8.2.0)

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -263,6 +263,14 @@ firmware:
   # Use legacy BIOS instead of UEFI. Ignored for aarch64.
   # 🟢 Builtin default: false
   legacyBIOS: null
+#  # Override UEFI images
+#  # 🟢 Builtin default: uses VM's default UEFI, except for qemu + aarch64.
+#  # See <https://lists.gnu.org/archive/html/qemu-devel/2023-12/msg01694.html>
+#  images:
+#  - location: "~/Downloads/edk2-aarch64-code.fd.gz"
+#    arch: "aarch64"
+#    digest: "sha256:..."
+#    vmType: "qemu"
 
 audio:
   # EXPERIMENTAL

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -112,6 +112,37 @@ func defaultGuestInstallPrefix() string {
 	return "/usr/local"
 }
 
+func defaultFirmwareImages() []FileWithVMType {
+	return []FileWithVMType{
+		/*
+			The "Firmware/edk2 20231213" patches <https://lists.gnu.org/archive/html/qemu-devel/2023-12/msg01694.html>
+			are necessary to boot most aarch64 images (except Debian, which does not use UEFI shim).
+
+			The patches are proposed for the QEMU v8.2.0 milestone, but likely to be postponed to v8.2.1.
+			Until the patches get accepted in the QEMU upstream, Lima fetches the patched edk2 binary from
+			<https://gitlab.com/kraxel/qemu/-/tags/firmware%2Fedk2-20231213-pull-request>.
+		*/
+		{
+			File: File{
+				Location: "https://gitlab.com/kraxel/qemu/-/raw/704f7cad5105246822686f65765ab92045f71a3b/pc-bios/edk2-aarch64-code.fd.bz2",
+				Arch:     AARCH64,
+				Digest:   "sha256:a5fc228623891297f2d82e22ea56ec57cde93fea5ec01abf543e4ed5cacaf277",
+			},
+			VMType: QEMU,
+		},
+		// Mirror
+		{
+			File: File{
+				Location: "https://github.com/AkihiroSuda/qemu/raw/704f7cad5105246822686f65765ab92045f71a3b/pc-bios/edk2-aarch64-code.fd.bz2",
+				Arch:     AARCH64,
+				Digest:   "sha256:a5fc228623891297f2d82e22ea56ec57cde93fea5ec01abf543e4ed5cacaf277",
+			},
+			VMType: QEMU,
+		},
+		// TODO: what about ARMv7?
+	}
+}
+
 // FillDefault updates undefined fields in y with defaults from d (or built-in default), and overwrites with values from o.
 // Both d and o may be empty.
 //
@@ -281,6 +312,17 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 	}
 	if y.Firmware.LegacyBIOS == nil {
 		y.Firmware.LegacyBIOS = ptr.Of(false)
+	}
+
+	y.Firmware.Images = append(append(o.Firmware.Images, y.Firmware.Images...), d.Firmware.Images...)
+	if len(y.Firmware.Images) == 0 {
+		y.Firmware.Images = defaultFirmwareImages()
+	}
+	for i := range y.Firmware.Images {
+		f := &y.Firmware.Images[i]
+		if f.Arch == "" {
+			f.Arch = *y.Arch
+		}
 	}
 
 	if y.SSH.LocalPort == nil {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -181,6 +181,27 @@ func TestFillDefault(t *testing.T) {
 				"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT\n-----END CERTIFICATE-----\n",
 			},
 		},
+		Firmware: Firmware{
+			LegacyBIOS: ptr.Of(false),
+			Images: []FileWithVMType{
+				{
+					File: File{
+						Location: "https://gitlab.com/kraxel/qemu/-/raw/704f7cad5105246822686f65765ab92045f71a3b/pc-bios/edk2-aarch64-code.fd.bz2",
+						Arch:     AARCH64,
+						Digest:   "sha256:a5fc228623891297f2d82e22ea56ec57cde93fea5ec01abf543e4ed5cacaf277",
+					},
+					VMType: QEMU,
+				},
+				{
+					File: File{
+						Location: "https://github.com/AkihiroSuda/qemu/raw/704f7cad5105246822686f65765ab92045f71a3b/pc-bios/edk2-aarch64-code.fd.bz2",
+						Arch:     AARCH64,
+						Digest:   "sha256:a5fc228623891297f2d82e22ea56ec57cde93fea5ec01abf543e4ed5cacaf277",
+					},
+					VMType: QEMU,
+				},
+			},
+		},
 	}
 
 	expect := builtin
@@ -252,6 +273,8 @@ func TestFillDefault(t *testing.T) {
 		},
 	}
 
+	expect.Firmware = y.Firmware
+
 	expect.Rosetta = Rosetta{
 		Enabled: ptr.Of(false),
 		BinFmt:  ptr.Of(false),
@@ -299,6 +322,14 @@ func TestFillDefault(t *testing.T) {
 		},
 		Firmware: Firmware{
 			LegacyBIOS: ptr.Of(true),
+			Images: []FileWithVMType{
+				{
+					File: File{
+						Location: "/dummy",
+						Arch:     X8664,
+					},
+				},
+			},
 		},
 		Audio: Audio{
 			Device: ptr.Of("coreaudio"),
@@ -427,6 +458,7 @@ func TestFillDefault(t *testing.T) {
 	expect.CopyToHost = append(append([]CopyToHost{}, y.CopyToHost...), d.CopyToHost...)
 	expect.Containerd.Archives = append(append([]File{}, y.Containerd.Archives...), d.Containerd.Archives...)
 	expect.AdditionalDisks = append(append([]Disk{}, y.AdditionalDisks...), d.AdditionalDisks...)
+	expect.Firmware.Images = append(append([]FileWithVMType{}, y.Firmware.Images...), d.Firmware.Images...)
 
 	// Mounts and Networks start with lowest priority first, so higher priority entries can overwrite
 	expect.Mounts = append(append([]Mount{}, d.Mounts...), y.Mounts...)
@@ -580,6 +612,7 @@ func TestFillDefault(t *testing.T) {
 	expect.CopyToHost = append(append(o.CopyToHost, y.CopyToHost...), d.CopyToHost...)
 	expect.Containerd.Archives = append(append(o.Containerd.Archives, y.Containerd.Archives...), d.Containerd.Archives...)
 	expect.AdditionalDisks = append(append(o.AdditionalDisks, y.AdditionalDisks...), d.AdditionalDisks...)
+	expect.Firmware.Images = append(append(o.Firmware.Images, y.Firmware.Images...), d.Firmware.Images...)
 
 	expect.HostResolver.Hosts["default"] = d.HostResolver.Hosts["default"]
 	expect.HostResolver.Hosts["MY.Host"] = d.HostResolver.Hosts["host.lima.internal"]

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -77,6 +77,11 @@ type File struct {
 	Digest   digest.Digest `yaml:"digest,omitempty" json:"digest,omitempty"`
 }
 
+type FileWithVMType struct {
+	File   `yaml:",inline"`
+	VMType VMType `yaml:"vmType,omitempty" json:"vmType,omitempty"`
+}
+
 type Kernel struct {
 	File    `yaml:",inline"`
 	Cmdline string `yaml:"cmdline,omitempty" json:"cmdline,omitempty"`
@@ -142,6 +147,10 @@ type Firmware struct {
 	// LegacyBIOS disables UEFI if set.
 	// LegacyBIOS is ignored for aarch64.
 	LegacyBIOS *bool `yaml:"legacyBIOS,omitempty" json:"legacyBIOS,omitempty"`
+
+	// Images specify UEFI images (edk2-aarch64-code.fd.gz).
+	// Defaults to built-in UEFI.
+	Images []FileWithVMType `yaml:"images,omitempty" json:"images,omitempty"`
 }
 
 type Audio struct {

--- a/pkg/store/filenames/filenames.go
+++ b/pkg/store/filenames/filenames.go
@@ -53,7 +53,8 @@ const (
 	HostAgentStdoutLog = "ha.stdout.log"
 	HostAgentStderrLog = "ha.stderr.log"
 	VzIdentifier       = "vz-identifier"
-	VzEfi              = "vz-efi"
+	VzEfi              = "vz-efi"           // efi variable store
+	QemuEfiCodeFD      = "qemu-efi-code.fd" // efi code; not always created
 
 	// SocketDir is the default location for forwarded sockets with a relative paths in HostSocket
 	SocketDir = "sock"

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -78,6 +78,14 @@ func (l *LimaVzDriver) Validate() error {
 	if *l.Yaml.Firmware.LegacyBIOS {
 		return fmt.Errorf("`firmware.legacyBIOS` configuration is not supported for VZ driver")
 	}
+	for _, f := range l.Yaml.Firmware.Images {
+		switch f.VMType {
+		case "", limayaml.VZ:
+			if f.Arch == *l.Yaml.Arch {
+				return fmt.Errorf("`firmware.images` configuration is not supported for VZ driver")
+			}
+		}
+	}
 	if unknown := reflectutil.UnknownNonEmptyFields(l.Yaml, knownYamlProperties...); len(unknown) > 0 {
 		logrus.Warnf("vmType %s: ignoring %+v", *l.Yaml.VMType, unknown)
 	}

--- a/website/content/en/docs/dev/Internals/_index.md
+++ b/website/content/en/docs/dev/Internals/_index.md
@@ -48,6 +48,7 @@ kernel:
 QEMU:
 - `qemu.pid`: QEMU PID
 - `qmp.sock`: QMP socket
+- `qemu-efi-code.fd`: QEMU UEFI code (not always present)
 
 VZ:
 - `vz.pid`: VZ PID


### PR DESCRIPTION
The "Firmware/edk2 20231213" patches <https://lists.gnu.org/archive/html/qemu-devel/2023-12/msg01694.html>
are necessary to boot most aarch64 images (except Debian, which does not use UEFI shim).

The patches are proposed for the QEMU v8.2.0 milestone, but likely to be postponed to v8.2.1.
Until the patches get accepted in the QEMU upstream, Lima fetches the patched
edk2 binary from <https://gitlab.com/kraxel/qemu/-/tags/firmware%2Fedk2-20231213-pull-request>.