### PR TITLE
Revert "templates: update Arch Linux to 20240315.221711" to avoid xz 5.6.1-1

### DIFF
--- a/examples/archlinux.yaml
+++ b/examples/archlinux.yaml
@@ -1,9 +1,9 @@
 # This template requires Lima v0.7.0 or later
 images:
 # Try to use yyyyMMdd.REV image if available. Note that yyyyMMdd.REV will be removed after several months.
-- location: "https://geo.mirror.pkgbuild.com/images/v20240315.221711/Arch-Linux-x86_64-cloudimg-20240315.221711.qcow2"
+- location: "https://geo.mirror.pkgbuild.com/images/v20240115.207158/Arch-Linux-x86_64-cloudimg-20240115.207158.qcow2"
   arch: "x86_64"
-  digest: "sha256:413b72d48e1135bda8a5a8ec889a30def2d3fb977b6367f29785e346232b2c6d"
+  digest: "sha256:feed602df4bcddb5082306a3a467164bddfe1be8f580e0b441566fd962ab25c2"
 - location: "https://github.com/mcginty/arch-boxes-arm/releases/download/v20220323/Arch-Linux-aarch64-cloudimg-20220323.0.qcow2"
   arch: "aarch64"
   digest: "sha512:27524910bf41cb9b3223c8749c6e67fd2f2fdb8b70d40648708e64d6b03c0b4a01b3c5e72d51fefd3e0c3f58487dbb400a79ca378cde2da341a3a19873612be8"


### PR DESCRIPTION
This reverts commit 5416270f8b175734cbc69d5ded09700f7c12b676.

The source code archive (not the git repo) of xz v5.6.0 and v5.6.1 turned out to be compromised:
- https://www.openwall.com/lists/oss-security/2024/03/29/4

While ArchLinux's xz package is very *unlikely* to be affected (see the `== Affected Systems ==` section in the email), it is better to rollback the ArchLinux image to use an older version of xz.

- ArchLinux v20240315.221711: xz v5.6.1-1
- ArchLinux v20240115.207158: xz v5.4.5-1

After running `pacman -Syu` on ArchLinux v20240115.207158, a user will get xz v5.6.1-2. This package revision does not use the compromised v5.6.1 source archive:
- https://gitlab.archlinux.org/archlinux/packaging/packages/xz/-/issues/2
- https://gitlab.archlinux.org/archlinux/packaging/packages/xz/-/commit/881385757abdc39d3cfea1c3e34ec09f637424ad