### PR TITLE
Change deprecated cloud-init key ca-certs → ca_certs

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -64,7 +64,7 @@ resolv_conf:
 {{- end }}
 
 {{ with .CACerts }}
-ca-certs:
+ca_certs:
   remove_defaults: {{ .RemoveDefaults }}
   trusted:
   {{- range $cert := .Trusted }}


### PR DESCRIPTION
> Deprecated in version 22.3. Use ``ca_certs`` instead.

https://cloudinit.readthedocs.io/en/latest/reference/modules.html#ca-certificates