### PR TITLE
limactl stop: extend the timeout for waiting for the hostAgent to stop

### DIFF
--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -75,7 +75,7 @@ func stopInstanceGracefully(inst *store.Instance) error {
 }
 
 func waitForHostAgentTermination(ctx context.Context, inst *store.Instance, begin time.Time) error {
-	ctx2, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	ctx2, cancel := context.WithTimeout(ctx, 3*time.Minute+10*time.Second)
 	defer cancel()
 
 	var receivedExitingEvent bool


### PR DESCRIPTION
Currently, both the timeout for waiting for the hostAgent to stop in `limactl stop` and the timeout for `LimaQemuDriver.Stop()` calling `shutdownQEMU()` are set to 3 minutes. https://github.com/lima-vm/lima/blob/6fa914519f9412519fee64619755aa4a9b3774f9/pkg/qemu/qemu_driver.go#L204 As a result, the `limactl stop` might time out before QEMU is forcibly terminated, leading to the error:
> level=fatal msg="did not receive an event with the \"exiting\" status"

With this change, `limactl stop` should be able to receive the `"status":{"exiting":true}` event output by the hostAgent after it has forcibly terminated QEMU, preventing `limactl stop` from resulting in an error.