### PR TITLE
limactl start: fix the issue where using `--set` would overwrite the existing instance's `lima.yaml` without validation.

### DIFF
--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -294,6 +294,18 @@ func applyYQExpressionToExistingInstance(inst *store.Instance, yq string) (*stor
 	if err != nil {
 		return nil, err
 	}
+	y, err := limayaml.Load(yBytes, filePath)
+	if err != nil {
+		return nil, err
+	}
+	if err := limayaml.Validate(y, true); err != nil {
+		rejectedYAML := "lima.REJECTED.yaml"
+		if writeErr := os.WriteFile(rejectedYAML, yBytes, 0o644); writeErr != nil {
+			return nil, fmt.Errorf("the YAML is invalid, attempted to save the buffer as %q but failed: %w: %w", rejectedYAML, writeErr, err)
+		}
+		// TODO: may need to support editing the rejected YAML
+		return nil, fmt.Errorf("the YAML is invalid, saved the buffer as %q: %w", rejectedYAML, err)
+	}
 	if err := os.WriteFile(filePath, yBytes, 0o644); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`limactl start --set` can overwrite the existing `lima.yaml` without validation, potentially creating an invalid `lima.yaml`.
e.g.
```console
$ limactl create template://docker-rootful --name docker-test --tty=false
INFO[0000] Terminal is not available, proceeding without opening an editor 
INFO[0000] Attempting to download the image              arch=aarch64 digest="sha256:c841bac00925d3e6892d979798103a867931f255f28fefd9d5e07e3e22d0ef22" location="https://cloud-images.ubuntu.com/releases/24.04/release-20240423/ubuntu-24.04-server-cloudimg-arm64.img"
INFO[0000] Using cache "/Users/norio/Library/Caches/lima/download/by-url-sha256/b154bd45a2ac868f3d26ef79c803af364d0c7308eb72e602324cbf04cf9a8455/data" 
INFO[0000] Run `limactl start docker-test` to start the instance. 
$ limactl start docker-test --tty=false --set ".os = 1"
INFO[0000] Using the existing instance "docker-test"    
FATA[0000] errors inspecting instance: [field `os` must be "Linux"; got "1"] 
$ limactl start docker-test --tty=false
INFO[0000] Using the existing instance "docker-test"    
FATA[0000] errors inspecting instance: [field `os` must be "Linux"; got "1"] 
```
This PR changes the process to include validation before overwriting.