### PR TITLE
Allow providing scripts as separate files

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -208,6 +208,7 @@ containerd:
 # Provisioning scripts need to be idempotent because they might be called
 # multiple times, e.g. when the host VM is being restarted.
 # The scripts can use the following template variables: {{.Home}}, {{.UID}}, {{.User}}, and {{.Param.Key}}
+# They can be provided inline (as field `script`), or in external files (as field `path`).
 # 🟢 Builtin default: null
 # provision:
 # # `system` is executed with root privileges
@@ -251,6 +252,7 @@ containerd:
 # Probe scripts to check readiness.
 # The scripts run in user mode. They must start with a '#!' line.
 # The scripts can use the following template variables: {{.Home}}, {{.UID}}, {{.User}}, and {{.Param.Key}}
+# They can be provided inline (as field `script`), or in external files (as field `path`).
 # 🟢 Builtin default: null
 # probes:
 # # Only `readiness` probes are supported right now.

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -332,11 +332,19 @@ func GenerateISO9660(instDir, name string, instConfig *limayaml.LimaYAML, udpDNS
 	}
 
 	for i, f := range instConfig.Provision {
+		script := f.Script
+		if f.Path != "" {
+			b, err := os.ReadFile(f.Path)
+			if err != nil {
+				return err
+			}
+			script = string(b)
+		}
 		switch f.Mode {
 		case limayaml.ProvisionModeSystem, limayaml.ProvisionModeUser, limayaml.ProvisionModeDependency:
 			layout = append(layout, iso9660util.Entry{
 				Path:   fmt.Sprintf("provision.%s/%08d", f.Mode, i),
-				Reader: strings.NewReader(f.Script),
+				Reader: strings.NewReader(script),
 			})
 		case limayaml.ProvisionModeBoot:
 			continue
@@ -415,8 +423,16 @@ func getBootCmds(p []limayaml.Provision) ([]BootCmds, error) {
 		if f.Mode != limayaml.ProvisionModeBoot {
 			continue
 		}
+		script := f.Script
+		if f.Path != "" {
+			b, err := os.ReadFile(f.Path)
+			if err != nil {
+				return nil, err
+			}
+			script = string(b)
+		}
 		lines := []string{}
-		for _, line := range strings.Split(f.Script, "\n") {
+		for _, line := range strings.Split(script, "\n") {
 			if line == "" {
 				continue
 			}

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -3,6 +3,7 @@ package hostagent
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/lima-vm/lima/pkg/limayaml"
@@ -201,10 +202,19 @@ Also see "/var/log/cloud-init-output.log" in the guest.
 			})
 	}
 	for _, probe := range a.instConfig.Probes {
+		script := probe.Script
+		if probe.Path != "" {
+			b, err := os.ReadFile(probe.Path)
+			if err != nil {
+				logrus.WithError(err).Errorf("failed to read script %q", probe.Path)
+				continue
+			}
+			script = string(b)
+		}
 		if probe.Mode == limayaml.ProbeModeReadiness {
 			req = append(req, requirement{
 				description: probe.Description,
-				script:      probe.Script,
+				script:      script,
 				debugHint:   probe.Hint,
 			})
 		}

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -198,6 +198,7 @@ type Provision struct {
 	Mode                            ProvisionMode `yaml:"mode" json:"mode"` // default: "system"
 	SkipDefaultDependencyResolution *bool         `yaml:"skipDefaultDependencyResolution,omitempty" json:"skipDefaultDependencyResolution,omitempty"`
 	Script                          string        `yaml:"script" json:"script"`
+	Path                            string        `yaml:"path,omitempty" json:"path,omitempty"`
 	Playbook                        string        `yaml:"playbook,omitempty" json:"playbook,omitempty"`
 }
 
@@ -217,6 +218,7 @@ type Probe struct {
 	Mode        ProbeMode // default: "readiness"
 	Description string
 	Script      string
+	Path        string `yaml:",omitempty" json:",omitempty"`
 	Hint        string
 }
 

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -208,6 +208,14 @@ func Validate(y *LimaYAML, warn bool) error {
 			return fmt.Errorf("field `provision[%d].mode` must one of %q, %q, %q, %q, or %q",
 				i, ProvisionModeSystem, ProvisionModeUser, ProvisionModeBoot, ProvisionModeDependency, ProvisionModeAnsible)
 		}
+		if p.Path != "" {
+			if p.Script != "" {
+				return fmt.Errorf("field `provision[%d].script must be empty if path is set", i)
+			}
+			if _, err := os.Stat(p.Path); err != nil {
+				return fmt.Errorf("field `provision[%d].path` refers to an inaccessible path: %q: %w", i, p.Path, err)
+			}
+		}
 		if strings.Contains(p.Script, "LIMA_CIDATA") {
 			logrus.Warn("provisioning scripts should not reference the LIMA_CIDATA variables")
 		}
@@ -231,6 +239,14 @@ func Validate(y *LimaYAML, warn bool) error {
 		case ProbeModeReadiness:
 		default:
 			return fmt.Errorf("field `probe[%d].mode` can only be %q", i, ProbeModeReadiness)
+		}
+		if p.Path != "" {
+			if p.Script != "" {
+				return fmt.Errorf("field `probe[%d].script must be empty if path is set", i)
+			}
+			if _, err := os.Stat(p.Path); err != nil {
+				return fmt.Errorf("field `probe[%d].path` refers to an inaccessible path: %q: %w", i, p.Path, err)
+			}
 		}
 	}
 	for i, rule := range y.PortForwards {


### PR DESCRIPTION
The "path" provided will be read, and used instead of the "script".

```yaml
provision:
- mode: user
  path: foo.sh

probes:
- mode: readiness
  path: bar.sh
```

* #2441

----

There are some unsolved issues with this, regarding relative paths.

* https://github.com/lima-vm/lima/issues/893

Currently it requires that `limactl` is always run from the top directory.

The paths PWD should probably be recorded in the instance directory?