### PR TITLE
The cloud-init documentation was remodelled

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -213,7 +213,7 @@ containerd:
 #     EOF
 # # `boot` is executed directly by /bin/sh as part of cloud-init-local.service's early boot process,
 # # which is why there is no hash-bang specified in the example
-# # See cloud-init docs for more info https://cloudinit.readthedocs.io/en/latest/topics/examples.html#run-commands-on-first-boot
+# # See cloud-init docs for more info https://docs.cloud-init.io/en/latest/reference/examples.html#run-commands-on-first-boot
 # - mode: boot
 #   script: |
 #     systemctl disable NetworkManager-wait-online.service

--- a/website/content/en/docs/dev/Internals/_index.md
+++ b/website/content/en/docs/dev/Internals/_index.md
@@ -140,9 +140,9 @@ The directory contains the following files:
 ## `cidata.iso`
 `cidata.iso` contains the following files:
 
-- `user-data`: [Cloud-init user-data](https://cloudinit.readthedocs.io/en/latest/topics/format.html)
-- `meta-data`: [Cloud-init meta-data](https://cloudinit.readthedocs.io/en/latest/topics/instancedata.html)
-- `network-config`: [Cloud-init Networking Config Version 2](https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v2.html)
+- `user-data`: [Cloud-init user-data](https://docs.cloud-init.io/en/latest/explanation/format.html)
+- `meta-data`: [Cloud-init meta-data](https://docs.cloud-init.io/en/latest/explanation/instancedata.html)
+- `network-config`: [Cloud-init Networking Config Version 2](https://docs.cloud-init.io/en/latest/reference/network-config-format-v2.html)
 - `lima.env`: The `LIMA_CIDATA_*` environment variables (see below) available during `boot.sh` processing
 - `lima-guestagent`: Lima guest agent binary
 - `nerdctl-full.tgz`: [`nerdctl-full-<VERSION>-<OS>-<ARCH>.tar.gz`](https://github.com/containerd/nerdctl/releases)
@@ -156,7 +156,7 @@ The directory contains the following files:
 Max file name length = 30
 
 ### Volume label
-The volume label is "cidata", as defined by [cloud-init NoCloud](https://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html).
+The volume label is "cidata", as defined by [cloud-init NoCloud](https://docs.cloud-init.io/en/latest/reference/datasources/nocloud.html).
 
 ### Environment variables
 - `LIMA_CIDATA_NAME`: the lima instance name


### PR DESCRIPTION
Broken into "explanation" and "reference", from "topics".

This broke the doc links, going from old docs to new docs.

Closes #2272