### PR TITLE
Allow compressing lima-guestagent with zstd

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -31,15 +31,35 @@ config GUESTAGENT_ARCH_RISCV64
 		Build lima-guestagent for "riscv64" Arch
 	default y
 
-config GUESTAGENT_COMPRESS_ZSTD
-	bool "guestagent compress zstd"
+config GUESTAGENT_COMPRESS
+	bool "guestagent compress"
 	help
-		Compress lima-guestagent using zstd
+		Compress lima-guestagent
 	default n
 
+choice GUESTAGENT_COMPRESS_PROGRAM
+	depends on GUESTAGENT_COMPRESS
+	bool "guestagent compress program"
+	default GUESTAGENT_COMPRESS_GZIP
+
+config GUESTAGENT_COMPRESS_GZIP
+	depends on GUESTAGENT_COMPRESS
+	bool "gzip"
+	help
+		Compress lima-guestagent using gzip
+
+config GUESTAGENT_COMPRESS_ZSTD
+	depends on GUESTAGENT_COMPRESS
+	bool "zstd"
+	help
+		Compress lima-guestagent using zstd
+
+endchoice
+
 config GUESTAGENT_COMPRESS_LEVEL
-	depends on GUESTAGENT_COMPRESS_ZSTD
+	depends on GUESTAGENT_COMPRESS
 	int "guestagent compress level"
 	help
 		Compression level to use (default: 3)
-	default 19
+	default 9 if GUESTAGENT_COMPRESS_GZIP
+	default 19 if GUESTAGENT_COMPRESS_ZSTD

--- a/Kconfig
+++ b/Kconfig
@@ -30,3 +30,16 @@ config GUESTAGENT_ARCH_RISCV64
 	help
 		Build lima-guestagent for "riscv64" Arch
 	default y
+
+config GUESTAGENT_COMPRESS_ZSTD
+	bool "guestagent compress zstd"
+	help
+		Compress lima-guestagent using zstd
+	default n
+
+config GUESTAGENT_COMPRESS_LEVEL
+	depends on GUESTAGENT_COMPRESS_ZSTD
+	int "guestagent compress level"
+	help
+		Compression level to use (default: 3)
+	default 19

--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,8 @@ binaries: clean \
 	$(HELPERS) \
 	$(GUESTAGENT)
 ifeq ($(CONFIG_GUESTAGENT_COMPRESS_ZSTD),y)
-	ZSTD_CLEVEL=$(CONFIG_GUESTAGENT_COMPRESS_LEVEL) \
-	$(ZSTD) --rm _output/share/lima/lima-guestagent.*
+	for ga in $(GUESTAGENT); do \
+	ZSTD_CLEVEL=$(CONFIG_GUESTAGENT_COMPRESS_LEVEL) $(ZSTD) --rm $$ga; done
 endif
 	cp -aL examples _output/share/lima/templates
 ifneq ($(GOOS),windows)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ DEST := $(shell echo "$(DESTDIR)/$(PREFIX)" | sed 's:///*:/:g; s://*$$::')
 GO ?= go
 TAR ?= tar
 ZIP ?= zip
+GZIP ?= gzip
 ZSTD ?= zstd
 PLANTUML ?= plantuml # may also be "java -jar plantuml.jar" if installed elsewhere
 
@@ -78,6 +79,9 @@ menuconfig: Kconfig
 
 -include .config
 
+ifneq ($(CONFIG_GUESTAGENT_COMPRESS_GZIP),y)
+GO_BUILDTAGS += no_gzip
+endif
 ifneq ($(CONFIG_GUESTAGENT_COMPRESS_ZSTD),y)
 GO_BUILDTAGS += no_zstd
 endif
@@ -118,6 +122,10 @@ binaries: clean \
 	codesign \
 	$(HELPERS) \
 	$(GUESTAGENT)
+ifeq ($(CONFIG_GUESTAGENT_COMPRESS_GZIP),y)
+	for ga in $(GUESTAGENT); do \
+	$(GZIP) -$(CONFIG_GUESTAGENT_COMPRESS_LEVEL) $$ga && $(GZIP) --list $$ga; done
+endif
 ifeq ($(CONFIG_GUESTAGENT_COMPRESS_ZSTD),y)
 	for ga in $(GUESTAGENT); do \
 	ZSTD_CLEVEL=$(CONFIG_GUESTAGENT_COMPRESS_LEVEL) $(ZSTD) --rm $$ga; done

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,6 @@ PACKAGE := github.com/lima-vm/lima
 VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 VERSION_TRIMMED := $(VERSION:v%=%)
 
-GO_BUILD := $(GO) build -ldflags="-s -w -X $(PACKAGE)/pkg/version.Version=$(VERSION)" -tags "$(GO_BUILDTAGS)"
-
 .NOTPARALLEL:
 
 .PHONY: all
@@ -83,6 +81,8 @@ menuconfig: Kconfig
 ifneq ($(CONFIG_GUESTAGENT_COMPRESS_ZSTD),y)
 GO_BUILDTAGS += no_zstd
 endif
