### PR TITLE
Issue warning message when using wrong LIMA_HOME

### DIFF
--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -114,6 +114,10 @@ func listAction(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	if err := store.Validate(); err != nil {
+		logrus.Warnf("The directory %q does not look like a valid Lima directory: %v", store.Directory(), err)
+	}
+
 	allinstances, err := store.Instances()
 	if err != nil {
 		return err

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -9,7 +9,38 @@ import (
 	"github.com/containerd/containerd/identifiers"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
+	"github.com/lima-vm/lima/pkg/store/filenames"
 )
+
+// Directory returns the LimaDir.
+func Directory() string {
+	limaDir, err := dirnames.LimaDir()
+	if err != nil {
+		return ""
+	}
+	return limaDir
+}
+
+// Validate checks the LimaDir.
+func Validate() error {
+	limaDir, err := dirnames.LimaDir()
+	if err != nil {
+		return err
+	}
+	names, err := Instances()
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		// Each instance directory needs to have limayaml
+		instDir := filepath.Join(limaDir, name)
+		yamlPath := filepath.Join(instDir, filenames.LimaYAML)
+		if _, err := os.Stat(yamlPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 // Instances returns the names of the instances under LimaDir.
 func Instances() ([]string, error) {


### PR DESCRIPTION
Improves the error message, when using a top-level directory by mistake.

```console
$ mkdir -p /tmp/foo/bar
$ LIMA_HOME=/tmp/foo _output/bin/limactl ls
WARN[0000] The directory "/tmp/foo" does not look like a valid Lima directory: stat /tmp/foo/bar/lima.yaml: no such file or directory 
FATA[0000] unable to load instance bar: open /tmp/foo/bar/lima.yaml: no such file or directory 
```

We want to avoid the case where people "forget" to include the lima subdirectory.

* #2325

----

Currently the semantics are hidden under "internals":  https://lima-vm.io/docs/dev/internals/

And it can be assumed that LIMA_HOME will work similar to HOME, i.e. add the subdir for you

Once we have documentation on how to relocate the instances to a local disk, we can recommend a subdir.

Something like `LIMA_HOME=/local/$USER/lima` or somesuch, for where `~/.lima` is on a network filesystem