### PR TITLE
Add unittest for pkg/limayaml/default.yaml

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -125,7 +125,7 @@ ssh:
   # 🟢 Builtin default: 0 (automatically assigned to a free port)
   # NOTE: when the instance name is "default", the builtin default value is set to
   # 60022 for backward compatibility.
-  localPort: 0
+  localPort: null
   # Load ~/.ssh/*.pub in addition to $LIMA_HOME/_config/user.pub .
   # This option is useful when you want to use other SSH-based
   # applications such as rsync with the Lima instance.

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -72,8 +72,8 @@ const (
 )
 
 type Rosetta struct {
-	Enabled *bool `yaml:"enabled" json:"enabled"`
-	BinFmt  *bool `yaml:"binfmt" json:"binfmt"`
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	BinFmt  *bool `yaml:"binfmt,omitempty" json:"binfmt,omitempty"`
 }
 
 type File struct {

--- a/pkg/limayaml/limayaml_test.go
+++ b/pkg/limayaml/limayaml_test.go
@@ -8,10 +8,10 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func dumpJSON(d interface{}) string {
+func dumpJSON(t *testing.T, d interface{}) string {
 	b, err := json.Marshal(d)
 	if err != nil {
-		return "ERROR"
+		t.Fatal(err)
 	}
 	return string(b)
 }
@@ -20,7 +20,7 @@ const emptyYAML = "images: []\n"
 
 func TestEmptyYAML(t *testing.T) {
 	var y LimaYAML
-	t.Log(dumpJSON(y))
+	t.Log(dumpJSON(t, y))
 	b, err := marshalYAML(y)
 	assert.NilError(t, err)
 	assert.Equal(t, string(b), emptyYAML)
@@ -36,7 +36,7 @@ func TestDefaultYAML(t *testing.T) {
 	assert.NilError(t, err)
 	y.Images = nil // remove default images
 	y.Mounts = nil // remove default mounts
-	t.Log(dumpJSON(y))
+	t.Log(dumpJSON(t, y))
 	b, err := marshalYAML(y)
 	assert.NilError(t, err)
 	assert.Equal(t, string(b), defaultYAML)

--- a/pkg/limayaml/limayaml_test.go
+++ b/pkg/limayaml/limayaml_test.go
@@ -1,11 +1,35 @@
 package limayaml
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 
 	"gotest.tools/v3/assert"
 )
+
+func dumpJSON(d interface{}) string {
+	b, err := json.Marshal(d)
+	if err != nil {
+		return "ERROR"
+	}
+	return string(b)
+}
+
+const emptyYAML = "images: []\n"
+
+func TestEmptyYAML(t *testing.T) {
+	var y LimaYAML
+	t.Log(dumpJSON(y))
+	b, err := marshalYAML(y)
+	assert.NilError(t, err)
+	assert.Equal(t, string(b), emptyYAML)
+}
+
+const defaultYAML = `images: []
+ssh:
+  localPort: 0
+`
 
 func TestDefaultYAML(t *testing.T) {
 	bytes, err := os.ReadFile("default.yaml")
@@ -13,4 +37,10 @@ func TestDefaultYAML(t *testing.T) {
 	var y LimaYAML
 	err = unmarshalYAML(bytes, &y, "")
 	assert.NilError(t, err)
+	y.Images = nil // remove default images
+	y.Mounts = nil // remove default mounts
+	t.Log(dumpJSON(y))
+	b, err := marshalYAML(y)
+	assert.NilError(t, err)
+	assert.Equal(t, string(b), defaultYAML)
 }

--- a/pkg/limayaml/limayaml_test.go
+++ b/pkg/limayaml/limayaml_test.go
@@ -1,0 +1,16 @@
+package limayaml
+
+import (
+	"os"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestDefaultYAML(t *testing.T) {
+	bytes, err := os.ReadFile("default.yaml")
+	assert.NilError(t, err)
+	var y LimaYAML
+	err = unmarshalYAML(bytes, &y, "")
+	assert.NilError(t, err)
+}

--- a/pkg/limayaml/limayaml_test.go
+++ b/pkg/limayaml/limayaml_test.go
@@ -26,10 +26,7 @@ func TestEmptyYAML(t *testing.T) {
 	assert.Equal(t, string(b), emptyYAML)
 }
 
-const defaultYAML = `images: []
-ssh:
-  localPort: 0
-`
+const defaultYAML = "images: []\n"
 
 func TestDefaultYAML(t *testing.T) {
 	bytes, err := os.ReadFile("default.yaml")


### PR DESCRIPTION
Make sure that it is possible to parse default.yaml to the expected LimaYAML structure

Add some minor changes, to make the internal representation (before defaults) "pretty"

Left to do is to remove the default list of architectures, from the default cpuType list:

* #2333

After that, the default YAML is simply `images: []` - since that value is still mandatory.

```yaml
images: null
```

With some additional default values and "omitempty", it also matches an empty template.

```yaml
vmType: null
os: null
arch: null
images: []
cpus: null
memory: null
disk: null
mountType: null
mountInotify: null
additionalDisks: null
ssh:
  localPort: null
  loadDotSSHPubKeys: null
  forwardAgent: null
  forwardX11: null
  forwardX11Trusted: null
caCerts:
  removeDefaults: null
  files: null
  certs: null
upgradePackages: null
containerd:
  system: null
  user: null
cpuType: null
rosetta:
  enabled: null
  binfmt: null
timezone: null
firmware:
  legacyBIOS: null
audio:
  device: null
video:
  display: null
  vnc:
    display: null
networks: null
propagateProxyEnv: null
hostResolver:
  enabled: null
  ipv6: null
  hosts: null
guestInstallPrefix: null
plain: null
```