### PR TITLE
Fix panic in stop when the VM goes away

### DIFF
--- a/pkg/hostagent/events/watcher.go
+++ b/pkg/hostagent/events/watcher.go
@@ -44,6 +44,9 @@ loop:
 		case <-ctx.Done():
 			break loop
 		case line := <-haStdoutTail.Lines:
+			if line == nil {
+				break loop
+			}
 			if line.Err != nil {
 				logrus.Error(line.Err)
 			}


### PR DESCRIPTION
Fixes #102

The panic occurs because the closed channel `haStdoutTail.Lines` returns `nil` when the file `haStdoutTail` is removed.

The test has not been added because writing it without `time.Sleep` is challenging.

<details><summary>Reproducing the problem locally</summary>

#### Before the PR

```
❯ _output/bin/limactl delete -f default
...
```

```
❯ _output/bin/limactl stop default
INFO[0000] Sending SIGINT to hostagent process 37797    
INFO[0000] Waiting for the host agent and the driver processes to shut down 
INFO[0000] [hostagent] Received SIGINT, shutting down the host agent 
INFO[0000] [hostagent] Shutting down the host agent     
INFO[0000] [hostagent] Stopping forwarding "/run/lima-guestagent.sock" (guest) to "/Users/Oleksandr_Redko/.lima/default/ga.sock" (host) 
INFO[0000] [hostagent] Unmounting "/Users/Oleksandr_Redko" 
INFO[0000] [hostagent] Unmounting "/tmp/lima"           
INFO[0000] [hostagent] Shutting down QEMU with ACPI     
INFO[0000] [hostagent] Sending QMP system_powerdown command 
2024/07/09 22:52:14 Stopping tail as file no longer exists: /Users/Oleksandr_Redko/.lima/default/ha.stdout.log
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x40 pc=0x10521f66c]

goroutine 1 [running]:
github.com/lima-vm/lima/pkg/hostagent/events.Watch({0x1059712e8, 0x140004e5490}, {0x14000552200?, 0x106d57ac8?}, {0x14000552240, 0x32}, {0x30?, 0x14000089b08?, 0x10626aa20?}, 0x14000427b50)
        /Users/Oleksandr_Redko/src/github.com/lima-vm/lima/pkg/hostagent/events/watcher.go:47 +0x1ec
main.waitForHostAgentTermination({0x105971160?, 0x1067fc940?}, 0x1400047d680, {0x1?, 0x1?, 0x10626aa20?})
        /Users/Oleksandr_Redko/src/github.com/lima-vm/lima/cmd/limactl/stop.go:96 +0x13c
main.stopInstanceGracefully(0x1400047d680)
        /Users/Oleksandr_Redko/src/github.com/lima-vm/lima/cmd/limactl/stop.go:74 +0x1d0
main.stopAction(0x14000341508, {0x140004f2a00?, 0x4?, 0x1054c8577?})
        /Users/Oleksandr_Redko/src/github.com/lima-vm/lima/cmd/limactl/stop.go:53 +0xd0
github.com/spf13/cobra.(*Command).execute(0x14000341508, {0x140004f29d0, 0x1, 0x1})
        /Users/Oleksandr_Redko/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x14000340c08)
        /Users/Oleksandr_Redko/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/Oleksandr_Redko/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
main.main()
        /Users/Oleksandr_Redko/src/github.com/lima-vm/lima/cmd/limactl/main.go:27 +0x20
```

#### After the PR

```
❯ _output/bin/limactl delete -f default
...
```

```
❯ _output/bin/limactl stop default
INFO[0000] Sending SIGINT to hostagent process 34969    
INFO[0000] Waiting for the host agent and the driver processes to shut down 
INFO[0000] [hostagent] Received SIGINT, shutting down the host agent 
INFO[0000] [hostagent] Shutting down the host agent     
INFO[0000] [hostagent] Stopping forwarding "/run/lima-guestagent.sock" (guest) to "/Users/Oleksandr_Redko/.lima/default/ga.sock" (host) 
INFO[0000] [hostagent] Unmounting "/Users/Oleksandr_Redko" 
INFO[0000] [hostagent] Unmounting "/tmp/lima"           
INFO[0000] [hostagent] Shutting down QEMU with ACPI     
INFO[0000] [hostagent] Sending QMP system_powerdown command 
2024/07/09 22:49:25 Stopping tail as file no longer exists: /Users/Oleksandr_Redko/.lima/default/ha.stdout.log
FATA[0000] did not receive an event with the "exiting" status 
```

</details>