### PR TITLE
Shorten the descriptions to fit in width 100

### DIFF
--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -108,7 +108,7 @@ A possible workaround is to run "apt-get install sshfs" in the guest.
 `,
 		})
 		req = append(req, requirement{
-			description: "/etc/fuse.conf (/etc/fuse3.conf) to contain \"user_allow_other\"",
+			description: "fuse to \"allow_other\" as user",
 			script: `#!/bin/bash
 set -eux -o pipefail
 if ! timeout 30s bash -c "until grep -q ^user_allow_other /etc/fuse*.conf; do sleep 3; done"; then


### PR DESCRIPTION
Trivial cosmetic change, so that all the essential steps have the same length.

```
INFO[0000] [hostagent] Waiting for the essential requirement 1 of 4: "ssh" 
INFO[0010] [hostagent] Waiting for the essential requirement 1 of 4: "ssh" 
INFO[0017] [hostagent] The essential requirement 1 of 4 is satisfied 
INFO[0017] [hostagent] Waiting for the essential requirement 2 of 4: "user session is ready for ssh" 
INFO[0017] [hostagent] The essential requirement 2 of 4 is satisfied 
INFO[0017] [hostagent] Waiting for the essential requirement 3 of 4: "sshfs binary to be installed" 
INFO[0017] [hostagent] The essential requirement 3 of 4 is satisfied 
INFO[0017] [hostagent] Waiting for the essential requirement 4 of 4: "fuse to \"allow_other\" as user" 
INFO[0017] [hostagent] The essential requirement 4 of 4 is satisfied 
```

From https://github.com/lima-vm/lima/issues/1311#issuecomment-1426666181