### PR TITLE
fix: COLORTERM quoting on Windows

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -180,7 +180,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	}
 	if _, present := os.LookupEnv("COLORTERM"); present {
 		// SendEnv config is cumulative, with already existing options in ssh_config
-		sshArgs = append(sshArgs, "-o", "SendEnv=\"COLORTERM\"")
+		sshArgs = append(sshArgs, "-o", "SendEnv=COLORTERM")
 	}
 	sshArgs = append(sshArgs, []string{
 		"-q",


### PR DESCRIPTION
On Windows, when `COLORTERM` is set, you'll get an error like this when trying to run any Lima command. exit status `255` with stderr:

```
command-line line 0: invalid quotes
```

This is an issue because some programs (like VSCode's integrated terminal) set `COLORTERM` by default.

I tracked this down to the quoting of `COLORTERM` in the `SendEnv` SSH option. The input to `SendEnv` doesn't even technically need to be quoted, but following the conventions already in the file, I just put it in single quotes instead, and it still works as expected.

---

Also, out of scope for this PR, but [the way we're adding COLORTERM to the sshd's `AcceptEnv`](https://github.com/lima-vm/lima/blob/88c89165273d87b33753a593af867b20c1d1c67d/pkg/cidata/cidata.TEMPLATE.d/boot/11-colorterm-environment.sh#L15) is broken on some modern distro's (like Fedora) because they don't ship an `/etc/ssh/sshd_config` with `AcceptEnv` in it at all.

I can make an issue or PR for this separately.

