### PR TITLE
add fuzz test for yqutil

### DIFF
--- a/pkg/yqutil/fuzz_test.go
+++ b/pkg/yqutil/fuzz_test.go
@@ -1,0 +1,11 @@
+package yqutil
+
+import (
+	"testing"
+)
+
+func FuzzEvaluateExpression(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, expression string, content []byte) {
+		_, _ = EvaluateExpression(expression, content)
+	})
+}


### PR DESCRIPTION
Adds a fuzz test for `EvaluateExpression`. Both of `EvaluateExpression` s parameters are provided by the fuzzer.