### PR TITLE
nerdctl: update to v1.7.6

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -39,7 +39,7 @@ const (
 var IPv4loopback1 = net.IPv4(127, 0, 0, 1)
 
 func defaultContainerdArchives() []File {
-	const nerdctlVersion = "1.7.5"
+	const nerdctlVersion = "1.7.6"
 	location := func(goos string, goarch string) string {
 		return "https://github.com/containerd/nerdctl/releases/download/v" + nerdctlVersion + "/nerdctl-full-" + nerdctlVersion + "-" + goos + "-" + goarch + ".tar.gz"
 	}
@@ -47,12 +47,12 @@ func defaultContainerdArchives() []File {
 		{
 			Location: location("linux", "amd64"),
 			Arch:     X8664,
-			Digest:   "sha256:adb246a4ef15b8f3d7eed4c6b61173014a6cf343e43ad95eae2087b454dcae5d",
+			Digest:   "sha256:2c841e097fcfb5a1760bd354b3778cb695b44cd01f9f271c17507dc4a0b25606",
 		},
 		{
 			Location: location("linux", "arm64"),
 			Arch:     AARCH64,
-			Digest:   "sha256:ff38142440b4705e12782b7a71074849e712a42ccb69a11306343a8d9f81d8ab",
+			Digest:   "sha256:77c747f09853ee3d229d77e8de0dd3c85622537d82be57433dc1fca4493bab95",
 		},
 		// No arm-v7
 		// No riscv64


### PR DESCRIPTION
https://github.com/containerd/nerdctl/releases/tag/v1.7.6