### PR TITLE
Propagate all logging fields to the tty logger

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -598,12 +598,12 @@ func (a *HostAgent) watchGuestAgentEvents(ctx context.Context) {
 		if err == nil {
 			if err := a.processGuestAgentEvents(ctx, client); err != nil {
 				if !errors.Is(err, context.Canceled) {
-					logrus.WithError(err).Warn("guest agent events closed unexpectedly", err)
+					logrus.WithError(err).Warn("guest agent events closed unexpectedly")
 				}
 			}
 		} else {
 			if !errors.Is(err, context.Canceled) {
-				logrus.WithError(err).Warn("connection to the guest agent was closed unexpectedly", err)
+				logrus.WithError(err).Warn("connection to the guest agent was closed unexpectedly")
 			}
 		}
 		select {

--- a/pkg/logrusutil/logrusutil.go
+++ b/pkg/logrusutil/logrusutil.go
@@ -19,10 +19,14 @@ func PropagateJSON(logger *logrus.Logger, jsonLine []byte, header string, begin 
 	}
 
 	var (
-		lv  logrus.Level
-		j   JSON
-		err error
+		entry  *logrus.Entry
+		fields logrus.Fields
+		lv     logrus.Level
+		j      JSON
+		err    error
 	)
+	entry = logrus.NewEntry(logger)
+
 	if err := json.Unmarshal(jsonLine, &j); err != nil {
 		goto fallback
 	}
@@ -33,24 +37,26 @@ func PropagateJSON(logger *logrus.Logger, jsonLine []byte, header string, begin 
 	if err != nil {
 		goto fallback
 	}
-	switch lv {
-	case logrus.PanicLevel, logrus.FatalLevel:
-		logger.WithField("level", lv).Error(header + j.Msg)
-	case logrus.ErrorLevel:
-		logger.Error(header + j.Msg)
-	case logrus.WarnLevel:
-		logger.Warn(header + j.Msg)
-	case logrus.InfoLevel:
-		logger.Info(header + j.Msg)
-	case logrus.DebugLevel:
-		logger.Debug(header + j.Msg)
-	case logrus.TraceLevel:
-		logger.Trace(header + j.Msg)
+	entry = entry.WithTime(j.Time)
+	// Unmarshal jsonLine once more to capture all the "extra" fields that have been added by
+	// WithError() and WithField(). The regular fields "level", "msg", and "time" are already
+	// unmarshalled into j and are handled specially. They must not be added again.
+	if err := json.Unmarshal(jsonLine, &fields); err == nil {
+		delete(fields, "level")
+		delete(fields, "msg")
+		delete(fields, "time")
+		entry = entry.WithFields(fields)
 	}
+	// Don't exit on Fatal or Panic entries
+	if lv <= logrus.FatalLevel {
+		entry = entry.WithField("level", lv)
+		lv = logrus.ErrorLevel
+	}
+	entry.Log(lv, header+j.Msg)
 	return
 
 fallback:
-	logger.Info(header + string(jsonLine))
+	entry.Info(header + string(jsonLine))
 }
 
 // JSON is the type used in logrus.JSONFormatter

--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -324,7 +324,11 @@ func (l *LimaQemuDriver) shutdownQEMU(ctx context.Context, timeout time.Duration
 	deadline := time.After(timeout)
 	select {
 	case qWaitErr := <-qWaitCh:
-		logrus.WithError(qWaitErr).Info("QEMU has exited")
+		entry := logrus.NewEntry(logrus.StandardLogger())
+		if qWaitErr != nil {
+			entry = entry.WithError(qWaitErr)
+		}
+		entry.Info("QEMU has exited")
 		_ = l.removeVNCFiles()
 		return errors.Join(qWaitErr, l.killVhosts())
 	case <-deadline:


### PR DESCRIPTION
The fields are serialized in JSON by the hostagent and then printed by the `limactl start` command to the console, so need to be explicitly added back to the logger entry.

This PR is in response to https://github.com/lima-vm/lima/pull/2228#discussion_r1513910877.

Note that nested structures (like `events.Event`) will be flattened by the standard logger, e.g.

```golang
       err := errors.New("oops")
       ev := events.Event{
               Status: events.Status{
                       Running: true,
                       Errors:  []string{"Error one", "Error two"},
               },
       }
       logrus.WithError(err).WithField("events", ev).Warn("Log message with error")
```

will result in

```console
WARN[0020] [hostagent] Log message with error            error=oops events="map[status:map[errors:[Error one Error two] running:true] time:0001-01-01T00:00:00Z]"
```
<img width="999" alt="CleanShot 2024-03-06 at 00 26 57@2x" src="https://github.com/lima-vm/lima/assets/78947/c5711b2f-4a87-41a0-a388-fc108bc6d989">

The change to `qemu_driver.go` is needed to avoid the ugly `<nil>` error in

```
INFO[0004] [hostagent] QEMU has exited                   error="<nil>"
```

@balajiv113 Your inotify PR has additional logging entries with duplicate `err` which should be changed if this PR is accepted/merged:

```
pkg/hostagent/hostagent.go
604:				logrus.WithError(err).Warn("failed to start inotify", err)

pkg/hostagent/inotify.go
52:				logrus.WithError(err).Warn("failed to send inotify", err)
```