### PR TITLE
Escape double quotes in ssh keys in user-data

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -32,9 +32,9 @@ users:
     sudo: ALL=(ALL) NOPASSWD:ALL
     lock_passwd: true
     ssh-authorized-keys:
-    {{- range $val := .SSHPubKeys}}
-      - "{{$val}}"
-    {{- end}}
+    {{- range $val := .SSHPubKeys }}
+      - {{ printf "%q" $val }}
+    {{- end }}
 
 write_files:
  - content: |


### PR DESCRIPTION
Escape double quotes in ssh public keys i.e `ssh-key "email"` converts to 

```yaml
ssh-keys:
  - "ssh-key \"email\""
```
Fixes #2192 