### PR TITLE
Fix cidata user-data ca_certs yaml content

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -66,12 +66,14 @@ resolv_conf:
 {{ with .CACerts }}
 ca_certs:
   remove_defaults: {{ .RemoveDefaults }}
+  {{- if .Trusted}}
   trusted:
   {{- range $cert := .Trusted }}
   - |
     {{- range $line := $cert.Lines }}
     {{ $line }}
     {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}
 

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -112,6 +112,9 @@ func ValidateTemplateArgs(args TemplateArgs) error {
 			return fmt.Errorf("field mounts[%d] must be absolute, got %q", i, f)
 		}
 	}
+	if args.CACerts.RemoveDefaults == nil {
+		return errors.New("field CACerts.RemoveDefaults must be set")
+	}
 	return nil
 }
 

--- a/pkg/cidata/template_test.go
+++ b/pkg/cidata/template_test.go
@@ -22,6 +22,9 @@ func TestTemplate(t *testing.T) {
 			{MountPoint: "/Users/dummy/lima"},
 		},
 		MountType: "reverse-sshfs",
+		CACerts: CACerts{
+			Trusted: []Cert{},
+		},
 	}
 	layout, err := ExecuteTemplate(args)
 	assert.NilError(t, err)
@@ -33,6 +36,8 @@ func TestTemplate(t *testing.T) {
 		if f.Path == "user-data" {
 			// mounted later
 			assert.Assert(t, !strings.Contains(string(b), "mounts:"))
+			// ca_certs:
+			assert.Assert(t, !strings.Contains(string(b), "trusted:"))
 		}
 	}
 }

--- a/pkg/cidata/template_test.go
+++ b/pkg/cidata/template_test.go
@@ -8,6 +8,8 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+var defaultRemoveDefaults = false
+
 func TestTemplate(t *testing.T) {
 	args := TemplateArgs{
 		Name: "default",
@@ -23,7 +25,8 @@ func TestTemplate(t *testing.T) {
 		},
 		MountType: "reverse-sshfs",
 		CACerts: CACerts{
-			Trusted: []Cert{},
+			RemoveDefaults: &defaultRemoveDefaults,
+			Trusted:        []Cert{},
 		},
 	}
 	layout, err := ExecuteTemplate(args)
@@ -56,6 +59,9 @@ func TestTemplate9p(t *testing.T) {
 			{Tag: "mount1", MountPoint: "/Users/dummy/lima", Type: "9p", Options: "rw,trans=virtio"},
 		},
 		MountType: "9p",
+		CACerts: CACerts{
+			RemoveDefaults: &defaultRemoveDefaults,
+		},
 	}
 	layout, err := ExecuteTemplate(args)
 	assert.NilError(t, err)


### PR DESCRIPTION
This is failing the cloud-config jsonschema validation, later.

```  $ sudo cloud-init schema --system
  Error: Cloud config schema errors:
    ca_certs.trusted: None is not of type 'array'
```

* #2265

----

There are some additional fixes, to be followed up in another PR:

* Cloud config schema deprecations: users.0.uid:  Changed in version 22.3. The use of ``string`` type is deprecated. Use an ``integer`` instead.

```diff
-    uid: '1000'
+    uid: 1000
```

* Error: Cloud config schema errors: users.0: Additional properties are not allowed ('ssh-authorized-keys' was unexpected

```diff
-    ssh-authorized-keys:
+    ssh_authorized_keys:
```

These are either version-dependent (on the runtime cloud-init version, which we don't know just yet)

Or depends on the implementation, where the canonical python implementation does a magic `replace`.