### PR TITLE
Adjust Guestagent OOM Parameters

### DIFF
--- a/cmd/lima-guestagent/lima-guestagent.TEMPLATE.service
+++ b/cmd/lima-guestagent/lima-guestagent.TEMPLATE.service
@@ -5,6 +5,8 @@ Description=lima-guestagent
 ExecStart={{.Binary}} daemon {{.Args}}
 Type=simple
 Restart=on-failure
+OOMPolicy=continue
+OOMScoreAdjust=-500
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I've been having issues with the guest agent being OOM killed in my vm. Changing these OOM parameters has helped with stability and I haven't seen this issue so far. Though, as a disclaimer I don't have experience with systemd so I don't know if this is the right thing to do. I've basically copied this pattern from what the docker daemon does.

Related to #2045 