### PR TITLE
Add timestamps to LIMA boot.sh messages

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.sh
@@ -2,11 +2,11 @@
 set -eu
 
 INFO() {
-	echo "LIMA| $*"
+	echo "LIMA $(date -Iseconds)| $*"
 }
 
 WARNING() {
-	echo "LIMA| WARNING: $*"
+	echo "LIMA $(date -Iseconds)| WARNING: $*"
 }
 
 # shellcheck disable=SC2163


### PR DESCRIPTION
to make it easier to correlate them to entries in ha.std*.log files.

Related to debugging #2064.

Messages look like this:

```
LIMA 2023-12-19T06:56:36+00:00| Executing /mnt/lima-cidata/boot/25-guestagent-base.sh
```

At first I appended them to the end:

```
LIMA| Executing /mnt/lima-cidata/boot/25-guestagent-base.sh at 2023-12-19T06:56:36+00:00
```

but I found that makes them hard to locate in the log file.