### PR TITLE
CI: increase timeout for golangci-lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3.7.0
       with:
         version: v1.55.2
-        args: --verbose
+        args: --verbose --timeout=10m
     - name: Run yamllint
       run: yamllint .
     - name: Install shellcheck


### PR DESCRIPTION
Fix #2079
