### PR TITLE
Add Host Provision to `default.yaml`

### DIFF
--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -88,6 +88,10 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := ha.ExecuteHostProvision(); err != nil {
+		return err
+	}
+
 	backend := &server.Backend{
 		Agent: ha,
 	}

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -241,59 +241,6 @@ containerd:
 #     vim was not installed in the guest. Make sure the package system is working correctly.
 #     Also see "/var/log/cloud-init-output.log" in the guest.
 
-# Host provisioning scripts are executed every time before starting the instance.
-# - the working directory is the instance directory `{{.Dir}}`
-# - the `runtime.GOOS` is used to determine the host OS. e.g. `darwin` for macOS, `linux` for Linux, and `windows` for Windows.
-# - if `wait` is true and the script exits with a non-zero status, the instance start will be aborted.
-# `shell` and `script` can include these template variables:
-# - `{{.ScriptName}}` that represents the temporary script file path.
-# - `{{.Index}}` that represents the index in the list of host provisioning scripts (0-based).
-# - template variables available in `limactl list --format` command.
-# 🟢 Builtin default: null
-# hostProvision:
-# - debug: false      # change the temporary script location to {{.Dir}} and not delete it after execution. default: false
-#   hostOS: darwin    # string or []string. The script is executed only on the specified host OS.
-#   script: |         # passed to the shell as temporary file argument if exists
-#     xattr -w com.apple.metadata:com_apple_backup_excludeItem true {{.Dir}}/{basedisk,diffdisk}
-#   shell: bash       # default: null
-#   wait: true        # wait for the script to finish before starting the instance. default: true
-# # If no shell is given, the default shell is selected based on the host OS. If the default shell is not
-# # located on the PATH, fallbacks to `sh` (when host OS is not windows) or `powershell` (when host OS is windows).
-# # `shell` can be either:
-# # 1. Builtin / Explicitly supported keywords
-# # | Keyword      | Command run internally                                 | Description                                    |
-# # | ------------ | ------------------------------------------------------ | ---------------------------------------------- |
-# # | `bash`       | `bash --noprofile --norc -eo pipefail {{.ScriptName}}` | The default shell when host OS is not windows. |
-# # | `sh`         | `sh -e {{.ScriptName}}`                                |                                                |
-# # | `pwsh`       | `pwsh -command ". '{{.ScriptName}}'"`                  | The default shell when host OS is windows.     |
-# # | `powershell` | `powershell -command ". '{{.ScriptName}}'"`            |                                                |
-# # | `cmd`        | `cmd /D /E:ON /V:OFF /S /C "CALL "{{.ScriptName}}""`   |                                                |
-# # 2. Template string: `command [...options] {{.ScriptName}} [...more_options]`
-# #   `{{.ScriptName}}` is replaced with the temporary script file path
-# #
-# # there are shorthand forms for the builtin shells:
-# - bash: echo "executed by bash"                    # interpreted as {shell: bash, hostOS: [darwin, linux], script: ...}
-# - sh: echo "executed by sh"                        # interpreted as {shell: sh, hostOS: [darwin, linux], script: ...}
-# - pwsh: Write-Host "executed by pwsh"              # interpreted as {shell: pwsh, hostOS: [windows], script: ...}
-# - powershell: Write-Host "executed by powershell"  # interpreted as {shell: powershell, hostOS: [windows], script: ...}
-# - cmd: echo "executed by cmd"                      # interpreted as {shell: cmd, hostOS: [windows], script: ...}
-# # e.g.
-# - bash: | # Post a notification when an error by the hostProvision script is detected
-#     jq=/opt/homebrew/bin/jq && test -x $jq || exit 0
-#     tail -n0 -F ha.stderr.log | while read -r line; do
-#       msg=$(echo "$line"|$jq -er '
-#         select(.hostProvision and .hostProvision != {{.Index}})| # select log lines from other hostProvision scripts
-#         select(.level == "error")|                               # select error log lines
-#         .msg
-#       ') || continue
-#       osascript -e "on run argv" -e "display notification (item 1 of argv) with title \"Lima\"" -e "end run" "$msg"
-#       echo Posted a notification
-#     done
-#   debug: false
-#   hostOS: darwin
-#   wait: false
-
-
 # ===================================================================== #
 # FURTHER ADVANCED CONFIGURATION
 # ===================================================================== #
@@ -563,6 +510,62 @@ plain: null
 #   name with higher priority definitions. This does not apply if the
 #  `interface` field is empty. `networks` are therefore also processed
 #  in lowest to highest priority order.
