### PR TITLE
hostagent: Handle SIGTERM signal for better compatibility with macOS launchd

### DIFF
--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"runtime"
 	"strconv"
+	"syscall"
 
 	"github.com/gorilla/mux"
 	"github.com/lima-vm/lima/pkg/hostagent"
@@ -67,8 +68,8 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 		defer runtime.UnlockOSThread()
 	}
 
-	sigintCh := make(chan os.Signal, 1)
-	signal.Notify(sigintCh, os.Interrupt)
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
 
 	stdout := &syncWriter{w: cmd.OutOrStdout()}
 	stderr := &syncWriter{w: cmd.ErrOrStderr()}
@@ -82,7 +83,7 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 	if nerdctlArchive != "" {
 		opts = append(opts, hostagent.WithNerdctlArchive(nerdctlArchive))
 	}
-	ha, err := hostagent.New(instName, stdout, sigintCh, opts...)
+	ha, err := hostagent.New(instName, stdout, signalCh, opts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/osutil/osutil_unix.go
+++ b/pkg/osutil/osutil_unix.go
@@ -2,8 +2,17 @@
 
 package osutil
 
-import "golang.org/x/sys/unix"
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
 
 func Ftruncate(fd int, length int64) (err error) {
 	return unix.Ftruncate(fd, length)
+}
+
+func SignalName(sig os.Signal) string {
+	return unix.SignalName(sig.(syscall.Signal))
 }

--- a/pkg/osutil/osutil_windows.go
+++ b/pkg/osutil/osutil_windows.go
@@ -3,6 +3,7 @@ package osutil
 import (
 	"fmt"
 	"io/fs"
+	"os"
 	"syscall"
 
 	"golang.org/x/sys/windows"
@@ -35,4 +36,15 @@ func SysKill(pid int, _ Signal) error {
 
 func Ftruncate(_ int, _ int64) (err error) {
 	return fmt.Errorf("unimplemented")
+}
+
+func SignalName(sig os.Signal) string {
+	switch sig {
+	case syscall.SIGINT:
+		return "SIGINT"
+	case syscall.SIGTERM:
+		return "SIGTERM"
+	default:
+		return fmt.Sprintf("Signal(%d)", sig)
+	}
 }


### PR DESCRIPTION
This PR modifies the hostagent to handle not only the SIGINT (Interrupt) signal, but also the SIGTERM signal. This allows the hostagent to gracefully shut down when it receives a SIGTERM signal, which is a common way to request a process to terminate. This change improves the compatibility with macOS launchd, which uses SIGTERM to stop services.

The following are the steps to set up the Docker instance of Lima to start at login using launchd on macOS:
```bash
# Create the docker instance
limactl start template://docker --vm-type vz --rosetta --network vzNAT --tty=false
# Stop the docker instance
limactl stop docker
# Create the launchd plist
echo '<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>Label</key>
	<string>io.lima-vm.docker</string>
	<key>ProgramArguments</key>
	<array>
		<string>'"$(which limactl)"'</string>
		<string>hostagent</string>
		<string>--pidfile</string>
		<string>ha.pid</string>
		<string>--socket</string>
		<string>ha.sock</string>
		<string>docker</string>
	</array>
	<key>RunAtLoad</key>
	<true/>
	<key>StandardErrorPath</key>
	<string>ha.stderr.log</string>
	<key>StandardOutPath</key>
	<string>ha.stdout.log</string>
	<key>WorkingDirectory</key>
	<string>'"$(limactl list docker --format '{{.Dir}}')"'</string>
</dict>
</plist>' > ~/Library/LaunchAgents/io.lima-vm.docker.plist
# Load the launchd plist and launchd will start the docker instance
launchctl load ~/Library/LaunchAgents/io.lima-vm.docker.plist
```

rel: #1027