### PR TITLE
Replacing available commands with basic and advanced commands

### DIFF
--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -30,6 +30,7 @@ func newCopyCommand() *cobra.Command {
 		Long:    copyHelp,
 		Args:    WrapArgsError(cobra.MinimumNArgs(2)),
 		RunE:    copyAction,
+		GroupID: advancedCommand,
 	}
 
 	copyCommand.Flags().BoolP("recursive", "r", false, "copy directories recursively")

--- a/cmd/limactl/delete.go
+++ b/cmd/limactl/delete.go
@@ -21,6 +21,7 @@ func newDeleteCommand() *cobra.Command {
 		Args:              WrapArgsError(cobra.MinimumNArgs(1)),
 		RunE:              deleteAction,
 		ValidArgsFunction: deleteBashComplete,
+		GroupID:           basicCommand,
 	}
 	deleteCommand.Flags().BoolP("force", "f", false, "forcibly kill the processes")
 	return deleteCommand

--- a/cmd/limactl/disk.go
+++ b/cmd/limactl/disk.go
@@ -32,6 +32,7 @@ func newDiskCommand() *cobra.Command {
   $ limactl disk resize DISK --size SIZE`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		GroupID:       advancedCommand,
 	}
 	diskCommand.AddCommand(
 		newDiskCreateCommand(),

--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -27,6 +27,7 @@ func newEditCommand() *cobra.Command {
 		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
 		RunE:              editAction,
 		ValidArgsFunction: editBashComplete,
+		GroupID:           basicCommand,
 	}
 	editflags.RegisterEdit(editCommand)
 	return editCommand

--- a/cmd/limactl/factory-reset.go
+++ b/cmd/limactl/factory-reset.go
@@ -19,6 +19,7 @@ func newFactoryResetCommand() *cobra.Command {
 		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
 		RunE:              factoryResetAction,
 		ValidArgsFunction: factoryResetBashComplete,
+		GroupID:           advancedCommand,
 	}
 	return resetCommand
 }

--- a/cmd/limactl/info.go
+++ b/cmd/limactl/info.go
@@ -10,10 +10,11 @@ import (
 
 func newInfoCommand() *cobra.Command {
 	infoCommand := &cobra.Command{
-		Use:   "info",
-		Short: "Show diagnostic information",
-		Args:  WrapArgsError(cobra.NoArgs),
-		RunE:  infoAction,
+		Use:     "info",
+		Short:   "Show diagnostic information",
+		Args:    WrapArgsError(cobra.NoArgs),
+		RunE:    infoAction,
+		GroupID: advancedCommand,
 	}
 	return infoCommand
 }

--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -52,6 +52,7 @@ func newListCommand() *cobra.Command {
 		Args:              WrapArgsError(cobra.ArbitraryArgs),
 		RunE:              listAction,
 		ValidArgsFunction: listBashComplete,
+		GroupID:           basicCommand,
 	}
 
 	listCommand.Flags().StringP("format", "f", "table", "output format, one of: json, yaml, table, go-template")

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -18,6 +18,8 @@ import (
 
 const (
 	DefaultInstanceName = "default"
+	basicCommand        = "basic"
+	advancedCommand     = "advanced"
 )
 
 func main() {
@@ -95,6 +97,8 @@ func newApp() *cobra.Command {
 		}
 		return nil
 	}
+	rootCmd.AddGroup(&cobra.Group{ID: "basic", Title: "Basic Commands:"})
+	rootCmd.AddGroup(&cobra.Group{ID: "advanced", Title: "Advanced Commands:"})
 	rootCmd.AddCommand(
 		newCreateCommand(),
 		newStartCommand(),

--- a/cmd/limactl/protect.go
+++ b/cmd/limactl/protect.go
@@ -18,6 +18,7 @@ The instance is not being protected against removal via '/bin/rm', Finder, etc.`
 		Args:              WrapArgsError(cobra.MinimumNArgs(1)),
 		RunE:              protectAction,
 		ValidArgsFunction: protectBashComplete,
+		GroupID:           advancedCommand,
 	}
 	return protectCommand
 }

--- a/cmd/limactl/prune.go
+++ b/cmd/limactl/prune.go
@@ -15,6 +15,7 @@ func newPruneCommand() *cobra.Command {
 		Args:              WrapArgsError(cobra.NoArgs),
 		RunE:              pruneAction,
 		ValidArgsFunction: cobra.NoFileCompletions,
+		GroupID:           advancedCommand,
 	}
 	return pruneCommand
 }

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -40,6 +40,7 @@ func newShellCommand() *cobra.Command {
 		RunE:              shellAction,
 		ValidArgsFunction: shellBashComplete,
 		SilenceErrors:     true,
+		GroupID:           basicCommand,
 	}
 
 	shellCmd.Flags().SetInterspersed(false)

--- a/cmd/limactl/show_ssh.go
+++ b/cmd/limactl/show_ssh.go
@@ -62,6 +62,7 @@ Instead, use 'ssh -F %s/default/ssh.config lima-default' .
 		RunE:              showSSHAction,
 		ValidArgsFunction: showSSHBashComplete,
 		SilenceErrors:     true,
