### PR TITLE
Group help commands

### DIFF
--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -30,6 +30,7 @@ func newCopyCommand() *cobra.Command {
 		Long:    copyHelp,
 		Args:    WrapArgsError(cobra.MinimumNArgs(2)),
 		RunE:    copyAction,
+		GroupID: "management",
 	}
 
 	copyCommand.Flags().BoolP("recursive", "r", false, "copy directories recursively")

--- a/cmd/limactl/delete.go
+++ b/cmd/limactl/delete.go
@@ -21,6 +21,7 @@ func newDeleteCommand() *cobra.Command {
 		Args:              WrapArgsError(cobra.MinimumNArgs(1)),
 		RunE:              deleteAction,
 		ValidArgsFunction: deleteBashComplete,
+		GroupID:           "instance",
 	}
 	deleteCommand.Flags().BoolP("force", "f", false, "forcibly kill the processes")
 	return deleteCommand

--- a/cmd/limactl/disk.go
+++ b/cmd/limactl/disk.go
@@ -27,11 +27,12 @@ func newDiskCommand() *cobra.Command {
 
   Delete a disk:
   $ limactl disk delete DISK
-  
+
   Resize a disk:
   $ limactl disk resize DISK --size SIZE`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		GroupID:       "management",
 	}
 	diskCommand.AddCommand(
 		newDiskCreateCommand(),

--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -27,6 +27,7 @@ func newEditCommand() *cobra.Command {
 		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
 		RunE:              editAction,
 		ValidArgsFunction: editBashComplete,
+		GroupID:           "instance",
 	}
 	editflags.RegisterEdit(editCommand)
 	return editCommand

--- a/cmd/limactl/factory-reset.go
+++ b/cmd/limactl/factory-reset.go
@@ -19,6 +19,7 @@ func newFactoryResetCommand() *cobra.Command {
 		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
 		RunE:              factoryResetAction,
 		ValidArgsFunction: factoryResetBashComplete,
+		GroupID:           "instance",
 	}
 	return resetCommand
 }

--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -20,11 +20,12 @@ import (
 
 func newHostagentCommand() *cobra.Command {
 	hostagentCommand := &cobra.Command{
-		Use:    "hostagent INSTANCE",
-		Short:  "run hostagent",
-		Args:   WrapArgsError(cobra.ExactArgs(1)),
-		RunE:   hostagentAction,
-		Hidden: true,
+		Use:     "hostagent INSTANCE",
+		Short:   "run hostagent",
+		Args:    WrapArgsError(cobra.ExactArgs(1)),
+		RunE:    hostagentAction,
+		Hidden:  true,
+		GroupID: "instance",
 	}
 	hostagentCommand.Flags().StringP("pidfile", "p", "", "write pid to file")
 	hostagentCommand.Flags().String("socket", "", "hostagent socket")

--- a/cmd/limactl/info.go
+++ b/cmd/limactl/info.go
@@ -10,10 +10,11 @@ import (
 
 func newInfoCommand() *cobra.Command {
 	infoCommand := &cobra.Command{
-		Use:   "info",
-		Short: "Show diagnostic information",
-		Args:  WrapArgsError(cobra.NoArgs),
-		RunE:  infoAction,
+		Use:     "info",
+		Short:   "Show diagnostic information",
+		Args:    WrapArgsError(cobra.NoArgs),
+		RunE:    infoAction,
+		GroupID: "management",
 	}
 	return infoCommand
 }

--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -52,6 +52,7 @@ func newListCommand() *cobra.Command {
 		Args:              WrapArgsError(cobra.ArbitraryArgs),
 		RunE:              listAction,
 		ValidArgsFunction: listBashComplete,
+		GroupID:           "management",
 	}
 
 	listCommand.Flags().StringP("format", "f", "table", "output format, one of: json, yaml, table, go-template")

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -40,6 +40,7 @@ func newApp() *cobra.Command {
 		Short:   "Lima: Linux virtual machines",
 		Version: strings.TrimPrefix(version.Version, "v"),
 		Example: fmt.Sprintf(`  Start the default instance:
+
   $ limactl start
 
   Open a shell:
@@ -95,29 +96,36 @@ func newApp() *cobra.Command {
 		}
 		return nil
 	}
