### PR TITLE
executil: change ctx parameter to be non-pointer

### DIFF
--- a/pkg/executil/command.go
+++ b/pkg/executil/command.go
@@ -10,15 +10,13 @@ import (
 )
 
 type options struct {
-	ctx *context.Context
+	ctx context.Context
 }
 
 type Opt func(*options) error
 
 // WithContext runs the command with CommandContext.
-//
-//nolint:gocritic // consider `ctx' to be of non-pointer type
-func WithContext(ctx *context.Context) Opt {
+func WithContext(ctx context.Context) Opt {
 	return func(o *options) error {
 		o.ctx = ctx
 		return nil
@@ -35,7 +33,7 @@ func RunUTF16leCommand(args []string, opts ...Opt) (string, error) {
 
 	var cmd *exec.Cmd
 	if o.ctx != nil {
-		cmd = exec.CommandContext(*o.ctx, args[0], args[1:]...)
+		cmd = exec.CommandContext(o.ctx, args[0], args[1:]...)
 	} else {
 		cmd = exec.Command(args[0], args[1:]...)
 	}

--- a/pkg/wsl2/vm_windows.go
+++ b/pkg/wsl2/vm_windows.go
@@ -23,7 +23,7 @@ func startVM(ctx context.Context, distroName string) error {
 		"wsl.exe",
 		"--distribution",
 		distroName,
-	}, executil.WithContext(&ctx))
+	}, executil.WithContext(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to run `wsl.exe --distribution %s`: %w (out=%q)",
 			distroName, err, string(out))
@@ -41,7 +41,7 @@ func initVM(ctx context.Context, instanceDir, distroName string) error {
 		distroName,
 		instanceDir,
 		baseDisk,
-	}, executil.WithContext(&ctx))
+	}, executil.WithContext(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to run `wsl.exe --import %s %s %s`: %w (out=%q)",
 			distroName, instanceDir, baseDisk, err, string(out))
@@ -55,7 +55,7 @@ func stopVM(ctx context.Context, distroName string) error {
 		"wsl.exe",
 		"--terminate",
 		distroName,
-	}, executil.WithContext(&ctx))
+	}, executil.WithContext(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to run `wsl.exe --terminate %s`: %w (out=%q)",
 			distroName, err, string(out))
@@ -164,7 +164,7 @@ func unregisterVM(ctx context.Context, distroName string) error {
 		"wsl.exe",
 		"--unregister",
 		distroName,
-	}, executil.WithContext(&ctx))
+	}, executil.WithContext(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to run `wsl.exe --unregister %s`: %w (out=%q)",
 			distroName, err, string(out))


### PR DESCRIPTION
The PR changes the parameter of `executil.WithContext` to a non-pointer type as suggested by `gocritic`. Since [`context.Context`](https://pkg.go.dev/context#Context) is an interface, there is no need to pass it as a pointer.