### PR TITLE
Enable protogetter linter and fix up issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,7 @@ linters:
   # - nlreturn
   - noctx
   - nolintlint
+  - protogetter
   # - rowserrcheck
   # - scopelint
   # - sqlclosecheck

--- a/pkg/guestagent/api/ipport.go
+++ b/pkg/guestagent/api/ipport.go
@@ -6,5 +6,5 @@ import (
 )
 
 func (x *IPPort) HostString() string {
-	return net.JoinHostPort(x.Ip, strconv.Itoa(int(x.Port)))
+	return net.JoinHostPort(x.GetIp(), strconv.Itoa(int(x.GetPort())))
 }

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -654,7 +654,7 @@ func (a *HostAgent) processGuestAgentEvents(ctx context.Context, client *guestag
 
 	onEvent := func(ev *guestagentapi.Event) {
 		logrus.Debugf("guest agent event: %+v", ev)
-		for _, f := range ev.Errors {
+		for _, f := range ev.GetErrors() {
 			logrus.Warnf("received error from the guest: %q", f)
 		}
 		a.portForwarder.OnEvent(ctx, ev)


### PR DESCRIPTION
The PR enables [`protogetter`](https://golangci-lint.run/usage/linters/#protogetter) linter and addresses lint issues.

This linter is designed to aid developers in preventing `invalid memory address or nil pointer dereference` errors arising from direct access to nested `protobuf` fields.
