### PR TITLE
Fix sshutil cpu.HasAES detection on linux/arm64

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -324,6 +324,11 @@ func detectValidPublicKey(content string) bool {
 
 func detectAESAcceleration() bool {
 	if !cpu.Initialized {
+		if runtime.GOOS == "linux" && runtime.GOARCH == "arm64" {
+			// cpu.Initialized seems to always be false, even when the cpu.ARM64 struct is filled out
+			// it is only being set by readARM64Registers, but not by readHWCAP or readLinuxProcCPUInfo
+			return cpu.ARM64.HasAES
+		}
 		if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
 			// golang.org/x/sys/cpu supports darwin/amd64, linux/amd64, and linux/arm64,
 			// but apparently lacks support for darwin/arm64: https://github.com/golang/sys/blob/v0.5.0/cpu/cpu_arm64.go#L43-L60


### PR DESCRIPTION
Tested on Raspberry Pi.

The cpu.ARM64 struct

`{_:{_:[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]} HasFP:true HasASIMD:true HasEVTSTRM:true HasAES:true HasPMULL:true HasSHA1:true HasSHA2:true HasCRC32:true HasATOMICS:true HasFPHP:true HasASIMDHP:true HasCPUID:true HasASIMDRDM:true HasJSCVT:false HasFCMA:false HasLRCPC:true HasDCPOP:true HasSHA3:false HasSM3:false HasSM4:false HasASIMDDP:true HasSHA512:false HasSVE:false HasSVE2:false HasASIMDFHM:false _:{_:[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]}}`

Matches /proc/cpuinfo

`Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp`

Closes #2400