### PR TITLE
Avoid mix between root and the root user (zero)

### DIFF
--- a/cmd/lima-guestagent/daemon_linux.go
+++ b/cmd/lima-guestagent/daemon_linux.go
@@ -44,7 +44,7 @@ func daemonAction(cmd *cobra.Command, _ []string) error {
 		return errors.New("tick must be specified")
 	}
 	if os.Geteuid() != 0 {
-		return errors.New("must run as the root")
+		return errors.New("must run as the root user")
 	}
 	logrus.Infof("event tick: %v", tick)
 

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -88,7 +88,7 @@ func newApp() *cobra.Command {
 			logrus.StandardLogger().SetFormatter(formatter)
 		}
 		if os.Geteuid() == 0 && cmd.Name() != "generate-doc" {
-			return errors.New("must not run as the root")
+			return errors.New("must not run as the root user")
 		}
 		// Make sure either $HOME or $LIMA_HOME is defined, so we don't need
 		// to check for errors later

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -30,7 +30,7 @@ $ limactl sudoers --check /etc/sudoers.d/lima
 		Short: "Generate the content of the /etc/sudoers.d/lima file",
 		Long: fmt.Sprintf(`Generate the content of the /etc/sudoers.d/lima file for enabling vmnet.framework support.
 The content is written to stdout, NOT to the file.
-This command must not run as the root.
+This command must not run as the root user.
 See %s for the usage.`, networksMD),
 		Args:    WrapArgsError(cobra.MaximumNArgs(1)),
 		RunE:    sudoersAction,

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -196,14 +196,14 @@ containerd:
 # The scripts can use the following template variables: {{.Home}}, {{.UID}}, and {{.User}}
 # 🟢 Builtin default: null
 # provision:
-# # `system` is executed with the root privilege
+# # `system` is executed with root privileges
 # - mode: system
 #   script: |
 #     #!/bin/bash
 #     set -eux -o pipefail
 #     export DEBIAN_FRONTEND=noninteractive
 #     apt-get install -y vim
-# # `user` is executed without the root privilege
+# # `user` is executed without root privileges
 # - mode: user
 #   script: |
 #     #!/bin/bash


### PR DESCRIPTION
Theoretically the root user could have another name*, but traditionally it is named "root" (run as root)

Sudo also talks about superuser, but let's use root. But use the same wording for privilege vs privileges.

---

\* Can only remember "gobo".

https://www.gobolinux.org/