### PR TITLE
Fix double quotes in ssh keys

### DIFF
--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -177,7 +177,7 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 		return errors.New("no SSH key was found, run `ssh-keygen`")
 	}
 	for _, f := range pubKeys {
-		args.SSHPubKeys = append(args.SSHPubKeys, f.Content)
+		args.SSHPubKeys = append(args.SSHPubKeys, strconv.Quote(f.Content))
 	}
 
 	var fstype string


### PR DESCRIPTION
Fixes #2192 

Other potential fix is to use yaml block instead of string in the user-data template

e.x:

```yaml
ssh_keys:
  - |
    ssh-key "me@email.com"
  - |
    ssh-key2 "me@email2.com"
```