### PR TITLE
limactl ls $INSTANCE should exit with non-0 status if $INSTANCE does not exist #1139

### DIFF
--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -130,7 +130,7 @@ func listAction(cmd *cobra.Command, args []string) error {
 			if len(matches) > 0 {
 				instanceNames = append(instanceNames, matches...)
 			} else {
-				logrus.Warnf("No instance matching %v found.", arg)
+				return fmt.Errorf("no instance matching %v found", arg)
 			}
 		}
 	} else {


### PR DESCRIPTION
- switched the warning message into an error message