### PR TITLE
`limactl prune`: add `--keep-referred` option to keep objects that are referred by some instances or templates

### DIFF
--- a/cmd/limactl/prune.go
+++ b/cmd/limactl/prune.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"crypto/sha256"
-	"fmt"
 	"os"
-	"path/filepath"
 
+	"github.com/lima-vm/lima/pkg/downloader"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/templatestore"
@@ -31,26 +29,13 @@ func pruneAction(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	ucd, err := os.UserCacheDir()
-	if err != nil {
-		return err
-	}
-	cacheDir := filepath.Join(ucd, "lima")
-	logrus.Infof("Pruning %q", cacheDir)
+	opt := downloader.WithCache()
 	if !keepReferred {
-		return os.RemoveAll(cacheDir)
+		return downloader.RemoveAllCacheDir(opt)
 	}
 
 	// Prune downloads that are not used by any instances or templates
-	downloadDir := filepath.Join(cacheDir, "download", "by-url-sha256")
-	_, err = os.Stat(downloadDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	cacheEntries, err := os.ReadDir(downloadDir)
+	cacheEntries, err := downloader.CacheEntries(opt)
 	if err != nil {
 		return err
 	}
@@ -58,13 +43,13 @@ func pruneAction(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	for _, entry := range cacheEntries {
-		if file, exists := knownLocations[entry.Name()]; exists {
-			logrus.Debugf("Keep %q caching %q", entry.Name(), file.Location)
+	for cacheKey, cachePath := range cacheEntries {
+		if file, exists := knownLocations[cacheKey]; exists {
+			logrus.Debugf("Keep %q caching %q", cacheKey, file.Location)
 		} else {
-			logrus.Debug("Deleting ", entry.Name())
-			if err := os.RemoveAll(filepath.Join(downloadDir, entry.Name())); err != nil {
-				logrus.Warnf("Failed to delete %q: %v", entry.Name(), err)
+			logrus.Debug("Deleting ", cacheKey)
+			if err := os.RemoveAll(cachePath); err != nil {
+				logrus.Warnf("Failed to delete %q: %v", cacheKey, err)
 				return err
 			}
 		}
@@ -114,23 +99,19 @@ func knownLocations() (map[string]limayaml.File, error) {
 func locationsFromLimaYAML(y *limayaml.LimaYAML) map[string]limayaml.File {
 	locations := make(map[string]limayaml.File)
 	for _, f := range y.Images {
-		locations[sha256OfURL(f.Location)] = f.File
+		locations[downloader.CacheKey(f.Location)] = f.File
 		if f.Kernel != nil {
-			locations[sha256OfURL(f.Kernel.Location)] = f.Kernel.File
+			locations[downloader.CacheKey(f.Kernel.Location)] = f.Kernel.File
 		}
 		if f.Initrd != nil {
-			locations[sha256OfURL(f.Initrd.Location)] = *f.Initrd
+			locations[downloader.CacheKey(f.Initrd.Location)] = *f.Initrd
 		}
 	}
 	for _, f := range y.Containerd.Archives {
-		locations[sha256OfURL(f.Location)] = f
+		locations[downloader.CacheKey(f.Location)] = f
 	}
 	for _, f := range y.Firmware.Images {
-		locations[sha256OfURL(f.Location)] = f.File
+		locations[downloader.CacheKey(f.Location)] = f.File
 	}
 	return locations
-}
-
-func sha256OfURL(url string) string {
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(url)))
 }

--- a/cmd/limactl/prune.go
+++ b/cmd/limactl/prune.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/lima-vm/lima/pkg/limayaml"
+	"github.com/lima-vm/lima/pkg/store"
+	"github.com/lima-vm/lima/pkg/templatestore"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -17,15 +22,115 @@ func newPruneCommand() *cobra.Command {
 		ValidArgsFunction: cobra.NoFileCompletions,
 		GroupID:           advancedCommand,
 	}
+	pruneCommand.Flags().Bool("keep-referred", false, "Keep objects that are referred by some instances or templates")
 	return pruneCommand
 }
 
-func pruneAction(_ *cobra.Command, _ []string) error {
+func pruneAction(cmd *cobra.Command, _ []string) error {
+	keepReferred, err := cmd.Flags().GetBool("keep-referred")
+	if err != nil {
+		return err
+	}
 	ucd, err := os.UserCacheDir()
 	if err != nil {
 		return err
 	}
 	cacheDir := filepath.Join(ucd, "lima")
 	logrus.Infof("Pruning %q", cacheDir)
-	return os.RemoveAll(cacheDir)
+	if !keepReferred {
+		return os.RemoveAll(cacheDir)
+	}
+
+	// Prune downloads that are not used by any instances or templates
+	downloadDir := filepath.Join(cacheDir, "download", "by-url-sha256")
+	_, err = os.Stat(downloadDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	cacheEntries, err := os.ReadDir(downloadDir)
+	if err != nil {
+		return err
+	}
+	knownLocations, err := knownLocations()
+	if err != nil {
+		return err
+	}
+	for _, entry := range cacheEntries {
+		if file, exists := knownLocations[entry.Name()]; exists {
+			logrus.Debugf("Keep %q caching %q", entry.Name(), file.Location)
+		} else {
+			logrus.Debug("Deleting ", entry.Name())
+			if err := os.RemoveAll(filepath.Join(downloadDir, entry.Name())); err != nil {
+				logrus.Warnf("Failed to delete %q: %v", entry.Name(), err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func knownLocations() (map[string]limayaml.File, error) {
+	locations := make(map[string]limayaml.File)
+
+	// Collect locations from instances
+	instances, err := store.Instances()
+	if err != nil {
+		return nil, err
+	}
+	for _, instanceName := range instances {
+		instance, err := store.Inspect(instanceName)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range locationsFromLimaYAML(instance.Config) {
+			locations[k] = v
+		}
+	}
+
+	// Collect locations from templates
+	templates, err := templatestore.Templates()
+	if err != nil {
+		return nil, err
+	}
+	for _, t := range templates {
+		b, err := templatestore.Read(t.Name)
+		if err != nil {
+			return nil, err
+		}
+		y, err := limayaml.Load(b, t.Name)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range locationsFromLimaYAML(y) {
+			locations[k] = v
+		}
+	}
+	return locations, nil
+}
+
+func locationsFromLimaYAML(y *limayaml.LimaYAML) map[string]limayaml.File {
+	locations := make(map[string]limayaml.File)
+	for _, f := range y.Images {
+		locations[sha256OfURL(f.Location)] = f.File
+		if f.Kernel != nil {
+			locations[sha256OfURL(f.Kernel.Location)] = f.Kernel.File
+		}
+		if f.Initrd != nil {
+			locations[sha256OfURL(f.Initrd.Location)] = *f.Initrd
+		}
+	}
+	for _, f := range y.Containerd.Archives {
+		locations[sha256OfURL(f.Location)] = f
+	}
+	for _, f := range y.Firmware.Images {
+		locations[sha256OfURL(f.Location)] = f.File
+	}
+	return locations
+}
+
+func sha256OfURL(url string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(url)))
 }

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -619,7 +619,7 @@ func CacheEntries(opt ...Opt) (map[string]string, error) {
 	downloadDir := filepath.Join(o.cacheDir, "download", "by-url-sha256")
 	_, err := os.Stat(downloadDir)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return entries, nil
 		}
 		return nil, err

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -341,7 +341,7 @@ func Cached(remote string, opts ...Opt) (*Result, error) {
 //   - "time" file contains the time (Last-Modified header)
 //   - "type" file contains the type (Content-Type header)
 func cacheDirectoryPath(cacheDir, remote string) string {
-	return filepath.Join(cacheDir, "download", "by-url-sha256", fmt.Sprintf("%x", sha256.Sum256([]byte(remote))))
+	return filepath.Join(cacheDir, "download", "by-url-sha256", CacheKey(remote))
 }
 
 // cacheDigestPath returns the cache digest file path.
@@ -600,4 +600,56 @@ func downloadHTTP(ctx context.Context, localPath, lastModified, contentType, url
 		return err
 	}
 	return os.Rename(localPathTmp, localPath)
+}
+
+// CacheEntries returns a map of cache entries.
+// The key is the SHA256 of the URL.
+// The value is the path to the cache entry.
+func CacheEntries(opt ...Opt) (map[string]string, error) {
+	entries := make(map[string]string)
+	var o options
+	for _, f := range opt {
+		if err := f(&o); err != nil {
+			return nil, err
+		}
+	}
+	if o.cacheDir == "" {
+		return entries, nil
+	}
+	downloadDir := filepath.Join(o.cacheDir, "download", "by-url-sha256")
+	_, err := os.Stat(downloadDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return entries, nil
+		}
+		return nil, err
+	}
+	cacheEntries, err := os.ReadDir(downloadDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range cacheEntries {
+		entries[entry.Name()] = filepath.Join(downloadDir, entry.Name())
+	}
+	return entries, nil
+}
+
+// CacheKey returns the key for a cache entry of the remote URL.
+func CacheKey(remote string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(remote)))
+}
+
+// RemoveAllCacheDir removes the cache directory.
+func RemoveAllCacheDir(opt ...Opt) error {
+	var o options
+	for _, f := range opt {
+		if err := f(&o); err != nil {
+			return err
+		}
+	}
+	if o.cacheDir == "" {
+		return nil
+	}
+	logrus.Infof("Pruning %q", o.cacheDir)
+	return os.RemoveAll(o.cacheDir)
 }


### PR DESCRIPTION
~~Also adds `--all` option to `prune` behaves as same as previous function. (Remove all cacheDir)~~