### PR TITLE
Remove the embedded default user in alpine cloud

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/00-alpine-user-group.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/00-alpine-user-group.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Remove the user embedded in the image,
+# and use cloud-init for users and groups.
+test -f /etc/alpine-release || exit 0
+test "$LIMA_CIDATA_USER" != "alpine" || exit 0
+
+if [ "$(id -u alpine 2>&1)" = "1000" ]; then
+	userdel alpine
+	rmdir /home/alpine
+	cloud-init clean --logs
+	reboot
+fi


### PR DESCRIPTION
There should not be a non-system user in the image.

Let cloud-init handle the users and groups instead.

Closes #2362

Fixes the boot on Linux, and then you can add nerdctl.

----

`sudo apk add nerdctl containerd buildctl buildkit`

```
lima-alpine-image:/home/anders$ sudo nerdctl version
Client:
 Version:	1.7.6
 OS/Arch:	linux/amd64
 Git commit:	<unknown>
 buildctl:
  Version:	0.12.5
  GitCommit:	alpine

Server:
 containerd:
  Version:	v1.7.10
  GitCommit:	4e1fe7492b9df85914c389d1f15a3ceedbb280ac
 runc:
  Version:	1.1.12
  GitCommit:	51d5e94601ceffbbd85688df1c928ecccbfa4685
```


```
lima-alpine-image:/home/anders$ df -h /dev/vda1 /dev/vda2
Filesystem      Size  Used Avail Use% Mounted on
/dev/vda1       486K  282K  204K  59% /boot/efi
/dev/vda2        94G  453M   90G   1% /
```