### PR TITLE
limayaml: add a `param` field for defining variables used to customize scripts and other elements within `lima.yaml`.

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -193,7 +193,7 @@ containerd:
 
 # Provisioning scripts need to be idempotent because they might be called
 # multiple times, e.g. when the host VM is being restarted.
-# The scripts can use the following template variables: {{.Home}}, {{.UID}}, and {{.User}}
+# The scripts can use the following template variables: {{.Home}}, {{.UID}}, {{.User}}, and {{.Param.Key}}
 # 🟢 Builtin default: null
 # provision:
 # # `system` is executed with root privileges
@@ -235,6 +235,7 @@ containerd:
 #   playbook: playbook.yaml
 
 # Probe scripts to check readiness.
+# The scripts can use the following template variables: {{.Home}}, {{.UID}}, {{.User}}, and {{.Param.Key}}
 # 🟢 Builtin default: null
 # probes:
 # # Only `readiness` probes are supported right now.
@@ -377,8 +378,8 @@ networks:
 # - guestSocket: "/run/user/{{.UID}}/my.sock"
 #   hostSocket: mysocket
 # # default: reverse: false
-# # "guestSocket" can include these template variables: {{.Home}}, {{.UID}}, and {{.User}}.
-# # "hostSocket" can include {{.Home}}, {{.Dir}}, {{.Name}}, {{.UID}}, and {{.User}}.
+# # "guestSocket" can include these template variables: {{.Home}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
+# # "hostSocket" can include {{.Home}}, {{.Dir}}, {{.Name}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
 # # "reverse" can only be used for unix sockets right now, not for tcp sockets.
 # # Put sockets into "{{.Dir}}/sock" to avoid collision with Lima internal sockets!
 # # Sockets can also be forwarded to ports and vice versa, but not to/from a range of ports.
@@ -397,8 +398,8 @@ networks:
 # - guest: "/etc/myconfig.cfg"
 #   host: "{{.Dir}}/copied-from-guest/myconfig"
 # # deleteOnStop: false
-# # "guest" can include these template variables: {{.Home}}, {{.UID}}, and {{.User}}.
-# # "host" can include {{.Home}}, {{.Dir}}, {{.Name}}, {{.UID}}, and {{.User}}.
+# # "guest" can include these template variables: {{.Home}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
+# # "host" can include {{.Home}}, {{.Dir}}, {{.Name}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
 # # "deleteOnStop" will delete the file from the host when the instance is stopped.
 
 # Message. Information to be shown to the user, given as a Go template for the instance.
@@ -417,6 +418,11 @@ networks:
 # 🟢 Builtin default: null
 # env:
 #   KEY: value
