### PR TITLE
Refactor CPUType to add defaultCPUType

### DIFF
--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -59,15 +59,10 @@ func TestFillDefault(t *testing.T) {
 
 	// Builtin default values
 	builtin := LimaYAML{
-		VMType: ptr.Of("qemu"),
-		OS:     ptr.Of(LINUX),
-		Arch:   ptr.Of(arch),
-		CPUType: map[Arch]string{
-			AARCH64: "cortex-a72",
-			ARMV7L:  "cortex-a7",
-			X8664:   "qemu64",
-			RISCV64: "rv64",
-		},
+		VMType:             ptr.Of("qemu"),
+		OS:                 ptr.Of(LINUX),
+		Arch:               ptr.Of(arch),
+		CPUType:            defaultCPUType(),
 		CPUs:               ptr.Of(defaultCPUs()),
 		Memory:             ptr.Of(defaultMemoryAsString()),
 		Disk:               ptr.Of(defaultDiskSizeAsString()),
@@ -107,19 +102,6 @@ func TestFillDefault(t *testing.T) {
 			RemoveDefaults: ptr.Of(false),
 		},
 		Plain: ptr.Of(false),
-	}
-	if IsAccelOS() {
-		if HasHostCPU() {
-			builtin.CPUType[arch] = "host"
-		} else if HasMaxCPU() {
-			builtin.CPUType[arch] = "max"
-		}
-		if arch == X8664 && runtime.GOOS == "darwin" {
-			switch builtin.CPUType[arch] {
-			case "host", "max":
-				builtin.CPUType[arch] += ",-pdpe1gb"
-			}
-		}
 	}
 
 	defaultPortForward := PortForward{
@@ -298,7 +280,7 @@ func TestFillDefault(t *testing.T) {
 		VMType: ptr.Of("vz"),
 		OS:     ptr.Of("unknown"),
 		Arch:   ptr.Of("unknown"),
-		CPUType: map[Arch]string{
+		CPUType: CPUType{
 			AARCH64: "arm64",
 			ARMV7L:  "armhf",
 			X8664:   "amd64",
@@ -487,7 +469,7 @@ func TestFillDefault(t *testing.T) {
 		VMType: ptr.Of("qemu"),
 		OS:     ptr.Of(LINUX),
 		Arch:   ptr.Of(arch),
-		CPUType: map[Arch]string{
+		CPUType: CPUType{
 			AARCH64: "uber-arm",
 			ARMV7L:  "armv8",
 			X8664:   "pentium",

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -7,31 +7,31 @@ import (
 )
 
 type LimaYAML struct {
-	VMType             *VMType         `yaml:"vmType,omitempty" json:"vmType,omitempty"`
-	OS                 *OS             `yaml:"os,omitempty" json:"os,omitempty"`
-	Arch               *Arch           `yaml:"arch,omitempty" json:"arch,omitempty"`
-	Images             []Image         `yaml:"images" json:"images"` // REQUIRED
-	CPUType            map[Arch]string `yaml:"cpuType,omitempty" json:"cpuType,omitempty"`
-	CPUs               *int            `yaml:"cpus,omitempty" json:"cpus,omitempty"`
-	Memory             *string         `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
-	Disk               *string         `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes
-	AdditionalDisks    []Disk          `yaml:"additionalDisks,omitempty" json:"additionalDisks,omitempty"`
-	Mounts             []Mount         `yaml:"mounts,omitempty" json:"mounts,omitempty"`
-	MountType          *MountType      `yaml:"mountType,omitempty" json:"mountType,omitempty"`
-	MountInotify       *bool           `yaml:"mountInotify,omitempty" json:"mountInotify,omitempty"`
-	SSH                SSH             `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
-	Firmware           Firmware        `yaml:"firmware,omitempty" json:"firmware,omitempty"`
-	Audio              Audio           `yaml:"audio,omitempty" json:"audio,omitempty"`
-	Video              Video           `yaml:"video,omitempty" json:"video,omitempty"`
-	Provision          []Provision     `yaml:"provision,omitempty" json:"provision,omitempty"`
-	UpgradePackages    *bool           `yaml:"upgradePackages,omitempty" json:"upgradePackages,omitempty"`
-	Containerd         Containerd      `yaml:"containerd,omitempty" json:"containerd,omitempty"`
-	GuestInstallPrefix *string         `yaml:"guestInstallPrefix,omitempty" json:"guestInstallPrefix,omitempty"`
-	Probes             []Probe         `yaml:"probes,omitempty" json:"probes,omitempty"`
-	PortForwards       []PortForward   `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
-	CopyToHost         []CopyToHost    `yaml:"copyToHost,omitempty" json:"copyToHost,omitempty"`
-	Message            string          `yaml:"message,omitempty" json:"message,omitempty"`
-	Networks           []Network       `yaml:"networks,omitempty" json:"networks,omitempty"`
+	VMType             *VMType       `yaml:"vmType,omitempty" json:"vmType,omitempty"`
+	OS                 *OS           `yaml:"os,omitempty" json:"os,omitempty"`
+	Arch               *Arch         `yaml:"arch,omitempty" json:"arch,omitempty"`
+	Images             []Image       `yaml:"images" json:"images"` // REQUIRED
+	CPUType            CPUType       `yaml:"cpuType,omitempty" json:"cpuType,omitempty"`
+	CPUs               *int          `yaml:"cpus,omitempty" json:"cpus,omitempty"`
+	Memory             *string       `yaml:"memory,omitempty" json:"memory,omitempty"` // go-units.RAMInBytes
+	Disk               *string       `yaml:"disk,omitempty" json:"disk,omitempty"`     // go-units.RAMInBytes
+	AdditionalDisks    []Disk        `yaml:"additionalDisks,omitempty" json:"additionalDisks,omitempty"`
+	Mounts             []Mount       `yaml:"mounts,omitempty" json:"mounts,omitempty"`
+	MountType          *MountType    `yaml:"mountType,omitempty" json:"mountType,omitempty"`
+	MountInotify       *bool         `yaml:"mountInotify,omitempty" json:"mountInotify,omitempty"`
+	SSH                SSH           `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
+	Firmware           Firmware      `yaml:"firmware,omitempty" json:"firmware,omitempty"`
+	Audio              Audio         `yaml:"audio,omitempty" json:"audio,omitempty"`
+	Video              Video         `yaml:"video,omitempty" json:"video,omitempty"`
+	Provision          []Provision   `yaml:"provision,omitempty" json:"provision,omitempty"`
+	UpgradePackages    *bool         `yaml:"upgradePackages,omitempty" json:"upgradePackages,omitempty"`
+	Containerd         Containerd    `yaml:"containerd,omitempty" json:"containerd,omitempty"`
+	GuestInstallPrefix *string       `yaml:"guestInstallPrefix,omitempty" json:"guestInstallPrefix,omitempty"`
+	Probes             []Probe       `yaml:"probes,omitempty" json:"probes,omitempty"`
+	PortForwards       []PortForward `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
+	CopyToHost         []CopyToHost  `yaml:"copyToHost,omitempty" json:"copyToHost,omitempty"`
+	Message            string        `yaml:"message,omitempty" json:"message,omitempty"`
+	Networks           []Network     `yaml:"networks,omitempty" json:"networks,omitempty"`
 	// `network` was deprecated in Lima v0.7.0, removed in Lima v0.14.0. Use `networks` instead.
 	Env          map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 	DNS          []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`
@@ -50,6 +50,8 @@ type (
 	MountType = string
 	VMType    = string
 )
+
+type CPUType = map[Arch]string
 
 const (
 	LINUX OS = "Linux"


### PR DESCRIPTION
Currently there is no check that the arch is actually in the cpu type, specifically this test case:

```go
                Arch:   ptr.Of("unknown"),
                CPUType: map[Arch]string{
                        AARCH64: "arm64",
                        ARMV7L:  "armhf",
                        X8664:   "amd64",
                        RISCV64: "riscv64",
                },
```

But normally this should be handled in the validate, which will reject any arch not in the set.

```go
        case X8664, AARCH64, ARMV7L, RISCV64:
```