### PR TITLE
pkg/ioutilx: fix typo in doc comment

### DIFF
--- a/pkg/ioutilx/ioutilx.go
+++ b/pkg/ioutilx/ioutilx.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/text/transform"
 )
 
-// ReadAtMaximum reands n at maximum.
+// ReadAtMaximum reads n at maximum.
 func ReadAtMaximum(r io.Reader, n int64) ([]byte, error) {
 	lr := &io.LimitedReader{
 		R: r,


### PR DESCRIPTION
The PR fixes a typo in the description for https://pkg.go.dev/github.com/lima-vm/lima/pkg/ioutilx#ReadAtMaximum