+	rootCmd.AddGroup(&cobra.Group{ID: "management", Title: "Management Commands:"})
+	rootCmd.AddGroup(&cobra.Group{ID: "instance", Title: "Instance Commands:"})
+	rootCmd.AddGroup(&cobra.Group{ID: "helper", Title: "Helper Commands:"})
 	rootCmd.AddCommand(
+		// management
+		newListCommand(),
+		newInfoCommand(),
+		newUsernetCommand(),
+		newDiskCommand(),
+		newCopyCommand(),
+		newPruneCommand(),
+		// instance
 		newCreateCommand(),
+		newDeleteCommand(),
+		newEditCommand(),
 		newStartCommand(),
 		newStopCommand(),
 		newShellCommand(),
-		newCopyCommand(),
-		newListCommand(),
-		newDeleteCommand(),
-		newValidateCommand(),
-		newSudoersCommand(),
-		newPruneCommand(),
-		newHostagentCommand(),
-		newInfoCommand(),
 		newShowSSHCommand(),
-		newDebugCommand(),
-		newEditCommand(),
+		newHostagentCommand(),
 		newFactoryResetCommand(),
-		newDiskCommand(),
-		newUsernetCommand(),
-		newGenDocCommand(),
 		newSnapshotCommand(),
 		newProtectCommand(),
 		newUnprotectCommand(),
+		// helper
+		newValidateCommand(),
+		newSudoersCommand(),
+		// development
+		newDebugCommand(),
+		newGenDocCommand(),
 	)
 	return rootCmd
 }

--- a/cmd/limactl/protect.go
+++ b/cmd/limactl/protect.go
@@ -18,6 +18,7 @@ The instance is not being protected against removal via '/bin/rm', Finder, etc.`
 		Args:              WrapArgsError(cobra.MinimumNArgs(1)),
 		RunE:              protectAction,
 		ValidArgsFunction: protectBashComplete,
+		GroupID:           "instance",
 	}
 	return protectCommand
 }

--- a/cmd/limactl/prune.go
+++ b/cmd/limactl/prune.go
@@ -15,6 +15,7 @@ func newPruneCommand() *cobra.Command {
 		Args:              WrapArgsError(cobra.NoArgs),
 		RunE:              pruneAction,
 		ValidArgsFunction: cobra.NoFileCompletions,
+		GroupID:           "management",
 	}
 	return pruneCommand
 }

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -40,6 +40,7 @@ func newShellCommand() *cobra.Command {
 		RunE:              shellAction,
 		ValidArgsFunction: shellBashComplete,
 		SilenceErrors:     true,
+		GroupID:           "instance",
 	}
 
 	shellCmd.Flags().SetInterspersed(false)

--- a/cmd/limactl/show_ssh.go
+++ b/cmd/limactl/show_ssh.go
@@ -62,6 +62,7 @@ Instead, use 'ssh -F %s/default/ssh.config lima-default' .
 		RunE:              showSSHAction,
 		ValidArgsFunction: showSSHBashComplete,
 		SilenceErrors:     true,
+		GroupID:           "instance",
 	}
 
 	shellCmd.Flags().StringP("format", "f", sshutil.FormatCmd, "Format: "+strings.Join(sshutil.Formats, ", "))

--- a/cmd/limactl/snapshot.go
+++ b/cmd/limactl/snapshot.go
@@ -13,8 +13,9 @@ import (
 
 func newSnapshotCommand() *cobra.Command {
 	snapshotCmd := &cobra.Command{
-		Use:   "snapshot",
-		Short: "Manage instance snapshots",
+		Use:     "snapshot",
+		Short:   "Manage instance snapshots",
+		GroupID: "instance",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			logrus.Warn("`limactl snapshot` is experimental")
 		},

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -68,6 +68,7 @@ $ cat template.yaml | limactl create --name=local -
 		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
 		ValidArgsFunction: createBashComplete,
 		RunE:              createAction,
+		GroupID:           "instance",
 	}
 	registerCreateFlags(createCommand, "")
 	return createCommand
@@ -90,6 +91,7 @@ See the examples in 'limactl create --help'.
 		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
 		ValidArgsFunction: startBashComplete,
 		RunE:              startAction,
+		GroupID:           "instance",
 	}
 	registerCreateFlags(startCommand, "[limactl create] ")
 	startCommand.Flags().Duration("timeout", start.DefaultWatchHostAgentEventsTimeout, "duration to wait for the instance to be running before timing out")

--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -25,6 +25,7 @@ func newStopCommand() *cobra.Command {
 		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
 		RunE:              stopAction,
 		ValidArgsFunction: stopBashComplete,
+		GroupID:           "instance",
 	}
 
 	stopCmd.Flags().BoolP("force", "f", false, "force stop the instance")

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -32,8 +32,9 @@ $ limactl sudoers --check /etc/sudoers.d/lima
 The content is written to stdout, NOT to the file.
 This command must not run as the root.
 See %s for the usage.`, networksMD),
