### PR TITLE
Remove redundant err from logrus that already uses WithError(err)

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -598,7 +598,7 @@ func (a *HostAgent) watchGuestAgentEvents(ctx context.Context) {
 			}
 			err := a.startInotify(ctx)
 			if err != nil {
-				logrus.WithError(err).Warn("failed to start inotify", err)
+				logrus.WithError(err).Warn("failed to start inotify")
 			}
 		}
 	}()


### PR DESCRIPTION
Sorry for the trivial PR; just something I noticed while cleaning up.