### PR TITLE
update golangci-lint (1.59.1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v6.0.1
       with:
-        version: v1.55.2
+        version: v1.59.1
         args: --verbose --timeout=10m
     - name: Run yamllint
       run: yamllint .

--- a/cmd/lima-guestagent/main_linux.go
+++ b/cmd/lima-guestagent/main_linux.go
@@ -21,7 +21,7 @@ func newApp() *cobra.Command {
 		Version: strings.TrimPrefix(version.Version, "v"),
 	}
 	rootCmd.PersistentFlags().Bool("debug", false, "debug mode")
-	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
 		debug, _ := cmd.Flags().GetBool("debug")
 		if debug {
 			logrus.SetLevel(logrus.DebugLevel)

--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -22,7 +22,7 @@ func registerEdit(cmd *cobra.Command, commentPrefix string) {
 	flags := cmd.Flags()
 
 	flags.Int("cpus", 0, commentPrefix+"number of CPUs") // Similar to colima's --cpu, but the flag name is slightly different (cpu vs cpus)
-	_ = cmd.RegisterFlagCompletionFunc("cpus", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc("cpus", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		var res []string
 		for _, f := range completeCPUs(runtime.NumCPU()) {
 			res = append(res, strconv.Itoa(f))
@@ -33,7 +33,7 @@ func registerEdit(cmd *cobra.Command, commentPrefix string) {
 	flags.IPSlice("dns", nil, commentPrefix+"specify custom DNS (disable host resolver)") // colima-compatible
 
 	flags.Float32("memory", 0, commentPrefix+"memory in GiB") // colima-compatible
-	_ = cmd.RegisterFlagCompletionFunc("memory", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc("memory", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		var res []string
 		for _, f := range completeMemoryGiB(memory.TotalMemory()) {
 			res = append(res, fmt.Sprintf("%.1f", f))
@@ -44,7 +44,7 @@ func registerEdit(cmd *cobra.Command, commentPrefix string) {
 	flags.StringSlice("mount", nil, commentPrefix+"directories to mount, suffix ':w' for writable (Do not specify directories that overlap with the existing mounts)") // colima-compatible
 
 	flags.String("mount-type", "", commentPrefix+"mount type (reverse-sshfs, 9p, virtiofs)") // Similar to colima's --mount-type=(sshfs|9p|virtiofs), but "reverse-sshfs" is Lima is called "sshfs" in colima
-	_ = cmd.RegisterFlagCompletionFunc("mount-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc("mount-type", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return []string{"reverse-sshfs", "9p", "virtiofs"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
@@ -52,7 +52,7 @@ func registerEdit(cmd *cobra.Command, commentPrefix string) {
 	flags.Bool("mount-inotify", false, commentPrefix+"enable inotify for mounts")
 
 	flags.StringSlice("network", nil, commentPrefix+"additional networks, e.g., \"vzNAT\" or \"lima:shared\" to assign vmnet IP")
-	_ = cmd.RegisterFlagCompletionFunc("network", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc("network", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		// TODO: retrieve the lima:* network list from networks.yaml
 		return []string{"lima:shared", "lima:bridged", "lima:host", "lima:user-v2", "vzNAT"}, cobra.ShellCompDirectiveNoFileComp
 	})
@@ -71,22 +71,22 @@ func RegisterCreate(cmd *cobra.Command, commentPrefix string) {
 	flags := cmd.Flags()
 
 	flags.String("arch", "", commentPrefix+"machine architecture (x86_64, aarch64, riscv64)") // colima-compatible
-	_ = cmd.RegisterFlagCompletionFunc("arch", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc("arch", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return []string{"x86_64", "aarch64", "riscv64"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	flags.String("containerd", "", commentPrefix+"containerd mode (user, system, user+system, none)")
-	_ = cmd.RegisterFlagCompletionFunc("vm-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc("vm-type", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return []string{"user", "system", "user+system", "none"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	flags.Float32("disk", 0, commentPrefix+"disk size in GiB") // colima-compatible
-	_ = cmd.RegisterFlagCompletionFunc("memory", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc("memory", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return []string{"10", "30", "50", "100", "200"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	flags.String("vm-type", "", commentPrefix+"virtual machine type (qemu, vz)") // colima-compatible
-	_ = cmd.RegisterFlagCompletionFunc("vm-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc("vm-type", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return []string{"qemu", "vz"}, cobra.ShellCompDirectiveNoFileComp
 	})
 

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -63,7 +63,7 @@ func newApp() *cobra.Command {
 	rootCmd.PersistentFlags().Bool("debug", false, "debug mode")
 	// TODO: "survey" does not support using cygwin terminal on windows yet
 	rootCmd.PersistentFlags().Bool("tty", isatty.IsTerminal(os.Stdout.Fd()), "Enable TUI interactions such as opening an editor. Defaults to true when stdout is a terminal. Set to false for automation.")
-	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
 		l, _ := cmd.Flags().GetString("log-level")
 		if l != "" {
 			lvl, err := logrus.ParseLevel(l)

--- a/cmd/limactl/show_ssh.go
+++ b/cmd/limactl/show_ssh.go
@@ -66,7 +66,7 @@ Instead, use 'ssh -F %s/default/ssh.config lima-default' .
 	}
 
 	shellCmd.Flags().StringP("format", "f", sshutil.FormatCmd, "Format: "+strings.Join(sshutil.Formats, ", "))
-	_ = shellCmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = shellCmd.RegisterFlagCompletionFunc("format", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return sshutil.Formats, cobra.ShellCompDirectiveNoFileComp
 	})
 	return shellCmd

--- a/cmd/limactl/snapshot.go
+++ b/cmd/limactl/snapshot.go
@@ -15,7 +15,7 @@ func newSnapshotCommand() *cobra.Command {
 	snapshotCmd := &cobra.Command{
 		Use:   "snapshot",
 		Short: "Manage instance snapshots",
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(*cobra.Command, []string) {
 			logrus.Warn("`limactl snapshot` is experimental")
 		},
 		GroupID: advancedCommand,

--- a/pkg/editutil/editutil.go
+++ b/pkg/editutil/editutil.go
@@ -24,7 +24,7 @@ func fileWarning(filename string) string {
 	s += "# -----------\n"
 	for _, line := range strings.Split(strings.TrimSuffix(string(b), "\n"), "\n") {
 		s += "#"
-		if len(line) > 0 {
+		if line != "" {
 			s += " " + line
 		}
 		s += "\n"

--- a/pkg/fsutil/fsutil_others.go
+++ b/pkg/fsutil/fsutil_others.go
@@ -2,6 +2,6 @@
 
 package fsutil
 
-func IsNFS(path string) (bool, error) {
+func IsNFS(string) (bool, error) {
 	return false, nil
 }

--- a/pkg/guestagent/api/client/client.go
+++ b/pkg/guestagent/api/client/client.go
@@ -15,7 +15,7 @@ type GuestAgentClient struct {
 
 func NewGuestAgentClient(dialFn func(ctx context.Context) (net.Conn, error)) (*GuestAgentClient, error) {
 	opts := []grpc.DialOption{
-		grpc.WithContextDialer(func(ctx context.Context, target string) (net.Conn, error) {
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 			return dialFn(ctx)
 		}),
 		grpc.WithTransportCredentials(NewCredentials()),

--- a/pkg/guestagent/kubernetesservice/kubernetesservice_test.go
+++ b/pkg/guestagent/kubernetesservice/kubernetesservice_test.go
@@ -28,7 +28,7 @@ func TestGetPorts(t *testing.T) {
 	kubeClient, informerFactory := newFakeKubeClient()
 	serviceInformer := informerFactory.Core().V1().Services().Informer()
 	_, err := serviceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) { serviceCreatedCh <- struct{}{} },
+		AddFunc: func(interface{}) { serviceCreatedCh <- struct{}{} },
 	})
 	assert.NilError(t, err)
 	informerFactory.Start(ctx.Done())

--- a/pkg/hostagent/dns/dns.go
+++ b/pkg/hostagent/dns/dns.go
@@ -400,7 +400,7 @@ func listenAndServe(network Network, opts ServerOptions) (*dns.Server, error) {
 
 func chunkify(buffer string, limit int) []string {
 	var result []string
-	for len(buffer) > 0 {
+	for buffer != "" {
 		if len(buffer) < limit {
 			limit = len(buffer)
 		}

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -211,19 +211,19 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 	cpuType := defaultCPUType()
 	var overrideCPUType bool
 	for k, v := range d.CPUType {
-		if len(v) > 0 {
+		if v != "" {
 			overrideCPUType = true
 			cpuType[k] = v
 		}
 	}
 	for k, v := range y.CPUType {
-		if len(v) > 0 {
+		if v != "" {
 			overrideCPUType = true
 			cpuType[k] = v
 		}
 	}
 	for k, v := range o.CPUType {
-		if len(v) > 0 {
+		if v != "" {
 			overrideCPUType = true
 			cpuType[k] = v
 		}

--- a/pkg/networks/usernet/client.go
+++ b/pkg/networks/usernet/client.go
@@ -129,7 +129,7 @@ func NewClient(endpointSock string, subnet net.IP) *Client {
 func create(sock string, subnet net.IP, base string) *Client {
 	client := &http.Client{
 		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			DialContext: func(context.Context, string, string) (net.Conn, error) {
 				return net.Dial("unix", sock)
 			},
 		},

--- a/pkg/networks/validate.go
+++ b/pkg/networks/validate.go
@@ -114,11 +114,11 @@ func validatePath(path string, allowDaemonGroupWritable bool) error {
 	}
 	ownerIsAdmin := owner.Uid == "0"
 	if !ownerIsAdmin {
-		ownerGroupIds, err := owner.GroupIds()
+		ownerGroupIDs, err := owner.GroupIds()
 		if err != nil {
 			return err
 		}
-		for _, g := range ownerGroupIds {
+		for _, g := range ownerGroupIDs {
 			if g == adminGroup.Gid {
 				ownerIsAdmin = true
 				break

--- a/pkg/templatestore/templatestore.go
+++ b/pkg/templatestore/templatestore.go
@@ -37,7 +37,7 @@ func Templates() ([]Template, error) {
 	templatesDir := filepath.Join(usrlocalsharelimaDir, "templates")
 
 	var res []Template
-	walkDirFn := func(p string, d fs.DirEntry, err error) error {
+	walkDirFn := func(p string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/pkg/vz/network_darwin.go
+++ b/pkg/vz/network_darwin.go
@@ -52,7 +52,7 @@ func DialQemu(unixSock string) (*os.File, error) {
 	}
 
 	remote := tcpproxy.DialProxy{
-		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
 			return dgramConn, nil
 		},
 	}

--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -711,10 +711,10 @@ func createSockPair() (server, client *os.File, _ error) {
 	}
 	server = os.NewFile(uintptr(serverFD), "server")
 	client = os.NewFile(uintptr(clientFD), "client")
-	runtime.SetFinalizer(server, func(file *os.File) {
+	runtime.SetFinalizer(server, func(*os.File) {
 		logrus.Debugf("Server network file GC'ed")
 	})
-	runtime.SetFinalizer(client, func(file *os.File) {
+	runtime.SetFinalizer(client, func(*os.File) {
 		logrus.Debugf("Client network file GC'ed")
 	})
 	vmNetworkFiles = append(vmNetworkFiles, server, client)


### PR DESCRIPTION
The PR updates golangci-lint to the latest [v1.59.1](https://github.com/golangci/golangci-lint/releases/tag/v1.59.1) and fixes up appeared lint issues.

Main lint issues:

- gocritic: emptyStringTest: `replace len(buffer) > 0 with buffer != ""` (see https://dmitri.shuralyov.com/idiomatic-go#empty-string-check)
- gocritic: unused-parameter: `cmd, args, toComplete`
- revive: var-naming: `var ownerGroupIds should be ownerGroupIDs`

<details>
<summary>The full log of running golangci-lint</summary>

```sh
❯ golangci-lint run
pkg/guestagent/api/client/client.go:18:52: unused-parameter: parameter 'target' seems to be unused, consider removing or renaming it as _ (revive)
                grpc.WithContextDialer(func(ctx context.Context, target string) (net.Conn, error) {
                                                                 ^
pkg/templatestore/templatestore.go:40:30: unused-parameter: parameter 'd' seems to be unused, consider removing or renaming it as _ (revive)
        walkDirFn := func(p string, d fs.DirEntry, err error) error {
                                    ^
pkg/networks/validate.go:117:3: var-naming: var ownerGroupIds should be ownerGroupIDs (revive)
                ownerGroupIds, err := owner.GroupIds()
                ^
pkg/guestagent/kubernetesservice/kubernetesservice_test.go:31:17: unused-parameter: parameter 'obj' seems to be unused, consider removing or renaming it as _ (revive)
                AddFunc: func(obj interface{}) { serviceCreatedCh <- struct{}{} },
                              ^
pkg/hostagent/dns/dns.go:403:6: emptyStringTest: replace `len(buffer) > 0` with `buffer != ""` (gocritic)
        for len(buffer) > 0 {
            ^
pkg/fsutil/fsutil_others.go:5:12: unused-parameter: parameter 'path' seems to be unused, consider removing or renaming it as _ (revive)
func IsNFS(path string) (bool, error) {
           ^
cmd/limactl/snapshot.go:18:26: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
                PersistentPreRun: func(cmd *cobra.Command, args []string) {
                                       ^
cmd/limactl/show_ssh.go:69:57: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
        _ = shellCmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
                                                               ^
cmd/limactl/main.go:66:55: unused-parameter: parameter 'args' seems to be unused, consider removing or renaming it as _ (revive)
        rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
                                                             ^
cmd/limactl/editflags/editflags.go:25:50: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
        _ = cmd.RegisterFlagCompletionFunc("cpus", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
                                                        ^
cmd/limactl/editflags/editflags.go:36:52: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
        _ = cmd.RegisterFlagCompletionFunc("memory", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
                                                          ^
cmd/limactl/editflags/editflags.go:47:56: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
        _ = cmd.RegisterFlagCompletionFunc("mount-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
                                                              ^
cmd/limactl/editflags/editflags.go:55:53: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
        _ = cmd.RegisterFlagCompletionFunc("network", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
                                                           ^
cmd/limactl/editflags/editflags.go:74:50: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
        _ = cmd.RegisterFlagCompletionFunc("arch", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
                                                        ^
cmd/limactl/editflags/editflags.go:79:53: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
        _ = cmd.RegisterFlagCompletionFunc("vm-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
                                                           ^
cmd/limactl/editflags/editflags.go:84:52: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
        _ = cmd.RegisterFlagCompletionFunc("memory", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
                                                          ^
cmd/limactl/editflags/editflags.go:89:53: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
        _ = cmd.RegisterFlagCompletionFunc("vm-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
                                                           ^
pkg/limayaml/defaults.go:214:6: emptyStringTest: replace `len(v) > 0` with `v != ""` (gocritic)
                if len(v) > 0 {
                   ^
pkg/limayaml/defaults.go:220:6: emptyStringTest: replace `len(v) > 0` with `v != ""` (gocritic)
                if len(v) > 0 {
                   ^
pkg/limayaml/defaults.go:226:6: emptyStringTest: replace `len(v) > 0` with `v != ""` (gocritic)
                if len(v) > 0 {
                   ^
pkg/vz/network_darwin.go:55:21: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
                DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
                                  ^
pkg/vz/vm_darwin.go:714:36: unused-parameter: parameter 'file' seems to be unused, consider removing or renaming it as _ (revive)
        runtime.SetFinalizer(server, func(file *os.File) {
                                          ^
pkg/vz/vm_darwin.go:717:36: unused-parameter: parameter 'file' seems to be unused, consider removing or renaming it as _ (revive)
        runtime.SetFinalizer(client, func(file *os.File) {
                                          ^
pkg/editutil/editutil.go:27:6: emptyStringTest: replace `len(line) > 0` with `line != ""` (gocritic)
                if len(line) > 0 {
                   ^
pkg/networks/usernet/client.go:132:22: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
                        DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
                                          ^
```

</details>