### PR TITLE
Bump alpine-lima image from 0.2.35 → 0.2.37

### DIFF
--- a/examples/alpine.yaml
+++ b/examples/alpine.yaml
@@ -2,12 +2,12 @@
 # Using the Alpine 3.19 aarch64 image with vmType=vz requires macOS Ventura 13.3 or later.
 
 images:
-- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.35/alpine-lima-std-3.19.0-x86_64.iso"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.37/alpine-lima-std-3.19.0-x86_64.iso"
   arch: "x86_64"
-  digest: "sha512:e02599dc7fc4dc279d66d800f6edc68f6f112c4b370d4c74f43040214c53b23ae4c903ce56c7083fd56d5027ec33711d30d1c2e71836c60dc3bf639f76d4fa0e"
-- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.35/alpine-lima-std-3.19.0-aarch64.iso"
+  digest: "sha512:568852df405e6b9858e678171a9894c058f483df0b0570c22cf33fc75f349ba6cc5bb3d50188180d8c31faaf53400fe884ca3e5f949961b03b2bf53e65de88d7"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.37/alpine-lima-std-3.19.0-aarch64.iso"
   arch: "aarch64"
-  digest: "sha512:13e50601ee65af5d7a6dfd30bb41fd89f8bf806ecdb516c61fe238c3cf3b57cf67469418a99f329bb4c343e3387e6e0fd4fe20501cfd501f031f7244adc67215"
+  digest: "sha512:3a4bd5ad0201f503e9bb9f3b812aa0df292e2e099148c0323d23244046ad199a2946ef9e0619fec28726bfdcc528233f43c3b4b036c9e06e92ac730d579f0ca3"
 
 mounts:
 - location: "~"


### PR DESCRIPTION
* Fix parsing ssh keys as block string
* Create a mount script instead of editing /etc/fstab
* Make lima-init.sh yaml parsing more robust