-		Args: WrapArgsError(cobra.MaximumNArgs(1)),
-		RunE: sudoersAction,
+		Args:    WrapArgsError(cobra.MaximumNArgs(1)),
+		RunE:    sudoersAction,
+		GroupID: "helper",
 	}
 	configFile, _ := networks.ConfigFile()
 	sudoersCommand.Flags().Bool("check", false,

--- a/cmd/limactl/unprotect.go
+++ b/cmd/limactl/unprotect.go
@@ -16,6 +16,7 @@ func newUnprotectCommand() *cobra.Command {
 		Args:              WrapArgsError(cobra.MinimumNArgs(1)),
 		RunE:              unprotectAction,
 		ValidArgsFunction: unprotectBashComplete,
+		GroupID:           "instance",
 	}
 	return unprotectCommand
 }

--- a/cmd/limactl/usernet.go
+++ b/cmd/limactl/usernet.go
@@ -12,11 +12,12 @@ import (
 
 func newUsernetCommand() *cobra.Command {
 	hostagentCommand := &cobra.Command{
-		Use:    "usernet",
-		Short:  "run usernet",
-		Args:   cobra.ExactArgs(0),
-		RunE:   usernetAction,
-		Hidden: true,
+		Use:     "usernet",
+		Short:   "run usernet",
+		Args:    cobra.ExactArgs(0),
+		RunE:    usernetAction,
+		Hidden:  true,
+		GroupID: "management",
 	}
 	hostagentCommand.Flags().StringP("pidfile", "p", "", "write pid to file")
 	hostagentCommand.Flags().StringP("endpoint", "e", "", "exposes usernet api(s) on this endpoint")

--- a/cmd/limactl/validate.go
+++ b/cmd/limactl/validate.go
@@ -12,10 +12,11 @@ import (
 
 func newValidateCommand() *cobra.Command {
 	validateCommand := &cobra.Command{
-		Use:   "validate FILE.yaml [FILE.yaml, ...]",
-		Short: "Validate YAML files",
-		Args:  WrapArgsError(cobra.MinimumNArgs(1)),
-		RunE:  validateAction,
+		Use:     "validate FILE.yaml [FILE.yaml, ...]",
+		Short:   "Validate YAML files",
+		Args:    WrapArgsError(cobra.MinimumNArgs(1)),
+		RunE:    validateAction,
+		GroupID: "helper",
 	}
 	return validateCommand
 }


### PR DESCRIPTION
Add `Management`, `Instance`, and `Helper` command groups to `limactl help`

```
$ limactl help
Lima: Linux virtual machines

Usage:
  limactl [command]

Examples:
  Start the default instance:

  $ limactl start

  Open a shell:
  $ lima

  Run a container:
  $ lima nerdctl run -d --name nginx -p 8080:80 nginx:alpine

  Stop the default instance:
  $ limactl stop

  See also template YAMLs: share/lima/templates

Management Commands:
  copy          Copy files between host and guest
  disk          Lima disk management
  info          Show diagnostic information
  list          List instances of Lima.
  prune         Prune garbage objects

Instance Commands:
  create        Create an instance of Lima
  delete        Delete an instance of Lima.
  edit          Edit an instance of Lima
  factory-reset Factory reset an instance of Lima
  protect       Protect an instance to prohibit accidental removal
  shell         Execute shell in Lima
  show-ssh      Show the ssh command line (DEPRECATED; use `ssh -F` instead)
  snapshot      Manage instance snapshots
  start         Start an instance of Lima
  stop          Stop an instance
  unprotect     Unprotect an instance

Helper Commands:
  sudoers       Generate the content of the /etc/sudoers.d/lima file
  validate      Validate YAML files

Additional Commands:
  completion    Generate the autocompletion script for the specified shell
  help          Help about any command

Flags:
      --debug              debug mode
  -h, --help               help for limactl
      --log-level string   Set the logging level [trace, debug, info, warn, error]
      --tty                Enable TUI interactions such as opening an editor. Defaults to true when stdout is a terminal. Set to false for automation. (default true)
  -v, --version            version for limactl

Use "limactl [command] --help" for more information about a command.
```