### PR TITLE
Make sure to set the compiler also for amd64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,10 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version: 1.22.x
+    - name: Install gcc-x86-64-linux-gnu
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-x86-64-linux-gnu
     - name: Install gcc-aarch64-linux-gnu
       run: |
         sudo apt-get update

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ artifacts-darwin:
 .PHONY: artifacts-linux
 artifacts-linux:
 	mkdir -p _artifacts
-	GOOS=linux GOARCH=amd64 make clean binaries
+	GOOS=linux GOARCH=amd64 CC=x86_64-linux-gnu-gcc make clean binaries
 	$(TAR) -C _output/ -czvf _artifacts/lima-$(VERSION_TRIMMED)-Linux-x86_64.tar.gz ./
 	GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc make clean binaries
 	$(TAR) -C _output/ -czvf _artifacts/lima-$(VERSION_TRIMMED)-Linux-aarch64.tar.gz ./


### PR DESCRIPTION
Allows building the artifacts, also on arm64

----

Previously it assumed that the host is x86_64 arch:

```
# runtime/cgo
gcc: error: unrecognized command-line option '-m64'
```

Similar to the errors you got without  $CC, for arm64

```
# runtime/cgo
gcc_arm64.S: Assembler messages:
gcc_arm64.S:30: Error: no such instruction: `stp x29,x30,[sp,'
gcc_arm64.S:34: Error: too many memory references for `mov'
gcc_arm64.S:36: Error: no such instruction: `stp x19,x20,[sp,'
gcc_arm64.S:39: Error: no such instruction: `stp x21,x22,[sp,'
gcc_arm64.S:42: Error: no such instruction: `stp x23,x24,[sp,'
gcc_arm64.S:45: Error: no such instruction: `stp x25,x26,[sp,'
gcc_arm64.S:48: Error: no such instruction: `stp x27,x28,[sp,'
gcc_arm64.S:52: Error: too many memory references for `mov'
gcc_arm64.S:53: Error: too many memory references for `mov'
gcc_arm64.S:54: Error: too many memory references for `mov'
gcc_arm64.S:56: Error: no such instruction: `blr x20'
gcc_arm64.S:57: Error: no such instruction: `blr x19'
gcc_arm64.S:59: Error: no such instruction: `ldp x27,x28,[sp,'
gcc_arm64.S:62: Error: no such instruction: `ldp x25,x26,[sp,'
gcc_arm64.S:65: Error: no such instruction: `ldp x23,x24,[sp,'
gcc_arm64.S:68: Error: no such instruction: `ldp x21,x22,[sp,'
gcc_arm64.S:71: Error: no such instruction: `ldp x19,x20,[sp,'
gcc_arm64.S:74: Error: no such instruction: `ldp x29,x30,[sp],'
```

So make sure to always specify the cross-compiler ($CC).

It is basically a no-op in apt, for the regular build environment:

`Note, selecting 'gcc' instead of 'gcc-x86-64-linux-gnu'`

`Note, selecting 'gcc' instead of 'gcc-aarch64-linux-gnu'`
