### PR TITLE
Enable noctx linter and fix up issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,7 +64,7 @@ linters:
   # - maligned
   # - nestif
   # - nlreturn
-  # - noctx
+  - noctx
   - nolintlint
   # - rowserrcheck
   # - scopelint

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -146,7 +146,11 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 			}
 		}
 		logrus.Debugf("interpreting argument %q as a http url for instance %q", arg, st.instName)
-		resp, err := http.Get(arg)
+		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, arg, http.NoBody)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -26,7 +26,7 @@ type Driver interface {
 	Initialize(_ context.Context) error
 
 	// CreateDisk returns error if the current driver fails in creating disk
-	CreateDisk() error
+	CreateDisk(_ context.Context) error
 
 	// Start is used for booting the vm using driver instance
 	// It returns a chan error on successful boot
@@ -90,7 +90,7 @@ func (d *BaseDriver) Initialize(_ context.Context) error {
 	return nil
 }
 
-func (d *BaseDriver) CreateDisk() error {
+func (d *BaseDriver) CreateDisk(_ context.Context) error {
 	return nil
 }
 

--- a/pkg/fileutils/download.go
+++ b/pkg/fileutils/download.go
@@ -1,6 +1,7 @@
 package fileutils
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path"
@@ -14,13 +15,13 @@ import (
 var ErrSkipped = errors.New("skipped to download")
 
 // DownloadFile downloads a file to the cache, optionally copying it to the destination. Returns path in cache.
-func DownloadFile(dest string, f limayaml.File, decompress bool, description string, expectedArch limayaml.Arch) (string, error) {
+func DownloadFile(ctx context.Context, dest string, f limayaml.File, decompress bool, description string, expectedArch limayaml.Arch) (string, error) {
 	if f.Arch != expectedArch {
 		return "", fmt.Errorf("%w: %q: unsupported arch: %q", ErrSkipped, f.Location, f.Arch)
 	}
 	fields := logrus.Fields{"location": f.Location, "arch": f.Arch, "digest": f.Digest}
 	logrus.WithFields(fields).Infof("Attempting to download %s", description)
-	res, err := downloader.Download(dest, f.Location,
+	res, err := downloader.Download(ctx, dest, f.Location,
 		downloader.WithCache(),
 		downloader.WithDecompress(decompress),
 		downloader.WithDescription(fmt.Sprintf("%s (%s)", description, path.Base(f.Location))),

--- a/pkg/networks/reconcile/reconcile.go
+++ b/pkg/networks/reconcile/reconcile.go
@@ -54,7 +54,7 @@ func Reconcile(ctx context.Context, newInst string) error {
 		if activeNetwork[name] {
 			err = startNetwork(ctx, &config, name)
 		} else {
-			err = stopNetwork(&config, name)
+			err = stopNetwork(ctx, &config, name)
 		}
 		if err != nil {
 			return err
@@ -218,7 +218,7 @@ func startNetwork(ctx context.Context, config *networks.YAML, name string) error
 	return nil
 }
 
-func stopNetwork(config *networks.YAML, name string) error {
+func stopNetwork(ctx context.Context, config *networks.YAML, name string) error {
 	logrus.Debugf("Make sure %q network is stopped", name)
 	// Handle usernet first without sudo requirements
 	isUsernet, err := config.Usernet(name)
@@ -226,7 +226,7 @@ func stopNetwork(config *networks.YAML, name string) error {
 		return err
 	}
 	if isUsernet {
-		if err := usernet.Stop(name); err != nil {
+		if err := usernet.Stop(ctx, name); err != nil {
 			return fmt.Errorf("failed to stop usernet %q: %w", name, err)
 		}
 		return nil

--- a/pkg/networks/usernet/recoincile.go
+++ b/pkg/networks/usernet/recoincile.go
@@ -121,7 +121,7 @@ func Start(ctx context.Context, name string) error {
 
 // Stop stops running instance a usernet network with the given name.
 // The name parameter must point to a valid network configuration name under <LIMA_HOME>/_config/networks.yaml with `mode: user-v2`
-func Stop(name string) error {
+func Stop(ctx context.Context, name string) error {
 	logrus.Debugf("Make sure usernet network is stopped")
 	pidFile, err := PIDFile(name)
 	if err != nil {
@@ -132,7 +132,7 @@ func Stop(name string) error {
 	if pid != 0 {
 		logrus.Debugf("Stopping usernet daemon")
 
-		err = writeLeases(name)
+		err = writeLeases(ctx, name)
 		if err != nil {
 			return err
 		}
@@ -190,9 +190,9 @@ func readLeases(name string) (map[string]string, error) {
 	return leases, err
 }
 
-func writeLeases(nwName string) error {
+func writeLeases(ctx context.Context, nwName string) error {
 	client := NewClientByName(nwName)
-	leases, err := client.Leases()
+	leases, err := client.Leases(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -50,13 +50,13 @@ func (l *LimaQemuDriver) Validate() error {
 	return nil
 }
 
-func (l *LimaQemuDriver) CreateDisk() error {
+func (l *LimaQemuDriver) CreateDisk(ctx context.Context) error {
 	qCfg := Config{
 		Name:        l.Instance.Name,
 		InstanceDir: l.Instance.Dir,
 		LimaYAML:    l.Yaml,
 	}
-	return EnsureDisk(qCfg)
+	return EnsureDisk(ctx, qCfg)
 }
 
 func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
@@ -73,7 +73,7 @@ func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
 		LimaYAML:     l.Yaml,
 		SSHLocalPort: l.SSHLocalPort,
 	}
-	qExe, qArgs, err := Cmdline(qCfg)
+	qExe, qArgs, err := Cmdline(ctx, qCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
 	go func() {
 		if usernetIndex := limayaml.FirstUsernetIndex(l.Yaml); usernetIndex != -1 {
 			client := usernet.NewClientByName(l.Yaml.Networks[usernetIndex].Lima)
-			err := client.ConfigureDriver(l.BaseDriver)
+			err := client.ConfigureDriver(ctx, l.BaseDriver)
 			if err != nil {
 				l.qWaitCh <- err
 			}

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -38,7 +38,7 @@ const DefaultWatchHostAgentEventsTimeout = 10 * time.Minute
 // ensureNerdctlArchiveCache prefetches the nerdctl-full-VERSION-GOOS-GOARCH.tar.gz archive
 // into the cache before launching the hostagent process, so that we can show the progress in tty.
 // https://github.com/lima-vm/lima/issues/326
-func ensureNerdctlArchiveCache(y *limayaml.LimaYAML, created bool) (string, error) {
+func ensureNerdctlArchiveCache(ctx context.Context, y *limayaml.LimaYAML, created bool) (string, error) {
 	if !*y.Containerd.System && !*y.Containerd.User {
 		// nerdctl archive is not needed
 		return "", nil
@@ -53,7 +53,7 @@ func ensureNerdctlArchiveCache(y *limayaml.LimaYAML, created bool) (string, erro
 				return path, nil
 			}
 		}
-		path, err := fileutils.DownloadFile("", f, false, "the nerdctl archive", *y.Arch)
+		path, err := fileutils.DownloadFile(ctx, "", f, false, "the nerdctl archive", *y.Arch)
 		if err != nil {
 			errs[i] = err
 			continue
@@ -101,10 +101,10 @@ func Prepare(ctx context.Context, inst *store.Instance) (*Prepared, error) {
 	if _, err := os.Stat(baseDisk); err == nil {
 		created = true
 	}
-	if err := limaDriver.CreateDisk(); err != nil {
+	if err := limaDriver.CreateDisk(ctx); err != nil {
 		return nil, err
 	}
-	nerdctlArchiveCache, err := ensureNerdctlArchiveCache(y, created)
+	nerdctlArchiveCache, err := ensureNerdctlArchiveCache(ctx, y, created)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vz/disk.go
+++ b/pkg/vz/disk.go
@@ -1,6 +1,7 @@
 package vz
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -14,7 +15,7 @@ import (
 	"github.com/lima-vm/lima/pkg/store/filenames"
 )
 
-func EnsureDisk(driver *driver.BaseDriver) error {
+func EnsureDisk(ctx context.Context, driver *driver.BaseDriver) error {
 	diffDisk := filepath.Join(driver.Instance.Dir, filenames.DiffDisk)
 	if _, err := os.Stat(diffDisk); err == nil || !errors.Is(err, os.ErrNotExist) {
 		// disk is already ensured
@@ -26,7 +27,7 @@ func EnsureDisk(driver *driver.BaseDriver) error {
 		var ensuredBaseDisk bool
 		errs := make([]error, len(driver.Yaml.Images))
 		for i, f := range driver.Yaml.Images {
-			if _, err := fileutils.DownloadFile(baseDisk, f.File, true, "the image", *driver.Yaml.Arch); err != nil {
+			if _, err := fileutils.DownloadFile(ctx, baseDisk, f.File, true, "the image", *driver.Yaml.Arch); err != nil {
 				errs[i] = err
 				continue
 			}

--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -102,7 +102,7 @@ func startVM(ctx context.Context, driver *driver.BaseDriver) (*virtualMachineWra
 					filesToRemove[pidFile] = struct{}{}
 					logrus.Info("[VZ] - vm state change: running")
 
-					err := usernetClient.ConfigureDriver(driver)
+					err := usernetClient.ConfigureDriver(ctx, driver)
 					if err != nil {
 						errCh <- err
 					}

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -147,8 +147,8 @@ func (l *LimaVzDriver) Initialize(_ context.Context) error {
 	return err
 }
 
-func (l *LimaVzDriver) CreateDisk() error {
-	return EnsureDisk(l.BaseDriver)
+func (l *LimaVzDriver) CreateDisk(ctx context.Context) error {
+	return EnsureDisk(ctx, l.BaseDriver)
 }
 
 func (l *LimaVzDriver) Start(ctx context.Context) (chan error, error) {

--- a/pkg/vz/vz_driver_others.go
+++ b/pkg/vz/vz_driver_others.go
@@ -27,7 +27,7 @@ func (l *LimaVzDriver) Validate() error {
 	return ErrUnsupported
 }
 
-func (l *LimaVzDriver) CreateDisk() error {
+func (l *LimaVzDriver) CreateDisk(_ context.Context) error {
 	return ErrUnsupported
 }
 

--- a/pkg/wsl2/fs.go
+++ b/pkg/wsl2/fs.go
@@ -1,6 +1,7 @@
 package wsl2
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -12,13 +13,13 @@ import (
 )
 
 // EnsureFs downloads the root fs.
-func EnsureFs(driver *driver.BaseDriver) error {
+func EnsureFs(ctx context.Context, driver *driver.BaseDriver) error {
 	baseDisk := filepath.Join(driver.Instance.Dir, filenames.BaseDisk)
 	if _, err := os.Stat(baseDisk); errors.Is(err, os.ErrNotExist) {
 		var ensuredBaseDisk bool
 		errs := make([]error, len(driver.Yaml.Images))
 		for i, f := range driver.Yaml.Images {
-			if _, err := fileutils.DownloadFile(baseDisk, f.File, true, "the image", *driver.Yaml.Arch); err != nil {
+			if _, err := fileutils.DownloadFile(ctx, baseDisk, f.File, true, "the image", *driver.Yaml.Arch); err != nil {
 				errs[i] = err
 				continue
 			}

--- a/pkg/wsl2/wsl_driver_others.go
+++ b/pkg/wsl2/wsl_driver_others.go
@@ -27,7 +27,7 @@ func (l *LimaWslDriver) Validate() error {
 	return ErrUnsupported
 }
 
-func (l *LimaWslDriver) CreateDisk() error {
+func (l *LimaWslDriver) CreateDisk(_ context.Context) error {
 	return ErrUnsupported
 }
 

--- a/pkg/wsl2/wsl_driver_windows.go
+++ b/pkg/wsl2/wsl_driver_windows.go
@@ -114,7 +114,7 @@ func (l *LimaWslDriver) Start(ctx context.Context) (chan error, error) {
 	distroName := "lima-" + l.Instance.Name
 
 	if status == store.StatusUninitialized {
-		if err := EnsureFs(l.BaseDriver); err != nil {
+		if err := EnsureFs(ctx, l.BaseDriver); err != nil {
 			return nil, err
 		}
 		if err := initVM(ctx, l.BaseDriver.Instance.Dir, distroName); err != nil {


### PR DESCRIPTION
This PR enables [`noctx`](https://github.com/sonatard/noctx) linter in golangci-lint's config. The linter requires the usage of HTTP requests with context for cancelation long-running requests. 