### PR TITLE
Add firmware search paths for fedora rpms

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -1100,17 +1100,21 @@ func getFirmware(qemuExe string, arch limayaml.Arch) (string, error) {
 		// Debian package "ovmf"
 		candidates = append(candidates, "/usr/share/OVMF/OVMF_CODE.fd")
 		candidates = append(candidates, "/usr/share/OVMF/OVMF_CODE_4M.fd")
+		// Fedora package "edk2-ovmf"
+		candidates = append(candidates, "/usr/share/edk2/ovmf/OVMF_CODE.fd")
 		// openSUSE package "qemu-ovmf-x86_64"
 		candidates = append(candidates, "/usr/share/qemu/ovmf-x86_64-code.bin")
 		// Archlinux package "edk2-ovmf"
 		candidates = append(candidates, "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd")
 	case limayaml.AARCH64:
 		// Debian package "qemu-efi-aarch64"
+		// Fedora package "edk2-aarch64"
 		candidates = append(candidates, "/usr/share/AAVMF/AAVMF_CODE.fd")
 		// Debian package "qemu-efi-aarch64" (unpadded, backwards compatibility)
 		candidates = append(candidates, "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd")
 	case limayaml.ARMV7L:
 		// Debian package "qemu-efi-arm"
+		// Fedora package "edk2-arm"
 		candidates = append(candidates, "/usr/share/AAVMF/AAVMF32_CODE.fd")
 	}
 


### PR DESCRIPTION
Including systems based on Fedora, such as CentOS and AlmaLinux.

~~There doesn't seem to be any arm32 firmware available in Fedora.~~

The standard path (OVMF) was never backported to Legacy Fedora (EL):

https://src.fedoraproject.org/rpms/edk2/c/e1a8a9caa18b10ff4ea5ee5d131c734e61b379de?branch=rawhide

`yum provides "*/OVMF_CODE.fd"`

`yum provides "*/AAVMF_CODE.fd"`

* https://github.com/lima-vm/lima/discussions/1917

`export QEMU_SYSTEM_X86_64=/usr/libexec/qemu-kvm`

`export QEMU_SYSTEM_AARCH64=/usr/libexec/qemu-kvm`

---

The 32-bit firmware was there as well, but it was hidden in the RHEL builds

	
```specfile
%if %{defined rhel}
%define build_ovmf 0
%define build_aarch64 0
%ifarch x86_64
  %define build_ovmf 1
%endif
%ifarch aarch64
  %define build_aarch64 1
%endif
%define build_riscv64 0
%define build_loongarch64 0
%else
%define build_ovmf 1
%define build_aarch64 1
%define build_riscv64 1
%define build_loongarch64 1
%endif
```