+
+GO_BUILD := $(GO) build -ldflags="-s -w -X $(PACKAGE)/pkg/version.Version=$(VERSION)" -tags "$(GO_BUILDTAGS)"
 
 HELPERS = \
 	_output/bin/nerdctl.lima \

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/foxcpp/go-mockdns v1.1.0
 	github.com/goccy/go-yaml v1.11.3
 	github.com/google/go-cmp v0.6.0
+	github.com/klauspost/compress v1.17.9
 	github.com/lima-vm/go-qcow2reader v0.1.1
 	github.com/lima-vm/sshocker v0.3.4
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNU
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
+github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -343,7 +343,7 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 	if err != nil {
 		return err
 	}
-	guestAgent, err := os.Open(guestAgentBinary)
+	guestAgent, err := usrlocalsharelima.Open(guestAgentBinary)
 	if err != nil {
 		return err
 	}

--- a/pkg/usrlocalsharelima/open_gzip.go
+++ b/pkg/usrlocalsharelima/open_gzip.go
@@ -1,0 +1,20 @@
+//go:build !no_gzip
+
+package usrlocalsharelima
+
+import (
+	"io"
+	"os"
+
+	"compress/gzip"
+)
+
+const Ext = ".gz"
+
+func Open(path string) (io.ReadCloser, error) {
+	reader, err := os.Open(path + Ext)
+	if err != nil {
+		return nil, err
+	}
+	return gzip.NewReader(reader)
+}

--- a/pkg/usrlocalsharelima/open_none.go
+++ b/pkg/usrlocalsharelima/open_none.go
@@ -1,0 +1,14 @@
+//go:build no_zstd
+
+package usrlocalsharelima
+
+import (
+	"io"
+	"os"
+)
+
+const Ext = ""
+
+func Open(path string) (io.ReadCloser, error) {
+	return os.Open(path)
+}

--- a/pkg/usrlocalsharelima/open_none.go
+++ b/pkg/usrlocalsharelima/open_none.go
@@ -1,4 +1,4 @@
-//go:build no_zstd
+//go:build no_gzip && no_zstd
 
 package usrlocalsharelima
 

--- a/pkg/usrlocalsharelima/open_zstd.go
+++ b/pkg/usrlocalsharelima/open_zstd.go
@@ -1,0 +1,24 @@
+//go:build !no_zstd
+
+package usrlocalsharelima
+
+import (
+	"io"
+	"os"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+const Ext = ".zst"
+
+func Open(path string) (io.ReadCloser, error) {
+	reader, err := os.Open(path + Ext)
+	if err != nil {
+		return nil, err
+	}
+	decoder, err := zstd.NewReader(reader)
+	if err != nil {
+		return nil, err
+	}
+	return decoder.IOReadCloser(), nil
+}

--- a/pkg/usrlocalsharelima/usrlocalsharelima.go
+++ b/pkg/usrlocalsharelima/usrlocalsharelima.go
@@ -60,3 +60,17 @@ func Dir() (string, error) {
 	return "", fmt.Errorf("failed to find \"lima-guestagent.%s-%s\" binary for %q, attempted %v",
 		ostype, arch, self, gaCandidates)
 }
+
+func GuestAgentBinary(ostype limayaml.OS, arch limayaml.Arch) (string, error) {
+	if ostype == "" {
+		return "", errors.New("os must be set")
+	}
+	if arch == "" {
+		return "", errors.New("arch must be set")
+	}
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "lima-guestagent."+ostype+"-"+arch), nil
+}

--- a/pkg/usrlocalsharelima/usrlocalsharelima.go
+++ b/pkg/usrlocalsharelima/usrlocalsharelima.go
@@ -41,12 +41,12 @@ func Dir() (string, error) {
 		// - self:  /Applications/Lima.app/Contents/MacOS/limactl
 		// - agent: /Applications/Lima.app/Contents/MacOS/lima-guestagent.Linux-x86_64
 		// - dir:   /Applications/Lima.app/Contents/MacOS
-		filepath.Join(selfDir, "lima-guestagent."+ostype+"-"+arch),
+		filepath.Join(selfDir, "lima-guestagent."+ostype+"-"+arch+Ext),
 		// candidate 1:
 		// - self:  /usr/local/bin/limactl
 		// - agent: /usr/local/share/lima/lima-guestagent.Linux-x86_64
 		// - dir:   /usr/local/share/lima
-		filepath.Join(selfDirDir, "share/lima/lima-guestagent."+ostype+"-"+arch),
+		filepath.Join(selfDirDir, "share/lima/lima-guestagent."+ostype+"-"+arch+Ext),
 		// TODO: support custom path
 	}
 	for _, gaCandidate := range gaCandidates {


### PR DESCRIPTION
Closes #2426

Compressing using highest level 19 takes forever (30 seconds), so should use something like 3 during development...

Everything is handled in the code, so that user doesn't need to have `zstd` installed - neither on the host or in instance