### PR TITLE
Remove dependency on github.com/lithammer/dedent

### DIFF
--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cheggaaa/pb/v3/termutil"
 	"github.com/lima-vm/lima/pkg/store"
-	"github.com/lithammer/dedent"
 	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -38,17 +37,17 @@ func newListCommand() *cobra.Command {
 		Use:     "list [flags] [INSTANCE]...",
 		Aliases: []string{"ls"},
 		Short:   "List instances of Lima.",
-		Long: "List instances of Lima.\n" + dedent.Dedent(`
-		The output can be presented in one of several formats, using the --format <format> flag.
+		Long: `List instances of Lima.
 
-		  --format json  - output in json format
-		  --format yaml  - output in yaml format
-		  --format table - output in table format
-		  --format '{{ <go template> }}' - if the format begins and ends with '{{ }}', then it is used as a go template.
-`) + store.FormatHelp + dedent.Dedent(`
-		The following legacy flags continue to function:
-		  --json - equal to '--format json'
-		`),
+The output can be presented in one of several formats, using the --format <format> flag.
+
+  --format json  - output in json format
+  --format yaml  - output in yaml format
+  --format table - output in table format
+  --format '{{ <go template> }}' - if the format begins and ends with '{{ }}', then it is used as a go template.
+` + store.FormatHelp + `
+The following legacy flags continue to function:
+  --json - equal to '--format json'`,
 		Args:              WrapArgsError(cobra.ArbitraryArgs),
 		RunE:              listAction,
 		ValidArgsFunction: listBashComplete,

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/lima-vm/go-qcow2reader v0.1.1
 	github.com/lima-vm/sshocker v0.3.4
-	github.com/lithammer/dedent v1.1.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mdlayher/vsock v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,6 @@ github.com/lima-vm/sshocker v0.3.4 h1:5rn6vMkfqwZSZiBW+Udo505OIRhPB4xbLUDdEnFgWw
 github.com/lima-vm/sshocker v0.3.4/go.mod h1:QT4c7XNmeQTv79h5/8EgiS7U51B9BLenlXV7idCY0tE=
 github.com/linuxkit/virtsock v0.0.0-20220523201153-1a23e78aa7a2 h1:DZMFueDbfz6PNc1GwDRA8+6lBx1TB9UnxDQliCqR73Y=
 github.com/linuxkit/virtsock v0.0.0-20220523201153-1a23e78aa7a2/go.mod h1:SWzULI85WerrFt3u+nIm5F9l7EvxZTKQvd0InF3nmgM=
-github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
-github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=


### PR DESCRIPTION
This PR removes `github.com/lithammer/dedent` dependency which is used only for the `limactl list` command. It's not worth to import the whole package for the one function [dedent#Dedent](https://pkg.go.dev/github.com/lithammer/dedent#Dedent).

The output of the `limactl list -h` is not changed.

<details><summary>Running `limactl list -h` before the PR changes:</summary>

```
> make _output/bin/limactl && _output/bin/limactl list -h
...
List instances of Lima.

The output can be presented in one of several formats, using the --format <format> flag.

  --format json  - output in json format
  --format yaml  - output in yaml format
  --format table - output in table format
  --format '{{ <go template> }}' - if the format begins and ends with '{{ }}', then it is used as a go template.

These functions are available to go templates:

  indent <size>: add spaces to beginning of each line
  missing <message>: return message if the text is empty

The following legacy flags continue to function:
  --json - equal to '--format json'
...
```

</details> 
<details><summary>Running `limactl list -h` with this PR changes:</summary>

```
> make _output/bin/limactl && _output/bin/limactl list -h
...
List instances of Lima.

The output can be presented in one of several formats, using the --format <format> flag.

  --format json  - output in json format
  --format yaml  - output in yaml format
  --format table - output in table format
  --format '{{ <go template> }}' - if the format begins and ends with '{{ }}', then it is used as a go template.

These functions are available to go templates:

  indent <size>: add spaces to beginning of each line
  missing <message>: return message if the text is empty

The following legacy flags continue to function:
  --json - equal to '--format json'
...
```

</details> 