### PR TITLE
cmd/limactl: return error instead of calling os.Exit

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,6 +102,33 @@ linters-settings:
     - filepathJoin
   errorlint:
     asserts: false
+  revive:
+    # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
+    rules:
+    - name: blank-imports
+    - name: context-as-argument
+    - name: context-keys-type
+    - name: deep-exit
+    - name: dot-imports
+    - name: empty-block
+    - name: error-naming
+    - name: error-return
+    - name: error-strings
+    - name: errorf
+    - name: exported
+    - name: increment-decrement
+    - name: indent-error-flow
+    - name: package-comments
+    - name: range
+    - name: receiver-naming
+    - name: redefines-builtin-id
+    - name: superfluous-else
+    - name: time-naming
+    - name: unexported-return
+    - name: unreachable-code
+    - name: unused-parameter
+    - name: var-declaration
+    - name: var-naming
 issues:
   # Maximum issues count per one linter.
   max-issues-per-linter: 0

--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -73,6 +73,19 @@ func instanceMatches(arg string, instances []string) []string {
 	return matches
 }
 
+// unmatchedInstancesError is created when unmatched instance names found.
+type unmatchedInstancesError struct{}
+
+// Error implements error.
+func (unmatchedInstancesError) Error() string {
+	return "unmatched instances"
+}
+
+// ExitCode implements ExitCoder.
+func (unmatchedInstancesError) ExitCode() int {
+	return 1
+}
+
 func listAction(cmd *cobra.Command, args []string) error {
 	quiet, err := cmd.Flags().GetBool("quiet")
 	if err != nil {
@@ -148,7 +161,7 @@ func listAction(cmd *cobra.Command, args []string) error {
 			fmt.Fprintln(cmd.OutOrStdout(), instName)
 		}
 		if unmatchedInstances {
-			os.Exit(1)
+			return unmatchedInstancesError{}
 		}
 		return nil
 	}
@@ -186,7 +199,7 @@ func listAction(cmd *cobra.Command, args []string) error {
 
 	err = store.PrintInstances(out, instances, format, &options)
 	if err == nil && unmatchedInstances {
-		os.Exit(1)
+		return unmatchedInstancesError{}
 	}
 	return err
 }

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -156,7 +156,7 @@ func handleExitCoder(err error) {
 	}
 
 	if exitErr, ok := err.(ExitCoder); ok {
-		os.Exit(exitErr.ExitCode())
+		os.Exit(exitErr.ExitCode()) //nolint:revive // it's intentional to call os.Exit in this function
 		return
 	}
 }

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -373,6 +373,21 @@ func modifyInPlace(st *creatorState, yq string) error {
 	return nil
 }
 
+// exitSuccessError is an error that indicates a successful exit.
+type exitSuccessError struct {
+	Msg string
+}
+
+// Error implements error.
+func (e exitSuccessError) Error() string {
+	return e.Msg
+}
+
+// ExitCode implements ExitCoder.
+func (exitSuccessError) ExitCode() int {
+	return 0
+}
+
 func chooseNextCreatorState(st *creatorState, yq string) (*creatorState, error) {
 	for {
 		if err := modifyInPlace(st, yq); err != nil {
@@ -411,9 +426,9 @@ func chooseNextCreatorState(st *creatorState, yq string) (*creatorState, error) 
 				return st, err
 			}
 			if len(st.yBytes) == 0 {
-				logrus.Info("Aborting, as requested by saving the file with empty content")
-				os.Exit(0)
-				return st, errors.New("should not reach here")
+				const msg = "Aborting, as requested by saving the file with empty content"
+				logrus.Info(msg)
+				return nil, exitSuccessError{Msg: msg}
 			}
 			return st, nil
 		case 2: // "Choose another template..."
@@ -446,8 +461,7 @@ func chooseNextCreatorState(st *creatorState, yq string) (*creatorState, error) 
 			}
 			continue
 		case 3: // "Exit"
-			os.Exit(0)
-			return st, errors.New("should not reach here")
+			return nil, exitSuccessError{Msg: "Choosing to exit"}
 		default:
 			return st, fmt.Errorf("unexpected answer %q", ans)
 		}


### PR DESCRIPTION
The PR fixes [`revive.deep-exit`](https://revive.run/r#deep-exit) lint issues by refactoring the code to return an error instead of directly calling `os.Exit`.

The issue with [`os.Exit`](https://pkg.go.dev/os#Exit) is that the program terminates immediately, and any deferred functions, if present, are not executed.

We need to list all revive rules in `.golangci.yml` to enable `deep-exit`. See [this PR](https://github.com/prometheus/prometheus/pull/13068) for a detailed explanation.