### PR TITLE
website: remove technical info from 404 page

### DIFF
--- a/website/layouts/404.html
+++ b/website/layouts/404.html
@@ -2,6 +2,5 @@
 <div class="td-content">
   <h1>Not found</h1>
   <p>Oops! This page doesn't exist. Try going back to the <a href="{{ "" | relURL }}">home page</a>.</p>
-  <p>You can learn how to make a 404 page like this in <a href="https://gohugo.io/templates/404/">Custom 404 Pages</a>.</p>
 </div>
 {{- end }}


### PR DESCRIPTION
The PR changes the 404 page by removing the unnecessary text "You can learn how to make a 404 page like this".

#### Before

<img width="581" alt="image" src="https://github.com/lima-vm/lima/assets/3228886/338c38ba-5668-4d9e-8d1e-6ebf60ea6843">

#### After

<img width="523" alt="image" src="https://github.com/lima-vm/lima/assets/3228886/544cb508-d6ca-4990-b519-2d709b3cf04a">
