### PR TITLE
fix copySparse for empty qcow2 disk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,10 @@ jobs:
         # For non-Homebrew we have to support an old release of Go
         go-version: ["1.21.x", "1.22.x"]
     steps:
+    - name: Install test dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends qemu-utils
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1

--- a/pkg/nativeimgutil/nativeimgutil_test.go
+++ b/pkg/nativeimgutil/nativeimgutil_test.go
@@ -1,0 +1,85 @@
+package nativeimgutil
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func createImg(name, format, size string) error {
+	return exec.Command("qemu-img", "create", name, "-f", format, size).Run()
+}
+
+func TestConvertToRaw(t *testing.T) {
+	_, err := exec.LookPath("qemu-img")
+	if err != nil {
+		t.Skipf("qemu-img does not seem installed: %v", err)
+	}
+	tmpDir := t.TempDir()
+
+	qcowImage, err := os.Create(filepath.Join(tmpDir, "qcow.img"))
+	assert.NilError(t, err)
+	defer qcowImage.Close()
+	err = createImg(qcowImage.Name(), "qcow2", "1M")
+	assert.NilError(t, err)
+
+	rawImage, err := os.Create(filepath.Join(tmpDir, "raw.img"))
+	assert.NilError(t, err)
+	defer rawImage.Close()
+	err = createImg(rawImage.Name(), "raw", "1M")
+	assert.NilError(t, err)
+
+	rawImageExtended, err := os.Create(filepath.Join(tmpDir, "raw_extended.img"))
+	assert.NilError(t, err)
+	defer rawImageExtended.Close()
+	err = createImg(rawImageExtended.Name(), "raw", "2M")
+	assert.NilError(t, err)
+
+	t.Run("qcow without backing file", func(t *testing.T) {
+		resultImage := filepath.Join(tmpDir, strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_"))
+		assert.NilError(t, err)
+
+		err = ConvertToRaw(qcowImage.Name(), resultImage, nil, false)
+		assert.NilError(t, err)
+		assertFileEquals(t, rawImage.Name(), resultImage)
+	})
+
+	t.Run("qcow with backing file", func(t *testing.T) {
+		resultImage := filepath.Join(tmpDir, strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_"))
+		assert.NilError(t, err)
+
+		err = ConvertToRaw(qcowImage.Name(), resultImage, nil, true)
+		assert.NilError(t, err)
+		assertFileEquals(t, rawImage.Name(), resultImage)
+	})
+
+	t.Run("qcow with extra size", func(t *testing.T) {
+		resultImage := filepath.Join(tmpDir, strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_"))
+		assert.NilError(t, err)
+		size := int64(2_097_152) // 2mb
+		err = ConvertToRaw(qcowImage.Name(), resultImage, &size, false)
+		assert.NilError(t, err)
+		assertFileEquals(t, rawImageExtended.Name(), resultImage)
+	})
+
+	t.Run("raw", func(t *testing.T) {
+		resultImage := filepath.Join(tmpDir, strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_"))
+		assert.NilError(t, err)
+
+		err = ConvertToRaw(rawImage.Name(), resultImage, nil, false)
+		assert.NilError(t, err)
+		assertFileEquals(t, rawImage.Name(), resultImage)
+	})
+}
+
+func assertFileEquals(t *testing.T, expected, actual string) {
+	expectedContent, err := os.ReadFile(expected)
+	assert.NilError(t, err)
+	actualContent, err := os.ReadFile(actual)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expectedContent, actualContent)
+}


### PR DESCRIPTION
Hi!

We are trying to migrate a vm for our users from qemu to vz virtualization. In our configuration we use an additional disk.

When the disk is empty and vmType is `vz` limactl hangs at `Waiting for the essential requirement 1 of 2: "ssh"`.

This happens because neither write nor ftruncate is called for the file. In result after conversion, the file size is 0 bytes and the operating system cannot boot.

Steps to reproduce:
```
$ limactl disk create --size 1GB --format qcow2 test-disk
$ limactl start --name=test <config_file>
```

lima config:
```
vmType: "vz"
mountType: "virtiofs"
additionalDisks:
  - name: test-disk
    format: true
    fsType: "ext4"
images:
- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20240308/ubuntu-22.04-server-cloudimg-amd64.img"
  arch: "x86_64"
  digest: "sha256:42dcf9757e75c3275486b397a752fb535c7cd8e5232ee5ee349554b7a55f1702"
- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20240308/ubuntu-22.04-server-cloudimg-arm64.img"
  arch: "aarch64"
  digest: "sha256:0f5f68b9b74686b8a847024364031e2b95e4d3855e5177a99b33d7c55e45907f"
```