### PR TITLE
Use `(*os.File).Write()` instead of `os.WriteFile()`

### DIFF
--- a/pkg/editutil/editutil.go
+++ b/pkg/editutil/editutil.go
@@ -63,9 +63,10 @@ func OpenEditor(content []byte, hdr string) ([]byte, error) {
 	}
 	tmpYAMLPath := tmpYAMLFile.Name()
 	defer os.RemoveAll(tmpYAMLPath)
-	if err := os.WriteFile(tmpYAMLPath,
-		append([]byte(hdr), content...),
-		0o600); err != nil {
+	if _, err := tmpYAMLFile.Write(append([]byte(hdr), content...)); err != nil {
+		return nil, err
+	}
+	if err := tmpYAMLFile.Close(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/yqutil/yqutil.go
+++ b/pkg/yqutil/yqutil.go
@@ -20,8 +20,11 @@ func EvaluateExpression(expression string, content []byte) ([]byte, error) {
 	}
 	tmpYAMLPath := tmpYAMLFile.Name()
 	defer os.RemoveAll(tmpYAMLPath)
-	err = os.WriteFile(tmpYAMLPath, content, 0o600)
+	_, err = tmpYAMLFile.Write(content)
 	if err != nil {
+		return nil, err
+	}
+	if err = tmpYAMLFile.Close(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
When `os.WriteFile()` writes to an existing file, it does not apply the permissions passed as parameter. The desired permissions have already been set by `os.CreateTemp()`, so to avoid confusion, it should be changed to a writing method that does not specify permissions.