### PR TITLE
limactl: run file manipulation subcommands under Rosetta

### DIFF
--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -77,8 +77,9 @@ func newApp() *cobra.Command {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
 
-		if osutil.IsBeingRosettaTranslated() {
+		if osutil.IsBeingRosettaTranslated() && cmd.Parent().Name() != "completion" && cmd.Name() != "generate-doc" && cmd.Name() != "validate" {
 			// running under rosetta would provide inappropriate runtime.GOARCH info, see: https://github.com/lima-vm/lima/issues/543
+			// allow commands that are used for packaging to run under rosetta to allow cross-architecture builds
 			return errors.New("limactl is running under rosetta, please reinstall lima with native arch")
 		}
 


### PR DESCRIPTION
This allows to run `completion`, `generate-doc` and `validate` subcommands when running under Rosetta.

This is useful when packaging lima or preparing configs for macOS on Apple Silicon for running on Intel arch.