+		GroupID:           advancedCommand,
 	}
 
 	shellCmd.Flags().StringP("format", "f", sshutil.FormatCmd, "Format: "+strings.Join(sshutil.Formats, ", "))

--- a/cmd/limactl/snapshot.go
+++ b/cmd/limactl/snapshot.go
@@ -18,6 +18,7 @@ func newSnapshotCommand() *cobra.Command {
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			logrus.Warn("`limactl snapshot` is experimental")
 		},
+		GroupID: advancedCommand,
 	}
 	snapshotCmd.AddCommand(newSnapshotApplyCommand())
 	snapshotCmd.AddCommand(newSnapshotCreateCommand())

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -69,6 +69,7 @@ $ cat template.yaml | limactl create --name=local -
 		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
 		ValidArgsFunction: createBashComplete,
 		RunE:              createAction,
+		GroupID:           basicCommand,
 	}
 	registerCreateFlags(createCommand, "")
 	return createCommand
@@ -91,6 +92,7 @@ See the examples in 'limactl create --help'.
 		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
 		ValidArgsFunction: startBashComplete,
 		RunE:              startAction,
+		GroupID:           basicCommand,
 	}
 	registerCreateFlags(startCommand, "[limactl create] ")
 	if runtime.GOOS != "windows" {

--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -25,6 +25,7 @@ func newStopCommand() *cobra.Command {
 		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
 		RunE:              stopAction,
 		ValidArgsFunction: stopBashComplete,
+		GroupID:           basicCommand,
 	}
 
 	stopCmd.Flags().BoolP("force", "f", false, "force stop the instance")

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -32,8 +32,9 @@ $ limactl sudoers --check /etc/sudoers.d/lima
 The content is written to stdout, NOT to the file.
 This command must not run as the root.
 See %s for the usage.`, networksMD),
-		Args: WrapArgsError(cobra.MaximumNArgs(1)),
-		RunE: sudoersAction,
+		Args:    WrapArgsError(cobra.MaximumNArgs(1)),
+		RunE:    sudoersAction,
+		GroupID: advancedCommand,
 	}
 	configFile, _ := networks.ConfigFile()
 	sudoersCommand.Flags().Bool("check", false,

--- a/cmd/limactl/unprotect.go
+++ b/cmd/limactl/unprotect.go
@@ -16,6 +16,7 @@ func newUnprotectCommand() *cobra.Command {
 		Args:              WrapArgsError(cobra.MinimumNArgs(1)),
 		RunE:              unprotectAction,
 		ValidArgsFunction: unprotectBashComplete,
+		GroupID:           advancedCommand,
 	}
 	return unprotectCommand
 }

--- a/cmd/limactl/validate.go
+++ b/cmd/limactl/validate.go
@@ -12,10 +12,11 @@ import (
 
 func newValidateCommand() *cobra.Command {
 	validateCommand := &cobra.Command{
-		Use:   "validate FILE.yaml [FILE.yaml, ...]",
-		Short: "Validate YAML files",
-		Args:  WrapArgsError(cobra.MinimumNArgs(1)),
-		RunE:  validateAction,
+		Use:     "validate FILE.yaml [FILE.yaml, ...]",
+		Short:   "Validate YAML files",
+		Args:    WrapArgsError(cobra.MinimumNArgs(1)),
+		RunE:    validateAction,
+		GroupID: advancedCommand,
 	}
 	return validateCommand
 }


### PR DESCRIPTION
This pull request closes:
 - #2147 

Changes made:
 - Added "github.com/spf13/pflag" package to the project dependencies.
 - Divided the available command list into two - Basic and Advanced commands
 - added the custom help function output using `SetHelpFunc`
 - added a function `printCommands` to print all the commands. Used the function in `SetHelpFunc`.

Output of `limactl help`  after changes:
```
Lima: Linux virtual machines

Usage:
  limactl [command]

Examples:
  Start the default instance:
  $ limactl start

  Open a shell:
  $ lima

  Run a container:
  $ lima nerdctl run -d --name nginx -p 8080:80 nginx:alpine

  Stop the default instance:
  $ limactl stop

  See also template YAMLs: /usr/local/share/lima/templates

Basic Commands:
  create          Create an instance of Lima
  delete          Delete an instance of Lima.
  edit            Edit an instance of Lima
  list            List instances of Lima.
  shell           Execute shell in Lima
  start           Start an instance of Lima
  stop            Stop an instance

Advanced Commands:
  copy            Copy files between host and guest
  disk            Lima disk management
  factory-reset   Factory reset an instance of Lima
  info            Show diagnostic information
  protect         Protect an instance to prohibit accidental removal
  prune           Prune garbage objects
  show-ssh        Show the ssh command line (DEPRECATED; use `ssh -F` instead)
  snapshot        Manage instance snapshots
  sudoers         Generate the content of the /etc/sudoers.d/lima file
  unprotect       Unprotect an instance
  validate        Validate YAML files

Flags:
  --debug           debug mode
  --help            help for limactl
  --log-level       Set the logging level [trace, debug, info, warn, error]
  --tty             Enable TUI interactions such as opening an editor. Defaults to true when stdout is a terminal. Set to false for automation.
  --version         version for limactl

Use "limactl [command] --help" for more information about a command.
```