+
+# Defines variables used for customizing the functionality.
+# These variables can be referenced as {{.Param.Key}} in lima.yaml.
+# param:
+#   Key: value
 
 # Lima will override the proxy environment variables with values from the current process
 # environment (the environment in effect when you run `limactl start`). It will automatically

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -155,13 +155,13 @@ func New(instName string, stdout io.Writer, signalCh chan os.Signal, opts ...Opt
 	// Block ports 22 and sshLocalPort on all IPs
 	for _, port := range []int{sshGuestPort, sshLocalPort} {
 		rule := limayaml.PortForward{GuestIP: net.IPv4zero, GuestPort: port, Ignore: true}
-		limayaml.FillPortForwardDefaults(&rule, inst.Dir)
+		limayaml.FillPortForwardDefaults(&rule, inst.Dir, inst.Param)
 		rules = append(rules, rule)
 	}
 	rules = append(rules, y.PortForwards...)
 	// Default forwards for all non-privileged ports from "127.0.0.1" and "::1"
 	rule := limayaml.PortForward{}
-	limayaml.FillPortForwardDefaults(&rule, inst.Dir)
+	limayaml.FillPortForwardDefaults(&rule, inst.Dir, inst.Param)
 	rules = append(rules, rule)
 
 	limaDriver := driverutil.CreateTargetDriverInstance(&driver.BaseDriver{

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -34,6 +34,7 @@ type LimaYAML struct {
 	Networks           []Network     `yaml:"networks,omitempty" json:"networks,omitempty"`
 	// `network` was deprecated in Lima v0.7.0, removed in Lima v0.14.0. Use `networks` instead.
 	Env          map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+	Param        map[string]string `yaml:"param,omitempty" json:"param,omitempty"`
 	DNS          []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`
 	HostResolver HostResolver      `yaml:"hostResolver,omitempty" json:"hostResolver,omitempty"`
 	// `useHostResolver` was deprecated in Lima v0.8.1, removed in Lima v0.14.0. Use `hostResolver.enabled` instead.

--- a/pkg/limayaml/load.go
+++ b/pkg/limayaml/load.go
@@ -86,6 +86,11 @@ func Load(b []byte, filePath string) (*LimaYAML, error) {
 		return nil, err
 	}
 
+	// It should be called before the `y` parameter is passed to FillDefault() that execute template.
+	if err := ValidateParamIsUsed(&y); err != nil {
+		return nil, err
+	}
+
 	FillDefault(&y, &d, &o, filePath)
 	return &y, nil
 }

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -59,6 +59,7 @@ type Instance struct {
 	SSHAddress      string             `json:"sshAddress,omitempty"`
 	Protected       bool               `json:"protected"`
 	LimaVersion     string             `json:"limaVersion"`
+	Param           map[string]string  `json:"param,omitempty"`
 }
 
 func (inst *Instance) LoadYAML() (*limayaml.LimaYAML, error) {
@@ -180,6 +181,7 @@ func Inspect(instName string) (*Instance, error) {
 	} else if !errors.Is(err, os.ErrNotExist) {
 		inst.Errors = append(inst.Errors, err)
 	}
+	inst.Param = y.Param
 	return inst, nil
 }
 

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -42,6 +42,7 @@ var knownYamlProperties = []string{
 	"MountInotify",
 	"Networks",
 	"OS",
+	"Param",
 	"Plain",
 	"PortForwards",
 	"Probes",

--- a/pkg/wsl2/wsl_driver_windows.go
+++ b/pkg/wsl2/wsl_driver_windows.go
@@ -29,6 +29,7 @@ var knownYamlProperties = []string{
 	"Message",
 	"Mounts",
 	"MountType",
+	"Param",
 	"Plain",
 	"PortForwards",
 	"Probes",


### PR DESCRIPTION
The defined variables can be referenced within `lima.yaml` as `{{.Param.Key}}`.
The fields where this can be utilized are as follows:
- `provision[%d].script`
- `probes[%d].script`
- `copyToHost[%d].{guest,host}`
- `portForwards[%d].{guestSocket,hostSocket}`

It also changes:
- `limayaml`: add a check to verify whether the variables defined in `param` are actually used.


Following change has been merged as a separated PR: https://github.com/lima-vm/lima/pull/2501
- ~~`limactl start`: fix the issue where using `--set` would overwrite the existing instance's `lima.yaml` without validation.~~  

Following changes will be opened as a separated PR: https://github.com/lima-vm/lima/pull/2515
- ~~`docker.yaml`: add `.param.ContainerdImageStore`  
  By passing the `--set .param.ContainerdImageStore=true` option to `limactl {create,start,edit}`, the `.features."containerd-snapshotter"` option will be enabled in `docker/daemon.json` inside the VM.~~
- ~~`docker.yaml`: add `.param.Rootful`  
  By passing the `--set .param.Rootful=true` option to `limactl {create,start,edit}`, Docker inside the VM will run in rootful mode.~~
- ~~`docker-rootful.yaml`: make everything common except for setting `.param.Rootful=true` in `docker.yaml`.~~  

 
It might be better to split this into multiple parts, but for now, I’ll open it as a draft.

Thanks,