### PR TITLE
add fuzzer for Inspect

### DIFF
--- a/pkg/store/fuzz_test.go
+++ b/pkg/store/fuzz_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/lima-vm/lima/pkg/store/filenames"
 )
 
 func FuzzLoadYAMLByFilePath(f *testing.F) {
@@ -15,5 +17,28 @@ func FuzzLoadYAMLByFilePath(f *testing.F) {
 		}
 		//nolint:errcheck // The test doesn't check the return value
 		LoadYAMLByFilePath(localFile)
+	})
+}
+
+func FuzzInspect(f *testing.F) {
+	f.Fuzz(func(t *testing.T, yml, limaVersion []byte) {
+		limaDir := t.TempDir()
+		os.Setenv("LIMA_HOME", limaDir)
+		err := os.MkdirAll(filepath.Join(limaDir, "fuzz-instance"), 0o700)
+		if err != nil {
+			// panic so that we know of problems here
+			panic(err)
+		}
+		ymlFile := filepath.Join(limaDir, "fuzz-instance", filenames.LimaYAML)
+		limaVersionFile := filepath.Join(limaDir, filenames.LimaVersion)
+		err = os.WriteFile(ymlFile, yml, 0o600)
+		if err != nil {
+			return
+		}
+		err = os.WriteFile(limaVersionFile, limaVersion, 0o600)
+		if err != nil {
+			return
+		}
+		_, _ = Inspect("fuzz-instance")
 	})
 }


### PR DESCRIPTION
Adds a fuzz test for `pkg/store.Inspect`. The fuzzer creates a file with the yaml in a temporary directory and then invokes `Inspect` with the name of that directory. It also creates a file from which Lima reads the version.