### PR TITLE
Add `excludeFromBackup` on macOS

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -265,6 +265,12 @@ rosetta:
   # 🟢 Builtin default: false
   binfmt: null
 
+# Exclude from backup: "all", "disks" or "none"
+# Specify which file in the instance's configuration to exclude from backup.
+# Only available on macOS.
+# 🟢 Builtin default: "disks"
+excludeFromBackup: null
+
 # Specify the timezone name (as used by the zoneinfo database). Specify the empty string
 # to not set a timezone in the instance.
 # 🟢 Builtin default: use name from /etc/timezone or deduce from symlink target of /etc/localtime

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -753,6 +753,20 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.Rosetta.BinFmt = ptr.Of(false)
 	}
 
+	if runtime.GOOS == "darwin" {
+		if y.ExcludeFromBackup == nil {
+			y.ExcludeFromBackup = d.ExcludeFromBackup
+		}
+		if o.ExcludeFromBackup != nil {
+			y.ExcludeFromBackup = o.ExcludeFromBackup
+		}
+		if y.ExcludeFromBackup == nil {
+			y.ExcludeFromBackup = ptr.Of(ExcludeFromBackupDisks)
+		}
+	} else {
+		y.ExcludeFromBackup = ptr.Of(ExcludeFromBackupNone)
+	}
+
 	if y.Plain == nil {
 		y.Plain = d.Plain
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -122,6 +122,11 @@ func TestFillDefault(t *testing.T) {
 			}
 		}
 	}
+	if runtime.GOOS == "darwin" {
+		builtin.ExcludeFromBackup = ptr.Of(ExcludeFromBackupDisks)
+	} else {
+		builtin.ExcludeFromBackup = ptr.Of(ExcludeFromBackupNone)
+	}
 
 	defaultPortForward := PortForward{
 		GuestIP:        api.IPv4loopback1,
@@ -444,6 +449,11 @@ func TestFillDefault(t *testing.T) {
 		}
 	}
 	expect.Plain = ptr.Of(false)
+	if runtime.GOOS == "darwin" {
+		expect.ExcludeFromBackup = ptr.Of(ExcludeFromBackupDisks)
+	} else {
+		expect.ExcludeFromBackup = ptr.Of(ExcludeFromBackupNone)
+	}
 
 	y = LimaYAML{}
 	FillDefault(&y, &d, &LimaYAML{}, filePath)
@@ -608,6 +618,7 @@ func TestFillDefault(t *testing.T) {
 			Enabled: ptr.Of(false),
 			BinFmt:  ptr.Of(false),
 		},
+		ExcludeFromBackup: ptr.Of(ExcludeFromBackupAll),
 	}
 
 	y = filledDefaults
@@ -661,6 +672,11 @@ func TestFillDefault(t *testing.T) {
 		BinFmt:  ptr.Of(false),
 	}
 	expect.Plain = ptr.Of(false)