+
+# ===================================================================== #
+# CONFIGURATION AVAILABLE ONLY IN $LIMA_HOME/_config/default.yaml
+# ===================================================================== #
+
+# Host provisioning scripts are executed every time before starting the instance.
+# - the working directory is the instance directory `{{.Dir}}`
+# - the `runtime.GOOS` is used to determine the host OS. e.g. `darwin` for macOS, `linux` for Linux, and `windows` for Windows.
+# - if `wait` is true and the script exits with a non-zero status, the instance start will be aborted.
+# `shell` and `script` can include these template variables:
+# - `{{.ScriptName}}` that represents the temporary script file path.
+# - `{{.Index}}` that represents the index in the list of host provisioning scripts (0-based).
+# - template variables available in `limactl list --format` command.
+# 🟢 Builtin default: null
+# hostProvision:
+# - debug: false      # change the temporary script location to {{.Dir}} and not delete it after execution. default: false
+#   hostOS: darwin    # string or []string. The script is executed only on the specified host OS.
+#   script: |         # passed to the shell as temporary file argument if exists
+#     xattr -w com.apple.metadata:com_apple_backup_excludeItem true {{.Dir}}/{basedisk,diffdisk}
+#   shell: bash       # default: null
+#   wait: true        # wait for the script to finish before starting the instance. default: true
+# # If no shell is given, the default shell is selected based on the host OS. If the default shell is not
+# # located on the PATH, fallbacks to `sh` (when host OS is not windows) or `powershell` (when host OS is windows).
+# # `shell` can be either:
+# # 1. Builtin / Explicitly supported keywords
+# # | Keyword      | Command run internally                                 | Description                                    |
+# # | ------------ | ------------------------------------------------------ | ---------------------------------------------- |
+# # | `bash`       | `bash --noprofile --norc -eo pipefail {{.ScriptName}}` | The default shell when host OS is not windows. |
+# # | `sh`         | `sh -e {{.ScriptName}}`                                |                                                |
+# # | `pwsh`       | `pwsh -command ". '{{.ScriptName}}'"`                  | The default shell when host OS is windows.     |
+# # | `powershell` | `powershell -command ". '{{.ScriptName}}'"`            |                                                |
+# # | `cmd`        | `cmd /D /E:ON /V:OFF /S /C "CALL "{{.ScriptName}}""`   |                                                |
+# # 2. Template string: `command [...options] {{.ScriptName}} [...more_options]`
+# #   `{{.ScriptName}}` is replaced with the temporary script file path
+# #
+# # there are shorthand forms for the builtin shells:
+# - bash: echo "executed by bash"                    # interpreted as {shell: bash, hostOS: [darwin, linux], script: ...}
+# - sh: echo "executed by sh"                        # interpreted as {shell: sh, hostOS: [darwin, linux], script: ...}
+# - pwsh: Write-Host "executed by pwsh"              # interpreted as {shell: pwsh, hostOS: [windows], script: ...}
+# - powershell: Write-Host "executed by powershell"  # interpreted as {shell: powershell, hostOS: [windows], script: ...}
+# - cmd: echo "executed by cmd"                      # interpreted as {shell: cmd, hostOS: [windows], script: ...}
+# # e.g.
+# - bash: | # Post a notification when an error by the hostProvision script is detected
+#     jq=/opt/homebrew/bin/jq && test -x $jq || exit 0
+#     tail -n0 -F ha.stderr.log | while read -r line; do
+#       msg=$(echo "$line"|$jq -er '
+#         select(.hostProvision and .hostProvision != {{.Index}})| # select log lines from other hostProvision scripts
+#         select(.level == "error")|                               # select error log lines
+#         .msg
+#       ') || continue
+#       osascript -e "on run argv" -e "display notification (item 1 of argv) with title \"Lima\"" -e "end run" "$msg"
+#       echo Posted a notification
+#     done
+#   debug: false
+#   hostOS: darwin
+#   wait: false
 
 # ===================================================================== #
 # END OF TEMPLATE

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -241,6 +241,59 @@ containerd:
 #     vim was not installed in the guest. Make sure the package system is working correctly.
 #     Also see "/var/log/cloud-init-output.log" in the guest.
 
+# Host provisioning scripts are executed every time before starting the instance.
+# - the working directory is the instance directory `{{.Dir}}`
+# - the `runtime.GOOS` is used to determine the host OS. e.g. `darwin` for macOS, `linux` for Linux, and `windows` for Windows.
+# - if `wait` is true and the script exits with a non-zero status, the instance start will be aborted.
+# `shell` and `script` can include these template variables:
+# - `{{.ScriptName}}` that represents the temporary script file path.
+# - `{{.Index}}` that represents the index in the list of host provisioning scripts (0-based).
+# - template variables available in `limactl list --format` command.
+# 🟢 Builtin default: null
+# hostProvision:
+# - debug: false      # change the temporary script location to {{.Dir}} and not delete it after execution. default: false
+#   hostOS: darwin    # string or []string. The script is executed only on the specified host OS.
+#   script: |         # passed to the shell as temporary file argument if exists
+#     xattr -w com.apple.metadata:com_apple_backup_excludeItem true {{.Dir}}/{basedisk,diffdisk}
+#   shell: bash       # default: null
+#   wait: true        # wait for the script to finish before starting the instance. default: true
+# # If no shell is given, the default shell is selected based on the host OS. If the default shell is not
+# # located on the PATH, fallbacks to `sh` (when host OS is not windows) or `powershell` (when host OS is windows).
+# # `shell` can be either:
+# # 1. Builtin / Explicitly supported keywords
+# # | Keyword      | Command run internally                                 | Description                                    |
+# # | ------------ | ------------------------------------------------------ | ---------------------------------------------- |
+# # | `bash`       | `bash --noprofile --norc -eo pipefail {{.ScriptName}}` | The default shell when host OS is not windows. |
+# # | `sh`         | `sh -e {{.ScriptName}}`                                |                                                |
+# # | `pwsh`       | `pwsh -command ". '{{.ScriptName}}'"`                  | The default shell when host OS is windows.     |
+# # | `powershell` | `powershell -command ". '{{.ScriptName}}'"`            |                                                |
+# # | `cmd`        | `cmd /D /E:ON /V:OFF /S /C "CALL "{{.ScriptName}}""`   |                                                |
+# # 2. Template string: `command [...options] {{.ScriptName}} [...more_options]`
+# #   `{{.ScriptName}}` is replaced with the temporary script file path
+# #
+# # there are shorthand forms for the builtin shells:
+# - bash: echo "executed by bash"                    # interpreted as {shell: bash, hostOS: [darwin, linux], script: ...}
+# - sh: echo "executed by sh"                        # interpreted as {shell: sh, hostOS: [darwin, linux], script: ...}
+# - pwsh: Write-Host "executed by pwsh"              # interpreted as {shell: pwsh, hostOS: [windows], script: ...}
+# - powershell: Write-Host "executed by powershell"  # interpreted as {shell: powershell, hostOS: [windows], script: ...}
+# - cmd: echo "executed by cmd"                      # interpreted as {shell: cmd, hostOS: [windows], script: ...}
+# # e.g.
+# - bash: | # Post a notification when an error by the hostProvision script is detected
+#     jq=/opt/homebrew/bin/jq && test -x $jq || exit 0
+#     tail -n0 -F ha.stderr.log | while read -r line; do
+#       msg=$(echo "$line"|$jq -er '
+#         select(.hostProvision and .hostProvision != {{.Index}})| # select log lines from other hostProvision scripts
+#         select(.level == "error")|                               # select error log lines
+#         .msg
+#       ') || continue
+#       osascript -e "on run argv" -e "display notification (item 1 of argv) with title \"Lima\"" -e "end run" "$msg"
+#       echo Posted a notification
+#     done
+#   debug: false
+#   hostOS: darwin
+#   wait: false
+
+
 # ===================================================================== #
 # FURTHER ADVANCED CONFIGURATION
 # ===================================================================== #

