### PR TITLE
Add new Debian testing/trixie UEFI firmware file

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -1129,6 +1129,7 @@ func getFirmware(qemuExe string, arch limayaml.Arch) (string, error) {
 	case limayaml.X8664:
 		// Debian package "ovmf"
 		candidates = append(candidates, "/usr/share/OVMF/OVMF_CODE.fd")
+		candidates = append(candidates, "/usr/share/OVMF/OVMF_CODE_4M.fd")
 		// openSUSE package "qemu-ovmf-x86_64"
 		candidates = append(candidates, "/usr/share/qemu/ovmf-x86_64-code.bin")
 		// Archlinux package "edk2-ovmf"


### PR DESCRIPTION
Debian Testing/Trixie recently updated the OVMF package which provides UEFI firmware for 64-bit x86 virtual machines.

Due to filename changes, Lima is no longer able to find firmware when starting a VM, resulting in the following error message: 

`{"level":"debug","msg":"firmware candidates = [/home/user/.local/share/qemu/edk2-x86_64-code.fd /usr/share/qemu/edk2-x86_64-code.fd /usr/share/OVMF/OVMF_CODE.fd /usr/share/qemu/ovmf-x86_64-code.bin /usr/share/edk2-ovmf/x64/OVMF_CODE.fd]","time":"2024-01-10T13:14:19+03:00"}`

`{"level":"fatal","msg":"could not find firmware for \"/usr/bin/qemu-system-x86_64\" (hint: try setting firmware.legacyBIOS to true)","time":"2024-01-10T13:14:19+03:00"}`



The change causing this error is as follows:

> /usr/share/OVMF/OVMF_CODE.fd
> to
> /usr/share/OVMF/OVMF_CODE_4M.fd


This PR adds the new Testing/Trixie file, which should resolve this issue.





