### PR TITLE
Add make target for generating current arch config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,11 @@ menuconfig: Kconfig
 	MENUCONFIG_STYLE=aquatic \
 	$(KCONFIG_MCONF) $<
 
+# Generate config for the current architecture (only)
+# This is done to avoid a dependency on KCONFIG tools
+nativeconfig: .config
+	./hack/native-config.sh $<
+
 # Copy the default config, if not overridden locally
 # This is done to avoid a dependency on KCONFIG tools
 .config: config.mk

--- a/hack/native-config.sh
+++ b/hack/native-config.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+file="$1"
+test -e "$file" || exit 1
+script=""
+ARCH=${ARCH:-$(uname -m | sed -e s/arm64/aarch64/)}
+for arch in x86_64 aarch64 armv7l riscv64; do
+	if [ $arch = "$ARCH" ]; then
+		x=y
+	else
+		x=n
+	fi
+	: ${arch^^}
+	config="CONFIG_GUESTAGENT_ARCH_${_//_/}"
+	script="$script;s/$config=./$config=$x/"
+done
+sed -e "$script" "$file" >"$file.new" && mv "$file.new" "$file"


### PR DESCRIPTION
`make nativeconfig`

* https://github.com/lima-vm/lima/issues/2426#issuecomment-2187316192

```console
$ make config
cp config.mk .config
/usr/local/bin/kconfig-conf Kconfig
*
* Lima
*
guestagent OS: Linux (GUESTAGENT_OS_LINUX) [Y/n/?] 
guestagent Arch: x86_64 (GUESTAGENT_ARCH_X8664) [Y/n/?] 
guestagent Arch: aarch64 (GUESTAGENT_ARCH_AARCH64) [Y/n/?] 
guestagent Arch: armv7l (GUESTAGENT_ARCH_ARMV7L) [Y/n/?] 
guestagent Arch: riscv64 (GUESTAGENT_ARCH_RISCV64) [Y/n/?] 
#
# configuration written to .config
#
```

```console
$ make menuconfig
cp config.mk .config
MENUCONFIG_STYLE=aquatic \
/usr/local/bin/kconfig-mconf Kconfig


*** End of the configuration.
*** Execute 'make' to start the build or try 'make help'.
```

![lima-menuconfig](https://github.com/lima-vm/lima/assets/10364051/b51b8c19-4b8e-4091-9275-7cc00430bfe8)

The goal was to generate a config file, with only the current architecture.

---

Default config, empty `defconfig`:

```Makefile
#
# Automatically generated file; DO NOT EDIT.
# Lima
#
CONFIG_GUESTAGENT_OS_LINUX=y
CONFIG_GUESTAGENT_ARCH_X8664=y
CONFIG_GUESTAGENT_ARCH_AARCH64=y
CONFIG_GUESTAGENT_ARCH_ARMV7L=y
CONFIG_GUESTAGENT_ARCH_RISCV64=y
```

Could have used files:

```
arch/x86_64/defconfig
arch/aarch64/defconfig
```

As in the tool default:

`ARCH=x86_64 kconfig-conf --defconfig Kconfig`
```
***
*** Can't find default configuration "arch/x86_64/defconfig"!
***
```

arch/x86_64/config.mk
```
CONFIG_GUESTAGENT_OS_LINUX=y
CONFIG_GUESTAGENT_ARCH_X8664=y
CONFIG_GUESTAGENT_ARCH_AARCH64=n
CONFIG_GUESTAGENT_ARCH_ARMV7L=n
CONFIG_GUESTAGENT_ARCH_RISCV64=n
```

alternatively, defconfig:
```Makefile
# CONFIG_GUESTAGENT_ARCH_X8664 is not set
# CONFIG_GUESTAGENT_ARCH_ARMV7L is not set
# CONFIG_GUESTAGENT_ARCH_RISCV64 is not set
```

`ARCH=aarch64 kconfig-conf --defconfig Kconfig`
```
***
*** Can't find default configuration "arch/aarch64/defconfig"!
***
```

arch/aarch64/config.mk
```
CONFIG_GUESTAGENT_OS_LINUX=y
CONFIG_GUESTAGENT_ARCH_X8664=n
CONFIG_GUESTAGENT_ARCH_AARCH64=y
CONFIG_GUESTAGENT_ARCH_ARMV7L=n
CONFIG_GUESTAGENT_ARCH_RISCV64=n
```

alternatively, defconfig:
```Makefile
# CONFIG_GUESTAGENT_ARCH_AARCH64 is not set
# CONFIG_GUESTAGENT_ARCH_ARMV7L is not set
# CONFIG_GUESTAGENT_ARCH_RISCV64 is not set
```

The framework is overkill here, compared with kernel.

https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/arch