### PR TITLE
Bump alpine image to 0.2.38

### DIFF
--- a/examples/alpine.yaml
+++ b/examples/alpine.yaml
@@ -2,12 +2,12 @@
 # Using the Alpine 3.19 aarch64 image with vmType=vz requires macOS Ventura 13.3 or later.
 
 images:
-- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.37/alpine-lima-std-3.19.0-x86_64.iso"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.38/alpine-lima-std-3.19.0-x86_64.iso"
   arch: "x86_64"
-  digest: "sha512:568852df405e6b9858e678171a9894c058f483df0b0570c22cf33fc75f349ba6cc5bb3d50188180d8c31faaf53400fe884ca3e5f949961b03b2bf53e65de88d7"
-- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.37/alpine-lima-std-3.19.0-aarch64.iso"
+  digest: "sha512:e0c7e88e4cccc24d4e1b3593198cc0bbc3dbc12d07f1d935da0fa73e5b96e19bb5f83925b9fd06c28dfb2278fc4b941333cf2b2565d346c3e3bc5559a268a82d"
+- location: "https://github.com/lima-vm/alpine-lima/releases/download/v0.2.38/alpine-lima-std-3.19.0-aarch64.iso"
   arch: "aarch64"
-  digest: "sha512:3a4bd5ad0201f503e9bb9f3b812aa0df292e2e099148c0323d23244046ad199a2946ef9e0619fec28726bfdcc528233f43c3b4b036c9e06e92ac730d579f0ca3"
+  digest: "sha512:bf195270ca0e101353ba346f4d651c0518bdea6f2b3845dd43a5c29cb5e1046274579b918bed2f5fb38ce7e9b2eccabe7fcf8040c29c22a3aa3f7a92ef831df7"
 
 mounts:
 - location: "~"


### PR DESCRIPTION
* Look for ssh_authorized_keys without dashes
* Bump QEMU version in tonistiigi/binfmt from 7.0.0 → 8.1.5