### PR TITLE
PoC: Allow loading images by name from imagestore

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -19,6 +19,10 @@ ls:
   docs:
     .md: kebab-case
 
+  images:
+    # valid names are `ubuntu-24.04` or `debian-12`
+    .yaml: regex:[a-z0-9-.]+
+
   website/content:
     .dir: lowercase
 

--- a/Makefile
+++ b/Makefile
@@ -91,11 +91,14 @@ help-targets:
 	@echo  '- default_template          : Copy default.yaml template'
 	@echo  '- create-examples-link      : Create a symlink at ../examples pointing to templates'
 	@echo
+	@echo  'Targets for files in _output/share/lima/images/:'
+	@echo  '- images                    : Copy images'
+	@echo
 	@echo  'Targets for files in _output/share/doc/lima:'
 	@echo  '- documentation             : Copy documentation to _output/share/doc/lima'
 	@echo  '- create-links-in-doc-dir   : Create some symlinks pointing ../../lima/templates'
 	@echo
-	@echo  '# e.g. to install limactl, helpers, native guestagent, and templates:'
+	@echo  '# e.g. to install limactl, helpers, native guestagent, images and templates:'
 	@echo  '#   make native install'
 
 .PHONY: help-artifact
@@ -311,6 +314,19 @@ _output/share/lima/templates/%: examples/%
 # $(1): target file
 # On Windows, always copy to ensure the target has the same file as the source.
 force_link = $(if $(filter windows,$(GOOS)),force,$(shell test ! -L $(1) && echo force))
