### PR TITLE
Store time of last modified in cache dir

### DIFF
--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -120,6 +120,20 @@ func WithExpectedDigest(expectedDigest digest.Digest) Opt {
 	}
 }
 
+func readFile(path string) string {
+	if path == "" {
+		return ""
+	}
+	if _, err := os.Stat(path); err != nil {
+		return ""
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
 // Download downloads the remote resource into the local path.
 //
 // Download caches the remote resource if WithCache or WithCacheDir option is specified.
@@ -214,8 +228,8 @@ func Download(ctx context.Context, local, remote string, opts ...Opt) (*Result, 
 		res := &Result{
 			Status:          StatusUsedCache,
 			CachePath:       shadData,
-			LastModified:    shadTime,
-			ContentType:     shadType,
+			LastModified:    readFile(shadTime),
+			ContentType:     readFile(shadType),
 			ValidatedDigest: o.expectedDigest != "",
 		}
 		return res, nil
@@ -245,8 +259,8 @@ func Download(ctx context.Context, local, remote string, opts ...Opt) (*Result, 
 	res := &Result{
 		Status:          StatusDownloaded,
 		CachePath:       shadData,
-		LastModified:    shadTime,
-		ContentType:     shadType,
+		LastModified:    readFile(shadTime),
+		ContentType:     readFile(shadType),
 		ValidatedDigest: o.expectedDigest != "",
 	}
 	return res, nil
@@ -295,8 +309,8 @@ func Cached(remote string, opts ...Opt) (*Result, error) {
 	res := &Result{
 		Status:          StatusUsedCache,
 		CachePath:       shadData,
-		LastModified:    shadTime,
-		ContentType:     shadType,
+		LastModified:    readFile(shadTime),
+		ContentType:     readFile(shadType),
 		ValidatedDigest: o.expectedDigest != "",
 	}
 	return res, nil

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -116,7 +116,7 @@ func TestDownloadRemote(t *testing.T) {
 		r, err := Download(context.Background(), "", dummyRemoteFileURL, WithExpectedDigest(dummyRemoteFileDigest), WithCacheDir(cacheDir))
 		assert.NilError(t, err)
 		assert.Equal(t, StatusDownloaded, r.Status)
-		assert.Equal(t, dummyRemoteFileStat.ModTime().UTC().Format(time.RFC1123), strings.Replace(r.LastModified, "GMT", "UTC", 1))
+		assert.Equal(t, dummyRemoteFileStat.ModTime().Truncate(time.Second).UTC(), r.LastModified)
 		assert.Equal(t, "text/plain; charset=utf-8", r.ContentType)
 	})
 }

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/opencontainers/go-digest"
 	"gotest.tools/v3/assert"
@@ -25,6 +26,8 @@ func TestDownloadRemote(t *testing.T) {
 	t.Cleanup(ts.Close)
 	dummyRemoteFileURL := ts.URL + "/downloader.txt"
 	const dummyRemoteFileDigest = "sha256:380481d26f897403368be7cb86ca03a4bc14b125bfaf2b93bff809a5a2ad717e"
+	dummyRemoteFileStat, err := os.Stat(filepath.Join("testdata", "downloader.txt"))
+	assert.NilError(t, err)
 
 	t.Run("without cache", func(t *testing.T) {
 		t.Run("without digest", func(t *testing.T) {
@@ -104,6 +107,17 @@ func TestDownloadRemote(t *testing.T) {
 		wrongDigest := digest.Digest("sha256:8313944efb4f38570c689813f288058b674ea6c487017a5a4738dc674b65f9d9")
 		_, err = Cached(dummyRemoteFileURL, WithExpectedDigest(wrongDigest), WithCacheDir(cacheDir))
 		assert.ErrorContains(t, err, "expected digest")
+	})
+	t.Run("metadata", func(t *testing.T) {
+		_, err := Cached(dummyRemoteFileURL, WithExpectedDigest(dummyRemoteFileDigest))
+		assert.ErrorContains(t, err, "cache directory to be specified")
+
+		cacheDir := filepath.Join(t.TempDir(), "cache")
+		r, err := Download(context.Background(), "", dummyRemoteFileURL, WithExpectedDigest(dummyRemoteFileDigest), WithCacheDir(cacheDir))
+		assert.NilError(t, err)
+		assert.Equal(t, StatusDownloaded, r.Status)
+		assert.Equal(t, dummyRemoteFileStat.ModTime().UTC().Format(time.RFC1123), strings.Replace(r.LastModified, "GMT", "UTC", 1))
+		assert.Equal(t, "text/plain; charset=utf-8", r.ContentType)
 	})
 }
 


### PR DESCRIPTION
Was looking more at caching, and thought it would be a good idea to store the last modified time too.

```console
$ more ~/.cache/lima/download/by-url-sha256/2385cd7cc68589b1dab56df12415b9151d977ba9b9b668e913f02ebd35804ef7/url 
https://github.com/lima-vm/alpine-lima/releases/download/v0.2.38/alpine-lima-std-3.19.0-x86_64.iso
$ more ~/.cache/lima/download/by-url-sha256/2385cd7cc68589b1dab56df12415b9151d977ba9b9b668e913f02ebd35804ef7/time 
Fri, 26 Apr 2024 05:04:22 GMT
$ more ~/.cache/lima/download/by-url-sha256/2385cd7cc68589b1dab56df12415b9151d977ba9b9b668e913f02ebd35804ef7/type 
application/octet-stream
```

Then you can do things such as If-Modified-Since and helps when looking at implementing a simple proxy.

* #2367

When caching more things than OS images, it is also useful to record the content type (deb, tar, whatever)

`WARN[0000] reference for unknown type: application/octet-stream`

----

The information is available in the `Result`, when retreiving cached files (but the string can be empty)

~~It would be possible to add the _content_ instead, and use empty string for older cache without the files.~~

```diff
 type Result struct {
        Status          Status
        CachePath       string // "/Users/foo/Library/Caches/lima/download/by-url-sha256/<SHA256_OF_URL>/data"
+       LastModified    time.Time
+       ContentType     string
        ValidatedDigest bool
 }

```