### PR TITLE
pkg/networks: refactor dnshosts.ExtractZones

### DIFF
--- a/pkg/networks/usernet/dnshosts/dnshosts.go
+++ b/pkg/networks/usernet/dnshosts/dnshosts.go
@@ -32,7 +32,7 @@ import (
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 )
 
-func ExtractZones(hosts hostMap) (zones []types.Zone) {
+func ExtractZones(hosts hostMap) []types.Zone {
 	list := make(map[string]types.Zone)
 
 	for host := range hosts {
@@ -57,10 +57,11 @@ func ExtractZones(hosts hostMap) (zones []types.Zone) {
 		list[h.name()] = zone
 	}
 
+	zones := make([]types.Zone, 0, len(list))
 	for _, zone := range list {
 		zones = append(zones, zone)
 	}
-	return
+	return zones
 }
 
 type hostMap map[string]string

--- a/pkg/networks/usernet/dnshosts/dnshosts_test.go
+++ b/pkg/networks/usernet/dnshosts/dnshosts_test.go
@@ -94,7 +94,7 @@ func Test_zoneHost(t *testing.T) {
 	}
 }
 
-func Test_extractZones(t *testing.T) {
+func TestExtractZones(t *testing.T) {
 	equalZones := func(za, zb []types.Zone) bool {
 		find := func(list []types.Zone, name string) (types.Zone, bool) {
 			for _, z := range list {


### PR DESCRIPTION
The PR refactors `dnshosts.ExtractZones` by preallocating the resulting `zones` slice due to the known length.