### PR TITLE
README.md: use white CNCF logo for a dark GitHub theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Lima follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/
 - - -
 **We are a [Cloud Native Computing Foundation](https://cncf.io/) sandbox project.**
 
-<img src="https://www.cncf.io/wp-content/uploads/2022/07/cncf-color-bg.svg" width=300 />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://www.cncf.io/wp-content/uploads/2022/07/cncf-white-logo.svg">
+  <img src="https://www.cncf.io/wp-content/uploads/2022/07/cncf-color-bg.svg" width=300 />
+</picture>
 
 The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [Trademark Usage](https://www.linuxfoundation.org/trademark-usage/).


### PR DESCRIPTION
This PR fixes displaying the CNCF logo in README.md on a GitHub dark theme.

This PR is similar to #2085.

Before:

<img width="1058" alt="image" src="https://github.com/lima-vm/lima/assets/3228886/29b74fd1-b71a-4696-af6b-82ce9bc19515">


After:

<img width="1042" alt="image" src="https://github.com/lima-vm/lima/assets/3228886/7fc558af-530b-415c-91ed-2ab0202d004b">
