### PR TITLE
Do guest template expansion for provisioning scripts

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -184,6 +184,7 @@ containerd:
 
 # Provisioning scripts need to be idempotent because they might be called
 # multiple times, e.g. when the host VM is being restarted.
+# The scripts can use the following template variables: {{.Home}}, {{.UID}}, and {{.User}}
 # 🟢 Builtin default: null
 # provision:
 # # `system` is executed with the root privilege

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -427,6 +427,11 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		if provision.Mode == ProvisionModeDependency && provision.SkipDefaultDependencyResolution == nil {
 			provision.SkipDefaultDependencyResolution = ptr.Of(false)
 		}
+		if out, err := executeGuestTemplate(provision.Script); err == nil {
+			provision.Script = out.String()
+		} else {
+			logrus.WithError(err).Warnf("Couldn't process provisioning script %q as a template", provision.Script)
+		}
 	}
 
 	if y.GuestInstallPrefix == nil {
@@ -795,7 +800,7 @@ func executeHostTemplate(format, instDir string) (bytes.Buffer, error) {
 			"User": user.Username,
 
 			"Instance": filepath.Base(instDir), // DEPRECATED, use `{{.Name}}`
-			"LimaHome": limaHome,               // DEPRECATED, (use `Dir` instead of `{{.LimaHome}}/{{.Instance}}`
+			"LimaHome": limaHome,               // DEPRECATED, use `{{.Dir}}` instead of `{{.LimaHome}}/{{.Instance}}`
 		}
 		var out bytes.Buffer
 		if err := tmpl.Execute(&out, data); err == nil {


### PR DESCRIPTION
The LIMA_CIDATA_* variables are not a supported API and can change without warning.

Fixes #2055