### PR TITLE
Add save functionality to limayaml

### DIFF
--- a/pkg/limayaml/save.go
+++ b/pkg/limayaml/save.go
@@ -1,0 +1,25 @@
+package limayaml
+
+import (
+	"github.com/goccy/go-yaml"
+)
+
+func marshalString(s string) ([]byte, error) {
+	if s == "null" || s == "~" {
+		// work around go-yaml bugs
+		return []byte("\"" + s + "\""), nil
+	}
+	return yaml.Marshal(s)
+}
+
+func marshalYAML(v interface{}) ([]byte, error) {
+	options := []yaml.EncodeOption{yaml.CustomMarshaler[string](marshalString)}
+	return yaml.MarshalWithOptions(v, options...)
+}
+
+// Save saves the yaml.
+//
+// Save does not fill defaults. Use FillDefaults.
+func Save(y *LimaYAML) ([]byte, error) {
+	return marshalYAML(y)
+}

--- a/pkg/limayaml/save_test.go
+++ b/pkg/limayaml/save_test.go
@@ -1,0 +1,35 @@
+package limayaml
+
+import (
+	"testing"
+
+	"github.com/lima-vm/lima/pkg/ptr"
+	"gotest.tools/v3/assert"
+)
+
+func TestSaveEmpty(t *testing.T) {
+	_, err := Save(&LimaYAML{})
+	assert.NilError(t, err)
+}
+
+func TestSaveTilde(t *testing.T) {
+	y := LimaYAML{
+		Mounts: []Mount{
+			{Location: "~", Writable: ptr.Of(false)},
+			{Location: "/tmp/lima", Writable: ptr.Of(true)},
+			{Location: "null"},
+		},
+	}
+	b, err := Save(&y)
+	assert.NilError(t, err)
+	// yaml will load ~ (or null) as null
+	// make sure that it is always quoted
+	assert.Equal(t, string(b), `images: []
+mounts:
+- location: "~"
+  writable: false
+- location: /tmp/lima
+  writable: true
+- location: "null"
+`)
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -102,3 +102,20 @@ func LoadYAMLByFilePath(filePath string) (*limayaml.LimaYAML, error) {
 	}
 	return y, nil
 }
+
+const documentStart = "---\n"
+
+const documentEnd = "...\n"
+
+// SaveYAML saves the yaml, optionally as a stream.
+func SaveYAML(y *limayaml.LimaYAML, stream bool) ([]byte, error) {
+	b, err := limayaml.Save(y)
+	if err != nil {
+		return nil, err
+	}
+	if stream {
+		doc := documentStart + string(b) + documentEnd
+		b = []byte(doc)
+	}
+	return b, nil
+}


### PR DESCRIPTION
Make it possible to fill in the defaults (null) with limactl validate, with a workaround for python yaml.

Was using a local patched version to test with the jsonschema and such, might as well be a flag ?

You can validate more than one yaml, then the output will be formatted with document separators.

`limactl validate examples/default.yaml examples/ubuntu.yaml`

---

Found an interesting python bug (libyaml difference?), when using `check-jsonschema`:

```
Schema validation errors were encountered.
  default.yaml::$.mounts[0].location: None is not of type 'string'
```
 
```yaml
mounts:
- location: ~
  mountPoint: ~
  writable: false
  sshfs:
    cache: true
    followSymlinks: false
    sftpDriver: ""
  9p:
    securityModel: none
    protocolVersion: 9p2000.L
    msize: 128KiB
    cache: fscache
- location: /tmp/lima
  mountPoint: /tmp/lima
  writable: true
  sshfs:
    cache: true
    followSymlinks: false
    sftpDriver: ""
  9p:
    securityModel: none
    protocolVersion: 9p2000.L
    msize: 128KiB
    cache: mmap
```

Added a workaround, not sure which language is "right" according to yaml spec ?