### PR TITLE
limactl start: add `--foreground` flag

### DIFF
--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -122,7 +122,7 @@ func editAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return start.Start(ctx, inst)
+	return start.Start(ctx, inst, false)
 }
 
 func askWhetherToStart() (bool, error) {

--- a/pkg/osutil/osutil_unix.go
+++ b/pkg/osutil/osutil_unix.go
@@ -9,6 +9,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func Dup2(oldfd, newfd int) (err error) {
+	return unix.Dup2(oldfd, newfd)
+}
+
 func Ftruncate(fd int, length int64) (err error) {
 	return unix.Ftruncate(fd, length)
 }

--- a/pkg/osutil/osutil_windows.go
+++ b/pkg/osutil/osutil_windows.go
@@ -34,6 +34,10 @@ func SysKill(pid int, _ Signal) error {
 	return windows.GenerateConsoleCtrlEvent(syscall.CTRL_BREAK_EVENT, uint32(pid))
 }
 
+func Dup2(oldfd int, newfd syscall.Handle) (err error) {
+	return fmt.Errorf("unimplemented")
+}
+
 func Ftruncate(_ int, _ int64) (err error) {
 	return fmt.Errorf("unimplemented")
 }


### PR DESCRIPTION
This change adds the `--foreground` flag to `limactl start`.

This flag:

- Launches `limactl hostagent` with `syscall.Exec`, which allows `limactl start --foreground` to be used in macOS's `launchd.plist`, making it possible to hide `limactl hostagent`.
- When launched from the terminal, it uses the terminal for standard output and standard error instead of the default `ha.std{out,err}.log` files. In this case, a message indicating that the default log files are not used is written to the log files.
- When launched from something other than the terminal, such as `launchd`, it uses the `ha.std{out,err}.log` files as before.
- Cannot be used on Windows.

The following are the updated steps to set up the Docker instance of Lima to start at login using launchd on macOS:
```bash
# Create the docker instance
limactl create template://docker --vm-type vz --rosetta --network vzNAT --tty=false

# Create the launchd plist
echo '<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>Label</key>
	<string>io.lima-vm.docker</string>
	<key>ProgramArguments</key>
	<array>
		<string>'"$(which limactl)"'</string>
		<string>start</string>
		<string>--foreground</string>
		<string>docker</string>
	</array>
	<key>RunAtLoad</key>
	<true/>
	<key>StandardErrorPath</key>
	<string>launchd.stderr.log</string>
	<key>StandardOutPath</key>
	<string>launchd.stdout.log</string>
	<key>WorkingDirectory</key>
	<string>'"$(limactl list docker --format '{{.Dir}}')"'</string>
</dict>
</plist>' > ~/Library/LaunchAgents/io.lima-vm.docker.plist

# Load the launchd plist and launchd will start the docker instance
launchctl load ~/Library/LaunchAgents/io.lima-vm.docker.plist
```
that changed from #2140:

- Changed to `limactl create` because it's no longer necessary to run `limactl start` before loading into `launchd`.
- Changed from `limactl hostagent` to `limactl start --foreground`.
- Changed `Standard{Error,Out}Path` to `launchd.std{err,out}.log`, so that only the output of `limactl start` is written.