### PR TITLE
Use integer instead of string for cidata uid

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -26,7 +26,7 @@ timezone: {{.TimeZone}}
 
 users:
   - name: "{{.User}}"
-    uid: "{{.UID}}"
+    uid: {{.UID}}
     homedir: "{{.Home}}"
     shell: /bin/bash
     sudo: ALL=(ALL) NOPASSWD:ALL


### PR DESCRIPTION
`sudo cloud-init schema --system`

Cloud config schema deprecations: users.0.uid:  Changed in version 22.3.
The use of ``string`` type is deprecated. Use an ``integer`` instead.

* #2265

It was already an integer, in the template data and in LIMA_CIDATA_UID