### PR TITLE
`cidata`: modify `user-data` to mount rosetta before `systemd-binfmt.service` starts.

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -14,7 +14,7 @@ package_reboot_if_required: true
 {{- if or .RosettaEnabled (or (eq .MountType "9p") (eq .MountType "virtiofs")) }}
 mounts:
   {{- if .RosettaEnabled }}{{/* Mount the rosetta volume before systemd-binfmt.service(8) starts */}}
-- [vz-rosetta, /mnt/lima-rosetta, virtiofs]
+- [vz-rosetta, /mnt/lima-rosetta, virtiofs, defaults, "0", "0"]
   {{- end }}
   {{- if .Mounts }}
     {{- range $m := $.Mounts}}


### PR DESCRIPTION


Explicitly set `fs_passno` to `0` in the mount entry for rosetta to ensure it is mounted earlier. The default value was `2`, which delayed the mount.

Without this change, ubuntu with `qemu-user-static` records error in clout-init.log:
> [FAILED] Failed to start systemd-binfmt.ser…- Set Up Additional Binary Formats.

```console
$ sudo systemctl status systemd-binfmt.service
× systemd-binfmt.service - Set Up Additional Binary Formats
     Loaded: loaded (/usr/lib/systemd/system/systemd-binfmt.service; static)
     Active: failed (Result: exit-code) since Tue 2024-07-30 15:41:08 JST; 1min 34s ago
       Docs: man:systemd-binfmt.service(8)
             man:binfmt.d(5)
             https://docs.kernel.org/admin-guide/binfmt-misc.html
             https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems
   Main PID: 285 (code=exited, status=1/FAILURE)
        CPU: 5ms

Jul 30 15:41:08 lima-docker systemd[1]: Starting systemd-binfmt.service - Set Up Additional Binary Formats...
Jul 30 15:41:08 lima-docker systemd-binfmt[285]: /usr/lib/binfmt.d/rosetta.conf:1: Failed to add binary format 'rosetta': No such file or directory
Jul 30 15:41:08 lima-docker systemd[1]: systemd-binfmt.service: Main process exited, code=exited, status=1/FAILURE
Jul 30 15:41:08 lima-docker systemd[1]: systemd-binfmt.service: Failed with result 'exit-code'.
Jul 30 15:41:08 lima-docker systemd[1]: Failed to start systemd-binfmt.service - Set Up Additional Binary Formats.
```