+	if runtime.GOOS == "darwin" {
+		expect.ExcludeFromBackup = ptr.Of(ExcludeFromBackupAll)
+	} else {
+		expect.ExcludeFromBackup = ptr.Of(ExcludeFromBackupNone)
+	}
 
 	FillDefault(&y, &d, &o, filePath)
 	assert.DeepEqual(t, &y, &expect, opts...)

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -36,11 +36,12 @@ type LimaYAML struct {
 	DNS          []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`
 	HostResolver HostResolver      `yaml:"hostResolver,omitempty" json:"hostResolver,omitempty"`
 	// `useHostResolver` was deprecated in Lima v0.8.1, removed in Lima v0.14.0. Use `hostResolver.enabled` instead.
-	PropagateProxyEnv *bool          `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty"`
-	CACertificates    CACertificates `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
-	Rosetta           Rosetta        `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
-	Plain             *bool          `yaml:"plain,omitempty" json:"plain,omitempty"`
-	TimeZone          *string        `yaml:"timezone,omitempty" json:"timezone,omitempty"`
+	PropagateProxyEnv *bool              `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty"`
+	CACertificates    CACertificates     `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
+	Rosetta           Rosetta            `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
+	ExcludeFromBackup *ExcludeFromBackup `yaml:"excludeFromBackup,omitempty" json:"excludeFromBackup,omitempty"`
+	Plain             *bool              `yaml:"plain,omitempty" json:"plain,omitempty"`
+	TimeZone          *string            `yaml:"timezone,omitempty" json:"timezone,omitempty"`
 }
 
 type (
@@ -259,6 +260,14 @@ type CACertificates struct {
 	Files          []string `yaml:"files,omitempty" json:"files,omitempty"`
 	Certs          []string `yaml:"certs,omitempty" json:"certs,omitempty"`
 }
+
+type ExcludeFromBackup = string
+
+const (
+	ExcludeFromBackupAll   ExcludeFromBackup = "all"
+	ExcludeFromBackupDisks ExcludeFromBackup = "disks"
+	ExcludeFromBackupNone  ExcludeFromBackup = "none"
+)
 
 // DEPRECATED types below
 

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -303,6 +303,16 @@ func Validate(y LimaYAML, warn bool) error {
 	if err := validateNetwork(y, warn); err != nil {
 		return err
 	}
+
+	switch *y.ExcludeFromBackup {
+	case ExcludeFromBackupAll, ExcludeFromBackupDisks, ExcludeFromBackupNone:
+	default:
+		return fmt.Errorf("field `excludeFromBackup` must be %q, %q, or %q; got %q", ExcludeFromBackupAll, ExcludeFromBackupDisks, ExcludeFromBackupNone, *y.ExcludeFromBackup)
+	}
+	if warn && runtime.GOOS != "darwin" && *y.ExcludeFromBackup != "none" {
+		logrus.Warn("field `excludeFromBackup` is only supported on macOS")
+	}
+
 	if warn {
 		warnExperimental(y)
 	}

--- a/pkg/osutil/exclude_from_backup_darwin.go
+++ b/pkg/osutil/exclude_from_backup_darwin.go
@@ -1,0 +1,38 @@
+package osutil
+
+/*
+#cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c
+#cgo darwin LDFLAGS: -lobjc -framework Foundation
+#import <Foundation/Foundation.h>
+
+void setExcludeFromBackup(const char *path, int exclude) {
+	@autoreleasepool {
+		NSURL *url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:path]];
+		NSError *error = nil;
+		if (![url setResourceValue: exclude == 1 ? @YES : @NO forKey:NSURLIsExcludedFromBackupKey error:&error]) {
+			NSLog(@"setResourceValue failed: %@", error);
+		}
+	}
+}
+*/
+import "C" //nolint:gocritic
+/*
+The reason for separating the import statement is that CGO only recognizes the standalone import of "C".
+However, the linter tool `gocritic` incorrectly identifies this separation as a duplicate import and raises
+a `dupImport` warning. To avoid this warning, the `gocritic` check has been disabled.
+Ref: https://github.com/go-critic/go-critic/issues/845
+*/
+import (
+	"unsafe" //nolint:gocritic
+)
+
+// SetExcludeFromBackup sets the `NSURLIsExcludedFromBackupKey` attribute of the specified file or directory.
+func SetExcludeFromBackup(path string, exclude bool) {
+	cs := C.CString(path)
+	defer C.free(unsafe.Pointer(cs))
+	if exclude {
+		C.setExcludeFromBackup(cs, C.int(1))
+	} else {
+		C.setExcludeFromBackup(cs, C.int(0))
+	}
+}

--- a/pkg/osutil/exclude_from_backup_others.go
+++ b/pkg/osutil/exclude_from_backup_others.go
@@ -1,0 +1,5 @@
+//go:build !darwin
+
+package osutil
+
+func SetExcludeFromBackup(path string, exclude bool) {}


### PR DESCRIPTION
```yml
# Exclude from backup: "all", "disks" or "none"
# Specify which file in the instance's configuration to exclude from backup.
# Only available on macOS.
# 🟢 Builtin default: "disks"
excludeFromBackup: null
```

Sets the [`NSURLIsExcludedFromBackupKey`](https://developer.apple.com/documentation/foundation/nsurlisexcludedfrombackupkey) attribute to:
- "all": the instance directory
- "disks": `basedisk` and `diffdisk` files
- "none": none