### PR TITLE
boot/04-persistent-data-volume.sh: fix 9p cache options

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/04-persistent-data-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/04-persistent-data-volume.sh
@@ -32,6 +32,10 @@ for DIR in ${DATADIRS}; do
 		[ "${MNTTYPE}" = "ext4" ] && continue
 		[ "${MNTTYPE}" = "tmpfs" ] && continue
 		MNTOPTS="$(echo "${LINE}" | awk '{print $4}')"
+		if [ "${MNTTYPE}" = "9p" ]; then
+			# https://github.com/torvalds/linux/blob/v6.6/fs/9p/v9fs.h#L61
+			MNTOPTS="$(echo "${MNTOPTS}" | sed -e 's/cache=8f,/cache=fscache,/; s/cache=f,/cache=loose,/; s/cache=5,/cache=mmap,/; s/cache=1,/cache=readahead,/; s/cache=0,/cache=none,/')"
+		fi
 		# Before mv, unmount filesystems (virtiofs, 9p, etc.) below "${DIR}", otherwise host mounts will be wiped out
 		# https://github.com/rancher-sandbox/rancher-desktop/issues/6582
 		umount "${MNTPNT}" || exit 1


### PR DESCRIPTION
`mount=fscache` is printed as `mount=8f` in /proc/mounts

https://github.com/torvalds/linux/blob/v6.6/fs/9p/v9fs.h#L61

--

Split from:
- #1953 