### PR TITLE
Automatically unlock disk if it is already locked to the same instance (after restarting macOS)

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -618,8 +618,15 @@ func Cmdline(cfg Config) (exe string, args []string, err error) {
 			}
 
 			if disk.Instance != "" {
-				logrus.Errorf("could not attach disk %q, in use by instance %q", diskName, disk.Instance)
-				return "", nil, err
+				if disk.InstanceDir != cfg.InstanceDir {
+					logrus.Errorf("could not attach disk %q, in use by instance %q", diskName, disk.Instance)
+					return "", nil, err
+				}
+				err = disk.Unlock()
+				if err != nil {
+					logrus.Errorf("could not unlock disk %q to reuse in the same instance %q", diskName, cfg.Name)
+					return "", nil, err
+				}
 			}
 			logrus.Infof("Mounting disk %q on %q", diskName, disk.MountPoint)
 			err = disk.Lock(cfg.InstanceDir)


### PR DESCRIPTION
This PR closes #1683 

Sometimes disk is not unlocked while shutdown (for example on macOS restart) and existing link prevents restarting vm without additional commands.
Automatically remove existing link when using with the same vm.