### PR TITLE
[Rosetta] Prioritize rosetta over `qemu-user-static` by creating `binfmt.d(5)` configuration

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-rosetta-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-rosetta-volume.sh
@@ -10,26 +10,31 @@ if [ -f /etc/alpine-release ]; then
 	rc-service qemu-binfmt stop --ifstarted
 fi
 
-mkdir -p /mnt/lima-rosetta
+# Mount the rosetta volume for non cloud-init based images
+rosetta_interpreter=/mnt/lima-rosetta/rosetta
+if [ ! -f "$rosetta_interpreter" ]; then
+	rosetta_mountpoint=$(dirname "$rosetta_interpreter")
+	mkdir -p "$rosetta_mountpoint"
 
-#Check selinux is enabled by kernel
-if [ -d /sys/fs/selinux ]; then
-	##########################################################################################
-	## When using vz & virtiofs, initially container_file_t selinux label
-	## was considered which works perfectly for container work loads
-	## but it might break for other work loads if the process is running with
-	## different label. Also these are the remote mounts from the host machine,
-	## so keeping the label as nfs_t fits right. Package container-selinux by
-	## default adds rules for nfs_t context which allows container workloads to work as well.
-	## https://github.com/lima-vm/lima/pull/1965
-	##########################################################################################
-	mount -t virtiofs vz-rosetta /mnt/lima-rosetta -o context="system_u:object_r:nfs_t:s0"
-else
-	mount -t virtiofs vz-rosetta /mnt/lima-rosetta
+	#Check selinux is enabled by kernel
+	if [ -d /sys/fs/selinux ]; then
+		##########################################################################################
+		## When using vz & virtiofs, initially container_file_t selinux label
+		## was considered which works perfectly for container work loads
+		## but it might break for other work loads if the process is running with
+		## different label. Also these are the remote mounts from the host machine,
+		## so keeping the label as nfs_t fits right. Package container-selinux by
+		## default adds rules for nfs_t context which allows container workloads to work as well.
+		## https://github.com/lima-vm/lima/pull/1965
+		##########################################################################################
+		mount -t virtiofs vz-rosetta "$rosetta_mountpoint" -o context="system_u:object_r:nfs_t:s0"
+	else
+		mount -t virtiofs vz-rosetta "$rosetta_mountpoint"
+	fi
 fi
 
 if [ "$LIMA_CIDATA_ROSETTA_BINFMT" = "true" ]; then
-	rosetta_binfmt=":rosetta:M::\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/mnt/lima-rosetta/rosetta:OCF"
+	rosetta_binfmt=":rosetta:M::\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:$rosetta_interpreter:OCF"
 
 	# If rosetta is not registered in binfmt_misc, register it.
 	[ -f /proc/sys/fs/binfmt_misc/rosetta ] || echo "$rosetta_binfmt" >/proc/sys/fs/binfmt_misc/register

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-rosetta-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-rosetta-volume.sh
@@ -10,31 +10,8 @@ if [ -f /etc/alpine-release ]; then
 	rc-service qemu-binfmt stop --ifstarted
 fi
 
-# Mount the rosetta volume for non cloud-init based images
-rosetta_interpreter=/mnt/lima-rosetta/rosetta
-if [ ! -f "$rosetta_interpreter" ]; then
-	rosetta_mountpoint=$(dirname "$rosetta_interpreter")
-	mkdir -p "$rosetta_mountpoint"
-
-	#Check selinux is enabled by kernel
-	if [ -d /sys/fs/selinux ]; then
-		##########################################################################################
-		## When using vz & virtiofs, initially container_file_t selinux label
-		## was considered which works perfectly for container work loads
-		## but it might break for other work loads if the process is running with
-		## different label. Also these are the remote mounts from the host machine,
-		## so keeping the label as nfs_t fits right. Package container-selinux by
-		## default adds rules for nfs_t context which allows container workloads to work as well.
-		## https://github.com/lima-vm/lima/pull/1965
-		##########################################################################################
-		mount -t virtiofs vz-rosetta "$rosetta_mountpoint" -o context="system_u:object_r:nfs_t:s0"
-	else
-		mount -t virtiofs vz-rosetta "$rosetta_mountpoint"
-	fi
-fi
-
 if [ "$LIMA_CIDATA_ROSETTA_BINFMT" = "true" ]; then
-	rosetta_binfmt=":rosetta:M::\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:$rosetta_interpreter:OCF"
+	rosetta_binfmt=":rosetta:M::\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/mnt/lima-rosetta/rosetta:OCF"
 
 	# If rosetta is not registered in binfmt_misc, register it.
 	[ -f /proc/sys/fs/binfmt_misc/rosetta ] || echo "$rosetta_binfmt" >/proc/sys/fs/binfmt_misc/register

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-rosetta-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-rosetta-volume.sh
@@ -29,7 +29,13 @@ else
 fi
 
 if [ "$LIMA_CIDATA_ROSETTA_BINFMT" = "true" ]; then
-	echo \
-		':rosetta:M::\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/mnt/lima-rosetta/rosetta:OCF' \
-		>/proc/sys/fs/binfmt_misc/register
+	rosetta_binfmt=":rosetta:M::\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/mnt/lima-rosetta/rosetta:OCF"
+
+	# If rosetta is not registered in binfmt_misc, register it.
+	[ -f /proc/sys/fs/binfmt_misc/rosetta ] || echo "$rosetta_binfmt" >/proc/sys/fs/binfmt_misc/register
+
+	# Create binfmt.d(5) configuration to prioritize rosetta even if qemu-user-static is installed on systemd based systems.
+	binfmtd_conf=/usr/lib/binfmt.d/rosetta.conf
+	# If the binfmt.d directory exists, consider systemd-binfmt.service(8) to be enabled and create the configuration file.
+	[ ! -d "$(dirname "$binfmtd_conf")" ] || [ -f "$binfmtd_conf" ] || echo "$rosetta_binfmt" >"$binfmtd_conf"
 fi

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-rosetta-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-rosetta-volume.sh
@@ -10,14 +10,20 @@ if [ -f /etc/alpine-release ]; then
 	rc-service qemu-binfmt stop --ifstarted
 fi
 
