### PR TITLE
Move containerd archives from code to yaml

### DIFF
--- a/pkg/limayaml/containerd.yaml
+++ b/pkg/limayaml/containerd.yaml
@@ -1,0 +1,9 @@
+archives:
+- location: https://github.com/containerd/nerdctl/releases/download/v1.7.6/nerdctl-full-1.7.6-linux-amd64.tar.gz
+  arch: x86_64
+  digest: sha256:2c841e097fcfb5a1760bd354b3778cb695b44cd01f9f271c17507dc4a0b25606
+- location: https://github.com/containerd/nerdctl/releases/download/v1.7.6/nerdctl-full-1.7.6-linux-arm64.tar.gz
+  arch: aarch64
+  digest: sha256:77c747f09853ee3d229d77e8de0dd3c85622537d82be57433dc1fca4493bab95
+# No arm-v7
+# No riscv64

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -673,3 +673,8 @@ func TestFillDefault(t *testing.T) {
 	FillDefault(&y, &d, &o, filePath)
 	assert.DeepEqual(t, &y, &expect, opts...)
 }
+
+func TestContainerdDefault(t *testing.T) {
+	archives := defaultContainerdArchives()
+	assert.Assert(t, len(archives) > 0)
+}

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -194,8 +194,15 @@ func Validate(y *LimaYAML, warn bool) error {
 		}
 	}
 	needsContainerdArchives := (y.Containerd.User != nil && *y.Containerd.User) || (y.Containerd.System != nil && *y.Containerd.System)
-	if needsContainerdArchives && len(y.Containerd.Archives) == 0 {
-		return fmt.Errorf("field `containerd.archives` must be provided")
+	if needsContainerdArchives {
+		if len(y.Containerd.Archives) == 0 {
+			return fmt.Errorf("field `containerd.archives` must be provided")
+		}
+		for i, f := range y.Containerd.Archives {
+			if err := validateFileObject(f, fmt.Sprintf("containerd.archives[%d]", i)); err != nil {
+				return err
+			}
+		}
 	}
 	for i, p := range y.Probes {
 		switch p.Mode {


### PR DESCRIPTION
This makes it more similar to update compared to the images, and allows for integrating with other archives in the future*.

* #1123