### PR TITLE
add fuzz test for IsISO9660

### DIFF
--- a/pkg/iso9660util/fuzz_test.go
+++ b/pkg/iso9660util/fuzz_test.go
@@ -1,0 +1,19 @@
+package iso9660util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func FuzzIsISO9660(f *testing.F) {
+	f.Fuzz(func(t *testing.T, fileContents []byte) {
+		imageFile := filepath.Join(t.TempDir(), "fuzz.iso")
+		err := os.WriteFile(imageFile, fileContents, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		//nolint:errcheck // The test doesn't check the return value
+		IsISO9660(imageFile)
+	})
+}


### PR DESCRIPTION
Adds a fuzz test that creates a file with random content and invokes `IsISO9660` with its path.