### PR TITLE
Uncapitalize error messages; enable revive.error-strings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,6 +106,8 @@ linters-settings:
   errorlint:
     asserts: false
   revive:
+    # Set below 0.8 to enable error-strings
+    confidence: 0.6
     # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
     rules:
     - name: blank-imports

--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -98,7 +98,7 @@ func copyAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if legacySSH && len(instDirs) > 1 {
-		return fmt.Errorf("More than one (instance) host is involved in this command, this is only supported for openSSH v8.0 or higher")
+		return fmt.Errorf("more than one (instance) host is involved in this command, this is only supported for openSSH v8.0 or higher")
 	}
 	scpFlags = append(scpFlags, "-3", "--")
 	scpArgs = append(scpFlags, scpArgs...)

--- a/cmd/limactl/disk.go
+++ b/cmd/limactl/disk.go
@@ -27,7 +27,7 @@ func newDiskCommand() *cobra.Command {
 
   Delete a disk:
   $ limactl disk delete DISK
-  
+
   Resize a disk:
   $ limactl disk resize DISK --size SIZE`,
 		SilenceUsage:  true,
@@ -106,7 +106,7 @@ func diskCreateAction(cmd *cobra.Command, args []string) error {
 		if rerr != nil {
 			err = errors.Join(err, fmt.Errorf("failed to remove a directory %q: %w", diskDir, rerr))
 		}
-		return fmt.Errorf("Failed to create %s disk in %q: %w", format, diskDir, err)
+		return fmt.Errorf("failed to create %s disk in %q: %w", format, diskDir, err)
 	}
 
 	return nil

--- a/pkg/qemu/entitlementutil/entitlementutil.go
+++ b/pkg/qemu/entitlementutil/entitlementutil.go
@@ -51,7 +51,7 @@ func Sign(qExe string) error {
   </dict>
 </plist>`
 	if _, err = ent.WriteString(entXML); err != nil {
-		return fmt.Errorf("Failed to write to a temporary file %q for signing QEMU binary: %w", entName, err)
+		return fmt.Errorf("failed to write to a temporary file %q for signing QEMU binary: %w", entName, err)
 	}
 	ent.Close()
 	signCmd := exec.Command("codesign", "--sign", "-", "--entitlements", entName, "--force", qExe)

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -998,7 +998,7 @@ func FindVirtiofsd(qemuExe string) (string, error) {
 		}
 	}
 
-	return "", errors.New("Failed to locate virtiofsd")
+	return "", errors.New("failed to locate virtiofsd")
 }
 
 func VirtiofsdCmdline(cfg Config, mountIndex int) ([]string, error) {

--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -288,7 +288,7 @@ func (l *LimaQemuDriver) killVhosts() error {
 	var errs []error
 	for i, vhost := range l.vhostCmds {
 		if err := vhost.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
-			errs = append(errs, fmt.Errorf("Failed to kill virtiofsd instance #%d: %w", i, err))
+			errs = append(errs, fmt.Errorf("failed to kill virtiofsd instance #%d: %w", i, err))
 		}
 	}
 

--- a/pkg/vz/errors_darwin.go
+++ b/pkg/vz/errors_darwin.go
@@ -4,4 +4,5 @@ package vz
 
 import "errors"
 
+//nolint:revive // error-strings
 var errRosettaUnsupported = errors.New("Rosetta is unsupported on non-ARM64 hosts")

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -182,6 +182,7 @@ func (l *LimaVzDriver) RunGUI() error {
 	if l.CanRunGUI() {
 		return l.machine.StartGraphicApplication(1920, 1200)
 	}
+	//nolint:revive // error-strings
 	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "vz", *l.Yaml.Video.Display)
 }
 


### PR DESCRIPTION
The PR fixes error messages according to the https://go.dev/wiki/CodeReviewComments#error-strings
> Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, since they are usually printed following other context.

Also, enables `revive.error-strings` to automatically detect this with golangci-lint.


<details>
<summary>Details</summary>

```
❯ golangci-lint run
pkg/qemu/qemu.go:1001:24: error-strings: error strings should not be capitalized or end with punctuation or a newline (revive)
        return "", errors.New("Failed to locate virtiofsd")
                              ^
pkg/qemu/qemu_driver.go:291:35: error-strings: error strings should not be capitalized or end with punctuation or a newline (revive)
                        errs = append(errs, fmt.Errorf("Failed to kill virtiofsd instance #%d: %w", i, err))
                                                       ^
pkg/qemu/entitlementutil/entitlementutil.go:54:21: error-strings: error strings should not be capitalized or end with punctuation or a newline (revive)
                return fmt.Errorf("Failed to write to a temporary file %q for signing QEMU binary: %w", entName, err)
                                  ^
pkg/vz/vz_driver_darwin.go:185:20: error-strings: error strings should not be capitalized or end with punctuation or a newline (revive)
        return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "vz", *l.Yaml.Video.Display)
                          ^
pkg/vz/errors_darwin.go:7:40: error-strings: error strings should not be capitalized or end with punctuation or a newline (revive)
var errRosettaUnsupported = errors.New("Rosetta is unsupported on non-ARM64 hosts")
                                       ^
cmd/limactl/copy.go:101:21: error-strings: error strings should not be capitalized or end with punctuation or a newline (revive)
                return fmt.Errorf("More than one (instance) host is involved in this command, this is only supported for openSSH v8.0 or higher")
                                  ^
cmd/limactl/disk.go:109:21: error-strings: error strings should not be capitalized or end with punctuation or a newline (revive)
                return fmt.Errorf("Failed to create %s disk in %q: %w", format, diskDir, err)
                                  ^
```

</details>