### PR TITLE
fix limactl shell k3s kubectl command failed

### DIFF
--- a/examples/k3s.yaml
+++ b/examples/k3s.yaml
@@ -1,6 +1,6 @@
 # Deploy kubernetes via k3s (which installs a bundled containerd).
 # $ limactl start ./k3s.yaml
-# $ limactl shell k3s sudo kubectl
+# $ limactl shell k3s kubectl
 #
 # It can be accessed from the host by exporting the kubeconfig file;
 # the ports are already forwarded automatically by lima:
@@ -40,7 +40,7 @@ provision:
   script: |
     #!/bin/sh
     if [ ! -d /var/lib/rancher/k3s ]; then
-            curl -sfL https://get.k3s.io | sh -
+            curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --write-kubeconfig-mode 644" sh -
     fi
 probes:
 - script: |


### PR DESCRIPTION
Fix: #2094

```shell
zjz:~$ limactl shell k3s ls -al /etc/rancher/k3s/k3s.yaml
-rw-r--r-- 1 root root 2961 Dec 21 09:01 /etc/rancher/k3s/k3s.yaml
# has been changed to 644

zjz:~$ limactl shell k3s kubectl get ns
NAME              STATUS   AGE
kube-system       Active   346d
default           Active   346d
kube-public       Active   346d
kube-node-lease   Active   346d
```

