### PR TITLE
Revert virtserialport back to unix socket for QEMU guest agent communication

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
@@ -35,7 +35,7 @@ name="lima-guestagent"
 description="Forward ports to the lima-hostagent"
 
 command=${LIMA_CIDATA_GUEST_INSTALL_PREFIX}/bin/lima-guestagent
-command_args="daemon --vsock-port "${LIMA_CIDATA_VSOCK_PORT}" --virtio-port "${LIMA_CIDATA_VIRTIO_PORT}""
+command_args="daemon --vsock-port \"${LIMA_CIDATA_VSOCK_PORT}\" --virtio-port \"${LIMA_CIDATA_VIRTIO_PORT}\""
 command_background=true
 pidfile="/run/lima-guestagent.pid"
 EOF

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -128,7 +128,8 @@ func New(instName string, stdout io.Writer, sigintCh chan os.Signal, opts ...Opt
 		}
 		vSockPort = port
 	} else if *y.VMType == limayaml.QEMU {
-		virtioPort = filenames.VirtioPort
+		// virtserialport doesn't seem to work reliably: https://github.com/lima-vm/lima/issues/2064
+		virtioPort = "" // filenames.VirtioPort
 	}
 
 	if err := cidata.GenerateISO9660(inst.Dir, instName, y, udpDNSLocalPort, tcpDNSLocalPort, o.nerdctlArchive, vSockPort, virtioPort); err != nil {


### PR DESCRIPTION
The serial port sometimes doesn't seem to work: #2064.

The vsock implementation used for VZ doesn't seem to have this problem.

It makes sense to revert to the old mechanism for QEMU until the serialport has been fixed (if possible).

Just commenting out the virtioPort will fall back to the old socket method thanks to #2006.