### PR TITLE
Refactor limayaml.FirstUsernetIndex implementation and usages

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -305,8 +305,7 @@ func (a *HostAgent) Run(ctx context.Context) error {
 	}()
 	adjustNofileRlimit()
 
-	firstUsernetIndex := limayaml.FirstUsernetIndex(a.y)
-	if firstUsernetIndex == -1 && *a.y.HostResolver.Enabled {
+	if limayaml.FirstUsernetIndex(a.y) == -1 && *a.y.HostResolver.Enabled {
 		hosts := a.y.HostResolver.Hosts
 		hosts["host.lima.internal"] = networks.SlirpGateway
 		hosts[fmt.Sprintf("lima-%s", a.instName)] = networks.SlirpIPAddress

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"text/template"
@@ -90,14 +91,7 @@ func defaultContainerdArchives() []File {
 
 // FirstUsernetIndex gets the index of first usernet network under l.Network[]. Returns -1 if no usernet network found
 func FirstUsernetIndex(l *LimaYAML) int {
-	for i := range l.Networks {
-		nwName := l.Networks[i].Lima
-		isUsernet, _ := networks.Usernet(nwName)
-		if isUsernet {
-			return i
-		}
-	}
-	return -1
+	return slices.IndexFunc(l.Networks, func(network Network) bool { return networks.IsUsernet(network.Lima) })
 }
 
 func MACAddress(uniqueID string) string {

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -171,11 +171,16 @@ func Sock(name string) (string, error) {
 	return cache.config.Sock(name), nil
 }
 
-// Usernet Returns true if the given network name is usernet network
-func Usernet(name string) (bool, error) {
+// IsUsernet returns true if the given network name is a usernet network.
+// It return false if the cache cannot be loaded or the network is not defined.
+func IsUsernet(name string) bool {
 	loadCache()
 	if cache.err != nil {
-		return false, cache.err
+		return false
 	}
-	return cache.config.Usernet(name)
+	isUsernet, err := cache.config.Usernet(name)
+	if err != nil {
+		return false
+	}
+	return isUsernet
 }


### PR DESCRIPTION
The PR refactors `limayaml.FirstUsernetIndex` implementation and it's usage:

- Rename `networks.Usernet` to `networks.IsUsernet`.
- Use `slices.IndexFunc` instead of raw `for` loop.
- Invert `if-else` conditions in the `startUsernet` function to decrease indentation and for consistency with other `limayaml.FirstUsernetIndex` usages.