### PR TITLE
Fix GuestAgentConn vsock support

### DIFF
--- a/pkg/windows/registry_windows.go
+++ b/pkg/windows/registry_windows.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	guestCommunicationsPrefix = `SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\GuestCommunicationServices`
-	MagicVSOCKSuffix          = "-facb-11e6-bd58-64006a7986d3"
+	magicVSOCKSuffix          = "-facb-11e6-bd58-64006a7986d3"
 	wslDistroInfoPrefix       = `SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss`
 )
 
@@ -34,7 +34,7 @@ func AddVSockRegistryKey(port int) error {
 		return fmt.Errorf("port %q in use", port)
 	}
 
-	vsockKeyPath := fmt.Sprintf(`%x%s`, port, MagicVSOCKSuffix)
+	vsockKeyPath := fmt.Sprintf(`%x%s`, port, magicVSOCKSuffix)
 	vSockKey, _, err := registry.CreateKey(
 		rootKey,
 		vsockKeyPath,
@@ -61,7 +61,7 @@ func RemoveVSockRegistryKey(port int) error {
 	}
 	defer rootKey.Close()
 
-	vsockKeyPath := fmt.Sprintf(`%x%s`, port, MagicVSOCKSuffix)
+	vsockKeyPath := fmt.Sprintf(`%x%s`, port, magicVSOCKSuffix)
 	if err := registry.DeleteKey(rootKey, vsockKeyPath); err != nil {
 		return fmt.Errorf(
 			"failed to create new key (%s%s): %w",
@@ -215,7 +215,7 @@ func getUsedPorts(key registry.Key) ([]int, error) {
 
 	out := []int{}
 	for _, k := range keys {
-		split := strings.Split(k, MagicVSOCKSuffix)
+		split := strings.Split(k, magicVSOCKSuffix)
 		if len(split) == 2 {
 			i, err := strconv.Atoi(split[0])
 			if err != nil {


### PR DESCRIPTION
When how Lima connects to the guest agent was refactored in #1998, https://github.com/mdlayher/vsock was used to support vsock connections on Windows, but the library doesn't support Windows. The following error log is from a WSL Lima instance on v0.19.1:

```
{"error":"dial vsock host(2):994831394: vsock: not implemented on windows","level":"warning","msg":"connection to the guest agent was closed unexpectedlydial vsock host(2):994831394: vsock: not implemented on windows","time":"2024-01-08T19:19:49Z"}
```

The corresponding log from the library is [here](https://github.com/mdlayher/vsock/blob/068aff8a5e29cc13661b0f5a16cc347614c2bc7d/vsock_others.go#L17).

With this change to revert to using [winio's Dial](https://github.com/microsoft/go-winio/blob/bc421d9108ade8ae2f76c8ef3e90cd4ee690e2c0/hvsock.go#L315), guestagent communication works as it did previously.

More information on the how the HyperV/Windows vsock support works (can add this to the comment in wsl_driver too):
* https://github.com/torvalds/linux/blob/master/net/vmw_vsock/hyperv_transport.c#L112-L156
* https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/make-integration-service#register-a-new-application

Also un-exported `MagicVSOCKSuffix` since it's now only used in the windows package.