### PR TITLE
Refactor to use switch instead of if-else chain

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,10 +96,13 @@ linters-settings:
     - rangeValCopy
     - hugeParam
     - importShadow
-    - ifElseChain
     - sprintfQuotedString
     - builtinShadow
     - filepathJoin
+    settings:
+      ifElseChain:
+        # Min number of if-else blocks that makes the warning trigger.
+        minThreshold: 3
   errorlint:
     asserts: false
   revive:

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -128,9 +128,11 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 
 	const yBytesLimit = 4 * 1024 * 1024 // 4MiB
 
-	if ok, u := guessarg.SeemsTemplateURL(arg); ok {
+	isTemplateURL, templateURL := guessarg.SeemsTemplateURL(arg)
+	switch {
+	case isTemplateURL:
 		// No need to use SecureJoin here. https://github.com/lima-vm/lima/pull/805#discussion_r853411702
-		templateName := filepath.Join(u.Host, u.Path)
+		templateName := filepath.Join(templateURL.Host, templateURL.Path)
 		logrus.Debugf("interpreting argument %q as a template name %q", arg, templateName)
 		if st.instName == "" {
 			// e.g., templateName = "deprecated/centos-7" , st.instName = "centos-7"
@@ -140,7 +142,7 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 		if err != nil {
 			return nil, err
 		}
-	} else if guessarg.SeemsHTTPURL(arg) {
+	case guessarg.SeemsHTTPURL(arg):
 		if st.instName == "" {
 			st.instName, err = guessarg.InstNameFromURL(arg)
 			if err != nil {
@@ -161,7 +163,7 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 		if err != nil {
 			return nil, err
 		}
-	} else if guessarg.SeemsFileURL(arg) {
+	case guessarg.SeemsFileURL(arg):
 		if st.instName == "" {
 			st.instName, err = guessarg.InstNameFromURL(arg)
 			if err != nil {
@@ -178,7 +180,7 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 		if err != nil {
 			return nil, err
 		}
-	} else if guessarg.SeemsYAMLPath(arg) {
+	case guessarg.SeemsYAMLPath(arg):
 		if st.instName == "" {
 			st.instName, err = guessarg.InstNameFromYAMLPath(arg)
 			if err != nil {
@@ -195,7 +197,7 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 		if err != nil {
 			return nil, err
 		}
-	} else if arg == "-" {
+	case arg == "-":
 		if st.instName == "" {
 			return nil, errors.New("must pass instance name with --name when reading template from stdin")
 		}
@@ -209,7 +211,7 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 			return nil, errors.New("cannot use --tty=true and read template from stdin together")
 		}
 		tty = false
-	} else {
+	default:
 		if arg == "" {
 			if st.instName == "" {
 				st.instName = DefaultInstanceName

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -270,17 +270,18 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 		return err
 	}
 
-	if len(y.DNS) > 0 {
+	switch {
+	case len(y.DNS) > 0:
 		for _, addr := range y.DNS {
 			args.DNSAddresses = append(args.DNSAddresses, addr.String())
 		}
-	} else if firstUsernetIndex != -1 || *y.VMType == limayaml.VZ {
+	case firstUsernetIndex != -1 || *y.VMType == limayaml.VZ:
 		args.DNSAddresses = append(args.DNSAddresses, args.SlirpDNS)
-	} else if *y.HostResolver.Enabled {
+	case *y.HostResolver.Enabled:
 		args.UDPDNSLocalPort = udpDNSLocalPort
 		args.TCPDNSLocalPort = tcpDNSLocalPort
 		args.DNSAddresses = append(args.DNSAddresses, args.SlirpDNS)
-	} else {
+	default:
 		args.DNSAddresses, err = osutil.DNSAddresses()
 		if err != nil {
 			return err

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -314,7 +314,8 @@ func validateNetwork(y *LimaYAML) error {
 	interfaceName := make(map[string]int)
 	for i, nw := range y.Networks {
 		field := fmt.Sprintf("networks[%d]", i)
-		if nw.Lima != "" {
+		switch {
+		case nw.Lima != "":
 			config, err := networks.Config()
 			if err != nil {
 				return err
@@ -335,7 +336,7 @@ func validateNetwork(y *LimaYAML) error {
 			if nw.VZNAT != nil && *nw.VZNAT {
 				return fmt.Errorf("field `%s.lima` and field `%s.vzNAT` are mutually exclusive", field, field)
 			}
-		} else if nw.Socket != "" {
+		case nw.Socket != "":
 			if nw.VZNAT != nil && *nw.VZNAT {
 				return fmt.Errorf("field `%s.socket` and field `%s.vzNAT` are mutually exclusive", field, field)
 			}
@@ -344,7 +345,7 @@ func validateNetwork(y *LimaYAML) error {
 			} else if err == nil && fi.Mode()&os.ModeSocket == 0 {
 				return fmt.Errorf("field `%s.socket` %q points to a non-socket file", field, nw.Socket)
 			}
-		} else if nw.VZNAT != nil && *nw.VZNAT {
+		case nw.VZNAT != nil && *nw.VZNAT:
 			if y.VMType == nil || *y.VMType != VZ {
 				return fmt.Errorf("field `%s.vzNAT` requires `vmType` to be %q", field, VZ)
 			}
@@ -354,7 +355,7 @@ func validateNetwork(y *LimaYAML) error {
 			if nw.Socket != "" {
 				return fmt.Errorf("field `%s.vzNAT` and field `%s.socket` are mutually exclusive", field, field)
 			}
-		} else {
+		default:
 			return fmt.Errorf("field `%s.lima` or  field `%s.socket must be set", field, field)
 		}
 		if nw.MACAddress != "" {

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -192,14 +192,15 @@ func inspectStatusWithPIDFiles(instDir string, inst *Instance, y *limayaml.LimaY
 	}
 
 	if inst.Status == StatusUnknown {
-		if inst.HostAgentPID > 0 && inst.DriverPID > 0 {
+		switch {
+		case inst.HostAgentPID > 0 && inst.DriverPID > 0:
 			inst.Status = StatusRunning
-		} else if inst.HostAgentPID == 0 && inst.DriverPID == 0 {
+		case inst.HostAgentPID == 0 && inst.DriverPID == 0:
 			inst.Status = StatusStopped
-		} else if inst.HostAgentPID > 0 && inst.DriverPID == 0 {
+		case inst.HostAgentPID > 0 && inst.DriverPID == 0:
 			inst.Errors = append(inst.Errors, errors.New("host agent is running but driver is not"))
 			inst.Status = StatusBroken
-		} else {
+		default:
 			inst.Errors = append(inst.Errors, fmt.Errorf("%s driver is running but host agent is not", inst.VMType))
 			inst.Status = StatusBroken
 		}


### PR DESCRIPTION
The PR refactors code by replacing `if-else` blocks with the `switch` statement. Enables `gocritic.ifElseChain` check to prevent future regressions.

From the [Effective Go](https://go.dev/doc/effective_go#switch):

> It's therefore possible—and idiomatic—to write an `if-else-if-else` chain as a `switch`.