### PR TITLE
fix state when create disk fails

### DIFF
--- a/cmd/limactl/disk.go
+++ b/cmd/limactl/disk.go
@@ -101,7 +101,11 @@ func diskCreateAction(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := qemu.CreateDataDisk(diskDir, format, int(diskSize)); err != nil {
-		return fmt.Errorf("Failed to create %s disk in %q", format, diskDir)
+		rerr := os.RemoveAll(diskDir)
+		if rerr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to remove a directory %q: %w", diskDir, rerr))
+		}
+		return fmt.Errorf("Failed to create %s disk in %q: %w", format, diskDir, err)
 	}
 
 	return nil


### PR DESCRIPTION
**User story:**
lima is built from source code. qemu not installed.

The user wants to run some vm with an additional disk:
```
$ limactl disk create --size=1G --format=qcow2 test
INFO[0000] Creating qcow2 disk "test" with size 1GiB
FATA[0000] Failed to create qcow2 disk in "/Users/testuser/.lima/_disks/test"
```
There are no details about qemu-img in the log. Let's assume he guessed the reason and installed the qemu package.

Now any actions with this disk will result in an error.:
```
$ limactl disk create --size=1G --format=qcow2 test
FATA[0000] disk "test" already exists ("/Users/testuser/.lima/_disks/test")
$ limactl disk rm test
WARN[0000] Ignoring non-existent disk "test"
```
Manual removing the directory helps, but it's not user friendly.

**PR:**
 - remove created directory if disk creation error occurs
 - add child error to error message 