### PR TITLE
30-install-packages.sh: Use `head` instead of `hexdump`

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -34,7 +34,7 @@ if [ "${LIMA_CIDATA_SKIP_DEFAULT_DEPENDENCY_RESOLUTION}" = 1 ]; then
 	exit 0
 fi
 
-if hexdump -C -n 4 "$(command -v apt-get)" | grep -qF 'ELF' >/dev/null 2>&1; then
+if head -c 4 "$(command -v apt-get)" | grep -qP '\x7fELF' >/dev/null 2>&1; then
 	pkgs=""
 	if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
 		if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ] && ! command -v sshfs >/dev/null 2>&1; then


### PR DESCRIPTION
The code changes in `30-install-packages.sh` modify the package installation script to use the `head` command instead of `hexdump` for checking the ELF header of the `apt-get` command.  
This change will allow the use of "Ubuntu Minimal Cloud Images" that do not include `hexdump`.  
https://cloud-images.ubuntu.com/minimal/releases/