### PR TITLE
add fuzz test for procnettcp parsing

### DIFF
--- a/pkg/guestagent/procnettcp/fuzz_test.go
+++ b/pkg/guestagent/procnettcp/fuzz_test.go
@@ -1,0 +1,18 @@
+package procnettcp
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzParse(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte, tcp6 bool) {
+		var kind Kind
+		if tcp6 {
+			kind = TCP6
+		} else {
+			kind = TCP
+		}
+		_, _ = Parse(bytes.NewReader(data), kind)
+	})
+}


### PR DESCRIPTION
Adds a fuzz test for `pkg/guestagent/procnettcp.Parse`.