### PR TITLE
Make sure /proc/sys/fs/binfmt_misc has been mounted (on Alpine)

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-rosetta-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-rosetta-volume.sh
@@ -7,6 +7,7 @@ if [ "$LIMA_CIDATA_ROSETTA_ENABLED" != "true" ]; then
 fi
 
 if [ -f /etc/alpine-release ]; then
+	rc-service procfs start --ifnotstarted
 	rc-service qemu-binfmt stop --ifstarted
 fi
 


### PR DESCRIPTION
Alpine cloud images don't mount the binfmt_misc filesystem by default. This is done by starting the `procfs` service.