### PR TITLE
docs/config/network: mention `lima-<NAME>.internal`

### DIFF
--- a/website/content/en/docs/Config/Network/_index.md
+++ b/website/content/en/docs/Config/Network/_index.md
@@ -249,6 +249,8 @@ networks:
 {{% /tab %}}
 {{< /tabpane >}}
 
+An instance's IP address is resolvable from another instance as `lima-<NAME>.internal.` (e.g., `lima-default.internal.`).
+
 _Note_
 
 - Enabling this network will disable the [default user-mode network](#user-mode-network--1921685024-)


### PR DESCRIPTION
With `user-v2` network, an instance's IP address is resolvable from another instance as `lima-<NAME>.internal.`
(e.g., `lima-default.internal.`)

- https://github.com/lima-vm/lima/discussions/2018