### PR TITLE
Add missing file.Close() method calls

### DIFF
--- a/pkg/editutil/editutil.go
+++ b/pkg/editutil/editutil.go
@@ -64,6 +64,7 @@ func OpenEditor(content []byte, hdr string) ([]byte, error) {
 	tmpYAMLPath := tmpYAMLFile.Name()
 	defer os.RemoveAll(tmpYAMLPath)
 	if _, err := tmpYAMLFile.Write(append([]byte(hdr), content...)); err != nil {
+		tmpYAMLFile.Close()
 		return nil, err
 	}
 	if err := tmpYAMLFile.Close(); err != nil {

--- a/pkg/qemu/entitlementutil/entitlementutil.go
+++ b/pkg/qemu/entitlementutil/entitlementutil.go
@@ -51,6 +51,7 @@ func Sign(qExe string) error {
   </dict>
 </plist>`
 	if _, err = ent.WriteString(entXML); err != nil {
+		ent.Close()
 		return fmt.Errorf("failed to write to a temporary file %q for signing QEMU binary: %w", entName, err)
 	}
 	ent.Close()

--- a/pkg/wsl2/vm_windows.go
+++ b/pkg/wsl2/vm_windows.go
@@ -81,6 +81,7 @@ func provisionVM(ctx context.Context, instanceDir, instanceName, distroName stri
 		return err
 	}
 	if _, err = limaBootFile.Write(limaBootB); err != nil {
+		limaBootFile.Close()
 		return err
 	}
 	limaBootFileWinPath := limaBootFile.Name()

--- a/pkg/yqutil/yqutil.go
+++ b/pkg/yqutil/yqutil.go
@@ -22,6 +22,7 @@ func EvaluateExpression(expression string, content []byte) ([]byte, error) {
 	defer os.RemoveAll(tmpYAMLPath)
 	_, err = tmpYAMLFile.Write(content)
 	if err != nil {
+		tmpYAMLFile.Close()
 		return nil, err
 	}
 	if err = tmpYAMLFile.Close(); err != nil {


### PR DESCRIPTION
[`os.CreateTemp`](https://pkg.go.dev/os#CreateTemp) creates a new temporary file, opens the file for reading and writing, and returns the resulting file. We must close the file to avoid a resource leaking.