### PR TITLE
Handle http.ErrServerClosed returned from srv.Listen

### DIFF
--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -105,7 +105,7 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 	go func() {
 		defer os.RemoveAll(socket)
 		defer srv.Close()
-		if serveErr := srv.Serve(l); serveErr != nil {
+		if serveErr := srv.Serve(l); serveErr != http.ErrServerClosed {
 			logrus.WithError(serveErr).Warn("hostagent API server exited with an error")
 		}
 	}()


### PR DESCRIPTION
The PR fixes error handling for the `srv.Serve(l)` call.

From the documentation of [http#Server.Serve](https://pkg.go.dev/net/http#Server.Serve):

> Serve always returns a non-nil error and closes l. After [Server.Shutdown](https://pkg.go.dev/net/http#Server.Shutdown) or [Server.Close](https://pkg.go.dev/net/http#Server.Close), the returned error is [ErrServerClosed](https://pkg.go.dev/net/http#ErrServerClosed).