### PR TITLE
Store Lima version in the instance directory

### DIFF
--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/lima-vm/lima/pkg/templatestore"
 	"github.com/lima-vm/lima/pkg/uiutil"
+	"github.com/lima-vm/lima/pkg/version"
 	"github.com/lima-vm/lima/pkg/yqutil"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -330,6 +331,9 @@ func createInstance(ctx context.Context, st *creatorState, saveBrokenEditorBuffe
 		return nil, err
 	}
 	if err := os.WriteFile(filePath, st.yBytes, 0o644); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(filepath.Join(instDir, filenames.LimaVersion), []byte(version.Version), 0o444); err != nil {
 		return nil, err
 	}
 

--- a/pkg/store/filenames/filenames.go
+++ b/pkg/store/filenames/filenames.go
@@ -27,6 +27,7 @@ const (
 
 const (
 	LimaYAML           = "lima.yaml"
+	LimaVersion        = "lima-version" // Lima version used to create instance
 	CIDataISO          = "cidata.iso"
 	CIDataISODir       = "cidata"
 	BaseDisk           = "basedisk"

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -16,12 +16,14 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/docker/go-units"
 	hostagentclient "github.com/lima-vm/lima/pkg/hostagent/api/client"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/lima-vm/lima/pkg/textutil"
+	"github.com/sirupsen/logrus"
 )
 
 type Status = string
@@ -56,6 +58,7 @@ type Instance struct {
 	Config          *limayaml.LimaYAML `json:"config,omitempty"`
 	SSHAddress      string             `json:"sshAddress,omitempty"`
 	Protected       bool               `json:"protected"`
+	LimaVersion     string             `json:"limaVersion"`
 }
 
 func (inst *Instance) LoadYAML() (*limayaml.LimaYAML, error) {
@@ -166,6 +169,16 @@ func Inspect(instName string) (*Instance, error) {
 				inst.Message = message.String()
 			}
 		}
+	}
+
+	limaVersionFile := filepath.Join(instDir, filenames.LimaVersion)
+	if version, err := os.ReadFile(limaVersionFile); err == nil {
+		inst.LimaVersion = strings.TrimSpace(string(version))
+		if _, err = parseLimaVersion(inst.LimaVersion); err != nil {
+			logrus.Warnf("treating lima version %q from %q as very latest release", inst.LimaVersion, limaVersionFile)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		inst.Errors = append(inst.Errors, err)
 	}
 	return inst, nil
 }
@@ -422,4 +435,37 @@ func (inst *Instance) Unprotect() error {
 	}
 	inst.Protected = false
 	return nil
+}
+
+// parseLimaVersion parses a Lima version string by removing the leading "v" character and
+// stripping everything from the first "-" forward (which are `git describe` artifacts and
+// not semver pre-release markers). So "v0.19.1-16-gf3dc6ed.m" will be parsed as "0.19.1".
+func parseLimaVersion(version string) (*semver.Version, error) {
+	version = strings.TrimPrefix(version, "v")
+	version, _, _ = strings.Cut(version, "-")
+	return semver.NewVersion(version)
+}
+
+// LimaVersionGreaterThan returns true if the Lima version used to create an instance is greater
+// than a specific older version. Always returns false if the Lima version is the empty string.
+// Unparsable lima versions (like SHA1 commit ids) are treated as the latest version and return true.
+// limaVersion is a `github describe` string, not a semantic version. So "0.19.1-16-gf3dc6ed.m"
+// will be considered greater than "0.19.1".
+func LimaVersionGreaterThan(limaVersion, oldVersion string) bool {
+	if limaVersion == "" {
+		return false
+	}
+	version, err := parseLimaVersion(limaVersion)
+	if err != nil {
+		return true
+	}
+	switch version.Compare(*semver.New(oldVersion)) {
+	case -1:
+		return false
+	case +1:
+		return true
+	case 0:
+		return strings.Contains(limaVersion, "-")
+	}
+	panic("unreachable")
 }

--- a/pkg/store/instance_test.go
+++ b/pkg/store/instance_test.go
@@ -155,3 +155,12 @@ func TestPrintInstanceTableTwo(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, tableTwo, buf.String())
 }
+
+func TestLimaVersionGreaterThan(t *testing.T) {
+	assert.Equal(t, LimaVersionGreaterThan("", "0.1.0"), false)
+	assert.Equal(t, LimaVersionGreaterThan("0.0.1", "0.1.0"), false)
+	assert.Equal(t, LimaVersionGreaterThan("0.1.0", "0.1.0"), false)
+	assert.Equal(t, LimaVersionGreaterThan("0.1.0-2", "0.1.0"), true)
+	assert.Equal(t, LimaVersionGreaterThan("0.2.0", "0.1.0"), true)
+	assert.Equal(t, LimaVersionGreaterThan("abacab", "0.1.0"), true)
+}

--- a/website/content/en/docs/dev/Internals/_index.md
+++ b/website/content/en/docs/dev/Internals/_index.md
@@ -30,6 +30,7 @@ having to specify an identity explicitly.
 An instance directory contains the following files:
 
 Metadata:
+- `lima-version`: the Lima version used to create this instance
 - `lima.yaml`: the YAML
 - `protected`: empty file, used by `limactl protect`
 


### PR DESCRIPTION
That way future Lima releases can make decisions about default settings based on the Lima version that created the instance instead of the current instance, and settings for existing instances will not change just because the user updated Lima.

This implements the mechanism I described in https://github.com/lima-vm/lima/pull/1953#issuecomment-1784546687. I'm leaving it in draft mode for now because I'm not sure if the `store.MinVersion` function is the right way to use the data; I originally wanted to make it an instance method, but then noticed that most location that would need to call it don't have a copy of the instance.

So this PR probably needs to wait until we have a companion PR that makes use of this new mechanism. Or I could drop the `MinVersion` function for now and leave it for the first PR that will take advantage of the data.

```console
$ limactl ls --format '{{.Name}} - {{.LimaVersion}}'
alpine - v0.19.1
default - v0.19.1-16-gf3dc6ed.m
```

Either way, feedback welcome!