--- a/pkg/hostagent/host_provision.go
+++ b/pkg/hostagent/host_provision.go
@@ -1,0 +1,261 @@
+package hostagent
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"runtime"
+	"strings"
+	"text/template"
+
+	"github.com/lima-vm/lima/pkg/limayaml"
+	"github.com/lima-vm/lima/pkg/ptr"
+	"github.com/lima-vm/lima/pkg/store"
+	"github.com/lima-vm/lima/pkg/textutil"
+	"github.com/mattn/go-shellwords"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
+)
+
+var (
+	defaultArguments = map[string][]string{
+		limayaml.HostProvisionShellBash:       {"--noprofile", "--norc", "-e", "-o", "pipefail", "{{.ScriptName}}"},
+		limayaml.HostProvisionShellSh:         {"-e", "{{.ScriptName}}"},
+		limayaml.HostProvisionShellPwsh:       {"-command", ". '{{.ScriptName}}'"},
+		limayaml.HostProvisionShellPowerShell: {"-command", ". '{{.ScriptName}}'"},
+		limayaml.HostProvisionShellCmd:        {"/D", "/E:ON", "/V:OFF", "/S", "/C", "CALL \"{{.ScriptName}}\""},
+	}
+	defaultHostOS = map[string]*limayaml.StringArray{
+		limayaml.HostProvisionShellBash:       {"darwin", "linux"},
+		limayaml.HostProvisionShellSh:         {"darwin", "linux"},
+		limayaml.HostProvisionShellPwsh:       {"windows"},
+		limayaml.HostProvisionShellPowerShell: {"windows"},
+		limayaml.HostProvisionShellCmd:        {"windows"},
+	}
+	extensions = map[string]string{
+		limayaml.HostProvisionShellBash:       ".sh",
+		limayaml.HostProvisionShellSh:         ".sh",
+		limayaml.HostProvisionShellPwsh:       ".ps1",
+		limayaml.HostProvisionShellPowerShell: ".ps1",
+		limayaml.HostProvisionShellCmd:        ".cmd",
+	}
+)
+
+func interpretShorthandHostProvision(p *limayaml.HostProvision) (limayaml.HostProvision, error) {
+	var interpreted limayaml.HostProvision
+	interpreted.Debug = p.Debug
+	interpreted.Wait = p.Wait
+	switch {
+	case p.Bash != nil:
+		interpreted.Shell = ptr.Of(limayaml.HostProvisionShellBash)
+		interpreted.Script = p.Bash
+	case p.Sh != nil:
+		interpreted.Shell = ptr.Of(limayaml.HostProvisionShellSh)
+		interpreted.Script = p.Sh
+	case p.Pwsh != nil:
+		interpreted.Shell = ptr.Of(limayaml.HostProvisionShellPwsh)
+		interpreted.Script = p.Pwsh
+	case p.PowerShell != nil:
+		interpreted.Shell = ptr.Of(limayaml.HostProvisionShellPowerShell)
+		interpreted.Script = p.PowerShell
+	case p.Cmd != nil:
+		interpreted.Shell = ptr.Of(limayaml.HostProvisionShellCmd)
+		interpreted.Script = p.Cmd
+	case p.Shell != nil && p.Script != nil:
+		interpreted.Shell = p.Shell
+		interpreted.Script = p.Script
+	case p.Shell == nil && p.Script != nil:
+		if runtime.GOOS == "windows" {
+			interpreted.Shell = ptr.Of(limayaml.HostProvisionShellPwsh)
+		} else {
+			interpreted.Shell = ptr.Of(limayaml.HostProvisionShellBash)
+		}
+		interpreted.Script = p.Script
+	case p.Shell != nil && p.Script == nil:
+		interpreted.Shell = p.Shell
+	}
+	if p.HostOS != nil {
+		interpreted.HostOS = p.HostOS
+	} else if interpreted.Shell != nil {
+		interpreted.HostOS = defaultHostOS[*interpreted.Shell]
+	} else if runtime.GOOS == "windows" {
+		interpreted.HostOS = defaultHostOS[limayaml.HostProvisionShellPwsh]
+	} else {
+		interpreted.HostOS = defaultHostOS[limayaml.HostProvisionShellBash]
+	}
+	return interpreted, nil
+}
+
+type HostProvisionFormatData struct {
+	store.Instance
+	ScriptName string
+	Index      int
+}
+
+func executeHostProvisionTemplate(format string, data *HostProvisionFormatData) (bytes.Buffer, error) {
+	tmpl, err := template.New("executeHostProvisionTemplate").Funcs(textutil.TemplateFuncMap).Parse(format)
+	if err == nil {
+		var out bytes.Buffer
+		if err := tmpl.Execute(&out, data); err == nil {
+			return out, nil
+		}
+	}
+	return bytes.Buffer{}, err
+}
+
+func templateAppliedDefaultArguments(shell string, data *HostProvisionFormatData) ([]string, error) {
+	args := defaultArguments[shell]
+	templateAppliedArgs := make([]string, len(args))
+	for i, arg := range args {
+		out, err := executeHostProvisionTemplate(arg, data)
+		if err != nil {
+			return nil, err
+		}
+		templateAppliedArgs[i] = out.String()
+	}
+	return templateAppliedArgs, nil
+}
+
+func prepareHostProvision(hp limayaml.HostProvision, index int, instance *store.Instance) (func(o, e io.Writer) error, error) {
+	var data HostProvisionFormatData
+	data.Instance = *instance
+	data.Index = index
+	isDebug := hp.Debug != nil && *hp.Debug
+	if hp.Script != nil {
+		debugProvisionScriptPath := path.Join(instance.Dir, fmt.Sprintf("provision%d%s", index, extensions[*hp.Shell]))
+		var tmpHostProvisionScriptFile *os.File
+		var err error
+		if isDebug {
+			tmpHostProvisionScriptFile, err = os.Create(debugProvisionScriptPath)
+		} else {
+			os.RemoveAll(debugProvisionScriptPath)
+			tmpHostProvisionScriptFile, err = os.CreateTemp("", "lima-provision-*"+extensions[*hp.Shell])
+		}
+		if err != nil {
+			return nil, err
+		}
+		data.ScriptName = tmpHostProvisionScriptFile.Name()
+		if runtime.GOOS == "windows" {
+			*hp.Script = strings.ReplaceAll(*hp.Script, "\r\n", "\n")
+		}
+		out, err := executeHostProvisionTemplate(*hp.Script, &data)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := tmpHostProvisionScriptFile.Write(out.Bytes()); err != nil {
+			return nil, err
+		}
+		if err := tmpHostProvisionScriptFile.Close(); err != nil {
+			return nil, err
+		}
+	}
+	var arg0 string
+	var args []string
+	var err error
+	if hp.Shell == nil { // The default shell has fallback functionality.
+		var defaultShells []string
+		if runtime.GOOS == "windows" {
+			defaultShells = []string{limayaml.HostProvisionShellPwsh, limayaml.HostProvisionShellPowerShell}
+		} else {
+			defaultShells = []string{limayaml.HostProvisionShellBash, limayaml.HostProvisionShellSh}
+		}
+		for _, shell := range defaultShells {
+			if found, err := exec.LookPath(shell); err == nil {
+				arg0 = found
+				args, err = templateAppliedDefaultArguments(shell, &data)
+				if err != nil {
+					return nil, err
+				}
+				break
+			}
+		}
+		if arg0 == "" {
+			return nil, fmt.Errorf("failed to find a default shell in %v", defaultShells)
+		}
+	} else {
+		args, err = templateAppliedDefaultArguments(*hp.Shell, &data)
+		if err != nil {
+			return nil, err
+		}
+		if len(args) == 0 { // custom shell
+			out, err := executeHostProvisionTemplate(*hp.Shell, &data)
+			if err != nil {
+				return nil, err
+			}
+			parsedArgs, err := shellwords.Parse(out.String())
+			if err != nil {
+				return nil, err
+			}
+			arg0 = parsedArgs[0]
+			args = parsedArgs[1:]
+		} else {
+			arg0 = *hp.Shell
+		}
+		arg0, err = exec.LookPath(arg0)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	cmd := exec.Command(arg0, args...)
+	cmd.Dir = instance.Dir
+	return func(o, e io.Writer) error {
+		if hp.Script != nil && !isDebug {
+			defer os.RemoveAll(data.ScriptName)
+		}
+		cmd.Stdout = o
+		cmd.Stderr = e
+		return cmd.Run()
+	}, nil
+}
+
+func (a *HostAgent) ExecuteHostProvision() error {
+	if len(a.y.HostProvision) == 0 {
+		return nil
+	}
+	instance, err := store.Inspect(a.instName)
+	if err != nil {
+		return err
+	}
+	for i, p := range a.y.HostProvision {
+		hp, err := interpretShorthandHostProvision(&p)
+		if err != nil {
+			return err
+		}
+		log := logrus.WithField("hostProvision", i)
+		log.WithField("interpreted", hp).Debug("interpreted hostProvision")
+		if hp.HostOS == nil {
+			log.Debugf("hostProvision[%d] executing because hostOS is not specified", i)
+		} else if !slices.Contains(*hp.HostOS, runtime.GOOS) {
+			log.Warnf("hostProvision[%d] skipped because runtime.GOOS=%q is not in %v", i, runtime.GOOS, *hp.HostOS)
+			continue
+		}
+		output, err := prepareHostProvision(hp, i, instance)
+		if err != nil {
+			return err
+		}
+		o := log.WriterLevel(logrus.DebugLevel)
+		e := log.WriterLevel(logrus.ErrorLevel)
+		if hp.Wait != nil && *hp.Wait {
+			if err := output(o, e); err != nil {
+				return fmt.Errorf("hostProvision[%d] failed: %w", i, err)
+			}
+			log.Debugf("hostProvision[%d] succeeded", i)
+		} else {
+			i := i
+			go func() {
+				log.Debugf("hostProvision[%d] started", i)
+				if err := output(o, e); err != nil {
+					log.Errorf("hostProvision[%d] failed: %v", i, err)
+				} else {
+					log.Debugf("hostProvision[%d] terminated", i)
+				}
+			}()
+		}
+	}
+
+	return nil
+}

--- a/pkg/hostagent/host_provision_test.go
+++ b/pkg/hostagent/host_provision_test.go
@@ -1,0 +1,192 @@
+package hostagent
+
+import (
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/lima-vm/lima/pkg/limayaml"
+	"github.com/lima-vm/lima/pkg/ptr"
+)
+
+func TestHostProvision_interpretShorthandHostProvision(t *testing.T) {
+	type args struct {
+		p *limayaml.HostProvision
+	}
+	var defaultShellByHostOS string
+	if runtime.GOOS == "windows" {
+		defaultShellByHostOS = limayaml.HostProvisionShellPwsh
+	} else {
+		defaultShellByHostOS = limayaml.HostProvisionShellBash
+	}
+	defaultHostOS := defaultHostOS[defaultShellByHostOS]
+	tests := []struct {
+		name    string
+		args    args
+		want    limayaml.HostProvision
+		wantErr bool
+	}{
+		{
+			name: "shorthand/bash",
+			args: args{
+				p: &limayaml.HostProvision{
+					Bash: ptr.Of("script.sh"),
+				},
+			},
+			want: limayaml.HostProvision{
+				Shell:  ptr.Of(limayaml.HostProvisionShellBash),
+				Script: ptr.Of("script.sh"),
+				HostOS: &limayaml.StringArray{"darwin", "linux"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "shorthand/sh",
+			args: args{
+				p: &limayaml.HostProvision{
+					Sh: ptr.Of("script.sh"),
+				},
+			},
+			want: limayaml.HostProvision{
+				Script: ptr.Of("script.sh"),
+				Shell:  ptr.Of(limayaml.HostProvisionShellSh),
+				HostOS: &limayaml.StringArray{"darwin", "linux"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "shorthand/pwsh",
+			args: args{
+				p: &limayaml.HostProvision{
+					Pwsh: ptr.Of("script.ps1"),
+				},
+			},
+			want: limayaml.HostProvision{
+				Script: ptr.Of("script.ps1"),
+				Shell:  ptr.Of(limayaml.HostProvisionShellPwsh),
+				HostOS: &limayaml.StringArray{"windows"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "shorthand/powershell",
+			args: args{
+				p: &limayaml.HostProvision{
+					PowerShell: ptr.Of("script.ps1"),
+				},
+			},
+			want: limayaml.HostProvision{
+				Script: ptr.Of("script.ps1"),
+				Shell:  ptr.Of(limayaml.HostProvisionShellPowerShell),
+				HostOS: &limayaml.StringArray{"windows"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "shorthand/cmd",
+			args: args{
+				p: &limayaml.HostProvision{
+					Cmd: ptr.Of("script.cmd"),
+				},
+			},
+			want: limayaml.HostProvision{
+				Script: ptr.Of("script.cmd"),
+				Shell:  ptr.Of(limayaml.HostProvisionShellCmd),
+				HostOS: &limayaml.StringArray{"windows"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "shell and script",
+			args: args{
+				p: &limayaml.HostProvision{
+					Script: ptr.Of("script.sh"),
+					Shell:  ptr.Of(limayaml.HostProvisionShellBash),
+				},
+			},
+			want: limayaml.HostProvision{
+				Script: ptr.Of("script.sh"),
+				Shell:  ptr.Of(limayaml.HostProvisionShellBash),
+				HostOS: &limayaml.StringArray{"darwin", "linux"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "script",
+			args: args{
+				p: &limayaml.HostProvision{
+					Script: ptr.Of("script.sh"),
+				},
+			},
+			want: limayaml.HostProvision{
+				Script: ptr.Of("script.sh"),
+				Shell:  ptr.Of(defaultShellByHostOS),
+				HostOS: defaultHostOS,
+			},
+			wantErr: false,
+		},
+		{
+			name: "shell predefined",
+			args: args{
+				p: &limayaml.HostProvision{
+					Shell: ptr.Of(limayaml.HostProvisionShellBash),
+				},
+			},
+			want: limayaml.HostProvision{
+				Shell:  ptr.Of(limayaml.HostProvisionShellBash),
+				HostOS: &limayaml.StringArray{"darwin", "linux"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "shell custom",
+			args: args{
+				p: &limayaml.HostProvision{
+					Shell: ptr.Of("custom"),
+				},
+			},
+			want: limayaml.HostProvision{
+				Shell: ptr.Of("custom"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty",
+			args: args{
+				p: &limayaml.HostProvision{},
+			},
+			want: limayaml.HostProvision{
+				HostOS: &limayaml.StringArray{"darwin", "linux"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error",
+			args: args{
+				p: &limayaml.HostProvision{
+					Shell:  ptr.Of(limayaml.HostProvisionShellBash),
+					Script: ptr.Of("script.sh"),
+					Bash:   ptr.Of("script.sh"),
+				},
+			},
+			want:    limayaml.HostProvision{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got limayaml.HostProvision
+			err := tt.args.p.Validate(0)
+			if err == nil {
+				got, err = interpretShorthandHostProvision(tt.args.p)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("interpretShorthandHostProvision() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("interpretShorthandHostProvision() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -136,7 +136,7 @@ func defaultGuestInstallPrefix() string {
 // Both d and o may be empty.
 //
 // Maps (`Env`) are being merged: first populated from d, overwritten by y, and again overwritten by o.
-// Slices (e.g. `Mounts`, `Provision`) are appended, starting with o, followed by y, and finally d. This
+// Slices (e.g. `Mounts`, `Provision`, `HostProvision`) are appended, starting with o, followed by y, and finally d. This
 // makes sure o takes priority over y over d, in cases it matters (e.g. `PortForwards`, where the first
 // matching rule terminates the search).
 //
@@ -459,6 +459,17 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		}
 		if probe.Description == "" {
 			probe.Description = fmt.Sprintf("user probe %d/%d", i+1, len(y.Probes))
+		}
+	}
+
+	y.HostProvision = append(append(o.HostProvision, y.HostProvision...), d.HostProvision...)
+	for i := range y.HostProvision {
+		hostProvision := &y.HostProvision[i]
+		if hostProvision.Debug == nil {
+			hostProvision.Debug = ptr.Of(false)
+		}
+		if hostProvision.Wait == nil {
+			hostProvision.Wait = ptr.Of(true)
 		}
 	}
 

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -146,7 +146,11 @@ func defaultGuestInstallPrefix() string {
 //   - Networks are appended in d, y, o order
 //   - DNS are picked from the highest priority where DNS is not empty.
 //   - CACertificates Files and Certs are uniquely appended in d, y, o order
-func FillDefault(y, d, o *LimaYAML, filePath string) {
+func FillDefault(y, d, o *LimaYAML, filePath string, opts ...Opt) {
+	var opt options
+	for _, f := range opts {
+		f(&opt)
+	}
 	instDir := filepath.Dir(filePath)
 	if y.VMType == nil {
 		y.VMType = d.VMType
@@ -462,6 +466,14 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		}
 	}
 
+	if !opt.enableHostProvision && len(y.HostProvision) > 0 {
+		y.HostProvision = nil
+		logrus.Warnf("HostProvision is not enabled in %q. Use them in %q", filePath, filenames.Default)
+	}
+	if len(o.HostProvision) > 0 {
+		o.HostProvision = nil
+		logrus.Warnf("HostProvision is not supported in %q. Use them in %q", filePath, filenames.Override)
+	}
 	y.HostProvision = append(append(o.HostProvision, y.HostProvision...), d.HostProvision...)
 	for i := range y.HostProvision {
 		hostProvision := &y.HostProvision[i]

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -153,6 +153,9 @@ func TestFillDefault(t *testing.T) {
 		Probes: []Probe{
 			{Script: "#!/bin/false"},
 		},
+		HostProvision: []HostProvision{
+			{Debug: ptr.Of(true), Script: ptr.Of("true")},
+		},
 		Networks: []Network{
 			{Lima: "shared"},
 		},
@@ -233,6 +236,10 @@ func TestFillDefault(t *testing.T) {
 	expect.Probes = y.Probes
 	expect.Probes[0].Mode = ProbeModeReadiness
 	expect.Probes[0].Description = "user probe 1/1"
+
+	expect.HostProvision = y.HostProvision
+	expect.HostProvision[0].Debug = ptr.Of(true)
+	expect.HostProvision[0].Wait = ptr.Of(true)
 
 	expect.Networks = y.Networks
 	expect.Networks[0].MACAddress = MACAddress(fmt.Sprintf("%s#%d", filePath, 0))
@@ -374,6 +381,13 @@ func TestFillDefault(t *testing.T) {
 				Description: "User Probe",
 			},
 		},
+		HostProvision: []HostProvision{
+			{
+				Debug:  ptr.Of(false),
+				Script: ptr.Of("false"),
+				Wait:   ptr.Of(false),
+			},
+		},
 		Networks: []Network{
 			{
 				VNLDeprecated:        "/tmp/vde.ctl",
@@ -460,6 +474,7 @@ func TestFillDefault(t *testing.T) {
 
 	expect.Provision = append(append([]Provision{}, y.Provision...), d.Provision...)
 	expect.Probes = append(append([]Probe{}, y.Probes...), d.Probes...)
+	expect.HostProvision = append(append([]HostProvision{}, y.HostProvision...), d.HostProvision...)
 	expect.PortForwards = append(append([]PortForward{}, y.PortForwards...), d.PortForwards...)
 	expect.CopyToHost = append(append([]CopyToHost{}, y.CopyToHost...), d.CopyToHost...)
 	expect.Containerd.Archives = append(append([]File{}, y.Containerd.Archives...), d.Containerd.Archives...)
@@ -573,6 +588,13 @@ func TestFillDefault(t *testing.T) {
 				Description: "Another Probe",
 			},
 		},
+		HostProvision: []HostProvision{
+			{
+				Debug:  ptr.Of(false),
+				Script: ptr.Of("false"),
+				Wait:   ptr.Of(false),
+			},
+		},
 		Networks: []Network{
 			{
 				Lima:       "shared",
@@ -616,6 +638,7 @@ func TestFillDefault(t *testing.T) {
 
 	expect.Provision = append(append(o.Provision, y.Provision...), d.Provision...)
 	expect.Probes = append(append(o.Probes, y.Probes...), d.Probes...)
+	expect.HostProvision = append(append(o.HostProvision, y.HostProvision...), d.HostProvision...)
 	expect.PortForwards = append(append(o.PortForwards, y.PortForwards...), d.PortForwards...)
 	expect.CopyToHost = append(append(o.CopyToHost, y.CopyToHost...), d.CopyToHost...)
 	expect.Containerd.Archives = append(append(o.Containerd.Archives, y.Containerd.Archives...), d.Containerd.Archives...)

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -291,8 +291,13 @@ func TestFillDefault(t *testing.T) {
 		BinFmt:  ptr.Of(false),
 	}
 
-	FillDefault(&y, &LimaYAML{}, &LimaYAML{}, filePath)
+	yLimited := y
+	FillDefault(&y, &LimaYAML{}, &LimaYAML{}, filePath, WithEnableHostProvision())
 	assert.DeepEqual(t, &y, &expect, opts...)
+
+	expect.HostProvision = nil
+	FillDefault(&yLimited, &LimaYAML{}, &LimaYAML{}, filePath)
+	assert.DeepEqual(t, &yLimited, &expect, opts...)
 
 	filledDefaults := y
 
@@ -460,8 +465,12 @@ func TestFillDefault(t *testing.T) {
 	expect.Plain = ptr.Of(false)
 
 	y = LimaYAML{}
-	FillDefault(&y, &d, &LimaYAML{}, filePath)
+	FillDefault(&y, &d, &LimaYAML{}, filePath, WithEnableHostProvision())
 	assert.DeepEqual(t, &y, &expect, opts...)
+
+	yLimited = LimaYAML{}
+	FillDefault(&yLimited, &d, &LimaYAML{}, filePath)
+	assert.DeepEqual(t, &yLimited, &expect, opts...)
 
 	// ------------------------------------------------------------------------------------
 	// User-provided defaults should not override user-provided config values
@@ -492,8 +501,13 @@ func TestFillDefault(t *testing.T) {
 	// "TWO" does not exist in filledDefaults.Env, so is set from d.Env
 	expect.Env["TWO"] = d.Env["TWO"]
 
-	FillDefault(&y, &d, &LimaYAML{}, filePath)
+	yLimited = y
+	FillDefault(&y, &d, &LimaYAML{}, filePath, WithEnableHostProvision())
 	assert.DeepEqual(t, &y, &expect, opts...)
+
+	expect.HostProvision = d.HostProvision
+	FillDefault(&yLimited, &d, &LimaYAML{}, filePath)
+	assert.DeepEqual(t, &yLimited, &expect, opts...)
 
 	// ------------------------------------------------------------------------------------
 	// User-provided overrides should override user-provided config settings
@@ -638,7 +652,8 @@ func TestFillDefault(t *testing.T) {
 
 	expect.Provision = append(append(o.Provision, y.Provision...), d.Provision...)
 	expect.Probes = append(append(o.Probes, y.Probes...), d.Probes...)
-	expect.HostProvision = append(append(o.HostProvision, y.HostProvision...), d.HostProvision...)
+	// HostProvision is not supported in override.yaml
+	expect.HostProvision = append(append([]HostProvision{}, y.HostProvision...), d.HostProvision...)
 	expect.PortForwards = append(append(o.PortForwards, y.PortForwards...), d.PortForwards...)
 	expect.CopyToHost = append(append(o.CopyToHost, y.CopyToHost...), d.CopyToHost...)
 	expect.Containerd.Archives = append(append(o.Containerd.Archives, y.Containerd.Archives...), d.Containerd.Archives...)
@@ -685,6 +700,11 @@ func TestFillDefault(t *testing.T) {
 	}
 	expect.Plain = ptr.Of(false)
 
-	FillDefault(&y, &d, &o, filePath)
+	yLimited = y
+	FillDefault(&y, &d, &o, filePath, WithEnableHostProvision())
 	assert.DeepEqual(t, &y, &expect, opts...)
+
+	expect.HostProvision = d.HostProvision
+	FillDefault(&yLimited, &d, &o, filePath)
+	assert.DeepEqual(t, &yLimited, &expect, opts...)
 }

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -36,11 +36,12 @@ type LimaYAML struct {
 	DNS          []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`
 	HostResolver HostResolver      `yaml:"hostResolver,omitempty" json:"hostResolver,omitempty"`
 	// `useHostResolver` was deprecated in Lima v0.8.1, removed in Lima v0.14.0. Use `hostResolver.enabled` instead.
-	PropagateProxyEnv *bool          `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty"`
-	CACertificates    CACertificates `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
-	Rosetta           Rosetta        `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
-	Plain             *bool          `yaml:"plain,omitempty" json:"plain,omitempty"`
-	TimeZone          *string        `yaml:"timezone,omitempty" json:"timezone,omitempty"`
+	PropagateProxyEnv *bool           `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty"`
+	CACertificates    CACertificates  `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
+	Rosetta           Rosetta         `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
+	Plain             *bool           `yaml:"plain,omitempty" json:"plain,omitempty"`
+	TimeZone          *string         `yaml:"timezone,omitempty" json:"timezone,omitempty"`
+	HostProvision     []HostProvision `yaml:"hostProvision,omitempty" json:"hostProvision,omitempty"`
 }
 
 type (
@@ -202,6 +203,31 @@ type Probe struct {
 	Description string
 	Script      string
 	Hint        string
+}
+
+type HostProvisionShell = string
+
+const (
+	HostProvisionShellBash       HostProvisionShell = "bash"
+	HostProvisionShellSh         HostProvisionShell = "sh"
+	HostProvisionShellPwsh       HostProvisionShell = "pwsh"
+	HostProvisionShellPowerShell HostProvisionShell = "powershell"
+	HostProvisionShellCmd        HostProvisionShell = "cmd"
+)
+
+type StringArray []string
+
+type HostProvision struct {
+	Debug      *bool               `yaml:"debug,omitempty" json:"debug,omitempty"`
+	HostOS     *StringArray        `yaml:"hostOS,omitempty" json:"hostOS,omitempty"`
+	Script     *string             `yaml:"script,omitempty" json:"script,omitempty"`
+	Shell      *HostProvisionShell `yaml:"shell,omitempty" json:"shell,omitempty"` // default: see defaultHostProvisionCmd
+	Wait       *bool               `yaml:"wait,omitempty" json:"wait,omitempty"`   // default: true
+	Bash       *string             `yaml:"bash,omitempty" json:"bash,omitempty"`
+	Sh         *string             `yaml:"sh,omitempty" json:"sh,omitempty"`
+	Pwsh       *string             `yaml:"pwsh,omitempty" json:"pwsh,omitempty"`
+	PowerShell *string             `yaml:"powershell,omitempty" json:"powershell,omitempty"`
+	Cmd        *string             `yaml:"cmd,omitempty" json:"cmd,omitempty"`
 }
 
 type Proto = string

--- a/pkg/limayaml/load.go
+++ b/pkg/limayaml/load.go
@@ -79,10 +79,22 @@ func unmarshalYAML(data []byte, v interface{}, comment string) error {
 	return nil
 }
 
+type options struct {
+	enableHostProvision bool // default: false
+}
+
+type Opt func(*options)
+
+func WithEnableHostProvision() Opt {
+	return func(o *options) {
+		o.enableHostProvision = true
+	}
+}
+
 // Load loads the yaml and fulfills unspecified fields with the default values.
 //
 // Load does not validate. Use Validate for validation.
-func Load(b []byte, filePath string) (*LimaYAML, error) {
+func Load(b []byte, filePath string, opts ...Opt) (*LimaYAML, error) {
 	var y, d, o LimaYAML
 
 	if err := unmarshalYAML(b, &y, fmt.Sprintf("main file %q", filePath)); err != nil {
@@ -115,6 +127,6 @@ func Load(b []byte, filePath string) (*LimaYAML, error) {
 		return nil, err
 	}
 
-	FillDefault(&y, &d, &o, filePath)
+	FillDefault(&y, &d, &o, filePath, opts...)
 	return &y, nil
 }

--- a/pkg/limayaml/load_test.go
+++ b/pkg/limayaml/load_test.go
@@ -71,7 +71,7 @@ func TestLoadHostProvisionWithStringHostOS(t *testing.T) {
 hostProvision:
 - hostOS: linux
 `
-	y, err := Load([]byte(s), "hostprovision.yaml")
+	y, err := Load([]byte(s), "hostprovision.yaml", WithEnableHostProvision())
 	assert.NilError(t, err)
 	assert.Equal(t, len(y.HostProvision), 1)
 	assert.Assert(t, y.HostProvision[0].HostOS != nil)
@@ -83,7 +83,7 @@ func TestLoadHostProvisionWithSliceHostOS(t *testing.T) {
 hostProvision:
 - hostOS: [linux, darwin]
 `
-	y, err := Load([]byte(s), "hostprovision.yaml")
+	y, err := Load([]byte(s), "hostprovision.yaml", WithEnableHostProvision())
 	assert.NilError(t, err)
 	assert.Equal(t, len(y.HostProvision), 1)
 	assert.Assert(t, y.HostProvision[0].HostOS != nil)

--- a/pkg/limayaml/load_test.go
+++ b/pkg/limayaml/load_test.go
@@ -65,3 +65,27 @@ additionalDisks:
 	assert.Equal(t, y.AdditionalDisks[0].FSArgs[0], "-i")
 	assert.Equal(t, y.AdditionalDisks[0].FSArgs[1], "size=512")
 }
+
+func TestLoadHostProvisionWithStringHostOS(t *testing.T) {
+	s := `
+hostProvision:
+- hostOS: linux
+`
+	y, err := Load([]byte(s), "hostprovision.yaml")
+	assert.NilError(t, err)
+	assert.Equal(t, len(y.HostProvision), 1)
+	assert.Assert(t, y.HostProvision[0].HostOS != nil)
+	assert.DeepEqual(t, *y.HostProvision[0].HostOS, StringArray{"linux"})
+}
+
+func TestLoadHostProvisionWithSliceHostOS(t *testing.T) {
+	s := `
+hostProvision:
+- hostOS: [linux, darwin]
+`
+	y, err := Load([]byte(s), "hostprovision.yaml")
+	assert.NilError(t, err)
+	assert.Equal(t, len(y.HostProvision), 1)
+	assert.Assert(t, y.HostProvision[0].HostOS != nil)
+	assert.DeepEqual(t, *y.HostProvision[0].HostOS, StringArray{"linux", "darwin"})
+}


### PR DESCRIPTION
Host provisioning scripts are executed every time before starting the instance.
- the working directory is the instance directory `{{.Dir}}`
- the `runtime.GOOS` is used to determine the host OS. e.g. `darwin` for macOS, `linux` for Linux, and `windows` for Windows.
- if `wait` is true and the script exits with a non-zero status, the instance start will be aborted.

`shell` and `script` can include these template variables:
- `{{.ScriptName}}` that represents the temporary script file path.
- `{{.Index}}` that represents the index in the list of host provisioning scripts (0-based).
- template variables available in `limactl list --format` command.

🟢 Builtin default: null

e.g.
```yaml
hostProvision:
- debug: false      # change the temporary script location to {{.Dir}} and not delete it after execution. default: false
  hostOS: darwin    # string or []string. The script is executed only on the specified host OS.
  script: |         # passed to the shell as temporary file argument if exists
    xattr -w com.apple.metadata:com_apple_backup_excludeItem true {{.Dir}}/{basedisk,diffdisk}
  shell: bash       # default: null
  wait: true        # wait for the script to finish before starting the instance. default: true
```
If no shell is given, the default shell is selected based on the host OS. If the default shell is not located on the PATH, fallbacks to `sh` (when host OS is not windows) or `powershell` (when host OS is windows).

`shell` can be either:
1. Builtin / Explicitly supported keywords

| Keyword      | Command run internally                                 | Description                                    |
| ------------ | ------------------------------------------------------ | ---------------------------------------------- |
| `bash`       | `bash --noprofile --norc -eo pipefail {{.ScriptName}}` | The default shell when host OS is not windows. |
| `sh`         | `sh -e {{.ScriptName}}`                                |                                                |
| `pwsh`       | `pwsh -command ". '{{.ScriptName}}'"`                  | The default shell when host OS is windows.     |
| `powershell` | `powershell -command ". '{{.ScriptName}}'"`            |                                                |
| `cmd`        | `cmd /D /E:ON /V:OFF /S /C "CALL "{{.ScriptName}}""`   |                                                |

2. Template string: `command [...options] {{.ScriptName}} [...more_options]` `{{.ScriptName}}` is replaced with the temporary script file path

there are shorthand forms for the builtin shells:
```yaml
- bash: echo "executed by bash"                    # interpreted as {shell: bash, hostOS: [darwin, linux], script: ...}
- sh: echo "executed by sh"                        # interpreted as {shell: sh, hostOS: [darwin, linux], script: ...}
- pwsh: Write-Host "executed by pwsh"              # interpreted as {shell: pwsh, hostOS: [windows], script: ...}
- powershell: Write-Host "executed by powershell"  # interpreted as {shell: powershell, hostOS: [windows], script: ...}
- cmd: echo "executed by cmd"                      # interpreted as {shell: cmd, hostOS: [windows], script: ...}
```

e.g.
```yaml
- bash: | # Post a notification when an error by the hostProvision script is detected
    jq=/opt/homebrew/bin/jq && test -x $jq || exit 0
    tail -n0 -F ha.stderr.log | while read -r line; do
      msg=$(echo "$line"|$jq -er '
        select(.hostProvision and .hostProvision != {{.Index}})| # select log lines from other hostProvision scripts
        select(.level == "error")|                               # select error log lines
        .msg
      ') || continue
      osascript -e "on run argv" -e "display notification (item 1 of argv) with title \"Lima\"" -e "end run" "$msg"
      echo Posted a notification
    done
  debug: false
  hostOS: darwin
  wait: false
```

This PR is an alternative solution to #2159.