### PR TITLE
test.yml: expand the use of `upload_failure_logs_if_exists`.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -394,6 +394,8 @@ jobs:
         retry_on: error
         max_attempts: 3
         command: ./hack/test-upgrade.sh ${{ matrix.oldver }} ${{ github.sha }}
+    - if: always()
+      uses: ./.github/actions/upload_failure_logs_if_exists
 
   vz:
     name: "vz"

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -334,7 +334,11 @@ if [[ -n ${CHECKS["restart"]} ]]; then
 
 	export ftp_proxy=my.proxy:8021
 	INFO "Restarting \"$NAME\""
-	limactl start "$NAME"
+	if ! limactl start "$NAME"; then
+		ERROR "Failed to start \"$NAME\""
+		diagnose "$NAME"
+		exit 1
+	fi
 
 	INFO "Make sure proxy setting is updated"
 	got=$(limactl shell "$NAME" env | grep FTP_PROXY)
@@ -367,7 +371,11 @@ if [[ -n ${CHECKS["user-v2"]} ]]; then
 	INFO "Testing user-v2 network"
 	secondvm="$NAME-1"
 	"${LIMACTL_CREATE[@]}" "$FILE" --name "$secondvm"
-	limactl start "$secondvm"
+	if ! limactl start "$secondvm"; then
+		ERROR "Failed to start \"$secondvm\""
+		diagnose "$secondvm"
+		exit 1
+	fi
 	secondvmDNS="lima-$secondvm.internal"
 	INFO "DNS of $secondvm is $secondvmDNS"
 	set -x

--- a/hack/test-upgrade.sh
+++ b/hack/test-upgrade.sh
@@ -49,6 +49,9 @@ function uninstall_lima() {
 
 function show_lima_log() {
 	tail -n 100 ~/.lima/"${LIMA_INSTANCE}"/*.log || true
+	mkdir -p failure-logs
+	cp -pf ~/.lima/"${LIMA_INSTANCE}"/*.log failure-logs/ || true
+	limactl shell "${LIMA_INSTANCE}" sudo cat /var/log/cloud-init-output.log | tee failure-logs/cloud-init-output.log || true
 }
 
 INFO "Uninstalling lima"
@@ -89,7 +92,7 @@ INFO "Installing the new Lima ${NEWVER}"
 install_lima "${NEWVER}"
 
 INFO "Restarting the instance"
-limactl start --tty=false "${LIMA_INSTANCE}"
+limactl start --tty=false "${LIMA_INSTANCE}" || show_lima_log
 lima nerdctl info
 
 INFO "Confirming that the host filesystem is still mounted"


### PR DESCRIPTION
This change expands the scope of #2507
- `test-templates.sh`: add calling `diagnose` to CHECKS on `restart` and `user-v2`
- `test.yml`: use `upload_failure_logs_if_exists` to "Upgrade test" job

Thanks,