### PR TITLE
pkg: move regexp compilation out of loops

### DIFF
--- a/pkg/store/instance_windows.go
+++ b/pkg/store/instance_windows.go
@@ -92,9 +92,10 @@ func GetWslStatus(instName string) (string, error) {
 	}
 
 	var instState string
+	wslListColsRegex := regexp.MustCompile(`\s+`)
 	// wsl --list --verbose may have different headers depending on localization, just split by line
 	for _, rows := range strings.Split(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n") {
-		cols := regexp.MustCompile(`\s+`).Split(strings.TrimSpace(rows), -1)
+		cols := wslListColsRegex.Split(strings.TrimSpace(rows), -1)
 		nameIdx := 0
 		// '*' indicates default instance
 		if cols[0] == "*" {

--- a/pkg/wsl2/wsl_driver_windows.go
+++ b/pkg/wsl2/wsl_driver_windows.go
@@ -69,16 +69,13 @@ func (l *LimaWslDriver) Validate() error {
 		}
 	}
 
-	re, err := regexp.Compile(`.*tar\.*`)
-	if err != nil {
-		return fmt.Errorf("failed to compile file check regex: %w", err)
-	}
+	// TODO: real filetype checks
+	tarFileRegex := regexp.MustCompile(`.*tar\.*`)
 	for i, image := range l.Yaml.Images {
 		if unknown := reflectutil.UnknownNonEmptyFields(image, "File"); len(unknown) > 0 {
 			logrus.Warnf("Ignoring: vmType %s: images[%d]: %+v", *l.Yaml.VMType, i, unknown)
 		}
-		// TODO: real filetype checks
-		match := re.MatchString(image.Location)
+		match := tarFileRegex.MatchString(image.Location)
 		if image.Arch == *l.Yaml.Arch && !match {
 			return fmt.Errorf("unsupported image type for vmType: %s, tarball root file system required: %q", *l.Yaml.VMType, image.Location)
 		}


### PR DESCRIPTION
This PR moves regexps out of `for` loops to recompile only once per function call.