### PR TITLE
Never retain ownership during installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ docs/lima-sequence-diagram.png: docs/images/lima-sequence-diagram.puml
 install: uninstall
 	mkdir -p "$(DEST)"
 	# Use tar rather than cp, for better symlink handling
-	( cd _output && tar c * | tar Cxv "$(DEST)" )
+	( cd _output && $(TAR) c * | $(TAR) -xv --no-same-owner -C "$(DEST)" )
 	if [ "$(shell uname -s )" != "Linux" -a ! -e "$(DEST)/bin/nerdctl" ]; then ln -sf nerdctl.lima "$(DEST)/bin/nerdctl"; fi
 	if [ "$(shell uname -s )" != "Linux" -a ! -e "$(DEST)/bin/apptainer" ]; then ln -sf apptainer.lima "$(DEST)/bin/apptainer"; fi
 


### PR DESCRIPTION
By default, tar will retain ownership when run as root. Even if built as a user, the install phase should not install binaries owned by that user. To suppress this, we pass `--no-same-owner` to tar.

While at it, I made it use the `TAR` environment variable during installation as well.