### PR TITLE
add fuzz test for ConvertToRaw

### DIFF
--- a/pkg/nativeimgutil/fuzz_test.go
+++ b/pkg/nativeimgutil/fuzz_test.go
@@ -1,0 +1,19 @@
+package nativeimgutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func FuzzConvertToRaw(f *testing.F) {
+	f.Fuzz(func(t *testing.T, imgData []byte, withBacking bool, size int64) {
+		srcPath := filepath.Join(t.TempDir(), "src.img")
+		destPath := filepath.Join(t.TempDir(), "dest.img")
+		err := os.WriteFile(srcPath, imgData, 0o600)
+		if err != nil {
+			return
+		}
+		_ = ConvertToRaw(srcPath, destPath, &size, withBacking)
+	})
+}


### PR DESCRIPTION
Adds a fuzz test that creates a `src.img` with pseudo random data and copies it by way of `ConvertToRaw`.

Can test it with `cd pkg/nativeimgutil && go test -fuzz=FuzzConvertToRaw`