+binfmt_entry=/proc/sys/fs/binfmt_misc/rosetta
+binfmtd_conf=/usr/lib/binfmt.d/rosetta.conf
 if [ "$LIMA_CIDATA_ROSETTA_BINFMT" = "true" ]; then
 	rosetta_binfmt=":rosetta:M::\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/mnt/lima-rosetta/rosetta:OCF"
 
 	# If rosetta is not registered in binfmt_misc, register it.
-	[ -f /proc/sys/fs/binfmt_misc/rosetta ] || echo "$rosetta_binfmt" >/proc/sys/fs/binfmt_misc/register
+	[ -f "$binfmt_entry" ] || echo "$rosetta_binfmt" >/proc/sys/fs/binfmt_misc/register
 
 	# Create binfmt.d(5) configuration to prioritize rosetta even if qemu-user-static is installed on systemd based systems.
-	binfmtd_conf=/usr/lib/binfmt.d/rosetta.conf
 	# If the binfmt.d directory exists, consider systemd-binfmt.service(8) to be enabled and create the configuration file.
 	[ ! -d "$(dirname "$binfmtd_conf")" ] || [ -f "$binfmtd_conf" ] || echo "$rosetta_binfmt" >"$binfmtd_conf"
+else
+	# unregister rosetta from binfmt_misc if it exists
+	[ ! -f "$binfmt_entry" ] || echo -1 | "$binfmt_entry"
+	# remove binfmt.d(5) configuration if it exists
+	[ ! -f "$binfmtd_conf" ] || rm "$binfmtd_conf"
 fi

--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -13,8 +13,7 @@ package_reboot_if_required: true
 
 {{- if or .RosettaEnabled (or (eq .MountType "9p") (eq .MountType "virtiofs")) }}
 mounts:
-  # Mount the rosetta volume before systemd-binfmt.service(8) starts
-  {{- if .RosettaEnabled }}
+  {{- if .RosettaEnabled }}{{/* Mount the rosetta volume before systemd-binfmt.service(8) starts */}}
 - ["vz-rosetta", "/mnt/lima-rosetta", "virtiofs", "context=\"system_u:object_r:nfs_t:s0\""]
   {{- end }}
   {{- if .Mounts }}

--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -11,13 +11,17 @@ package_upgrade: true
 package_reboot_if_required: true
 {{- end }}
 
-{{- if or (eq .MountType "9p") (eq .MountType "virtiofs") }}
-{{- if .Mounts }}
+{{- if or .RosettaEnabled (or (eq .MountType "9p") (eq .MountType "virtiofs")) }}
 mounts:
-  {{- range $m := $.Mounts}}
-- [{{$m.Tag}}, {{$m.MountPoint}}, {{$m.Type}}, "{{$m.Options}}", "0", "0"]
+  # Mount the rosetta volume before systemd-binfmt.service(8) starts
+  {{- if .RosettaEnabled }}
+- ["vz-rosetta", "/mnt/lima-rosetta", "virtiofs", "context=\"system_u:object_r:nfs_t:s0\""]
   {{- end }}
-{{- end }}
+  {{- if .Mounts }}
+    {{- range $m := $.Mounts}}
+- [{{$m.Tag}}, {{$m.MountPoint}}, {{$m.Type}}, "{{$m.Options}}", "0", "0"]
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{- if .TimeZone }}

--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -14,7 +14,7 @@ package_reboot_if_required: true
 {{- if or .RosettaEnabled (or (eq .MountType "9p") (eq .MountType "virtiofs")) }}
 mounts:
   {{- if .RosettaEnabled }}{{/* Mount the rosetta volume before systemd-binfmt.service(8) starts */}}
-- ["vz-rosetta", "/mnt/lima-rosetta", "virtiofs", "context=\"system_u:object_r:nfs_t:s0\""]
+- [vz-rosetta, /mnt/lima-rosetta, virtiofs]
   {{- end }}
   {{- if .Mounts }}
     {{- range $m := $.Mounts}}


### PR DESCRIPTION
This change aims to ensure that Rosetta is prioritized over `qemu-user-static` when both are installed. The key steps and intentions of this change include:

1. **Creating a `binfmt.d(5)` Configuration for Rosetta**: This configuration ensures that Rosetta is registered with `systemd-binfmt`, taking precedence over `qemu-user-static`.

2. **Early Mounting of Rosetta Volume**: Using `user-data` to mount the Rosetta volume earlier in the boot process, preventing errors related to the Rosetta interpreter not being found by `systemd-binfmt.service(8)`.

3. **Duplicate Registration Check**: Adding a check to avoid errors from duplicate registrations in binfmt_misc during subsequent startups, ensuring smooth operation when Rosetta is already registered.

The expected methods for installing `qemu-user-static` are as follows:
- Running `docker run --rm --privileged multiarch/qemu-user-static --reset -p yes` on a Docker rootful VM.
- Executing `apt-get install qemu-user-static` within the provision script in `lima.yaml`.

Both methods create configuration files for `binfmt.d(5)`.

Thanks,