### PR TITLE
Add support for ignition to cidata, for CoreOS

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,10 @@
 
 extends: default
 
+ignore: |
+  # this is a yaml template, needs to executed
+  pkg/cidata/cidata.TEMPLATE.d/ignition.yaml
+
 rules:
   indentation:
     indent-sequences: false

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,7 @@ Distro:
 - [`ubuntu-lts`](./ubuntu-lts.yaml): Ubuntu LTS (same as `ubuntu.yaml` but pinned to an LTS version)
 - [`deprecated/centos-7`](./deprecated/centos-7.yaml): [deprecated] CentOS Linux 7
 - [`experimental/gentoo`](./experimental/gentoo.yaml): [experimental] Gentoo
+- [`experimental/fedora-coreos`](./experimental/fedora-coreos.yaml): [experimental] Fedora CoreOS
 - [`experimental/opensuse-tumbleweed`](./experimental/opensuse-tumbleweed.yaml): [experimental] openSUSE Tumbleweed
 
 Container engines:

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,7 @@ Distro:
 - [`experimental/fedora-coreos`](./experimental/fedora-coreos.yaml): [experimental] Fedora CoreOS
 - [`experimental/flatcar`](experimental/flatcar.yaml): [experimental] Flatcar Container Linux
 - [`experimental/opensuse-tumbleweed`](./experimental/opensuse-tumbleweed.yaml): [experimental] openSUSE Tumbleweed
+- [`experimental/microos`](experimental/microos.yaml): [experimental] openSUSE Tumbleweed MicroOS
 
 Container engines:
 - [`apptainer`](./apptainer.yaml): Apptainer

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,7 @@ Distro:
 - [`deprecated/centos-7`](./deprecated/centos-7.yaml): [deprecated] CentOS Linux 7
 - [`experimental/gentoo`](./experimental/gentoo.yaml): [experimental] Gentoo
 - [`experimental/fedora-coreos`](./experimental/fedora-coreos.yaml): [experimental] Fedora CoreOS
+- [`experimental/flatcar`](experimental/flatcar.yaml): [experimental] Flatcar Container Linux
 - [`experimental/opensuse-tumbleweed`](./experimental/opensuse-tumbleweed.yaml): [experimental] openSUSE Tumbleweed
 
 Container engines:

--- a/examples/experimental/fedora-coreos.yaml
+++ b/examples/experimental/fedora-coreos.yaml
@@ -1,0 +1,20 @@
+# This example requires Lima v0.15.1 or later.
+# <https://fedoraproject.org/coreos/download/>
+
+images:
+- location: "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-qemu.x86_64.qcow2.xz"
+  arch: "x86_64"
+  digest: "sha256:52d98121563a61fdab6924a8e3190bc1cbf7775942d8a8046f9ef2a689ed7aa0"
+- location: "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-qemu.aarch64.qcow2.xz"
+  arch: "aarch64"
+  digest: "sha256:432b5af49f56fcf6d2ed9046ee7b3654adb6345203d69fa14fe8d37b72b79eb9"
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+
+# The built-in containerd installer does not support CoreOS currently.
+containerd:
+  system: false
+  user: false

--- a/examples/experimental/fedora-coreos.yaml
+++ b/examples/experimental/fedora-coreos.yaml
@@ -13,8 +13,3 @@ images:
 mounts:
 - location: "/tmp/lima"
   writable: true
-
-# The built-in containerd installer does not support CoreOS currently.
-containerd:
-  system: false
-  user: false

--- a/examples/experimental/fedora-coreos.yaml
+++ b/examples/experimental/fedora-coreos.yaml
@@ -2,12 +2,12 @@
 # <https://fedoraproject.org/coreos/download/>
 
 images:
-- location: "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-qemu.x86_64.qcow2.xz"
+- location: "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-qemu.x86_64.qcow2.xz"
   arch: "x86_64"
-  digest: "sha256:52d98121563a61fdab6924a8e3190bc1cbf7775942d8a8046f9ef2a689ed7aa0"
-- location: "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-qemu.aarch64.qcow2.xz"
+  digest: "sha256:df4b55402472dcabe7f19e9215193643e5e34513d20afea6f1d7326ab5b3c239"
+- location: "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-qemu.aarch64.qcow2.xz"
   arch: "aarch64"
-  digest: "sha256:432b5af49f56fcf6d2ed9046ee7b3654adb6345203d69fa14fe8d37b72b79eb9"
+  digest: "sha256:df4b55402472dcabe7f19e9215193643e5e34513d20afea6f1d7326ab5b3c239"
 
 # The guest home directory can not be changed with CoreOS currently.
 mounts:

--- a/examples/experimental/fedora-coreos.yaml
+++ b/examples/experimental/fedora-coreos.yaml
@@ -9,8 +9,8 @@ images:
   arch: "aarch64"
   digest: "sha256:432b5af49f56fcf6d2ed9046ee7b3654adb6345203d69fa14fe8d37b72b79eb9"
 
+# The guest home directory can not be changed with CoreOS currently.
 mounts:
