### PR TITLE
templates: update Arch Linux to v20240601.239419

### DIFF
--- a/examples/archlinux.yaml
+++ b/examples/archlinux.yaml
@@ -1,9 +1,9 @@
 # This template requires Lima v0.7.0 or later
 images:
 # Try to use yyyyMMdd.REV image if available. Note that yyyyMMdd.REV will be removed after several months.
-- location: "https://geo.mirror.pkgbuild.com/images/v20240501.233015/Arch-Linux-x86_64-cloudimg-20240501.233015.qcow2"
+- location: "https://geo.mirror.pkgbuild.com/images/v20240601.239419/Arch-Linux-x86_64-cloudimg-20240601.239419.qcow2"
   arch: "x86_64"
-  digest: "sha256:bf87b7c03d77bff13d8079eef70c05d14b7ebdb761d01b7f95c2d335b41e0e50"
+  # TODO: digest
 - location: "https://github.com/mcginty/arch-boxes-arm/releases/download/v20220323/Arch-Linux-aarch64-cloudimg-20220323.0.qcow2"
   arch: "aarch64"
   digest: "sha512:27524910bf41cb9b3223c8749c6e67fd2f2fdb8b70d40648708e64d6b03c0b4a01b3c5e72d51fefd3e0c3f58487dbb400a79ca378cde2da341a3a19873612be8"


### PR DESCRIPTION
https://geo.mirror.pkgbuild.com/images/
✅ v20240501.233015
...
❌ v20240615.241534
❌  v20240701.244476
❌ v20240715.247370

---
```
TEST| [INFO] Testing home bind mount ("/home/runner/lima-container-engine-test-tmp")
+ limactl shell archlinux nerdctl pull --quiet ghcr.io/containerd/alpine:3.14.0
time="2024-07-31T19:01:37Z" level=warning msg="treating lima version \"0f86a2c\" from \"/home/runner/.lima/archlinux/lima-version\" as very latest release"
+ echo random-content-21214
++ cat /home/runner/lima-container-engine-test-tmp/random
+ expected=random-content-21214
++ limactl shell archlinux nerdctl run --rm -v /home/runner/lima-container-engine-test-tmp/random:/mnt/foo ghcr.io/containerd/alpine:3.14.0 cat /mnt/foo
time="[202](https://github.com/lima-vm/lima/actions/runs/10186029409/job/28176899735?pr=2524#step:11:203)4-07-31T19:01:41Z" level=warning msg="treating lima version \"0f86a2c\" from \"/home/runner/.lima/archlinux/lima-version\" as very latest release"
time="2024-07-31T19:01:42Z" level=fatal msg="failed to get unprivileged mount flags for \"/home/runner/lima-container-engine-test-tmp/random\": stat /home/runner/lima-container-engine-test-tmp/random: no such file or directory"
+ got=
+ eval rm -rf '"/home/runner/lima-config-tmp";' limactl delete -f '"archlinux";' rm -f '"/home/runner/lima-hostname";' rm -rf '"/home/runner/lima-container-engine-test-tmp"'
++ rm -rf /home/runner/lima-config-tmp
++ limactl delete -f archlinux
```
https://github.com/lima-vm/lima/actions/runs/10186029409/job/28176899735?pr=2524