### PR TITLE
k8s: stop using sudo kubectl for kubeconfig

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -1,6 +1,6 @@
 # Deploy kubernetes via kubeadm.
 # $ limactl start ./k8s.yaml
-# $ limactl shell k8s sudo kubectl
+# $ limactl shell k8s kubectl
 
 # It can be accessed from the host by exporting the kubeconfig file;
 # the ports are already forwarded automatically by lima:
@@ -126,6 +126,14 @@ provision:
     # Replace the server address with localhost, so that it works also from the host
     sed -e "/server:/ s|https://.*:\([0-9]*\)$|https://127.0.0.1:\1|" -i $KUBECONFIG
     mkdir -p ${HOME:-/root}/.kube && cp -f $KUBECONFIG ${HOME:-/root}/.kube/config
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    export KUBECONFIG=/etc/kubernetes/admin.conf
+    mkdir -p ${LIMA_CIDATA_HOME}/.kube
+    cp -f $KUBECONFIG ${LIMA_CIDATA_HOME}/.kube/config
+    chown -R ${LIMA_CIDATA_USER} ${LIMA_CIDATA_HOME}/.kube
 probes:
 - description: "kubeadm to be installed"
   script: |
@@ -151,7 +159,7 @@ probes:
   script: |
     #!/bin/bash
     set -eux -o pipefail
-    if ! timeout 300s bash -c "until sudo kubectl version >/dev/null 2>&1; do sleep 3; done"; then
+    if ! timeout 300s bash -c "until kubectl version >/dev/null 2>&1; do sleep 3; done"; then
       echo >&2 "kubernetes cluster is not up and running yet"
       exit 1
     fi
@@ -159,7 +167,7 @@ probes:
   script: |
     #!/bin/bash
     set -eux -o pipefail
-    sudo kubectl wait -n kube-system --timeout=180s --for=condition=available deploy coredns
+    kubectl wait -n kube-system --timeout=180s --for=condition=available deploy coredns
 copyToHost:
 - guest: "/etc/kubernetes/admin.conf"
   host: "{{.Dir}}/copied-from-guest/kubeconfig.yaml"


### PR DESCRIPTION
Applies change from 0aed87173d47327049d3006dfd1b564e0d17f20e

```
The connection to the server localhost:8080 was refused - did you specify the right host or port?
```

Reverts the previous a5427ddca0f87cf60235400feeac514782f57b80

Still need to run `sudo crictl`