-- location: "~"
 - location: "/tmp/lima"
   writable: true
 

--- a/examples/experimental/flatcar.yaml
+++ b/examples/experimental/flatcar.yaml
@@ -1,0 +1,21 @@
+# # This example requires Lima v0.15.1 or later.
+# <https://www.flatcar.org/releases#stable-release>
+
+images:
+- location: "https://stable.release.flatcar-linux.net/amd64-usr/3602.2.3/flatcar_production_qemu_uefi_image.img.bz2"
+  arch: "x86_64"
+  digest: "sha512:88d58a5db4a6de69cc146c867378a5ef192f9f5b9e831d7fcce598874fd60500bf1486e3764d22f89cf3442ff729363eb72b07668337e4c45611fbdf65ad6526"
+- location: "https://stable.release.flatcar-linux.net/arm64-usr/3602.2.3/flatcar_production_qemu_uefi_image.img.bz2"
+  arch: "aarch64"
+  digest: "sha512:5e0bd2ac81f6fa5bb0360e1741af97db9bca4fc91f31ce006faf61b4c7c9a194f5af06ac71f6368d402018006e3a13b1b6ffbdc23dacdaff4a5ab49f1c8a6e98"
+
+# The /usr/local prefix is read-only under Flatcar Container Linux.
+guestInstallPrefix: /opt
+
+# The guest home directory can not be changed with CoreOS currently.
+mounts:
+- location: "/tmp/lima"
+  writable: true
+
+# There is no support for FUSE or sshfs in Flatcar Container Linux.
+mountType: "9p"

--- a/examples/experimental/microos.yaml
+++ b/examples/experimental/microos.yaml
@@ -1,0 +1,12 @@
+# This example requires Lima v0.15.1 or later.
+images:
+# Hint: run `limactl prune` to invalidate the cache
+- location: https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2
+  arch: "x86_64"
+- location: https://download.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-OpenStack-Cloud.qcow2
+  arch: "aarch64"
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true

--- a/pkg/cidata/cidata.TEMPLATE.d/ignition.yaml
+++ b/pkg/cidata/cidata.TEMPLATE.d/ignition.yaml
@@ -1,0 +1,85 @@
+variant: fcos
+version: 1.4.0
+passwd:
+  users:
+    - name: "{{.User}}"
+      groups:
+        - sudo
+      ssh_authorized_keys:
+{{- range $val := .SSHPubKeys}}
+        - "{{$val}}"
+{{- end}}
+storage:
+  files:
+    - path: /etc/hostname
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: "lima-{{.Name}}"
+{{- if or (eq .MountType "9p") (eq .MountType "virtiofs") }}
+{{- if .Mounts }}
+    - path: /etc/fstab
+      mode: 0644
+      contents:
+        inline: |
+{{- range $m := $.Mounts}}
+          {{$m.Tag}} {{$m.MountPoint}} {{$m.Type}} {{$m.Options}} 0 0
+{{- end }}
+{{- end }}
+{{- end }}
+    - path: /etc/fuse.conf
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: "user_allow_other\n"
+systemd:
+  units:
+    # Note1: name must systemd-escape path
+    # Note2: path must not contain symlinks
+    - name: "var-mnt-lima\\x2dcidata.mount"
+      enabled: true
+      contents: |
+        [Unit]
+        Before=local-fs.target
+
+        [Mount]
+        What=/dev/disk/by-label/cidata
+        Where=/var/mnt/lima-cidata
+        Options=ro,mode=0700,dmode=0700,overriderockperm,exec,uid=0
+
+        [Install]
+        RequiredBy=local-fs.target
+    - name: lima-ssh-ready.service
+      enabled: true
+      contents: |
+        [Unit]
+        After=sshd.service
+
+        [Service]
+        Type=oneshot
+        ExecStart=/bin/cp /mnt/lima-cidata/meta-data /run/lima-ssh-ready
+
+        [Install]
+        RequiredBy=multi-user.target
+    - name: lima-install-guestagent.service
+      enabled: true
+      contents: |
+        [Service]
+        Type=oneshot
+        ExecStart=/bin/sh -c "install -m 755 /mnt/lima-cidata/lima-guestagent /usr/local/bin/lima-guestagent"
+        ExecStartPost=/usr/local/bin/lima-guestagent install-systemd
+
+        [Install]
+        RequiredBy=multi-user.target
+    - name: lima-boot-done.service
+      enabled: true
+      contents: |
+        [Unit]
+        After=lima-install-guestagent.service
+
+        [Service]
+        Type=oneshot
+        ExecStart=/bin/cp /mnt/lima-cidata/meta-data /run/lima-boot-done
+
+        [Install]
+        RequiredBy=multi-user.target

--- a/pkg/cidata/cidata.TEMPLATE.d/ignition.yaml
+++ b/pkg/cidata/cidata.TEMPLATE.d/ignition.yaml
@@ -61,6 +61,17 @@ systemd:
 
         [Install]
         RequiredBy=multi-user.target
