### PR TITLE
Replace github.com/gorilla/mux with net/http

### DIFF
--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/gorilla/mux"
 	"github.com/lima-vm/lima/pkg/hostagent"
 	"github.com/lima-vm/lima/pkg/hostagent/api/server"
 	"github.com/sirupsen/logrus"
@@ -91,7 +90,7 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 	backend := &server.Backend{
 		Agent: ha,
 	}
-	r := mux.NewRouter()
+	r := http.NewServeMux()
 	server.AddRoutes(r, backend)
 	srv := &http.Server{Handler: r}
 	err = os.RemoveAll(socket)

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/foxcpp/go-mockdns v1.1.0
 	github.com/goccy/go-yaml v1.11.3
 	github.com/google/go-cmp v0.6.0
-	github.com/gorilla/mux v1.8.1
 	github.com/lima-vm/go-qcow2reader v0.1.1
 	github.com/lima-vm/sshocker v0.3.4
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,6 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLe
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=

--- a/pkg/hostagent/api/server/server.go
+++ b/pkg/hostagent/api/server/server.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/lima-vm/lima/pkg/hostagent"
 	"github.com/lima-vm/lima/pkg/httputil"
 )
@@ -25,8 +24,13 @@ func (b *Backend) onError(w http.ResponseWriter, err error, ec int) {
 	_ = json.NewEncoder(w).Encode(e)
 }
 
-// GetInfo is the handler for GET /v{N}/info
+// GetInfo is the handler for GET /v1/info
 func (b *Backend) GetInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
 	ctx := r.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -46,7 +50,6 @@ func (b *Backend) GetInfo(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(m)
 }
 
-func AddRoutes(r *mux.Router, b *Backend) {
-	v1 := r.PathPrefix("/v1").Subrouter()
-	v1.Path("/info").Methods("GET").HandlerFunc(b.GetInfo)
+func AddRoutes(r *http.ServeMux, b *Backend) {
+	r.Handle("/v1/info", http.HandlerFunc(b.GetInfo))
 }


### PR DESCRIPTION
This PR removes the dependency on `github.com/gorilla/mux`. `gorilla/mux` is a powerful router, but it's simply not needed for routing a single route: `GET http://lima-hostagent/v1/info`.

### How to Verify Changes

1. Start instance, e.g. `docker`:
```
$ ./_output/bin/limactl start docker
```
2. Make HTTP request:
```
$ curl --unix-socket ~/.lima/docker/ha.sock http://lima-hostagent/v1/info
```
The response is JSON containing `sshLocalPort` value:
```
{"sshLocalPort":55234}
```

<details>
<summary>Future Improvement</summary>

With Go 1.22, we will simplify routing a little further by rewriting `AddRoutes`:

```go
r.Handle("GET /v1/info", http.HandlerFunc(b.GetInfo))
```

and removing the following code from `GetInfo`:
```go
	if r.Method != http.MethodGet {
		w.WriteHeader(http.StatusMethodNotAllowed)
		return
	}
```

</details>

