### PR TITLE
Switch vmnet tests to macos-12 runners because macos-11 is going away

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -306,7 +306,7 @@ jobs:
 
   vmnet:
     name: "VMNet test"
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
> The macOS 11 runner image will be removed by 6/28/24. To raise awareness of the upcoming removal, jobs using macOS 11 will temporarily fail during scheduled time periods defined below:
>
> June 17 2024, 8:00 AM - 2:00 PM EST
> June 19 2024, 12:00 PM - 6:00 PM EST
> June 24 2024, 3:00 AM - 9:00 PM EST
> June 26 2024, 8:00 AM - 2:00 PM EST