+{{- if or .Containerd.User .Containerd.System }}
+    - name: lima-install-containerd.service
+      enabled: true
+      contents: |
+        [Service]
+        Type=oneshot
+        ExecStart=/bin/sh -c "/usr/bin/tar Cxzf /usr/local /mnt/lima-cidata/nerdctl-full.tgz"
+
+        [Install]
+        RequiredBy=multi-user.target
+{{- end}}
     - name: lima-install-guestagent.service
       enabled: true
       contents: |

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -324,7 +324,7 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 		return err
 	}
 	if ignition != nil {
-		if err := os.WriteFile(filepath.Join(instDir, filenames.Ignition), ignition, 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(instDir, filenames.Ignition), ignition, 0o600); err != nil {
 			return err
 		}
 	}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -319,9 +319,14 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 		return err
 	}
 
-	layout, err := ExecuteTemplate(args)
+	layout, ignition, err := ExecuteTemplate(args)
 	if err != nil {
 		return err
+	}
+	if ignition != nil {
+		if err := os.WriteFile(filepath.Join(instDir, filenames.Ignition), ignition, 0600); err != nil {
+			return err
+		}
 	}
 
 	for i, f := range y.Provision {

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -125,7 +125,7 @@ func ExecuteTemplate(args TemplateArgs) ([]iso9660util.Entry, error) {
 	}
 
 	var layout []iso9660util.Entry
-	walkFn := func(path string, d fs.DirEntry, walkErr error) error {
+	walkFn := func(p string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -133,9 +133,9 @@ func ExecuteTemplate(args TemplateArgs) ([]iso9660util.Entry, error) {
 			return nil
 		}
 		if !d.Type().IsRegular() {
-			return fmt.Errorf("got non-regular file %q", path)
+			return fmt.Errorf("got non-regular file %q", p)
 		}
-		templateB, err := fs.ReadFile(fsys, path)
+		templateB, err := fs.ReadFile(fsys, p)
 		if err != nil {
 			return err
 		}
@@ -144,7 +144,7 @@ func ExecuteTemplate(args TemplateArgs) ([]iso9660util.Entry, error) {
 			return err
 		}
 		layout = append(layout, iso9660util.Entry{
-			Path:   path,
+			Path:   p,
 			Reader: bytes.NewReader(b),
 		})
 		return nil

--- a/pkg/cidata/template_test.go
+++ b/pkg/cidata/template_test.go
@@ -23,7 +23,7 @@ func TestTemplate(t *testing.T) {
 		},
 		MountType: "reverse-sshfs",
 	}
-	layout, err := ExecuteTemplate(args)
+	layout, _, err := ExecuteTemplate(args)
 	assert.NilError(t, err)
 	for _, f := range layout {
 		t.Logf("=== %q ===", f.Path)
@@ -52,7 +52,7 @@ func TestTemplate9p(t *testing.T) {
 		},
 		MountType: "9p",
 	}
-	layout, err := ExecuteTemplate(args)
+	layout, _, err := ExecuteTemplate(args)
 	assert.NilError(t, err)
 	for _, f := range layout {
 		t.Logf("=== %q ===", f.Path)

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -674,6 +674,13 @@ func Cmdline(cfg Config) (exe string, args []string, err error) {
 		"-device", "virtio-scsi-pci,id=scsi0",
 		"-device", "scsi-cd,bus=scsi0.0,drive=cdrom0")
 
+	// ignition
+	ignition := filepath.Join(cfg.InstanceDir, filenames.Ignition)
+	if _, err := os.Stat(ignition); err == nil {
+		args = append(args,
+			"-fw_cfg", "name=opt/com.coreos/config,file="+ignition)
+	}
+
 	// Kernel
 	kernel := filepath.Join(cfg.InstanceDir, filenames.Kernel)
 	kernelCmdline := filepath.Join(cfg.InstanceDir, filenames.KernelCmdline)

--- a/pkg/store/filenames/filenames.go
+++ b/pkg/store/filenames/filenames.go
@@ -30,6 +30,7 @@ const (
 	LimaVersion        = "lima-version" // Lima version used to create instance
 	CIDataISO          = "cidata.iso"
 	CIDataISODir       = "cidata"
+	Ignition           = "config.ign"
 	BaseDisk           = "basedisk"
 	DiffDisk           = "diffdisk"
 	Kernel             = "kernel"


### PR DESCRIPTION
* #1372
* #1456

Examples:
* Fedora **CoreOS**
* **Flatcar** Container Linux
* openSUSE Tumbleweed **MicroOS**

Requirements:
* https://coreos.github.io/butane/ to be installed

Squashed and rebased the old PRs, for re-evaluation.

* ~~#1653~~
* ~~#1657~~

----

Needs testing, I have only updated the numbers and checksums but haven't verified if it actually works or not.

Running an immutable OS (for Lima) is still annoying, the scripts don't work and there are reboots all the time.

```
limactl start template://experimental/fedora-coreos
```

It runs Docker by default (enabled), and Podman on demand (disabled)

Note: [CoreOS Container Linux](https://en.wikipedia.org/wiki/Container_Linux) is a common ancestor for both FCOS and Flatcar.