### PR TITLE
replacing available commands with basic and advanced commands

### DIFF
--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -180,10 +180,10 @@ func newApp() *cobra.Command {
 		fmt.Println("\nAdvanced Commands:")
 		printCommands(advancedCmds.Commands())
 		fmt.Println("\nFlags:")
-    cmd.Flags().VisitAll(func(flag *pflag.Flag) {
-        fmt.Printf("  --%-15s %s\n", flag.Name, flag.Usage)
-    })
-    fmt.Println("\nUse \"limactl [command] --help\" for more information about a command.")
+		cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+			fmt.Printf("  --%-15s %s\n", flag.Name, flag.Usage)
+		})
+		fmt.Println("\nUse \"limactl [command] --help\" for more information about a command.")
 	})
 
 	return rootCmd

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -133,7 +133,6 @@ func newApp() *cobra.Command {
 		Run:   func(cmd *cobra.Command, args []string) {},
 	}
 
-	// Add basic commands
 	basicCmds.AddCommand(
 		newCreateCommand(),
 		newStartCommand(),
@@ -144,7 +143,6 @@ func newApp() *cobra.Command {
 		newEditCommand(),
 	)
 
-	// Add advanced commands
 	advancedCmds.AddCommand(
 		newCopyCommand(),
 		newValidateCommand(),
@@ -160,9 +158,9 @@ func newApp() *cobra.Command {
 	)
 
 	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		fmt.Println("Lima: Linux virtual machines\n")
-		fmt.Println("Usage:")
-		fmt.Println("  limactl [command]\n")
+		fmt.Print("Lima: Linux virtual machines\n\n")
+		fmt.Print("Usage:\n")
+		fmt.Print("  limactl [command]\n\n")
 		fmt.Println("Examples:")
 		fmt.Printf(`  Start the default instance:
   $ limactl start

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 const (
@@ -119,12 +120,86 @@ func newApp() *cobra.Command {
 		newProtectCommand(),
 		newUnprotectCommand(),
 	)
+
+	basicCmds := &cobra.Command{
+		Use:   "Basic commands",
+		Short: "Basic commands for managing Lima instances",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+
+	advancedCmds := &cobra.Command{
+		Use:   "Advanced commands",
+		Short: "Advanced commands for managing Lima instances",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+
+	// Add basic commands
+	basicCmds.AddCommand(
+		newCreateCommand(),
+		newStartCommand(),
+		newStopCommand(),
+		newShellCommand(),
+		newListCommand(),
+		newDeleteCommand(),
+		newEditCommand(),
+	)
+
+	// Add advanced commands
+	advancedCmds.AddCommand(
+		newCopyCommand(),
+		newValidateCommand(),
+		newSudoersCommand(),
+		newPruneCommand(),
+		newInfoCommand(),
+		newShowSSHCommand(),
+		newFactoryResetCommand(),
+		newDiskCommand(),
+		newSnapshotCommand(),
+		newProtectCommand(),
+		newUnprotectCommand(),
+	)
+
+	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		fmt.Println("Lima: Linux virtual machines\n")
+		fmt.Println("Usage:")
+		fmt.Println("  limactl [command]\n")
+		fmt.Println("Examples:")
+		fmt.Printf(`  Start the default instance:
+  $ limactl start
+
+  Open a shell:
+  $ lima
+
+  Run a container:
+  $ lima nerdctl run -d --name nginx -p 8080:80 nginx:alpine
+
+  Stop the default instance:
+  $ limactl stop
+
+  See also template YAMLs: %s`, templatesDir)
+		fmt.Println("\n\nBasic Commands:")
+		printCommands(basicCmds.Commands())
+		fmt.Println("\nAdvanced Commands:")
+		printCommands(advancedCmds.Commands())
+		fmt.Println("\nFlags:")
+    cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+        fmt.Printf("  --%-15s %s\n", flag.Name, flag.Usage)
+    })
+    fmt.Println("\nUse \"limactl [command] --help\" for more information about a command.")
+	})
+
 	return rootCmd
 }
 
 type ExitCoder interface {
 	error
 	ExitCode() int
+}
+
+func printCommands(commands []*cobra.Command) {
+	for _, cmd := range commands {
+		fmt.Printf("  %-15s %s\n", cmd.Name(), cmd.Short)
+	}
 }
 
 func handleExitCoder(err error) {


### PR DESCRIPTION
This pull request closes:
 - #2147 

Changes made:
 - Added "github.com/spf13/pflag" package to the project dependencies.
 - Divided the available command list into two - Basic and Advanced commands
 - added the custom help function output using `SetHelpFunc`
 - added a function `printCommands` to print all the commands. Used the function in `SetHelpFunc`.

Output of `limactl help`  after changes:
```
Lima: Linux virtual machines

Usage:
  limactl [command]

Examples:
  Start the default instance:
  $ limactl start

  Open a shell:
  $ lima

  Run a container:
  $ lima nerdctl run -d --name nginx -p 8080:80 nginx:alpine

  Stop the default instance:
  $ limactl stop

  See also template YAMLs: /usr/local/share/lima/templates

Basic Commands:
  create          Create an instance of Lima
  delete          Delete an instance of Lima.
  edit            Edit an instance of Lima
  list            List instances of Lima.
  shell           Execute shell in Lima
  start           Start an instance of Lima
  stop            Stop an instance

Advanced Commands:
  copy            Copy files between host and guest
  disk            Lima disk management
  factory-reset   Factory reset an instance of Lima
  info            Show diagnostic information
  protect         Protect an instance to prohibit accidental removal
  prune           Prune garbage objects
  show-ssh        Show the ssh command line (DEPRECATED; use `ssh -F` instead)
  snapshot        Manage instance snapshots
  sudoers         Generate the content of the /etc/sudoers.d/lima file
  unprotect       Unprotect an instance
  validate        Validate YAML files

Flags:
  --debug           debug mode
  --help            help for limactl
  --log-level       Set the logging level [trace, debug, info, warn, error]
  --tty             Enable TUI interactions such as opening an editor. Defaults to true when stdout is a terminal. Set to false for automation.
  --version         version for limactl

Use "limactl [command] --help" for more information about a command.
```
