### PR TITLE
Remove  the support for `vde_vmnet` (Deprecated since Sep 2022, in favor of `socket_vmnet`)

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -319,7 +319,6 @@ networks:
 # Lima can manage daemons for networks defined in $LIMA_HOME/_config/networks.yaml
 # automatically. The socket_vmnet binary must be installed into
 # secure locations only alterable by the "root" user.
-# The same applies to vde_switch and vde_vmnet for the deprecated VDE mode.
 # - lima: shared
 #   # MAC address of the instance; lima will pick one based on the instance name,
 #   # so DHCP assigned ip addresses should remain constant over instance restarts.
@@ -337,19 +336,6 @@ networks:
 # The "vzNAT" IP address is accessible from the host, but not from other guests.
 # Needs `vmType: vz` (EXPERIMENTAL).
 # - vzNAT: true
-
-# vnl (virtual network locator) points to the vde_switch socket directory,
-# optionally with vde:// prefix
-# ⚠️  vnl is deprecated, use socket.
-# - vnl: "vde:///var/run/vde.ctl"
-#   # VDE Switch port number (not TCP/UDP port number). Set to 65535 for PTP mode.
-#   # Builtin default: 0
-#   switchPort: 0
-#   # MAC address of the instance; lima will pick one based on the instance name,
-#   # so DHCP assigned ip addresses should remain constant over instance restarts.
-#   macAddress: ""
-#   # Interface name, defaults to "lima0", "lima1", etc.
-#   interface: ""
 
 # Port forwarding rules. Forwarding between ports 22 and ssh.localPort cannot be overridden.
 # Rules are checked sequentially until the first one matches.

--- a/examples/vmnet.yaml
+++ b/examples/vmnet.yaml
@@ -28,8 +28,7 @@ mounts:
   writable: true
 networks:
 # The instance can get routable IP addresses from the vmnet framework using