+
+################################################################################
+# _output/share/lima/images
+IMAGES = $(addprefix _output/share/lima/images/,$(notdir $(wildcard images/*)))
+
+.PHONY: images
+images: $(IMAGES)
+
+$(IMAGES): | _output/share/lima/images
+MKDIR_TARGETS += _output/share/lima/images
+
+_output/share/lima/images/%: images/%
+	cp -aL $< $@
 
 ################################################################################
 # _output/share/lima/examples

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/lima-vm/lima/pkg/fsutil"
+	"github.com/lima-vm/lima/pkg/imagestore"
+	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/version"
@@ -111,6 +113,8 @@ func newApp() *cobra.Command {
 		if err != nil {
 			return err
 		}
+		// Connect limayaml.Load to imagestore
+		limayaml.ReadImage = imagestore.Read
 		// Make sure that directory is on a local filesystem, not on NFS
 		// if the directory does not yet exist, check the home directory
 		_, err = os.Stat(dir)

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -33,21 +33,9 @@ arch: null
 
 # OpenStack-compatible disk image.
 # 🟢 Builtin default: null (must be specified)
-# 🔵 This file: Ubuntu images
+# 🔵 This file: ["default"] (see the output of `limactl info | jq .defaultImage.images`)
 images:
-# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
-- location: "https://cloud-images.ubuntu.com/releases/24.04/release-20240821/ubuntu-24.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-  digest: "sha256:0e25ca6ee9f08ec5d4f9910054b66ae7163c6152e81a3e67689d89bd6e4dfa69"
-- location: "https://cloud-images.ubuntu.com/releases/24.04/release-20240821/ubuntu-24.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
-  digest: "sha256:5ecac6447be66a164626744a87a27fd4e6c6606dc683e0a233870af63df4276a"
-# Fallback to the latest release image.
-# Hint: run `limactl prune` to invalidate the cache
-- location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img"
-  arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
-  arch: "aarch64"
+- default
 
 # CPUs
 # 🟢 Builtin default: min(4, host CPU cores)

--- a/images/ubuntu-24.04.yaml
+++ b/images/ubuntu-24.04.yaml
@@ -1,0 +1,14 @@
+images:
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+- location: "https://cloud-images.ubuntu.com/releases/24.04/release-20240821/ubuntu-24.04-server-cloudimg-amd64.img"
+  arch: "x86_64"
+  digest: "sha256:0e25ca6ee9f08ec5d4f9910054b66ae7163c6152e81a3e67689d89bd6e4dfa69"
+- location: "https://cloud-images.ubuntu.com/releases/24.04/release-20240821/ubuntu-24.04-server-cloudimg-arm64.img"
+  arch: "aarch64"
+  digest: "sha256:5ecac6447be66a164626744a87a27fd4e6c6606dc683e0a233870af63df4276a"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
+  arch: "aarch64"

--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -1,0 +1,63 @@
+package imagestore
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/lima-vm/lima/pkg/usrlocalsharelima"
+)
+
+type Image struct {
+	Name     string `json:"name"`
+	Location string `json:"location"`
+}
+
+func Read(name string) ([]byte, error) {
+	dir, err := usrlocalsharelima.Dir()
+	if err != nil {
+		return nil, err
+	}
+	if name == "default" {
+		name = Default
+	}
+	yamlPath, err := securejoin.SecureJoin(filepath.Join(dir, "images"), name+".yaml")
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadFile(yamlPath)
+}
+
+const Default = "ubuntu-24.04"
+
+func Images() ([]Image, error) {
+	usrlocalsharelimaDir, err := usrlocalsharelima.Dir()
+	if err != nil {
+		return nil, err
+	}
+	imagesDir := filepath.Join(usrlocalsharelimaDir, "images")
+
+	var res []Image
+	walkDirFn := func(p string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		base := filepath.Base(p)
+		if strings.HasPrefix(base, ".") || !strings.HasSuffix(base, ".yaml") {
+			return nil
+		}
+		x := Image{
+			// Name is like "ubuntu-24.04", "debian-12", ...
+			Name:     strings.TrimSuffix(strings.TrimPrefix(p, imagesDir+"/"), ".yaml"),
+			Location: p,
+		}
+		res = append(res, x)
+		return nil
+	}
+	if err = filepath.WalkDir(imagesDir, walkDirFn); err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/pkg/infoutil/infoutil.go
+++ b/pkg/infoutil/infoutil.go
@@ -2,6 +2,7 @@ package infoutil
 
 import (
 	"github.com/lima-vm/lima/pkg/driverutil"
+	"github.com/lima-vm/lima/pkg/imagestore"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/templatestore"
@@ -12,6 +13,8 @@ type Info struct {
 	Version         string                   `json:"version"`
 	Templates       []templatestore.Template `json:"templates"`
 	DefaultTemplate *limayaml.LimaYAML       `json:"defaultTemplate"`
+	Images          []imagestore.Image       `json:"images"`
+	DefaultImage    *limayaml.ImageYAML      `json:"defaultImage"`
 	LimaHome        string                   `json:"limaHome"`
 	VMTypes         []string                 `json:"vmTypes"` // since Lima v0.14.2
 }
@@ -25,12 +28,25 @@ func GetInfo() (*Info, error) {
 	if err != nil {
 		return nil, err
 	}
+	bi, err := imagestore.Read(imagestore.Default)
+	if err != nil {
+		return nil, err
+	}
+	yi, err := limayaml.LoadImage(bi, "")
+	if err != nil {
+		return nil, err
+	}
 	info := &Info{
 		Version:         version.Version,
 		DefaultTemplate: y,
+		DefaultImage:    yi,
 		VMTypes:         driverutil.Drivers(),
 	}
 	info.Templates, err = templatestore.Templates()
+	if err != nil {
+		return nil, err
+	}
+	info.Images, err = imagestore.Images()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -155,6 +155,8 @@ func defaultGuestInstallPrefix() string {
 	return "/usr/local"
 }
 
+var ReadImage func(name string) ([]byte, error)
+
 // FillDefault updates undefined fields in y with defaults from d (or built-in default), and overwrites with values from o.
 // Both d and o may be empty.
 //
@@ -194,6 +196,26 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 	y.Arch = ptr.Of(ResolveArch(y.Arch))
 
 	y.Images = append(append(o.Images, y.Images...), d.Images...)
+	images := []Image{}
+	for i := range y.Images {
+		img := &y.Images[i]
+		if img.Name != "" && ReadImage != nil {
+			ib, err := ReadImage(img.Name)
+			if err != nil {
+				logrus.Error(err)
+				continue
+			}
+			iy, err := LoadImage(ib, img.Name)
+			if err != nil {
+				logrus.Error(err)
+				continue
+			}
+			images = append(images, iy.Images...)
+		} else {
+			images = append(images, *img)
+		}
+	}
+	y.Images = images
 	for i := range y.Images {
 		img := &y.Images[i]
 		if img.Arch == "" {

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -88,6 +88,19 @@ func defaultContainerdArchives() []File {
 	return containerd.Archives
 }
 
+func defaultMounts() []Mount {
+	return []Mount{
+		{
+			Location: "~",
+			Writable: ptr.Of(false),
+		},
+		{
+			Location: "/tmp/lima",
+			Writable: ptr.Of(true),
+		},
+	}
+}
+
 // FirstUsernetIndex gets the index of first usernet network under l.Network[]. Returns -1 if no usernet network found.
 func FirstUsernetIndex(l *LimaYAML) int {
 	return slices.IndexFunc(l.Networks, func(network Network) bool { return networks.IsUsernet(network.Lima) })
@@ -644,6 +657,16 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 			location[mount.Location] = len(mounts)
 			mounts = append(mounts, mount)
 		}
+	}
+	y.Mounts = mounts
+
+	mounts = []Mount{}
+	for _, mount := range y.Mounts {
+		if mount.Name == "default" {
+			mounts = append(mounts, defaultMounts()...)
+			continue
+		}
+		mounts = append(mounts, mount)
 	}
 	y.Mounts = mounts
 

--- a/pkg/limayaml/image.yaml
+++ b/pkg/limayaml/image.yaml
@@ -1,0 +1,1 @@
+../../images/ubuntu-24.04.yaml

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -47,6 +47,10 @@ type LimaYAML struct {
 	TimeZone          *string        `yaml:"timezone,omitempty" json:"timezone,omitempty"`
 }
 
+type ImageYAML struct {
+	Images []Image `yaml:"images" json:"images"`
+}
+
 type (
 	OS        = string
 	Arch      = string
@@ -104,6 +108,7 @@ type Kernel struct {
 }
 
 type Image struct {
+	Name   string `yaml:"name,omitempty" json:"name,omitempty"`
 	File   `yaml:",inline"`
 	Kernel *Kernel `yaml:"kernel,omitempty" json:"kernel,omitempty"`
 	Initrd *File   `yaml:"initrd,omitempty" json:"initrd,omitempty"`

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -122,6 +122,7 @@ type Disk struct {
 }
 
 type Mount struct {
+	Name       string   `yaml:"name,omitempty" json:"name,omitempty"`
 	Location   string   `yaml:"location" json:"location"` // REQUIRED
 	MountPoint string   `yaml:"mountPoint,omitempty" json:"mountPoint,omitempty"`
 	Writable   *bool    `yaml:"writable,omitempty" json:"writable,omitempty"`

--- a/pkg/limayaml/load.go
+++ b/pkg/limayaml/load.go
@@ -13,6 +13,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func unmarshalMount(dst *Mount, b []byte) error {
+	var s string
+	if err := yaml.Unmarshal(b, &s); err == nil {
+		*dst = Mount{Name: s}
+		return nil
+	}
+	return yaml.Unmarshal(b, dst)
+}
+
 func unmarshalDisk(dst *Disk, b []byte) error {
 	var s string
 	if err := yaml.Unmarshal(b, &s); err == nil {
@@ -32,6 +41,7 @@ func unmarshalImage(dst *Image, b []byte) error {
 }
 
 var customMarshalers = []yaml.DecodeOption{
+	yaml.CustomUnmarshaler[Mount](unmarshalMount),
 	yaml.CustomUnmarshaler[Disk](unmarshalDisk),
 	yaml.CustomUnmarshaler[Image](unmarshalImage),
 }

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -153,6 +153,13 @@ func Validate(y *LimaYAML, warn bool) error {
 	reservedHome := fmt.Sprintf("/home/%s.linux", u.Username)
 
 	for i, f := range y.Mounts {
+		if f.Name != "" {
+			if f.Name != "default" {
+				return fmt.Errorf("field `mounts[%d].name` refers to an unknown name: %q",
+					i, f.Name)
+			}
+			continue
+		}
 		if !filepath.IsAbs(f.Location) && !strings.HasPrefix(f.Location, "~") {
 			return fmt.Errorf("field `mounts[%d].location` must be an absolute path, got %q",
 				i, f.Location)

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -91,6 +91,15 @@ func Validate(y *LimaYAML, warn bool) error {
 		return errors.New("field `images` must be set")
 	}
 	for i, f := range y.Images {
+		if f.Name != "" {
+			if ReadImage == nil {
+				return fmt.Errorf("limayaml.ReadImage is not set")
+			}
+			if _, err := ReadImage(f.Name); err != nil {
+				return err
+			}
+			continue
+		}
 		if err := validateFileObject(f.File, fmt.Sprintf("images[%d]", i)); err != nil {
 			return err
 		}

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -1,6 +1,7 @@
 package limayaml
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"testing"
@@ -17,6 +18,13 @@ func TestValidateEmpty(t *testing.T) {
 
 // Note: can't embed symbolic links, use "os"
 
+func readImage(name string) ([]byte, error) {
+	if name != "default" {
+		return nil, fmt.Errorf("unexpected image: %s", name)
+	}
+	return os.ReadFile("image.yaml")
+}
+
 func TestValidateDefault(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		// FIXME: `assertion failed: error is not nil: field `mounts[1].location` must be an absolute path, got "/tmp/lima"`
@@ -25,6 +33,7 @@ func TestValidateDefault(t *testing.T) {
 
 	bytes, err := os.ReadFile("default.yaml")
 	assert.NilError(t, err)
+	ReadImage = readImage
 	y, err := Load(bytes, "default.yaml")
 	assert.NilError(t, err)
 	err = Validate(y, true)


### PR DESCRIPTION
This allows you to have a template like:

```yaml
images:
- ubuntu-24.04
mounts:
- location: "~"
- location: "/tmp/lima"
  writable: true
```

Loading from another document like:

```yaml
images:
# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
- location: "https://cloud-images.ubuntu.com/releases/24.04/release-20240423/ubuntu-24.04-server-cloudimg-amd64.img"
  arch: "x86_64"
  digest: "sha256:32a9d30d18803da72f5936cf2b7b9efcb4d0bb63c67933f17e3bdfd1751de3f3"
- location: "https://cloud-images.ubuntu.com/releases/24.04/release-20240423/ubuntu-24.04-server-cloudimg-arm64.img"
  arch: "aarch64"
  digest: "sha256:c841bac00925d3e6892d979798103a867931f255f28fefd9d5e07e3e22d0ef22"
# Fallback to the latest release image.
# Hint: run `limactl prune` to invalidate the cache
- location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img"
  arch: "x86_64"
- location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
  arch: "aarch64"
```

This makes it more similar to an OCI registry (or Vagrant), and allows for even using one (or IPFS) in the future.

* #824

Perhaps "images" isn't the best name, since unlike a vagrant box there are no images contained in the directory.

~~The current implementation is just using the yaml filename, rather than the "name" field in the document itself.~~


Closes #2418
Closes #2422