### PR TITLE
Reinstall apk packages on reboot

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/04-persistent-data-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/04-persistent-data-volume.sh
@@ -90,4 +90,6 @@ if [ "$(awk '$2 == "/" {print $3}' /proc/mounts)" == "tmpfs" ]; then
 	done
 	# Make sure to re-mount any mount points under /tmp
 	mount -a
+	# Reinstall packages from /mnt/data/apk/cache into the RAM disk
+	apk fix --no-network
 fi


### PR DESCRIPTION
Because we are running from a RAM disk, any packages not installed from the ISO are removed after a reboot. They are still registered in `/etc/apk/world` (which is on `/mnt/data/etc/apk/world`), and the packages themselves are cached on `/mnt/data/apk/cache`, so reinstalling is quick and easy.

This worked fine in my testing (`apk fix` seems to reinstall the software, but not the config files in `/etc`), but I haven't found any documentation that guarantees that the config will not be touched).