### PR TITLE
MAINTAINERS: invite Norio Nomura (norio-nomura) as a Reviewer

### DIFF
--- a/website/content/en/docs/community/governance/_index.md
+++ b/website/content/en/docs/community/governance/_index.md
@@ -30,13 +30,14 @@ See also the [Contributing](../contributing) page.
 
 ### Current maintainers
 
-| Name               | Role      | GitHub ID (not X ID)                           | GPG fingerprint                                                                          |
-|--------------------|-----------|------------------------------------------------|------------------------------------------------------------------------------------------|
-| Akihiro Suda       | Committer | [@AkihiroSuda](https://github.com/AkihiroSuda) | [C020 EA87 6CE4 E06C 7AB9  5AEF 4952 4C6F 9F63 8F1A](https://github.com/AkihiroSuda.gpg) |
-| Jan Dubois         | Committer | [@jandubois](https://github.com/jandubois)     | [DBF6 DA01 BD81 2D63 3B77  300F A2CA E583 3B6A D416](https://github.com/jandubois.gpg)   |
-| Anders F Björklund | Committer | [@afbjorklund](https://github.com/afbjorklund) | [5981 D2E8 4E4B 9197 95B3  2174 DC05 CAD2 E73B 0C92](https://github.com/afbjorklund.gpg) |
-| Balaji Vijayakumar | Committer | [@balajiv113](https://github.com/balajiv113)   | [80E1 01FE 5C89 FCF6 6171  72C8 377C 6A63 934B 8E6E](https://github.com/balajiv113.gpg)  |
-| Oleksandr Redko    | Reviewer  | [@alexandear](https://github.com/alexandear)   | [50F8 9811 D8D8 3E79 3E7E  0680 A947 E3F1 1A61 2A57](https://github.com/alexandear.gpg)  |
+| Name               | Role      | GitHub ID (not X ID)                             | GPG fingerprint                                                                           |
+|--------------------|-----------|--------------------------------------------------|-------------------------------------------------------------------------------------------|
+| Akihiro Suda       | Committer | [@AkihiroSuda](https://github.com/AkihiroSuda)   | [C020 EA87 6CE4 E06C 7AB9  5AEF 4952 4C6F 9F63 8F1A](https://github.com/AkihiroSuda.gpg)  |
+| Jan Dubois         | Committer | [@jandubois](https://github.com/jandubois)       | [DBF6 DA01 BD81 2D63 3B77  300F A2CA E583 3B6A D416](https://github.com/jandubois.gpg)    |
+| Anders F Björklund | Committer | [@afbjorklund](https://github.com/afbjorklund)   | [5981 D2E8 4E4B 9197 95B3  2174 DC05 CAD2 E73B 0C92](https://github.com/afbjorklund.gpg)  |
+| Balaji Vijayakumar | Committer | [@balajiv113](https://github.com/balajiv113)     | [80E1 01FE 5C89 FCF6 6171  72C8 377C 6A63 934B 8E6E](https://github.com/balajiv113.gpg)   |
+| Oleksandr Redko    | Reviewer  | [@alexandear](https://github.com/alexandear)     | [50F8 9811 D8D8 3E79 3E7E  0680 A947 E3F1 1A61 2A57](https://github.com/alexandear.gpg)   |
+| Norio Nomura       | Reviewer  | [@norio-nomura](https://github.com/norio-nomura) | [0010 36FA 2504 DBFF 37BA  2EF8 D4A7 318E B7F7 138D](https://github.com/norio-nomura.gpg) |
 
 ### Addition and promotion of Maintainers
 An active contributor to the project can be invited as a Reviewer,


### PR DESCRIPTION
Norio Nomura (@norio-nomura) has been very enthusiastically contributing to the project:
https://github.com/lima-vm/lima/pulls?q=author%3Anorio-nomura

- - -
https://lima-vm.io/docs/community/governance/

> A proposal to add or promote a Maintainer must be approved by 2/3 of the Committers who vote within 7 days. Voting needs 2 approvals at least. The proposer can vote too.


- [ ] @AkihiroSuda 
- [ ] @jandubois 
- [ ] @afbjorklund 
- [ ] @balajiv113 

Needs an approval from @norio-nomura  himself too
- [ ] @norio-nomura 
