### PR TITLE
Update Oracle Linux templates to OL8.10/OL9.4

### DIFF
--- a/examples/oraclelinux-8.yaml
+++ b/examples/oraclelinux-8.yaml
@@ -6,12 +6,12 @@
 # EL9-based distros are known to work.
 
 images:
-- location: "https://yum.oracle.com/templates/OracleLinux/OL8/u9/x86_64/OL8U9_x86_64-kvm-b210.qcow"
+- location: "https://yum.oracle.com/templates/OracleLinux/OL8/u10/x86_64/OL8U10_x86_64-kvm-b237.qcow2"
   arch: "x86_64"
-  digest: "sha256:1a2764476748c57bcf5bf9a9fcfa445da77b62d06614a87599e4b483426c8758"
-- location: "https://yum.oracle.com/templates/OracleLinux/OL8/u9/aarch64/OL8U9_aarch64-kvm-b47.qcow"
+  digest: "sha256:53a5eee27c59f335ba1bdb0afc2c3273895f128dd238b51a78f46ad515cbc662"
+- location: "https://yum.oracle.com/templates/OracleLinux/OL8/u10/aarch64/OL8U10_aarch64-kvm-cloud-b100.qcow2"
   arch: "aarch64"
-  digest: "sha256:f6ea4019b67e873606fc47b88639da1a52320d7bc6453d918915b22a77247be5"
+  digest: "sha256:def7b8055e275507a593f07dc6076a2adc5967af046c003072b479e69f25f407"
 mounts:
 - location: "~"
 - location: "/tmp/lima"

--- a/examples/oraclelinux-9.yaml
+++ b/examples/oraclelinux-9.yaml
@@ -3,12 +3,12 @@
 # Image source: https://yum.oracle.com/oracle-linux-templates.html
 
 images:
-- location: "https://yum.oracle.com/templates/OracleLinux/OL9/u3/x86_64/OL9U3_x86_64-kvm-b211.qcow"
+- location: "https://yum.oracle.com/templates/OracleLinux/OL9/u4/x86_64/OL9U4_x86_64-kvm-b234.qcow2"
   arch: "x86_64"
-  digest: "sha256:b37061c50d341d01b674455eca404d0bdcf2c8391665eca7e601cbd4aef456f8"
-- location: "https://yum.oracle.com/templates/OracleLinux/OL9/u3/aarch64/OL9U3_aarch64-kvm-b50.qcow"
+  digest: "sha256:7f1cf4e1fafda55bb4d837d0eeb9592d60e896fa56565081fc4d8519c0a3fd1a"
+- location: "https://yum.oracle.com/templates/OracleLinux/OL9/u4/aarch64/OL9U4_aarch64-kvm-cloud-b90.qcow2"
   arch: "aarch64"
-  digest: "sha256:14428b531c1e2c76cd33bdbd69acc4d65ec9c12dd5eef7c8c1de2119adc3f8c8"
+  digest: "sha256:1f4e20190e87c76e8c3b4a9e15e660972386cbfa4f128e5cdcd8faa43a713d44"
 mounts:
 - location: "~"
 - location: "/tmp/lima"


### PR DESCRIPTION
Update sample templates for new Oracle Linux releases.

For aarch64, use the "cloud images" instead of the "full" ones as they are half the size. Only difference is that they don't include bare metal drivers.

Verified both OL8/OL9 on x86_64 and aarch64 platforms.