### PR TITLE
Enable godot linter; append dot at the end of comments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,7 @@ linters:
   # - goconst
   - gocritic
   # - gocyclo
-  # - godot
+  - godot
   # - godox
   # - goerr113
   - gofumpt
@@ -111,3 +111,7 @@ issues:
   # Allow using Uid, Gid in pkg/osutil.
   - path: "pkg/osutil/"
     text: "uid"
+  # Disable some linters for test files.
+  - path: _test\.go
+    linters:
+    - godot

--- a/cmd/limactl/gendoc.go
+++ b/cmd/limactl/gendoc.go
@@ -116,7 +116,7 @@ weight: 3
 	})
 }
 
-// replaceAll replaces all occurrences of new with old, for all files in dir
+// replaceAll replaces all occurrences of new with old, for all files in dir.
 func replaceAll(dir, old, new string) error {
 	logrus.Infof("Replacing %q with %q", old, new)
 	return filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {

--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -112,7 +112,7 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 	return ha.Run(cmd.Context())
 }
 
-// syncer is implemented by *os.File
+// syncer is implemented by *os.File.
 type syncer interface {
 	Sync() error
 }

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -161,7 +161,7 @@ func handleExitCoder(err error) {
 	}
 }
 
-// WrapArgsError annotates cobra args error with some context, so the error message is more user-friendly
+// WrapArgsError annotates cobra args error with some context, so the error message is more user-friendly.
 func WrapArgsError(argFn cobra.PositionalArgs) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		err := argFn(cmd, args)

--- a/pkg/autostart/autostart.go
+++ b/pkg/autostart/autostart.go
@@ -21,7 +21,7 @@ var systemdTemplate string
 //go:embed io.lima-vm.autostart.INSTANCE.plist
 var launchdTemplate string
 
