### PR TITLE
fix: guestagent port forwarding behavior on wsl2

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -510,13 +510,7 @@ sudo chown -R "${USER}" /run/host-services`
 		case <-a.guestAgentAliveCh:
 			// NOP
 		case <-time.After(time.Minute):
-			err := errors.New("guest agent does not seem to be running; port forwards will not work")
-			if *a.y.VMType == limayaml.WSL2 {
-				// geustagent is currently not available for WSL2: https://github.com/lima-vm/lima/issues/2025
-				logrus.Warn(err)
-			} else {
-				errs = append(errs, err)
-			}
+			errs = append(errs, errors.New("guest agent does not seem to be running; port forwards will not work"))
 		}
 	}
 	if err := a.waitForRequirements("final", a.finalRequirements()); err != nil {
@@ -660,7 +654,7 @@ func (a *HostAgent) processGuestAgentEvents(ctx context.Context, client *guestag
 		for _, f := range ev.Errors {
 			logrus.Warnf("received error from the guest: %q", f)
 		}
-		a.portForwarder.OnEvent(ctx, ev, a.instSSHAddress)
+		a.portForwarder.OnEvent(ctx, ev)
 	}
 
 	if err := client.Events(ctx, onEvent); err != nil {


### PR DESCRIPTION
The recent change to make the guestagent use grpc broke some special-cased behavior for port forwarding on WSL2.

Turns out the special-casing is unnecessary though, so I just removed it.

<details>
<summary>Example</summary>

We'll host a server, and show that the Lima logs are correct, and that it's accessible from the host system.

  <details>

  <summary>Host a server on port 8080</summary>

  ```
  nerdctl.lima run --rm -p 8080:80 nginx:latest
  /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
  /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
  /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
  10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
  10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
  /docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
  /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
  /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
  /docker-entrypoint.sh: Configuration complete; ready for start up
  2024/02/16 22:56:32 [notice] 1#1: using the "epoll" event method
  2024/02/16 22:56:32 [notice] 1#1: nginx/1.25.4
  2024/02/16 22:56:32 [notice] 1#1: built by gcc 12.2.0 (Debian 12.2.0-14)
  2024/02/16 22:56:32 [notice] 1#1: OS: Linux 5.15.146.1-microsoft-standard-WSL2
  2024/02/16 22:56:32 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1073741816:1073741816
  2024/02/16 22:56:32 [notice] 1#1: start worker processes
  2024/02/16 22:56:32 [notice] 1#1: start worker process 29
  2024/02/16 22:56:32 [notice] 1#1: start worker process 30
  2024/02/16 22:56:32 [notice] 1#1: start worker process 31
  2024/02/16 22:56:32 [notice] 1#1: start worker process 32
  2024/02/16 22:56:32 [notice] 1#1: start worker process 33
  2024/02/16 22:56:32 [notice] 1#1: start worker process 34
  2024/02/16 22:56:32 [notice] 1#1: start worker process 35
  2024/02/16 22:56:32 [notice] 1#1: start worker process 36
  2024/02/16 22:56:32 [notice] 1#1: start worker process 37
  2024/02/16 22:56:32 [notice] 1#1: start worker process 38
  2024/02/16 22:56:32 [notice] 1#1: start worker process 39
  2024/02/16 22:56:32 [notice] 1#1: start worker process 40
  2024/02/16 22:56:32 [notice] 1#1: start worker process 41
  2024/02/16 22:56:32 [notice] 1#1: start worker process 42
  2024/02/16 22:56:32 [notice] 1#1: start worker process 43
  2024/02/16 22:56:32 [notice] 1#1: start worker process 44
  2024/02/16 22:56:32 [notice] 1#1: start worker process 45
  2024/02/16 22:56:32 [notice] 1#1: start worker process 46
  2024/02/16 22:56:32 [notice] 1#1: start worker process 47
  2024/02/16 22:56:32 [notice] 1#1: start worker process 48
  2024/02/16 22:56:32 [notice] 1#1: start worker process 49
  2024/02/16 22:56:32 [notice] 1#1: start worker process 50
  2024/02/16 22:56:32 [notice] 1#1: start worker process 51
  2024/02/16 22:56:32 [notice] 1#1: start worker process 52
  2024/02/16 22:56:32 [notice] 1#1: start worker process 53
  2024/02/16 22:56:32 [notice] 1#1: start worker process 54
  2024/02/16 22:56:32 [notice] 1#1: start worker process 55
  2024/02/16 22:56:32 [notice] 1#1: start worker process 56
  2024/02/16 22:56:32 [notice] 1#1: start worker process 57
  2024/02/16 22:56:32 [notice] 1#1: start worker process 58
  2024/02/16 22:56:32 [notice] 1#1: start worker process 59
  2024/02/16 22:56:32 [notice] 1#1: start worker process 60
  2024/02/16 22:56:32 [notice] 1#1: start worker process 61
  2024/02/16 22:56:32 [notice] 1#1: start worker process 62
  2024/02/16 22:56:32 [notice] 1#1: start worker process 63
  2024/02/16 22:56:32 [notice] 1#1: start worker process 64
  2024/02/16 22:56:32 [notice] 1#1: start worker process 65
  2024/02/16 22:56:32 [notice] 1#1: start worker process 66
  2024/02/16 22:56:32 [notice] 1#1: start worker process 67
  2024/02/16 22:56:32 [notice] 1#1: start worker process 68
  2024/02/16 22:56:32 [notice] 1#1: start worker process 69
  2024/02/16 22:56:32 [notice] 1#1: start worker process 70
  2024/02/16 22:56:32 [notice] 1#1: start worker process 71
  2024/02/16 22:56:32 [notice] 1#1: start worker process 72
  2024/02/16 22:56:32 [notice] 1#1: start worker process 73
  2024/02/16 22:56:32 [notice] 1#1: start worker process 74
  2024/02/16 22:56:32 [notice] 1#1: start worker process 75
  2024/02/16 22:56:32 [notice] 1#1: start worker process 76
  10.4.0.1 - - [16/Feb/2024:22:56:48 +0000] "GET / HTTP/1.1" 200 615 "-" "curl/8.0.1" "-"
  10.4.0.1 - - [16/Feb/2024:22:56:58 +0000] "GET / HTTP/1.1" 200 615 "-" "curl/8.4.0" "-"
  ```

  </details>

  <details>

  <summary>Lima logs (<code>ha.stderr.log</code>, truncated)</summary>

  ```json
  ...
  {"level":"debug","msg":"guest agent event: {Time:2024-02-16 17:33:01.337334017 -0500 EST LocalPortsAdded:[{IP:0.0.0.0 Port:8080}] LocalPortsRemoved:[] Errors:[]}","time":"2024-02-16T17:33:01-05:00"}
  {"level":"info","msg":"Forwarding TCP from 0.0.0.0:8080 to 127.0.0.1:8080","time":"2024-02-16T17:33:01-05:00"}
  {"level":"debug","msg":"guest agent event: {Time:2024-02-16 17:33:58.338057783 -0500 EST LocalPortsAdded:[] LocalPortsRemoved:[{IP:0.0.0.0 Port:8080}] Errors:[]}","time":"2024-02-16T17:33:58-05:00"}
  {"level":"info","msg":"Stopping forwarding TCP from 0.0.0.0:8080 to 127.0.0.1:8080","time":"2024-02-16T17:33:58-05:00"}
  ...
  ```

  </details>

  <details>

  <summary>Access from the host</summary>

  ```shell
  PS> curl http://localhost:8080
  <!DOCTYPE html>
  <html>
  <head>
  <title>Welcome to nginx!</title>
  <style>
  html { color-scheme: light dark; }
  body { width: 35em; margin: 0 auto;
  font-family: Tahoma, Verdana, Arial, sans-serif; }
  </style>
  </head>
  <body>
  <h1>Welcome to nginx!</h1>
  <p>If you see this page, the nginx web server is successfully installed and
  working. Further configuration is required.</p>

  <p>For online documentation and support please refer to
  <a href="http://nginx.org/">nginx.org</a>.<br/>
  Commercial support is available at
  <a href="http://nginx.com/">nginx.com</a>.</p>

  <p><em>Thank you for using nginx.</em></p>
  </body>
  </html>
  ```

  </details>

</details>