### PR TITLE
Add sudo when trying to read fuse.conf

### DIFF
--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -111,7 +111,7 @@ A possible workaround is to run "apt-get install sshfs" in the guest.
 			description: "fuse to \"allow_other\" as user",
 			script: `#!/bin/bash
 set -eux -o pipefail
-if ! timeout 30s bash -c "until grep -q ^user_allow_other /etc/fuse*.conf; do sleep 3; done"; then
+if ! timeout 30s bash -c "until sudo grep -q ^user_allow_other /etc/fuse*.conf; do sleep 3; done"; then
 	echo >&2 "/etc/fuse.conf (/etc/fuse3.conf) is not updated to contain \"user_allow_other\""
 	exit 1
 fi


### PR DESCRIPTION
On some distributions this configuration was only readable by members in the "fuse" group, not by the general public.

Closes #2387