### PR TITLE
Fix "FATA[0002] networks.yaml field `paths.varRun` error: path "." is not an absolute path"

### DIFF
--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -135,6 +135,7 @@ func loadCache() {
 		cache.err = yaml.UnmarshalWithOptions(b, &cache.config, yaml.Strict())
 		if cache.err != nil {
 			cache.err = fmt.Errorf("cannot parse %q: %w", configFile, cache.err)
+			return
 		}
 		cache.config, cache.err = fillDefaults(cache.config)
 		if cache.err != nil {


### PR DESCRIPTION
Non-nil `cache.err` was overwritten by nil

Fix #2313