### PR TITLE
Update Guest Agent error message

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -598,12 +598,12 @@ func (a *HostAgent) watchGuestAgentEvents(ctx context.Context) {
 		if err == nil {
 			if err := a.processGuestAgentEvents(ctx, client); err != nil {
 				if !errors.Is(err, context.Canceled) {
-					logrus.WithError(err).Warn("guest agent events closed unexpectedly", err)
+					logrus.WithError(err).Warn("guest agent events closed unexpectedly: ", err)
 				}
 			}
 		} else {
 			if !errors.Is(err, context.Canceled) {
-				logrus.WithError(err).Warn("connection to the guest agent was closed unexpectedly", err)
+				logrus.WithError(err).Warn("connection to the guest agent was closed unexpectedly: ", err)
 			}
 		}
 		select {


### PR DESCRIPTION
Updated Guest Agent error message to include a colon & space before the actual error message is written out to make it more readable.

**Before**
> WARN[0073] [hostagent] connection to the guest agent was closed **unexpectedlydial** unix /home/drasey/.lima/fedora-rawhide/ga.sock: connect: no such file or directory

**After**
> WARN[0073] [hostagent] connection to the guest agent was closed unexpectedly: dial unix /home/drasey/.lima/fedora-rawhide/ga.sock: connect: no such file or directory 

