### PR TITLE
Add possibility to override /tmp

### DIFF
--- a/pkg/infoutil/infoutil.go
+++ b/pkg/infoutil/infoutil.go
@@ -13,6 +13,7 @@ type Info struct {
 	Templates       []templatestore.Template `json:"templates"`
 	DefaultTemplate *limayaml.LimaYAML       `json:"defaultTemplate"`
 	LimaHome        string                   `json:"limaHome"`
+	LimaTemp        string                   `json:"limaTemp"`
 	VMTypes         []string                 `json:"vmTypes"` // since Lima v0.14.2
 }
 
@@ -38,5 +39,6 @@ func GetInfo() (*Info, error) {
 	if err != nil {
 		return nil, err
 	}
+	info.LimaTemp = dirnames.LimaTmp()
 	return info, nil
 }

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/cpu"
 
+	"github.com/lima-vm/lima/pkg/localpathutil"
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/ptr"
@@ -650,8 +651,11 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 				mounts[i].NineP.Cache = ptr.Of(Default9pCacheForRO)
 			}
 		}
+		if mount.Location == "/tmp/lima" {
+			mounts[i].Location = filepath.Join(os.TempDir(), "lima")
+		}
 		if mount.MountPoint == "" {
-			mounts[i].MountPoint = mount.Location
+			mounts[i].MountPoint = localpathutil.Path(mount.Location)
 		}
 	}
 

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -652,7 +652,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 			}
 		}
 		if mount.Location == "/tmp/lima" {
-			mounts[i].Location = filepath.Join(os.TempDir(), "lima")
+			mounts[i].Location = dirnames.LimaTmp()
 		}
 		if mount.MountPoint == "" {
 			mounts[i].MountPoint = localpathutil.Path(mount.Location)

--- a/pkg/localpathutil/localpathutil.go
+++ b/pkg/localpathutil/localpathutil.go
@@ -32,3 +32,17 @@ func Expand(orig string) (string, error) {
 	}
 	return filepath.Abs(s)
 }
+
+// Path converts a filepath to a path
+// Unix:        /foo/bar => /foo/bar
+// Windows:     C:\foo\bar => /c/foo/bar
+func Path(orig string) string {
+	s := filepath.ToSlash(orig)
+	vol := filepath.VolumeName(orig)
+	if vol != "" && strings.Contains(vol, ":") {
+		v := "/"
+		v += strings.ToLower(vol[0:1])
+		s = strings.Replace(s, vol, v, 1)
+	}
+	return s
+}

--- a/pkg/store/dirnames/dirnames.go
+++ b/pkg/store/dirnames/dirnames.go
@@ -36,6 +36,15 @@ func LimaDir() (string, error) {
 	return realdir, nil
 }
 
+// Lima is a directory that appears under the temporary directory.
+const Lima = "lima"
+
+// LimaTmp returns the path of `/tmp/lima`
+func LimaTmp() string {
+	tmp := os.TempDir()
+	return filepath.Join(tmp, Lima)
+}
+
 // LimaConfigDir returns the path of the config directory, $LIMA_HOME/_config.
 func LimaConfigDir() (string, error) {
 	limaDir, err := LimaDir()

--- a/website/content/en/docs/Config/_index.md
+++ b/website/content/en/docs/Config/_index.md
@@ -12,3 +12,8 @@ The current default spec:
 - Disk: 100 GiB
 - Mounts: `~` (read-only), `/tmp/lima` (writable)
 - SSH: 127.0.0.1:60022
+
+{{% alert title="Temp" color="info" %}}
+Use `$TMPDIR` to change the location of `/tmp` on Unix.
+Use `$TEMP` to change the location of `/tmp` on Windows.
+{{% /alert %}}


### PR DESCRIPTION
Use `$TMPDIR` to change the location of `/tmp` on Unix.

Use `$TEMP` to change the location of `/tmp` on Windows.

https://pkg.go.dev/os#TempDir

Closes #2339