### PR TITLE
website: add community governance, etc.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,8 @@ jobs:
         The build log is available for 90 days: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
         The sha256sum of the SHA256SUMS file itself is \`${shasha}\` .
+        - - -
+        Release manager: [ADD YOUR NAME HERE] (@[ADD YOUR GITHUB ID HERE])`
         EOF
     - name: "Create release"
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,10 +1,1 @@
-# Lima maintainers
-
-| Name               | GitHub ID (not Twitter ID)                     | GPG fingerprint                                                                          |
-|--------------------|------------------------------------------------|------------------------------------------------------------------------------------------|
-| Akihiro Suda       | [@AkihiroSuda](https://github.com/AkihiroSuda) | [C020 EA87 6CE4 E06C 7AB9  5AEF 4952 4C6F 9F63 8F1A](https://github.com/AkihiroSuda.gpg) |
-| Jan Dubois         | [@jandubois](https://github.com/jandubois)     |                                                                                          |
-| Anders F Björklund | [@afbjorklund](https://github.com/afbjorklund) |                                                                                          |
-| Balaji Vijayakumar | [@balajiv113](https://github.com/balajiv113)   |                                                                                          |
-
-See https://github.com/lima-vm/.github/blob/main/SECURITY.md for how to report security issues.
+Moved to <https://lima-vm.io/docs/community/governance/>.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ kubectl apply -f ...
 See <https://lima-vm.io/docs/> for the further information.
 
 ## Community
-<!-- TODO: move or copy the most of this section to https://lima-vm.io/community/ -->
 ### Adopters
 
 Container environments:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,11 +1,1 @@
-# Lima roadmap
-
-Instead of using a static text file, Lima uses the `roadmap` label on GitHub issues to designate features or bug fixes that we plan to implement.
-
-Issues are tagged with the `roadmap` label when at least one maintainer or contributor has declared intent to work on or help with the implementation.
-
-There are no commitments or timelines attached to the label, and the label may be removed again from an abandoned issue at any time.
-
-Non-roadmap issues are kept open (as long as they fit the scope of the project) in case a volunteer one day appears and offers to work on them.
-
-To find the items currently planned for Lima you can filter on [open issues with the `roadmap` label]( https://github.com/lima-vm/lima/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap).
+Moved to <https://lima-vm.io/docs/community/roadmap/>.

--- a/website/content/en/docs/Community/Contributing/_index.md
+++ b/website/content/en/docs/Community/Contributing/_index.md
@@ -1,0 +1,32 @@
+---
+title: Contributing
+weight: 20
+---
+
+## Developer Certificate of Origin
+
+Every commit must be signed off with the `Signed-off-by: REAL NAME <email@example.com>` line.
+
+Use the `git commit -s` command to add the Signed-off-by line.
+
+See also <https://github.com/cncf/foundation/blob/main/dco-guidelines.md>.
+
+## Licensing
+
+Lima is licensed under the terms of [Apache License, Version 2.0](https://github.com/lima-vm/lima/blob/master/LICENSE).
+
+See also <https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md> for third-party dependencies.
+
+## Sending pull requests
+
+Pull requests can be submitted to <https://github.com/lima-vm/lima/pulls>.
+
+## Merging pull requests
+
+[Committers](../governance) can merge pull requests.
+[Reviewers](../governance) can approve, but cannot merge, pull requests.
+
+A Committer shouldn't merge their own pull requests without approval by at least one other Maintainer (Committer or Reviewer).
+
+This rule does not apply to trivial pull requests such as fixing typos, CI failures,
+and updating image references in templates (e.g., <https://github.com/lima-vm/lima/pull/2318>).

--- a/website/content/en/docs/Community/Governance/_index.md
+++ b/website/content/en/docs/Community/Governance/_index.md
@@ -1,0 +1,93 @@
+---
+title: Governance
+weight: 10
+---
+
+<!-- The governance model is similar to https://github.com/containerd/project/blob/main/GOVERNANCE.md but simplified -->
+
+## Code of Conduct
+Lima follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+## Maintainership
+Lima is governed by Maintainers who are elected from active contributors.
+
+As a [Cloud Native Computing Foundation](https://cncf.io/) project, Lima will keep its [vendor-neutrality](https://contribute.cncf.io/maintainers/community/vendor-neutrality/).
+
+### Roles
+Maintainers consist of two roles:
+
+- **Committer** (Full maintainership): Committers have full write accesses to repos under <https://github.com/lima-vm>.
+  Committers' commits should still be made via GitHub pull requests (except for urgent security fixes), and should not be pushed directly.
+  Committers are also recognized as Maintainers in <https://github.com/cncf/foundation/blob/main/project-maintainers.csv>.
+
+- **Reviewer** (Limited maintainership): Reviewers may moderate GitHub issues and pull requests (such as adding labels and cleaning up spams),
+  but they do not have any access to merge pull requests nor push commits.
+  A Reviewer is considered as a candidate to become a Committer.
+  Reviewers are not recognized as Maintainers in <https://github.com/cncf/foundation/blob/main/project-maintainers.csv>.
+
+See also the [Contributing](../contributing) page.
+
+### Current maintainers
+
+| Name               | Role      | GitHub ID (not X ID)                           | GPG fingerprint                                                                          |
+|--------------------|-----------|------------------------------------------------|------------------------------------------------------------------------------------------|
+| Akihiro Suda       | Committer | [@AkihiroSuda](https://github.com/AkihiroSuda) | [C020 EA87 6CE4 E06C 7AB9  5AEF 4952 4C6F 9F63 8F1A](https://github.com/AkihiroSuda.gpg) |
+| Jan Dubois         | Committer | [@jandubois](https://github.com/jandubois)     | [DBF6 DA01 BD81 2D63 3B77  300F A2CA E583 3B6A D416](https://github.com/jandubois.gpg)   |
+| Anders F Björklund | Committer | [@afbjorklund](https://github.com/afbjorklund) | [5981 D2E8 4E4B 9197 95B3  2174 DC05 CAD2 E73B 0C92](https://github.com/afbjorklund.gpg) |
+| Balaji Vijayakumar | Committer | [@balajiv113](https://github.com/balajiv113)   | [80E1 01FE 5C89 FCF6 6171  72C8 377C 6A63 934B 8E6E](https://github.com/balajiv113.gpg)  |
+
+<!-- TODO: invite non-committer reviewers -->
+
+### Addition and promotion of Maintainers
+An active contributor to the project can be invited as a Reviewer,
+and can be eventually promoted to a Committer after 2 months at least.
+
+A contributor who have made significant contributions in quality and in quantity
+can be also directly invited as a Committer.
+
+A proposal to add or promote a Maintainer must be approved by 2/3 of the Committers who vote within 7 days.
+Voting needs 2 approvals at least. The proposer can vote too.
+
+A proposal should happen as a GitHub pull request to the Maintainer list above.
+It is highly suggested to reach out to the Committers before submitting a pull request to check the will of the Committers.
+
+### Removal and demotion of Maintainers
+A Maintainer who do not show significant activities for 6 months, or, who have been violating the Code of Conduct,
+may be demoted or removed from the project.
+
+A proposal to demote or remove a Maintainer must be approved by 2/3 of the Committers (excluding the person in question) who vote within 14 days.
+Voting needs 2 approvals at least. The proposer can vote too.
+
+A proposal may happen as a GitHub pull request, or, as a private discussion in the case of removal of a harmful Maintainer.
+It is highly suggested to reach out to the Committers before submitting a pull request to check the will of the Committers.
+
+### Other decisions
+Any decision that is not documented here can be made by the Committers.
+When a dispute happens across the Committers, it will be resolved through a majority vote within the Committers.
+A tie should be considered as a failed vote.
+
+## Release process
+
+Eligibility to be a release manager:
+- MUST be an active Committer
+- MUST have the GPG fingerprint listed in the maintainer list above
+- MUST upload the GPG public key to `https://github.com/USERNAME.gpg`
+- MUST protect the GPG key with a passphrase or a hardware token.
+
+Release steps:
+- Open an issue to propose making a new release. e.g., <https://github.com/lima-vm/lima/issues/2296>.
+  The proposal should be public, with an exception for vulnerability fixes.
+  If this is the first time for you to take a role of release management,
+  you SHOULD make a beta (or alpha, RC) release as an exercise before releasing GA.
+- Make sure that all the merged PRs are associated with the correct [Milestone](https://github.com/lima-vm/lima/milestones).
+- Run `git tag --sign vX.Y.Z-beta.W` .
+- Run `git push UPSTREAM vX.Y.Z-beta.W` .
+- Wait for the `Release` action on GitHub Actions to complete. A draft release will appear in https://github.com/lima-vm/lima/releases .
+- Download `SHA256SUMS` from the draft release, and confirm that it corresponds to the hashes printed in the build logs on the `Release` action.
+- Sign `SHA256SUMS` with `gpg --detach-sign -a SHA256SUMS` to produce `SHA256SUMS.asc`, and upload it to the draft release.
+- Add release notes in the draft release, to explain the changes and show appreciation to the contributors.
+  Make sure to fulfill the `Release manager: [ADD YOUR NAME HERE] (@[ADD YOUR GITHUB ID HERE])` line with your name.
+  e.g., `Release manager: Akihiro Suda (@AkihiroSuda)` .
+- Click the `Set as a pre-release` checkbox if this release is a beta (or alpha, RC).
+- Click the `Publish release` button.
+- Close the [Milestone](https://github.com/lima-vm/lima/milestones).

--- a/website/content/en/docs/Community/Roadmap/_index.md
+++ b/website/content/en/docs/Community/Roadmap/_index.md
@@ -1,0 +1,14 @@
+---
+title: Roadmap
+weight: 50
+---
+
+Instead of using a static text file, Lima uses the `roadmap` label on GitHub issues to designate features or bug fixes that we plan to implement.
+
+Issues are tagged with the `roadmap` label when at least one maintainer or contributor has declared intent to work on or help with the implementation.
+
+There are no commitments or timelines attached to the label, and the label may be removed again from an abandoned issue at any time.
+
+Non-roadmap issues are kept open (as long as they fit the scope of the project) in case a volunteer one day appears and offers to work on them.
+
+To find the items currently planned for Lima you can filter on [open issues with the `roadmap` label]( https://github.com/lima-vm/lima/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap).

--- a/website/content/en/docs/Community/Subprojects/_index.md
+++ b/website/content/en/docs/Community/Subprojects/_index.md
@@ -1,0 +1,15 @@
+---
+title: Subprojects
+weight: 90
+---
+
+Some portions of Lima are useful for other projects too and split out to separate repos:
+
+- <https://github.com/lima-vm/socket_vmnet>: vmnet.framework support for unmodified rootless QEMU
+- <https://github.com/lima-vm/go-qcow2reader>: qcow2 reader for Go
+- <https://github.com/lima-vm/sshocker>: ssh + reverse sshfs + port forwarder, in Docker-like CLI (predecessor of Lima)
+- <https://github.com/lima-vm/alpine-lima>: Create an alpine based image for lima
+
+See also <https://github.com/lima-vm> for other subprojects.
+
+The maintainership of the subprojects corresponds to the [maintainership](../governance) of Lima itself.

--- a/website/content/en/docs/Community/_index.md
+++ b/website/content/en/docs/Community/_index.md
@@ -1,0 +1,31 @@
+---
+title: Community
+weight: 400
+---
+
+The GitHub repo of Lima can be found at <https://github.com/lima-vm/lima>.
+
+## Communication channels
+
+- [GitHub Discussions](https://github.com/lima-vm/lima/discussions)
+
+- `#lima` channel in the CNCF Slack
+  - New account: <https://slack.cncf.io/>
+  - Login: <https://cloud-native.slack.com/>
+
+- Zoom meetings are currently not regularly held due to timezone diversity,
+  but feel free to reach out to us if you want to host meetings
+
+- See <https://github.com/lima-vm/.github/blob/main/SECURITY.md> for how to report security issues.
+
+## Projects using Lima
+
+### Container environments
+- [Rancher Desktop](https://rancherdesktop.io/): Kubernetes and container management to the desktop
+- [Colima](https://github.com/abiosoft/colima): Docker (and Kubernetes) on macOS with minimal setup
+- [Finch](https://github.com/runfinch/finch): Finch is a command line client for local container development
+- [Podman Desktop](https://podman-desktop.io/): Podman Desktop GUI has a plug-in for Lima virtual machines
+
+### GUI
+- [Lima xbar plugin](https://github.com/unixorn/lima-xbar-plugin): [xbar](https://xbarapp.com/) plugin to start/stop VMs from the menu bar and see their running status.
+- [lima-gui](https://github.com/afbjorklund/lima-gui): Qt GUI for Lima

--- a/website/layouts/partials/community_links.html
+++ b/website/layouts/partials/community_links.html
@@ -16,7 +16,7 @@
         {{ end }}
         <p>
             {{ T "community_how_to" . }}
-            <a href="https://github.com/lima-vm/lima#developer-guide">{{ T "community_guideline" }}</a>.
+            <a href="/docs/community">{{ T "community_guideline" }}</a>.
         </p>
     </div>
 </section>


### PR DESCRIPTION
Preview: https://deploy-preview-2353--lima-vm.netlify.app/docs/community/
- - -
Establish the governance model so as to facilitate getting more contributions from new and existing contributors.

I also expect that this will help getting more involvements from other maintainers for reviewing/merging PRs and making new releases. Too much power and reponsibility have been concentrating on me.

This PR is intended to fulfill the requirements listed in [CNCF Incubation Application v1.5](https://github.com/cncf/toc/blob/8211f562bb3123a7be85c2de4f3b741a0e448e66/.github/ISSUE_TEMPLATE/template-incubation-application.md).

See also ["Applying to become an Incubating or Graduating project"](https://github.com/cncf/toc/tree/8211f562bb3123a7be85c2de4f3b741a0e448e66/process#applying-to-become-an-incubating-or-graduating-project)

- [X] Governance
- [X] Release process
- [X] Contribution guide
- [X] Subproject list

TODOs:
- Complete [OpenSSF Best Practices](https://www.bestpractices.dev/en/projects/6505)
- Submit [Security Self-Assessment](https://github.com/cncf/tag-security/blob/main/assessments/guide/self-assessment.md) to <https://github.com/cncf/tag-security/tree/main/assessments/projects>

- Submit an incubation application to <https://github.com/cncf/toc/issues>