### PR TITLE
Update difference between Colima and Lima

### DIFF
--- a/website/content/en/docs/faq/colima/_index.md
+++ b/website/content/en/docs/faq/colima/_index.md
@@ -8,8 +8,8 @@ weight: 0
 [Colima](https://github.com/abiosoft/colima) is a third-party project
 that wraps Lima to provide an alternative user experience for launching containers.
 
-The key difference is that Colima launches Docker on Alpine VM by default,
-while Lima launches containerd on Ubuntu VM by default.
+The key difference is that Colima launches Docker by default,
+while Lima launches containerd by default.
 
 | Container  | Lima                              | Colima                              |
 |------------|-----------------------------------|-------------------------------------|


### PR DESCRIPTION
There is probably a better way to word this, but since the [v0.6.0](https://github.com/abiosoft/colima/releases/tag/v0.6.0) release of Colima, the default distro is Ubuntu. I would highlight the difference between Colima and Lima, is that Colima uses an opinionated version Ubuntu image with custom bundled software that cannot be [overridden](https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#are-lima-overrides-supported). 