### PR TITLE
docs/config: fix broken links

### DIFF
--- a/website/content/en/docs/Config/Mount/_index.md
+++ b/website/content/en/docs/Config/Mount/_index.md
@@ -134,7 +134,7 @@ mounts:
 {{< /tabpane >}}
 
 #### Caveats
-- For macOS, the "virtiofs" mount type is supported only on macOS 13 or above with `vmType: vz` config. See also [`vmtype.md`](./vmtype.md).
+- For macOS, the "virtiofs" mount type is supported only on macOS 13 or above with `vmType: vz` config. See also [`vmtype`](../vmtype/).
 - For Linux, the "virtiofs" mount type requires the [Rust version of virtiofsd](https://gitlab.com/virtio-fs/virtiofsd).
   Using the version from QEMU (usually packaged as `qemu-virtiofsd`) will *not* work, as it requires root access to run.
 

--- a/website/content/en/docs/Config/Multi-arch/_index.md
+++ b/website/content/en/docs/Config/Multi-arch/_index.md
@@ -69,7 +69,7 @@ See also https://github.com/containerd/nerdctl/blob/master/docs/multi-platform.m
 |-------------------|----------------------------------|
 
 [Rosetta](https://developer.apple.com/documentation/virtualization/running_intel_binaries_in_linux_vms_with_rosetta) is known to be much faster than QEMU User Mode Emulation.
-Rosetta is available for [VZ](./vmtype.md) instances on ARM hosts.
+Rosetta is available for [VZ](../vmtype/#vz) instances on ARM hosts.
 
 {{< tabpane text=true >}}
 {{% tab header="CLI" %}}

--- a/website/content/en/docs/Config/Network/_index.md
+++ b/website/content/en/docs/Config/Network/_index.md
@@ -190,7 +190,7 @@ networks:
 | ⚡ Requirement | Lima >= 0.14, macOS >= 13.0 |
 |-------------------|-----------------------------|
 
-For [VZ](./vmtype.md) instances, the "vzNAT" network can be configured as follows:
+For [VZ](../vmtype/#vz) instances, the "vzNAT" network can be configured as follows:
 {{< tabpane text=true >}}
 {{% tab header="CLI" %}}
 ```bash

--- a/website/content/en/docs/Config/VMType/_index.md
+++ b/website/content/en/docs/Config/VMType/_index.md
@@ -106,7 +106,7 @@ containerd:
 - "wsl2" option is only supported on newer versions of Windows (roughly anything since 2019)
 
 ### Known Issues
-- "wsl2" currently doesn't support many of Lima's options. See [this file](../pkg/wsl2/wsl_driver_windows.go#35) for the latest supported options.
+- "wsl2" currently doesn't support many of Lima's options. See [this file](https://github.com/lima-vm/lima/blob/master/pkg/wsl2/wsl_driver_windows.go#L19) for the latest supported options.
 - When running lima using "wsl2", `${LIMA_HOME}/<INSTANCE>/serial.log` will not contain kernel boot logs
 - WSL2 requires a `tar` formatted rootfs archive instead of a VM image
 - Windows doesn't ship with ssh.exe, gzip.exe, etc. which are used by Lima at various points. The easiest way around this is to run `winget install -e --id Git.MinGit` (winget is now built in to Windows as well), and add the resulting `C:\Program Files\Git\usr\bin\` directory to your path.


### PR DESCRIPTION
The PR fixes broken URLs on https://lima-vm.io/

Broken links found by the [linkchecker](https://linkchecker.github.io/linkchecker/).

<details>
<summary>linkchecker output</summary>

```
❯ linkchecker --no-warnings https://lima-vm.io/
INFO linkcheck.cmdline 2024-03-15 22:57:21,456 MainThread Checking intern URLs only; use --check-extern to check extern URLs.
LinkChecker 10.4.0
Copyright (C) 2000-2016 Bastian Kleineidam, 2010-2023 LinkChecker Authors
LinkChecker comes with ABSOLUTELY NO WARRANTY!
This is free software, and you are welcome to redistribute it under
certain conditions. Look at the file `COPYING' within this distribution.
Read the documentation at https://linkchecker.github.io/linkchecker/
Write comments and bugs to https://github.com/linkchecker/linkchecker/issues

Start checking at 2024-03-15 22:57:21+003
10 threads active,    17 links queued,   16 links in  43 URLs checked, runtime 1 seconds
10 threads active,    62 links queued,   69 links in 141 URLs checked, runtime 6 seconds
10 threads active,    49 links queued,  102 links in 161 URLs checked, runtime 11 seconds
10 threads active,    47 links queued,  201 links in 258 URLs checked, runtime 16 seconds
10 threads active,    59 links queued,  261 links in 330 URLs checked, runtime 21 seconds
10 threads active,    54 links queued,  334 links in 398 URLs checked, runtime 26 seconds
10 threads active,    62 links queued,  449 links in 521 URLs checked, runtime 31 seconds
10 threads active,    48 links queued,  463 links in 521 URLs checked, runtime 36 seconds
10 threads active,    35 links queued,  476 links in 521 URLs checked, runtime 41 seconds
10 threads active,    21 links queued,  490 links in 521 URLs checked, runtime 46 seconds

URL        `../pkg/wsl2/wsl_driver_windows.go#35'
Name       `this file'
Parent URL https://lima-vm.io/docs/config/vmtype/, line 99, col 338
Real URL   https://lima-vm.io/docs/config/pkg/wsl2/wsl_driver_windows.go#35
Check time 3.611 seconds
Result     Error: 404 Not Found

URL        `./vmtype.md'
Name       `VZ'
Parent URL https://lima-vm.io/docs/config/multi-arch/, line 85, col 26
Real URL   https://lima-vm.io/docs/config/multi-arch/vmtype.md
Check time 2.830 seconds
Result     Error: 404 Not Found

URL        `./vmtype.md'
Name       `VZ'
Parent URL https://lima-vm.io/docs/config/network/, line 136, col 159
Real URL   https://lima-vm.io/docs/config/network/vmtype.md
Check time 2.375 seconds
Result     Error: 404 Not Found

URL        `./vmtype.md'
Name       `vmtype.md'
Parent URL https://lima-vm.io/docs/config/mount/, line 118, col 228
Real URL   https://lima-vm.io/docs/config/mount/vmtype.md
Check time 2.414 seconds
Result     Error: 404 Not Found
10 threads active,     4 links queued,  507 links in 521 URLs checked, runtime 51 seconds

Statistics:
Downloaded: 4.38MB.
Content types: 18 image, 117 text, 0 video, 0 audio, 24 application, 0 mail and 362 other.
URL lengths: min=15, max=1053, avg=168.

That's it. 521 links in 521 URLs checked. 0 warnings found (39 ignored or duplicates not printed). 4 errors found.
Stopped checking at 2024-03-15 22:58:17+003 (56 seconds)
```

</details>