### PR TITLE
Allow lima-guestagent to start on older systemd

### DIFF
--- a/cmd/lima-guestagent/install_systemd_linux.go
+++ b/cmd/lima-guestagent/install_systemd_linux.go
@@ -53,7 +53,8 @@ func installSystemdAction(cmd *cobra.Command, _ []string) error {
 	logrus.Infof("Written file %q", unitPath)
 	args := [][]string{
 		{"daemon-reload"},
-		{"enable", "--now", "lima-guestagent.service"},
+		{"enable", "lima-guestagent.service"},
+		{"start", "lima-guestagent.service"},
 		{"try-restart", "lima-guestagent.service"},
 	}
 	for _, args := range args {


### PR DESCRIPTION
I was trying to install Ubuntu 15.04, as part of the Kubernetes anniversary (14.04 did not use systemd at all)

But it was getting systemctl syntax errors, when it comes to starting the `lima-guestagent` after installation...

`systemctl: unrecognized option '--now'`

It seemed harmless enough, to use the traditional method of using two commands? Even if it is obsolete.

----

Here is the workaround, meanwhile:

```yaml
- mode: boot
  script: |
   printf '#!/bin/sh\nif [ "$2" = "enable" -a "$3" = "--now" ]; then /bin/systemctl $1 enable $4; /bin/systemctl $1 start $4; else /bin/systemctl "$@"; fi\n' >/usr/local/bin/systemctl
   chmod 755 /usr/local/bin/systemctl

```