-# https://github.com/lima-vm/socket_vmnet (since Lima v0.12) or
-# https://github.com/lima-vm/vde_vmnet (deprecated) .
+# https://github.com/lima-vm/socket_vmnet (since Lima v0.12).
 #
 # Available networks are defined in
 # $LIMA_HOME/_config/networks.yaml. Supported network types are "host",

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -508,29 +508,11 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 	iface := make(map[string]int)
 	for _, nw := range append(append(d.Networks, y.Networks...), o.Networks...) {
 		if i, ok := iface[nw.Interface]; ok {
-			if nw.VNLDeprecated != "" {
-				networks[i].VNLDeprecated = nw.VNLDeprecated
-				networks[i].SwitchPortDeprecated = nw.SwitchPortDeprecated
-				networks[i].Socket = ""
-				networks[i].Lima = ""
-			}
 			if nw.Socket != "" {
-				if nw.VNLDeprecated != "" {
-					// We can't return an error, so just log it, and prefer `socket` over `vnl`
-					logrus.Errorf("Network %q has both vnl=%q and socket=%q fields; ignoring vnl",
-						nw.Interface, nw.VNLDeprecated, nw.Socket)
-				}
 				networks[i].Socket = nw.Socket
-				networks[i].VNLDeprecated = ""
-				networks[i].SwitchPortDeprecated = 0
 				networks[i].Lima = ""
 			}
 			if nw.Lima != "" {
-				if nw.VNLDeprecated != "" {
-					// We can't return an error, so just log it, and prefer `lima` over `vnl`
-					logrus.Errorf("Network %q has both vnl=%q and lima=%q fields; ignoring vnl",
-						nw.Interface, nw.VNLDeprecated, nw.Lima)
-				}
 				if nw.Socket != "" {
 					// We can't return an error, so just log it, and prefer `lima` over `socket`
 					logrus.Errorf("Network %q has both socket=%q and lima=%q fields; ignoring socket",
@@ -538,8 +520,6 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 				}
 				networks[i].Lima = nw.Lima
 				networks[i].Socket = ""
-				networks[i].VNLDeprecated = ""
-				networks[i].SwitchPortDeprecated = 0
 			}
 			if nw.MACAddress != "" {
 				networks[i].MACAddress = nw.MACAddress

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -377,10 +377,8 @@ func TestFillDefault(t *testing.T) {
 		},
 		Networks: []Network{
 			{
-				VNLDeprecated:        "/tmp/vde.ctl",
-				SwitchPortDeprecated: 65535,
-				MACAddress:           "11:22:33:44:55:66",
-				Interface:            "def0",
+				MACAddress: "11:22:33:44:55:66",
+				Interface:  "def0",
 			},
 		},
 		DNS: []net.IP{
@@ -645,8 +643,6 @@ func TestFillDefault(t *testing.T) {
 	// o.Networks[1] is overriding the d.Networks[0].Lima entry for the "def0" interface
 	expect.Networks = append(append(d.Networks, y.Networks...), o.Networks[0])
 	expect.Networks[0].Lima = o.Networks[1].Lima
-	expect.Networks[0].VNLDeprecated = ""
-	expect.Networks[0].SwitchPortDeprecated = 0
 
 	// Only highest prio DNS are retained
 	expect.DNS = o.DNS

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -233,20 +233,15 @@ type CopyToHost struct {
 }
 
 type Network struct {
-	// `Lima`, `Socket`, and `VNL` are mutually exclusive; exactly one is required
+	// `Lima` and `Socket` are mutually exclusive; exactly one is required
 	Lima string `yaml:"lima,omitempty" json:"lima,omitempty"`
 	// Socket is a QEMU-compatible socket
 	Socket string `yaml:"socket,omitempty" json:"socket,omitempty"`
 	// VZNAT uses VZNATNetworkDeviceAttachment. Needs VZ. No root privilege is required.
 	VZNAT *bool `yaml:"vzNAT,omitempty" json:"vzNAT,omitempty"`
 
-	// VNLDeprecated is a Virtual Network Locator (https://github.com/rd235/vdeplug4/commit/089984200f447abb0e825eb45548b781ba1ebccd).
-	// On macOS, only VDE2-compatible form (optionally with vde:// prefix) is supported.
-	// VNLDeprecated is deprecated. Use Socket.
-	VNLDeprecated        string `yaml:"vnl,omitempty" json:"vnl,omitempty"`
-	SwitchPortDeprecated uint16 `yaml:"switchPort,omitempty" json:"switchPort,omitempty"` // VDE Switch port, not TCP/UDP port (only used by VDE networking)
-	MACAddress           string `yaml:"macAddress,omitempty" json:"macAddress,omitempty"`
-	Interface            string `yaml:"interface,omitempty" json:"interface,omitempty"`
+	MACAddress string `yaml:"macAddress,omitempty" json:"macAddress,omitempty"`
+	Interface  string `yaml:"interface,omitempty" json:"interface,omitempty"`
 }
 
 type HostResolver struct {
@@ -259,16 +254,4 @@ type CACertificates struct {
 	RemoveDefaults *bool    `yaml:"removeDefaults,omitempty" json:"removeDefaults,omitempty"` // default: false
 	Files          []string `yaml:"files,omitempty" json:"files,omitempty"`
 	Certs          []string `yaml:"certs,omitempty" json:"certs,omitempty"`
-}
-
-// DEPRECATED types below
-
-// Types have been renamed to turn all references to the old names into compiler errors,
-// and to avoid accidental usage in new code.
-
-type VDEDeprecated struct {
-	VNL        string `yaml:"vnl,omitempty" json:"vnl,omitempty"`
-	SwitchPort uint16 `yaml:"switchPort,omitempty" json:"switchPort,omitempty"` // VDE Switch port, not TCP/UDP port
-	MACAddress string `yaml:"macAddress,omitempty" json:"macAddress,omitempty"`
-	Name       string `yaml:"name,omitempty" json:"name,omitempty"`
 }

--- a/pkg/networks/commands.go
+++ b/pkg/networks/commands.go
@@ -6,15 +6,12 @@ import (
 	"io/fs"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 )
 
 const (
-	VDESwitch   = "vde_switch" // Deprecated
-	VDEVMNet    = "vde_vmnet"  // Deprecated
 	SocketVMNet = "socket_vmnet"
 )
 
@@ -39,10 +36,6 @@ func (config *YAML) Usernet(name string) (bool, error) {
 // DaemonPath returns the daemon path.
 func (config *YAML) DaemonPath(daemon string) (string, error) {
 	switch daemon {
-	case VDESwitch:
-		return config.Paths.VDESwitch, nil
-	case VDEVMNet:
-		return config.Paths.VDEVMNet, nil
 	case SocketVMNet:
 		return config.Paths.SocketVMNet, nil
 	default:
@@ -73,22 +66,13 @@ func (config *YAML) Sock(name string) string {
 	return filepath.Join(config.Paths.VarRun, fmt.Sprintf("socket_vmnet.%s", name))
 }
 
-// VDESock returns a vde socket.
-//
-// Deprecated: Use Sock.
-func (config *YAML) VDESock(name string) string {
-	return filepath.Join(config.Paths.VarRun, fmt.Sprintf("%s.ctl", name))
-}
-
 func (config *YAML) PIDFile(name, daemon string) string {
-	daemonTrimmed := strings.TrimPrefix(daemon, "vde_") // for compatibility
-	return filepath.Join(config.Paths.VarRun, fmt.Sprintf("%s_%s.pid", name, daemonTrimmed))
+	return filepath.Join(config.Paths.VarRun, fmt.Sprintf("%s_%s.pid", name, daemon))
 }
 
 func (config *YAML) LogFile(name, daemon, stream string) string {
 	networksDir, _ := dirnames.LimaNetworksDir()
-	daemonTrimmed := strings.TrimPrefix(daemon, "vde_") // for compatibility
-	return filepath.Join(networksDir, fmt.Sprintf("%s_%s.%s.log", name, daemonTrimmed, stream))
+	return filepath.Join(networksDir, fmt.Sprintf("%s_%s.%s.log", name, daemon, stream))
 }
 
 func (config *YAML) User(daemon string) (osutil.User, error) {
@@ -96,17 +80,9 @@ func (config *YAML) User(daemon string) (osutil.User, error) {
 		daemonPath, _ := config.DaemonPath(daemon)
 		return osutil.User{}, fmt.Errorf("daemon %q (path=%q) is not available", daemon, daemonPath)
 	}
+	//nolint:gocritic // singleCaseSwitch: should rewrite switch statement to if statement
 	switch daemon {
-	case VDESwitch:
-		user, err := osutil.LookupUser("daemon")
-		if err != nil {
-			return user, err
-		}
-		group, err := osutil.LookupGroup(config.Group)
-		user.Group = group.Name
-		user.Gid = group.Gid
-		return user, err
-	case VDEVMNet, SocketVMNet:
+	case SocketVMNet:
 		return osutil.LookupUser("root")
 	}
 	return osutil.User{}, fmt.Errorf("daemon %q not defined", daemon)
@@ -122,27 +98,6 @@ func (config *YAML) StartCmd(name, daemon string) string {
 	}
 	var cmd string
 	switch daemon {
-	case VDESwitch:
-		if config.Paths.VDESwitch == "" {
-			panic("config.Paths.VDESwitch is empty")
-		}
-		cmd = fmt.Sprintf("%s --pidfile=%s --sock=%s --group=%s --dirmode=0770 --nostdin",
-			config.Paths.VDESwitch, config.PIDFile(name, VDESwitch), config.VDESock(name), config.Group)
-	case VDEVMNet:
-		nw := config.Networks[name]
-		if config.Paths.VDEVMNet == "" {
-			panic("config.Paths.VDEVMNet is empty")
-		}
-		cmd = fmt.Sprintf("%s --pidfile=%s --vde-group=%s --vmnet-mode=%s",
-			config.Paths.VDEVMNet, config.PIDFile(name, VDEVMNet), config.Group, nw.Mode)
-		switch nw.Mode {
-		case ModeBridged:
-			cmd += fmt.Sprintf(" --vmnet-interface=%s", nw.Interface)
-		case ModeHost, ModeShared:
-			cmd += fmt.Sprintf(" --vmnet-gateway=%s --vmnet-dhcp-end=%s --vmnet-mask=%s",
-				nw.Gateway, nw.DHCPEnd, nw.NetMask)
-		}
-		cmd += " " + config.VDESock(name)
 	case SocketVMNet:
 		nw := config.Networks[name]
 		if config.Paths.SocketVMNet == "" {
@@ -158,6 +113,8 @@ func (config *YAML) StartCmd(name, daemon string) string {
 				nw.Gateway, nw.DHCPEnd, nw.NetMask)
 		}
 		cmd += " " + config.Sock(name)
+	default:
+		panic(fmt.Errorf("unexpected daemon %q", daemon))
 	}
 	return cmd
 }

--- a/pkg/networks/commands_darwin_test.go
+++ b/pkg/networks/commands_darwin_test.go
@@ -14,14 +14,6 @@ func TestSock(t *testing.T) {
 	assert.Equal(t, sock, "/private/var/run/lima/socket_vmnet.foo")
 }
 
-func TestVDESock(t *testing.T) {
-	config, err := DefaultConfig()
-	assert.NilError(t, err)
-
-	vdeSock := config.VDESock("foo")
-	assert.Equal(t, vdeSock, "/private/var/run/lima/foo.ctl")
-}
-
 func TestPIDFile(t *testing.T) {
 	config, err := DefaultConfig()
 	assert.NilError(t, err)

--- a/pkg/networks/commands_test.go
+++ b/pkg/networks/commands_test.go
@@ -58,30 +58,6 @@ func TestUser(t *testing.T) {
 		assert.Equal(t, user.Uid, uint32(0))
 		assert.Equal(t, user.Gid, uint32(0))
 	})
-
-	t.Run("vde_vmnet", func(t *testing.T) {
-		if ok, _ := config.IsDaemonInstalled(VDEVMNet); !ok {
-			t.Skipf("vde_vmnet is not installed")
-		}
-		user, err := config.User(VDESwitch)
-		assert.NilError(t, err)
-		assert.Equal(t, user.User, "daemon")
-		assert.Equal(t, user.Group, config.Group)
-		if runtime.GOOS == "darwin" {
-			assert.Equal(t, user.Uid, uint32(1))
-		}
-
-		user, err = config.User(VDEVMNet)
-		assert.NilError(t, err)
-		assert.Equal(t, user.User, "root")
-		if runtime.GOOS == "darwin" {
-			assert.Equal(t, user.Group, "wheel")
-		} else {
-			assert.Equal(t, user.Group, "root")
-		}
-		assert.Equal(t, user.Uid, uint32(0))
-		assert.Equal(t, user.Gid, uint32(0))
-	})
 }
 
 func TestMkdirCmd(t *testing.T) {
@@ -110,23 +86,6 @@ func TestStartCmd(t *testing.T) {
 		cmd = config.StartCmd("bridged", SocketVMNet)
 		assert.Equal(t, cmd, "/opt/socket_vmnet/bin/socket_vmnet --pidfile="+filepath.Join(varRunDir, "bridged_socket_vmnet.pid")+" --socket-group=everyone --vmnet-mode=bridged "+
 			"--vmnet-interface=en0 "+filepath.Join(varRunDir, "socket_vmnet.bridged"))
-	})
-
-	t.Run("vde_vmnet", func(t *testing.T) {
-		if ok, _ := config.IsDaemonInstalled(VDEVMNet); !ok {
-			t.Skipf("vde_vmnet is not installed")
-		}
-		cmd := config.StartCmd("shared", VDESwitch)
-		assert.Equal(t, cmd, "/opt/vde/bin/vde_switch --pidfile="+filepath.Join(varRunDir, "shared_switch.pid")+" "+
-			"--sock="+filepath.Join(varRunDir, "shared.ctl")+" --group=everyone --dirmode=0770 --nostdin")
-
-		cmd = config.StartCmd("shared", VDEVMNet)
-		assert.Equal(t, cmd, "/opt/vde/bin/vde_vmnet --pidfile="+filepath.Join(varRunDir, "shared_vmnet.pid")+" --vde-group=everyone --vmnet-mode=shared "+
-			"--vmnet-gateway=192.168.105.1 --vmnet-dhcp-end=192.168.105.254 --vmnet-mask=255.255.255.0 "+filepath.Join(varRunDir, "shared.ctl"))
-
-		cmd = config.StartCmd("bridged", VDEVMNet)
-		assert.Equal(t, cmd, "/opt/vde/bin/vde_vmnet --pidfile="+filepath.Join(varRunDir, "bridged_vmnet.pid")+" --vde-group=everyone --vmnet-mode=bridged "+
-			"--vmnet-interface=en0 "+filepath.Join(varRunDir, "bridged.ctl"))
 	})
 }
 

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -172,20 +172,3 @@ func Usernet(name string) (bool, error) {
 	}
 	return cache.config.Usernet(name)
 }
-
-// VDESock returns a vde socket.
-//
-// Deprecated: Use Sock.
-func VDESock(name string) (string, error) {
-	loadCache()
-	if cache.err != nil {
-		return "", cache.err
-	}
-	if err := cache.config.Check(name); err != nil {
-		return "", err
-	}
-	if cache.config.Paths.VDEVMNet == "" {
-		return "", errors.New("vdeVMnet is not set")
-	}
-	return cache.config.VDESock(name), nil
-}

--- a/pkg/networks/networks.TEMPLATE.yaml
+++ b/pkg/networks/networks.TEMPLATE.yaml
@@ -11,11 +11,7 @@
 # instead of /var etc.
 paths:
 # socketVMNet requires Lima >= 0.12 .
-# socketVMNet has precedence over vdeVMNet.
   socketVMNet: "{{.SocketVMNet}}"
-# vdeSwitch and vdeVMNet are DEPRECATED.
-  vdeSwitch: /opt/vde/bin/vde_switch
-  vdeVMNet: /opt/vde/bin/vde_vmnet
   varRun: /private/var/run/lima
   sudoers: /private/etc/sudoers.d/lima
 

--- a/pkg/networks/networks.go
+++ b/pkg/networks/networks.go
@@ -10,8 +10,6 @@ type YAML struct {
 
 type Paths struct {
 	SocketVMNet string `yaml:"socketVMNet"`
-	VDESwitch   string `yaml:"vdeSwitch"` // Deprecated
-	VDEVMNet    string `yaml:"vdeVMNet"`  // Deprecated
 	VarRun      string `yaml:"varRun"`
 	Sudoers     string `yaml:"sudoers,omitempty"`
 }

--- a/pkg/networks/reconcile/reconcile.go
+++ b/pkg/networks/reconcile/reconcile.go
@@ -200,11 +200,8 @@ func startNetwork(ctx context.Context, config *networks.YAML, name string) error
 	}
 	if ok {
 		daemons = append(daemons, networks.SocketVMNet)
-		if ok, _ := config.IsDaemonInstalled(networks.VDEVMNet); ok {
-			logrus.Debugf("Ignoring deprecated vde_vmnet (%q)", networks.VDEVMNet)
-		}
 	} else {
-		daemons = append(daemons, networks.VDESwitch, networks.VDEVMNet)
+		return fmt.Errorf("daemon %q needs to be installed", networks.SocketVMNet)
 	}
 	for _, daemon := range daemons {
 		pid, _ := store.ReadPIDFile(config.PIDFile(name, daemon))
@@ -237,8 +234,8 @@ func stopNetwork(ctx context.Context, config *networks.YAML, name string) error 
 	}
 
 	// Don't call validateConfig() until we actually need to stop a daemon because
-	// stopNetwork() may be called even when the vde daemons are not installed.
-	for _, daemon := range []string{networks.SocketVMNet, networks.VDEVMNet, networks.VDESwitch} {
+	// stopNetwork() may be called even when the daemons are not installed.
+	for _, daemon := range []string{networks.SocketVMNet} {
 		if ok, _ := config.IsDaemonInstalled(daemon); !ok {
 			continue
 		}

--- a/pkg/networks/sudoers.go
+++ b/pkg/networks/sudoers.go
@@ -33,7 +33,7 @@ func Sudoers() (string, error) {
 	for _, name := range names {
 		sb.WriteRune('\n')
 		sb.WriteString(fmt.Sprintf("# Manage %q network daemons\n", name))
-		for _, daemon := range []string{VDESwitch, VDEVMNet, SocketVMNet} {
+		for _, daemon := range []string{SocketVMNet} {
 			if ok, err := config.IsDaemonInstalled(daemon); err != nil {
 				return "", err
 			} else if !ok {
@@ -61,7 +61,7 @@ func (config *YAML) passwordLessSudo() error {
 	}
 	// Verify that user/groups for both daemons work without a password, e.g.
 	// %admin ALL = (ALL:ALL) NOPASSWD: ALL
-	for _, daemon := range []string{VDESwitch, VDEVMNet, SocketVMNet} {
+	for _, daemon := range []string{SocketVMNet} {
 		if ok, err := config.IsDaemonInstalled(daemon); err != nil {
 			return err
 		} else if !ok {

--- a/pkg/networks/validate.go
+++ b/pkg/networks/validate.go
@@ -19,7 +19,7 @@ func (config *YAML) Validate() error {
 	// validate all paths.* values
 	paths := reflect.ValueOf(&config.Paths).Elem()
 	pathsMap := make(map[string]string, paths.NumField())
-	var socketVMNetNotFound, vdeVMNetNotFound, vdeSwitchNotFound bool
+	var socketVMNetNotFound bool
 	for i := 0; i < paths.NumField(); i++ {
 		// extract YAML name from struct tag; strip options like "omitempty"
 		name := paths.Type().Field(i).Tag.Get("yaml")
@@ -42,22 +42,13 @@ func (config *YAML) Validate() error {
 				case "socketVMNet":
 					socketVMNetNotFound = true
 					continue
-				case "vdeVMNet":
-					vdeVMNetNotFound = true
-					continue
-				case "vdeSwitch":
-					vdeSwitchNotFound = true
-					continue
 				}
 			}
 			return fmt.Errorf("networks.yaml field `paths.%s` error: %w", name, err)
 		}
 	}
-	if socketVMNetNotFound && vdeVMNetNotFound {
-		return fmt.Errorf("networks.yaml: either %q (`paths.socketVMNet`) or %q (`paths.vdeVMNet`) has to be installed", pathsMap["socketVMNet"], pathsMap["vdeVMNet"])
-	}
-	if socketVMNetNotFound && !vdeVMNetNotFound && vdeSwitchNotFound {
-		return fmt.Errorf("networks.yaml: %q (`paths.vdeVMNet`) requires %q (`paths.vdeSwitch`) to be installed", pathsMap["vdeVMNet"], pathsMap["vdeSwitch"])
+	if socketVMNetNotFound {
+		return fmt.Errorf("networks.yaml: %q (`paths.socketVMNet`) has to be installed", pathsMap["socketVMNet"])
 	}
 	// TODO(jandubois): validate network definitions
 	return nil

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -709,7 +709,6 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	args = append(args, "-device", "virtio-net-pci,netdev=net0,mac="+limayaml.MACAddress(cfg.InstanceDir))
 
 	for i, nw := range y.Networks {
-		var vdeSock string
 		if nw.Lima != "" {
 			nwCfg, err := networks.Config()
 			if err != nil {
@@ -735,60 +734,19 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 				if runtime.GOOS != "darwin" {
 					return "", nil, fmt.Errorf("networks.yaml '%s' configuration is only supported on macOS right now", nw.Lima)
 				}
-				socketVMNetOk, err := nwCfg.IsDaemonInstalled(networks.SocketVMNet)
+				logrus.Debugf("Using socketVMNet (%q)", nwCfg.Paths.SocketVMNet)
+				sock, err := networks.Sock(nw.Lima)
 				if err != nil {
 					return "", nil, err
 				}
-				if socketVMNetOk {
-					logrus.Debugf("Using socketVMNet (%q)", nwCfg.Paths.SocketVMNet)
-					if vdeVMNetOk, _ := nwCfg.IsDaemonInstalled(networks.VDEVMNet); vdeVMNetOk {
-						logrus.Debugf("Ignoring vdeVMNet (%q), as socketVMNet (%q) is available and has higher precedence", nwCfg.Paths.VDEVMNet, nwCfg.Paths.SocketVMNet)
-					}
-					sock, err := networks.Sock(nw.Lima)
-					if err != nil {
-						return "", nil, err
-					}
-					args = append(args, "-netdev", fmt.Sprintf("socket,id=net%d,fd={{ fd_connect %q }}", i+1, sock))
-				} else if nwCfg.Paths.VDEVMNet != "" {
-					logrus.Warn("vdeVMNet is deprecated, use socketVMNet instead (See docs/network.md)")
-					vdeSock, err = networks.VDESock(nw.Lima) //nolint:staticcheck // deprecated
-					if err != nil {
-						return "", nil, err
-					}
-				}
+				args = append(args, "-netdev", fmt.Sprintf("socket,id=net%d,fd={{ fd_connect %q }}", i+1, sock))
 				// TODO: should we also validate that the socket exists, or do we rely on the
 				// networks reconciler to throw an error when the network cannot start?
 			}
 		} else if nw.Socket != "" {
 			args = append(args, "-netdev", fmt.Sprintf("socket,id=net%d,fd={{ fd_connect %q }}", i+1, nw.Socket))
-		} else if nw.VNLDeprecated != "" {
-			// VDE4 accepts VNL like vde:///var/run/vde.ctl as well as file path like /var/run/vde.ctl .
-			// VDE2 only accepts the latter form.
-			// VDE2 supports macOS but VDE4 does not yet, so we trim vde:// prefix here for VDE2 compatibility.
-			vdeSock = strings.TrimPrefix(nw.VNLDeprecated, "vde://")
-			if !strings.Contains(vdeSock, "://") {
-				if _, err := os.Stat(vdeSock); err != nil {
-					return "", nil, fmt.Errorf("cannot use VNL %q: %w", nw.VNLDeprecated, err)
-				}
-				// vdeSock is a directory, unless vde.SwitchPort == 65535 (PTP)
-				actualSocket := filepath.Join(vdeSock, "ctl")
-				if nw.SwitchPortDeprecated == 65535 { // PTP
-					actualSocket = vdeSock
-				}
-				if st, err := os.Stat(actualSocket); err != nil {
-					return "", nil, fmt.Errorf("cannot use VNL %q: failed to stat %q: %w", nw.VNLDeprecated, actualSocket, err)
-				} else if st.Mode()&fs.ModeSocket == 0 {
-					return "", nil, fmt.Errorf("cannot use VNL %q: %q is not a socket: %w", nw.VNLDeprecated, actualSocket, err)
-				}
-			}
 		} else {
 			return "", nil, fmt.Errorf("invalid network spec %+v", nw)
-		}
-		if vdeSock != "" {
-			if !strings.Contains(string(features.NetdevHelp), "vde") {
-				return "", nil, fmt.Errorf("netdev \"vde\" is not supported by %s ( Hint: recompile QEMU with `configure --enable-vde` )", exe)
-			}
-			args = append(args, "-netdev", fmt.Sprintf("vde,id=net%d,sock=%s", i+1, vdeSock))
 		}
 		args = append(args, "-device", fmt.Sprintf("virtio-net-pci,netdev=net%d,mac=%s", i+1, nw.MACAddress))
 	}

--- a/website/content/en/docs/Config/Network/_index.md
+++ b/website/content/en/docs/Config/Network/_index.md
@@ -82,7 +82,7 @@ sudo install -o root etc_sudoers.d_lima /etc/sudoers.d/lima
 > **Note**
 >
 > Lima before v0.12 used `vde_vmnet` for managing the networks.
-> `vde_vmnet` is still supported but it is deprecated and no longer documented here.
+> `vde_vmnet` is no longer supported.
 
 The networks are defined in `$LIMA_HOME/_config/networks.yaml`. If this file doesn't already exist, it will be created with these default
 settings:
@@ -106,11 +106,7 @@ settings:
 # instead of /var etc.
 paths:
 # socketVMNet requires Lima >= 0.12 .
-# socketVMNet has precedence over vdeVMNet.
   socketVMNet: /opt/socket_vmnet/bin/socket_vmnet
-# vdeSwitch and vdeVMNet are DEPRECATED.
-  vdeSwitch: /opt/vde/bin/vde_switch
-  vdeVMNet: /opt/vde/bin/vde_vmnet
   varRun: /private/var/run/lima
   sudoers: /private/etc/sudoers.d/lima
 
@@ -150,7 +146,6 @@ limactl start --network=lima:shared
 networks:
   # Lima can manage the socket_vmnet daemon for networks defined in $LIMA_HOME/_config/networks.yaml automatically.
   # The socket_vmnet binary must be installed into a secure location only alterable by the admin.
-  # The same applies to vde_switch and vde_vmnet for the deprecated VDE mode.
   # - lima: shared
   #   # MAC address of the instance; lima will pick one based on the instance name,
   #   # so DHCP assigned ip addresses should remain constant over instance restarts.

--- a/website/content/en/docs/Releases/Deprecated/_index.md
+++ b/website/content/en/docs/Releases/Deprecated/_index.md
@@ -5,7 +5,6 @@ weight: 10
 
 The following features are deprecated:
 
-- VDE support, including VNL and `vde_vmnet`
 - CentOS 7 support
 - Loading non-strict YAMLs (i.e., YAMLs with unknown properties)
 - `limactl show-ssh` command (Use `ssh -F ~/.lima/default/ssh.config lima-default` instead)
@@ -15,3 +14,5 @@ The following features are deprecated:
   and removed in Lima v0.14.0, in favor of `networks`
 - YAML property `useHostResolver`: deprecated in [Lima v0.8.1](https://github.com/lima-vm/lima/commit/eaeee31b0496174363c55da732c855ae21e9ad97)
   and removed in Lima v0.14.0,in favor of `hostResolver.enabled`
+- VDE support, including VNL and `vde_vmnet`: deprecated in [Lima v0.12.0](https://github.com/lima-vm/lima/pull/851/commits/b5e0d5abd0fb2f74b7ddf8faea7a855b5a14ceda)
+  and removed in Lima v0.22.0, in favor of `socket_vmnet`

--- a/website/content/en/docs/faq/_index.md
+++ b/website/content/en/docs/faq/_index.md
@@ -187,8 +187,7 @@ Try `softwareupdate --install-rosetta` from a terminal.
 {{% fixlinks %}}
 The default guest IP 192.168.5.15 is not accessible from the host and other guests.
 
-To add another IP address that is accessible from the host and other virtual machines, enable [`socket_vmnet`](https://github.com/lima-vm/socket_vmnet) (since Lima v0.12)
-or [`vde_vmnet`](https://github.com/lima-vm/vde_vmnet) (Deprecated).
+To add another IP address that is accessible from the host and other virtual machines, enable [`socket_vmnet`](https://github.com/lima-vm/socket_vmnet) (since Lima v0.12).
 
 See [`./docs/network.md`](./docs/network.md).
 {{% /fixlinks %}}


### PR DESCRIPTION
`vde_vmnet` has been deprecated since Lima v0.12.0 (Sep 2022), in favor of `socket_vmnet`:
- https://github.com/lima-vm/lima/pull/851

- - -
Close #2096 