### PR TITLE
Fix function and package comments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -137,6 +137,9 @@ issues:
   max-issues-per-linter: 0
   # Maximum count of issues with the same text.
   max-same-issues: 0
+  include:
+  - EXC0013  # revive: package comment should be of the form "(.+)..."
+  - EXC0014  # revive: comment on exported (.+) should be of the form "(.+)..."
   exclude-rules:
   # Allow using Uid, Gid in pkg/osutil.
   - path: "pkg/osutil/"
@@ -145,3 +148,7 @@ issues:
   - path: _test\.go
     linters:
     - godot
+  # Disable revive.exported for constants.
+  - text: "exported: comment on exported const"
+    linters:
+    - revive

--- a/pkg/guestagent/api/gen.go
+++ b/pkg/guestagent/api/gen.go
@@ -1,2 +1,3 @@
 //go:generate protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative guestservice.proto --descriptor_set_out=guestservice.pb.desc
+
 package api

--- a/pkg/guestagent/kubernetesservice/kubernetesservice.go
+++ b/pkg/guestagent/kubernetesservice/kubernetesservice.go
@@ -23,6 +23,7 @@ type Protocol string
 
 const (
 	// UDP/SCTP when lima port forwarding works on those protocols.
+
 	TCP Protocol = "TCP"
 )
 

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -324,13 +324,13 @@ func watchHostAgentEvents(ctx context.Context, inst *store.Instance, haStdoutPat
 
 type watchHostAgentEventsTimeoutKey = struct{}
 
-// WithWatchHostAgentEventsTimeout sets the value of the timeout to use for
+// WithWatchHostAgentTimeout sets the value of the timeout to use for
 // watchHostAgentEvents in the given Context.
 func WithWatchHostAgentTimeout(ctx context.Context, timeout time.Duration) context.Context {
 	return context.WithValue(ctx, watchHostAgentEventsTimeoutKey{}, timeout)
 }
 
-// watchHostAgentEventsTimeout returns the value of the timeout to use for
+// watchHostAgentTimeout returns the value of the timeout to use for
 // watchHostAgentEvents contained in the given Context, or its default value.
 func watchHostAgentTimeout(ctx context.Context) time.Duration {
 	if timeout, ok := ctx.Value(watchHostAgentEventsTimeoutKey{}).(time.Duration); ok {


### PR DESCRIPTION
This PR updates comments for functions and packages to ensure that the names in comments and code are synchronized. See https://go.dev/doc/comment.

Additionally, it enables `EXC0013` and `EXC0014` to prevent these issues from recurring. `revive` will now flag any discrepancies. Comments on exported constants are ignored.

<details>
<summary>The full list of comment issues that were fixed</summary>

```
❯ golangci-lint run
pkg/start/start.go:327:1: exported: comment on exported function WithWatchHostAgentTimeout should be of the form "WithWatchHostAgentTimeout ..." (revive)
// WithWatchHostAgentEventsTimeout sets the value of the timeout to use for
^
pkg/guestagent/kubernetesservice/kubernetesservice.go:25:2: exported: comment on exported const TCP should be of the form "TCP ..." (revive)
        // UDP/SCTP when lima port forwarding works on those protocols.
        ^
pkg/guestagent/api/gen.go:1:1: package-comments: package comment should be of the form "Package api ..." (revive)
//go:generate protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative guestservice.proto --descriptor_set_out=guestservice.pb.desc
^
pkg/store/filenames/filenames.go:11:28: exported: comment on exported const CacheDir should be of the form "CacheDir ..." (revive)
        CacheDir    = "_cache"    // not yet implemented
                                  ^
pkg/store/filenames/filenames.go:12:28: exported: comment on exported const NetworksDir should be of the form "NetworksDir ..." (revive)
        NetworksDir = "_networks" // network log files are stored here
                                  ^
pkg/store/filenames/filenames.go:13:28: exported: comment on exported const DisksDir should be of the form "DisksDir ..." (revive)
        DisksDir    = "_disks"    // disks are stored here
                                  ^
pkg/store/filenames/filenames.go:30:40: exported: comment on exported const LimaVersion should be of the form "LimaVersion ..." (revive)
        LimaVersion          = "lima-version" // Lima version used to create instance
                                              ^
pkg/store/filenames/filenames.go:39:38: exported: comment on exported const SerialLog should be of the form "SerialLog ..." (revive)
        SerialLog            = "serial.log" // default serial (ttyS0, but ttyAMA0 on qemu-system-{arm,aarch64})
                                            ^
pkg/store/filenames/filenames.go:41:39: exported: comment on exported const SerialPCILog should be of the form "SerialPCILog ..." (revive)
        SerialPCILog         = "serialp.log" // pci serial (ttyS0 on qemu-system-{arm,aarch64})
                                             ^
pkg/store/filenames/filenames.go:43:39: exported: comment on exported const SerialVirtioLog should be of the form "SerialVirtioLog ..." (revive)
        SerialVirtioLog      = "serialv.log" // virtio serial
                                             ^
pkg/store/filenames/filenames.go:57:44: exported: comment on exported const VzEfi should be of the form "VzEfi ..." (revive)
        VzEfi                = "vz-efi"           // efi variable store
                                                  ^
pkg/store/filenames/filenames.go:58:44: exported: comment on exported const QemuEfiCodeFD should be of the form "QemuEfiCodeFD ..." (revive)
        QemuEfiCodeFD        = "qemu-efi-code.fd" // efi code; not always created
                                                  ^
pkg/store/filenames/filenames.go:64:26: exported: comment on exported const Protected should be of the form "Protected ..." (revive)
        Protected = "protected" // empty file; used by `limactl protect`
                                ^
pkg/networks/const.go:5:2: exported: comment on exported const SlirpNetwork should be of the form "SlirpNetwork ..." (revive)
        // CIDR is intentionally hardcoded to 192.168.5.0/24, as each of QEMU has its own independent slirp network.
        ^
```

</details>