-// CreateStartAtLoginEntry respect host OS arch and create unit file
+// CreateStartAtLoginEntry respect host OS arch and create unit file.
 func CreateStartAtLoginEntry(hostOS, instName, workDir string) error {
 	unitPath := GetFilePath(hostOS, instName)
 	if _, err := os.Stat(unitPath); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -40,8 +40,8 @@ func CreateStartAtLoginEntry(hostOS, instName, workDir string) error {
 	return enableDisableService("enable", hostOS, GetFilePath(hostOS, instName))
 }
 
-// DeleteStartAtLoginEntry respect host OS arch and delete unit file
-// return true, nil if unit file has been deleted
+// DeleteStartAtLoginEntry respect host OS arch and delete unit file.
+// Return true, nil if unit file has been deleted.
 func DeleteStartAtLoginEntry(hostOS, instName string) (bool, error) {
 	unitPath := GetFilePath(hostOS, instName)
 	if _, err := os.Stat(unitPath); err != nil {
@@ -56,7 +56,7 @@ func DeleteStartAtLoginEntry(hostOS, instName string) (bool, error) {
 	return true, nil
 }
 
-// GetFilePath returns the path to autostart file with respect of host
+// GetFilePath returns the path to autostart file with respect of host.
 func GetFilePath(hostOS, instName string) string {
 	var fileTmpl string
 	if hostOS == "darwin" { // launchd plist

--- a/pkg/bicopy/bicopy.go
+++ b/pkg/bicopy/bicopy.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Bicopy is from https://github.com/rootless-containers/rootlesskit/blob/v0.10.1/pkg/port/builtin/parent/tcp/tcp.go#L73-L104
-// (originally from libnetwork, Apache License 2.0)
+// (originally from libnetwork, Apache License 2.0).
 func Bicopy(x, y io.ReadWriter, quit <-chan struct{}) {
 	type closeReader interface {
 		CloseRead() error

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -23,10 +23,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// HideProgress is used only for testing
+// HideProgress is used only for testing.
 var HideProgress bool
 
-// hideBar is used only for testing
+// hideBar is used only for testing.
 func hideBar(bar *pb.ProgressBar) {
 	bar.Set(pb.ReturnSymbol, "")
 	bar.SetTemplateString("")
@@ -96,8 +96,8 @@ func WithDecompress(decompress bool) Opt {
 // WithExpectedDigest is used to validate the downloaded file against the expected digest.
 //
 // The digest is not verified in the following cases:
-// - The digest was not specified.
-// - The file already exists in the local target path.
+//   - The digest was not specified.
+//   - The file already exists in the local target path.
 //
 // When the `data` file exists in the cache dir with `<ALGO>.digest` file,
 // the digest is verified by comparing the content of `<ALGO>.digest` with the expected
@@ -291,14 +291,14 @@ func Cached(remote string, opts ...Opt) (*Result, error) {
 }
 
 // cacheDirectoryPath returns the cache subdirectory path.
-// - "url" file contains the url
-// - "data" file contains the data
+//   - "url" file contains the url
+//   - "data" file contains the data
 func cacheDirectoryPath(cacheDir, remote string) string {
 	return filepath.Join(cacheDir, "download", "by-url-sha256", fmt.Sprintf("%x", sha256.Sum256([]byte(remote))))
 }
 
 // cacheDigestPath returns the cache digest file path.
-// - "<ALGO>.digest" contains the digest
+//   - "<ALGO>.digest" contains the digest
 func cacheDigestPath(shad string, expectedDigest digest.Digest) (string, error) {
 	shadDigest := ""
 	if expectedDigest != "" {
@@ -316,9 +316,9 @@ func IsLocal(s string) bool {
 }
 
 // canonicalLocalPath canonicalizes the local path string.
-// - Make sure the file has no scheme, or the `file://` scheme
-// - If it has the `file://` scheme, strip the scheme and make sure the filename is absolute
-// - Expand a leading `~`, or convert relative to absolute name
+//   - Make sure the file has no scheme, or the `file://` scheme
+//   - If it has the `file://` scheme, strip the scheme and make sure the filename is absolute
+//   - Expand a leading `~`, or convert relative to absolute name
 func canonicalLocalPath(s string) (string, error) {
 	if s == "" {
 		return "", fmt.Errorf("got empty path")

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -12,7 +12,7 @@ import (
 // Driver interface is used by hostagent for managing vm.
 //
 // This interface is extended by BaseDriver which provides default implementation.
-// All other driver definition must extend BaseDriver
+// All other driver definition must extend BaseDriver.
 type Driver interface {
 	// Validate returns error if the current driver isn't support for given config
 	Validate() error

--- a/pkg/guestagent/kubernetesservice/kubernetesservice.go
+++ b/pkg/guestagent/kubernetesservice/kubernetesservice.go
@@ -22,7 +22,7 @@ import (
 type Protocol string
 
 const (
-	// UDP/SCTP when lima port forwarding works on those protocols
+	// UDP/SCTP when lima port forwarding works on those protocols.
 	TCP Protocol = "TCP"
 )
 

--- a/pkg/guestagent/procnettcp/procnettcp.go
+++ b/pkg/guestagent/procnettcp/procnettcp.go
@@ -15,7 +15,7 @@ type Kind = string
 const (
 	TCP  Kind = "tcp"
 	TCP6 Kind = "tcp6"
-	// TODO: "udp", "udp6", "udplite", "udplite6"
+	// TODO: "udp", "udp6", "udplite", "udplite6".
 )
 
 type State = int

--- a/pkg/guestagent/procnettcp/procnettcp_linux.go
+++ b/pkg/guestagent/procnettcp/procnettcp_linux.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-// ParseFiles parses /proc/net/{tcp, tcp6}
+// ParseFiles parses /proc/net/{tcp, tcp6}.
 func ParseFiles() ([]Entry, error) {
 	var res []Entry
 	files := map[string]Kind{

--- a/pkg/hostagent/api/server/server.go
+++ b/pkg/hostagent/api/server/server.go
@@ -24,7 +24,7 @@ func (b *Backend) onError(w http.ResponseWriter, err error, ec int) {
 	_ = json.NewEncoder(w).Encode(e)
 }
 
-// GetInfo is the handler for GET /v1/info
+// GetInfo is the handler for GET /v1/info.
 func (b *Backend) GetInfo(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.WriteHeader(http.StatusMethodNotAllowed)

--- a/pkg/hostagent/port_darwin.go
+++ b/pkg/hostagent/port_darwin.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// forwardTCP is not thread-safe
+// forwardTCP is not thread-safe.
 func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote, verb string) error {
 	if strings.HasPrefix(local, "/") {
 		return forwardSSH(ctx, sshConfig, port, local, remote, verb, false)

--- a/pkg/httpclientutil/httpclientutil.go
+++ b/pkg/httpclientutil/httpclientutil.go
@@ -63,10 +63,10 @@ func readAtMost(r io.Reader, maxBytes int) ([]byte, error) {
 	return b, nil
 }
 
-// HTTPStatusErrorBodyMaxLength specifies the maximum length of HTTPStatusError.Body
+// HTTPStatusErrorBodyMaxLength specifies the maximum length of HTTPStatusError.Body.
 const HTTPStatusErrorBodyMaxLength = 64 * 1024
 
-// HTTPStatusError is created from non-2XX HTTP response
+// HTTPStatusError is created from non-2XX HTTP response.
 type HTTPStatusError struct {
 	// StatusCode is non-2XX status code
 	StatusCode int

--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -1,6 +1,6 @@
 package httputil
 
-// ErrorJSON is returned with "application/json" content type and non-2XX status code
+// ErrorJSON is returned with "application/json" content type and non-2XX status code.
 type ErrorJSON struct {
 	Message string `json:"message"`
 }

--- a/pkg/ioutilx/ioutilx.go
+++ b/pkg/ioutilx/ioutilx.go
@@ -29,7 +29,7 @@ func ReadAtMaximum(r io.Reader, n int64) ([]byte, error) {
 
 // FromUTF16le returns an io.Reader for UTF16le data.
 // Windows uses little endian by default, use unicode.UseBOM policy to retrieve BOM from the text,
-// and unicode.LittleEndian as a fallback
+// and unicode.LittleEndian as a fallback.
 func FromUTF16le(r io.Reader) io.Reader {
 	o := transform.NewReader(r, unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewDecoder())
 	return o

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -89,7 +89,7 @@ func defaultContainerdArchives() []File {
 	}
 }
 
-// FirstUsernetIndex gets the index of first usernet network under l.Network[]. Returns -1 if no usernet network found
+// FirstUsernetIndex gets the index of first usernet network under l.Network[]. Returns -1 if no usernet network found.
 func FirstUsernetIndex(l *LimaYAML) int {
 	return slices.IndexFunc(l.Networks, func(network Network) bool { return networks.IsUsernet(network.Lima) })
 }

--- a/pkg/logrusutil/logrusutil.go
+++ b/pkg/logrusutil/logrusutil.go
@@ -59,7 +59,7 @@ fallback:
 	entry.Info(header + string(jsonLine))
 }
 
-// JSON is the type used in logrus.JSONFormatter
+// JSON is the type used in logrus.JSONFormatter.
 type JSON struct {
 	Level string    `json:"level"`
 	Msg   string    `json:"msg"`

--- a/pkg/networks/commands.go
+++ b/pkg/networks/commands.go
@@ -25,7 +25,7 @@ func (config *YAML) Check(name string) error {
 	return fmt.Errorf("network %q is not defined", name)
 }
 
-// Usernet Returns true if the mode of given network is ModeUserV2
+// Usernet returns true if the mode of given network is ModeUserV2.
 func (config *YAML) Usernet(name string) (bool, error) {
 	if nw, ok := config.Networks[name]; ok {
 		return nw.Mode == ModeUserV2, nil

--- a/pkg/networks/usernet/config.go
+++ b/pkg/networks/usernet/config.go
@@ -28,7 +28,7 @@ func Sock(name string, sockType SockType) (string, error) {
 	return SockWithDirectory(filepath.Join(dir, name), name, sockType)
 }
 
-// SockWithDirectory return a usernet socket based on dir, name and sockType
+// SockWithDirectory return a usernet socket based on dir, name and sockType.
 func SockWithDirectory(dir, name string, sockType SockType) (string, error) {
 	if name == "" {
 		name = "default"
@@ -41,7 +41,7 @@ func SockWithDirectory(dir, name string, sockType SockType) (string, error) {
 	return sockPath, nil
 }
 
-// PIDFile returns a path for usernet PID file
+// PIDFile returns a path for usernet PID file.
 func PIDFile(name string) (string, error) {
 	dir, err := dirnames.LimaNetworksDir()
 	if err != nil {
@@ -84,12 +84,12 @@ func Subnet(name string) (net.IP, error) {
 	return ipNet.IP, err
 }
 
-// GatewayIP returns the 2nd IP for the given subnet
+// GatewayIP returns the 2nd IP for the given subnet.
 func GatewayIP(subnet net.IP) string {
 	return cidr.Inc(cidr.Inc(subnet)).String()
 }
 
-// DNSIP returns the 3rd IP for the given subnet
+// DNSIP returns the 3rd IP for the given subnet.
 func DNSIP(subnet net.IP) string {
 	return cidr.Inc(cidr.Inc(cidr.Inc(subnet))).String()
 }

--- a/pkg/networks/usernet/recoincile.go
+++ b/pkg/networks/usernet/recoincile.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Start starts a instance a usernet network with the given name.
-// The name parameter must point to a valid network configuration name under <LIMA_HOME>/_config/networks.yaml with `mode: user-v2`
+// The name parameter must point to a valid network configuration name under <LIMA_HOME>/_config/networks.yaml with `mode: user-v2`.
 func Start(ctx context.Context, name string) error {
 	logrus.Debugf("Make sure usernet network is started")
 	networksDir, err := dirnames.LimaNetworksDir()
@@ -120,7 +120,7 @@ func Start(ctx context.Context, name string) error {
 }
 
 // Stop stops running instance a usernet network with the given name.
-// The name parameter must point to a valid network configuration name under <LIMA_HOME>/_config/networks.yaml with `mode: user-v2`
+// The name parameter must point to a valid network configuration name under <LIMA_HOME>/_config/networks.yaml with `mode: user-v2`.
 func Stop(ctx context.Context, name string) error {
 	logrus.Debugf("Make sure usernet network is stopped")
 	pidFile, err := PIDFile(name)

--- a/pkg/osutil/osutil_linux.go
+++ b/pkg/osutil/osutil_linux.go
@@ -8,7 +8,7 @@ import (
 // UnixPathMax is the value of UNIX_PATH_MAX.
 const UnixPathMax = 108
 
-// Stat is a selection of syscall.Stat_t
+// Stat is a selection of syscall.Stat_t.
 type Stat struct {
 	Uid uint32
 	Gid uint32

--- a/pkg/osutil/osutil_others.go
+++ b/pkg/osutil/osutil_others.go
@@ -10,7 +10,7 @@ import (
 // UnixPathMax is the value of UNIX_PATH_MAX.
 const UnixPathMax = 104
 
-// Stat is a selection of syscall.Stat_t
+// Stat is a selection of syscall.Stat_t.
 type Stat struct {
 	Uid uint32
 	Gid uint32

--- a/pkg/qemu/imgutil/imgutil.go
+++ b/pkg/qemu/imgutil/imgutil.go
@@ -64,7 +64,7 @@ type InfoFormatSpecificDataVmdkExtent struct {
 	ClusterSize int    `json:"cluster-size,omitempty"` // since QEMU 1.7
 }
 
-// Info corresponds to the output of `qemu-img info --output=json FILE`
+// Info corresponds to the output of `qemu-img info --output=json FILE`.
 type Info struct {
 	Filename              string              `json:"filename,omitempty"`                // since QEMU 1.3
 	Format                string              `json:"format,omitempty"`                  // since QEMU 1.3

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -43,12 +43,12 @@ type Config struct {
 	SSHLocalPort int
 }
 
-// MinimumQemuVersion is the minimum supported QEMU version
+// MinimumQemuVersion is the minimum supported QEMU version.
 const (
 	MinimumQemuVersion = "4.0.0"
 )
 
-// EnsureDisk also ensures the kernel and the initrd
+// EnsureDisk also ensures the kernel and the initrd.
 func EnsureDisk(ctx context.Context, cfg Config) error {
 	diffDisk := filepath.Join(cfg.InstanceDir, filenames.DiffDisk)
 	if _, err := os.Stat(diffDisk); err == nil || !errors.Is(err, os.ErrNotExist) {
@@ -227,7 +227,7 @@ func Load(cfg Config, run bool, tag string) error {
 	return err
 }
 
-// List returns a space-separated list of all snapshots, with header and newlines
+// List returns a space-separated list of all snapshots, with header and newlines.
 func List(cfg Config, run bool) (string, error) {
 	if run {
 		out, err := sendHmpCommand(cfg, "info", "snapshots")
@@ -455,7 +455,7 @@ func adjustMemBytesDarwinARM64HVF(memBytes int64, accel string, features *featur
 	return memBytes
 }
 
-// qemuMachine returns string to use for -machine
+// qemuMachine returns string to use for -machine.
 func qemuMachine(arch limayaml.Arch) string {
 	if arch == limayaml.X8664 {
 		return "q35"
@@ -1004,7 +1004,7 @@ func VirtiofsdCmdline(cfg Config, mountIndex int) ([]string, error) {
 	}, nil
 }
 
-// qemuArch returns the arch string used by qemu
+// qemuArch returns the arch string used by qemu.
 func qemuArch(arch limayaml.Arch) string {
 	if arch == limayaml.ARMV7L {
 		return "arm"

--- a/pkg/sshutil/format.go
+++ b/pkg/sshutil/format.go
@@ -12,29 +12,29 @@ type FormatT = string
 const (
 	// FormatCmd prints the full ssh command line.
 	//
-	// ssh -o IdentityFile="/Users/example/.lima/_config/user" -o User=example -o Hostname=127.0.0.1 -o Port=60022 lima-default
+	//	ssh -o IdentityFile="/Users/example/.lima/_config/user" -o User=example -o Hostname=127.0.0.1 -o Port=60022 lima-default
 	FormatCmd = FormatT("cmd")
 
-	// FormatArgs is similar to FormatCmd but omits "ssh" and the destination address
+	// FormatArgs is similar to FormatCmd but omits "ssh" and the destination address.
 	//
-	// -o IdentityFile="/Users/example/.lima/_config/user" -o User=example -o Hostname=127.0.0.1 -o Port=60022
+	//	-o IdentityFile="/Users/example/.lima/_config/user" -o User=example -o Hostname=127.0.0.1 -o Port=60022
 	FormatArgs = FormatT("args")
 
 	// FormatOptions prints the ssh option key value pairs.
 	//
-	// IdentityFile="/Users/example/.lima/_config/user"
-	// User=example
-	// Hostname=127.0.0.1
-	// Port=60022
+	//	IdentityFile="/Users/example/.lima/_config/user"
+	//	User=example
+	//	Hostname=127.0.0.1
+	//	Port=60022
 	FormatOptions = FormatT("options")
 
 	// FormatConfig uses the ~/.ssh/config format
 	//
-	// Host lima-default
-	//  IdentityFile "/Users/example/.lima/_config/user "
-	//  User example
-	//  Hostname 127.0.0.1
-	//  Port 60022
+	//	Host lima-default
+	//	  IdentityFile "/Users/example/.lima/_config/user "
+	//	  User example
+	//	  Hostname 127.0.0.1
+	//	  Port 60022
 	FormatConfig = FormatT("config")
 
 // TODO: consider supporting "url" format (ssh://USER@HOSTNAME:PORT)

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -222,7 +222,7 @@ func CommonOpts(useDotSSH bool) ([]string, error) {
 	return opts, nil
 }
 
-// SSHOpts adds the following options to CommonOptions: User, ControlMaster, ControlPath, ControlPersist
+// SSHOpts adds the following options to CommonOptions: User, ControlMaster, ControlPath, ControlPersist.
 func SSHOpts(instDir string, useDotSSH, forwardAgent, forwardX11, forwardX11Trusted bool) ([]string, error) {
 	controlSock := filepath.Join(instDir, filenames.SSHSock)
 	if len(controlSock) >= osutil.UnixPathMax {

--- a/pkg/store/filenames/filenames.go
+++ b/pkg/store/filenames/filenames.go
@@ -57,7 +57,7 @@ const (
 	VzEfi              = "vz-efi"           // efi variable store
 	QemuEfiCodeFD      = "qemu-efi-code.fd" // efi code; not always created
 
-	// SocketDir is the default location for forwarded sockets with a relative paths in HostSocket
+	// SocketDir is the default location for forwarded sockets with a relative paths in HostSocket.
 	SocketDir = "sock"
 
 	Protected = "protected" // empty file; used by `limactl protect`

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -70,7 +70,7 @@ func (inst *Instance) LoadYAML() (*limayaml.LimaYAML, error) {
 }
 
 // Inspect returns err only when the instance does not exist (os.ErrNotExist).
-// Other errors are returned as *Instance.Errors
+// Other errors are returned as *Instance.Errors.
 func Inspect(instName string) (*Instance, error) {
 	inst := &Instance{
 		Name:   instName,
@@ -283,7 +283,7 @@ type PrintOptions struct {
 }
 
 // PrintInstances prints instances in a requested format to a given io.Writer.
-// Supported formats are "json", "yaml", "table", or a go template
+// Supported formats are "json", "yaml", "table", or a go template.
 func PrintInstances(w io.Writer, instances []*Instance, format string, options *PrintOptions) error {
 	switch format {
 	case "json":

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -88,7 +88,7 @@ func Disks() ([]string, error) {
 }
 
 // InstanceDir returns the instance dir.
-// InstanceDir does not check whether the instance exists
+// InstanceDir does not check whether the instance exists.
 func InstanceDir(name string) (string, error) {
 	if err := identifiers.Validate(name); err != nil {
 		return "", err

--- a/pkg/textutil/textutil.go
+++ b/pkg/textutil/textutil.go
@@ -24,7 +24,7 @@ func ExecuteTemplate(tmpl string, args interface{}) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-// PrefixString adds prefix to beginning of each line
+// PrefixString adds prefix to beginning of each line.
 func PrefixString(prefix, text string) string {
 	result := []string{}
 	for _, line := range strings.Split(text, "\n") {
@@ -37,18 +37,18 @@ func PrefixString(prefix, text string) string {
 	return strings.Join(result, "\n")
 }
 
-// IndentString add spaces to beginning of each line
+// IndentString add spaces to beginning of each line.
 func IndentString(size int, text string) string {
 	prefix := strings.Repeat(" ", size)
 	return PrefixString(prefix, text)
 }
 
-// TrimString removes characters from beginning and end
+// TrimString removes characters from beginning and end.
 func TrimString(cutset, text string) string {
 	return strings.Trim(text, cutset)
 }
 
-// MissingString returns message if the text is empty
+// MissingString returns message if the text is empty.
 func MissingString(message, text string) string {
 	if text == "" {
 		return message
@@ -117,7 +117,7 @@ var TemplateFuncMap = template.FuncMap{
 	},
 }
 
-// TemplateFuncHelp is help for TemplateFuncMap.
+// FuncHelp is help for TemplateFuncMap.
 var FuncHelp = []string{
 	"indent <size>: add spaces to beginning of each line",
 	"missing <message>: return message if the text is empty",

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-// Version is filled on compilation time
+// Version is filled on compilation time.
 var Version = "<unknown>"

--- a/pkg/vz/network_darwin.go
+++ b/pkg/vz/network_darwin.go
@@ -33,8 +33,8 @@ func PassFDToUnix(unixSock string) (*os.File, error) {
 	return client, nil
 }
 
-// DialQemu support connecting to QEMU supported network stack via unix socket
-// Returns os.File, connected dgram connection to be used for vz
+// DialQemu support connecting to QEMU supported network stack via unix socket.
+// Returns os.File, connected dgram connection to be used for vz.
 func DialQemu(unixSock string) (*os.File, error) {
 	unixConn, err := net.Dial("unix", unixSock)
 	if err != nil {
@@ -68,7 +68,7 @@ type QEMUPacketConn struct {
 
 var _ net.Conn = (*QEMUPacketConn)(nil)
 
-// Read gets rid of the QEMU header packet and returns the raw packet as response
+// Read gets rid of the QEMU header packet and returns the raw packet as response.
 func (v *QEMUPacketConn) Read(b []byte) (n int, err error) {
 	header := make([]byte, 4)
 	_, err = io.ReadFull(v.unixConn, header)
@@ -85,7 +85,7 @@ func (v *QEMUPacketConn) Read(b []byte) (n int, err error) {
 	return int(size), nil
 }
 
-// Write puts QEMU header packet first and then writes the raw packet
+// Write puts QEMU header packet first and then writes the raw packet.
 func (v *QEMUPacketConn) Write(b []byte) (n int, err error) {
 	header := make([]byte, 4)
 	binary.BigEndian.PutUint32(header, uint32(len(b)))


### PR DESCRIPTION
This PR enables `godot` linter to ensure comments always end with a full stop. This is for consistency with other comments and to comply with the guidelines at https://go.dev/wiki/CodeReviewComments#comment-sentences:
> Comments should begin with the name of the thing being described and end in a period