### PR TITLE
Add limayaml param settings to provisioning script environment

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -237,6 +237,7 @@ containerd:
 #   playbook: playbook.yaml
 
 # Probe scripts to check readiness.
+# The scripts run in user mode. They must start with a '#!' line.
 # The scripts can use the following template variables: {{.Home}}, {{.UID}}, {{.User}}, and {{.Param.Key}}
 # 🟢 Builtin default: null
 # probes:
@@ -422,7 +423,12 @@ networks:
 #   KEY: value
 
 # Defines variables used for customizing the functionality.
+# Key names must start with an uppercase or lowercase letter followed by
+# any number of letters, digits, and underscores.
+# Values must not contain non-printable characters except for spaces and tabs.
 # These variables can be referenced as {{.Param.Key}} in lima.yaml.
+# In provisioning scripts and probes they are also available as predefined
+# environment variables, prefixed with "PARAM` (so `Key` → `$PARAM_Key`).
 # param:
 #   Key: value
 

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -36,6 +36,7 @@ declare -A CHECKS=(
 	["user-v2"]=""
 	["mount-path-with-spaces"]=""
 	["provision-ansible"]=""
+	["param-env-variables"]=""
 )
 
 case "$NAME" in
@@ -64,6 +65,7 @@ case "$NAME" in
 	CHECKS["snapshot-offline"]="1"
 	CHECKS["mount-path-with-spaces"]="1"
 	CHECKS["provision-ansible"]="1"
+	CHECKS["param-env-variables"]="1"
 	;;
 "net-user-v2")
 	CHECKS["port-forwards"]=""
@@ -150,6 +152,15 @@ fi
 if [[ -n ${CHECKS["provision-ansible"]} ]]; then
 	INFO 'Testing that /tmp/ansible was created successfully on provision'
 	limactl shell "$NAME" test -e /tmp/ansible
+fi
+
+if [[ -n ${CHECKS["param-env-variables"]} ]]; then
+	INFO 'Testing that PARAM env variables are exported to all types of provisioning scripts and probes'
+	limactl shell "$NAME" test -e /tmp/param-boot
+	limactl shell "$NAME" test -e /tmp/param-dependency
+	limactl shell "$NAME" test -e /tmp/param-probe
+	limactl shell "$NAME" test -e /tmp/param-system
+	limactl shell "$NAME" test -e /tmp/param-user
 fi
 
 INFO "Testing proxy settings are imported"

--- a/hack/test-templates/test-misc.yaml
+++ b/hack/test-templates/test-misc.yaml
@@ -2,7 +2,7 @@
 # - disk
 # - (More to come)
 #
-# This template requires Lima v0.14.0 or later.
+# This template requires Lima v1.0.0-alpha.0 or later.
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
 - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220902/ubuntu-22.04-server-cloudimg-amd64.img"
@@ -26,9 +26,30 @@ mounts:
 - location: "/tmp/lima"
   writable: true
 
+param:
+  BOOT: boot
+  DEPENDENCY: dependency
+  PROBE: probe
+  SYSTEM: system
+  USER: user
+
 provision:
 - mode: ansible
   playbook: ./hack/ansible-test.yaml
+- mode: boot
+  script: "touch /tmp/param-$PARAM_BOOT"
+- mode: dependency
+  script: "touch /tmp/param-$PARAM_DEPENDENCY"
+- mode: system
+  script: "touch /tmp/param-$PARAM_SYSTEM"
+- mode: user
+  script: "touch /tmp/param-$PARAM_USER"
+
+probes:
+- mode: readiness
+  script: |
+    #!/bin/sh
+    touch /tmp/param-$PARAM_PROBE
 
 # in order to use this example, you must first create the disk "data". run:
 # $ limactl disk create data --size 10G

--- a/pkg/cidata/cidata.TEMPLATE.d/param.env
+++ b/pkg/cidata/cidata.TEMPLATE.d/param.env
@@ -1,0 +1,3 @@
+{{range $key, $val := .Param -}}
+PARAM_{{ $key }}={{ $val }}
+{{end -}}

--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -84,6 +84,12 @@ ca_certs:
 bootcmd:
   {{- range $cmd := $.BootCmds }}
 - |
+  # We need to embed the params.env as a here-doc because /mnt/lima-cidata is not yet mounted
+  while read -r line; do [ -n "$line" ] && export "$line"; done <<'EOF'
+    {{- range $key, $val := $.Param }}
+  PARAM_{{ $key }}={{ $val }}
+    {{- end }}
+  EOF
     {{- range $line := $cmd.Lines }}
   {{ $line }}
     {{- end }}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -140,6 +140,7 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML, udpDNSLocalPort
 		VirtioPort:     virtioPort,
 		Plain:          *y.Plain,
 		TimeZone:       *y.TimeZone,
+		Param:          y.Param,
 	}
 
 	firstUsernetIndex := limayaml.FirstUsernetIndex(y)

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -73,6 +73,7 @@ type TemplateArgs struct {
 	UDPDNSLocalPort                 int
 	TCPDNSLocalPort                 int
 	Env                             map[string]string
+	Param                           map[string]string
 	DNSAddresses                    []string
 	CACerts                         CACerts
 	HostHomeMountPoint              string

--- a/website/content/en/docs/dev/internals/_index.md
+++ b/website/content/en/docs/dev/internals/_index.md
@@ -157,6 +157,7 @@ See [Building Ansible inventories](https://docs.ansible.com/ansible/latest/inven
 - `meta-data`: [Cloud-init meta-data](https://docs.cloud-init.io/en/latest/explanation/instancedata.html)
 - `network-config`: [Cloud-init Networking Config Version 2](https://docs.cloud-init.io/en/latest/reference/network-config-format-v2.html)
 - `lima.env`: The `LIMA_CIDATA_*` environment variables (see below) available during `boot.sh` processing
+- `param.env`: The `PARAM_*` environment variables corresponding to the `param` settings from `lima.yaml`
 - `lima-guestagent`: Lima guest agent binary
 - `nerdctl-full.tgz`: [`nerdctl-full-<VERSION>-<OS>-<ARCH>.tar.gz`](https://github.com/containerd/nerdctl/releases)
 - `boot.sh`: Boot script


### PR DESCRIPTION
They will be prefixed with `PARAM_`, so `param.FOO` becomes `PARAM_FOO`.

This is useful because parameter substitution happens when a template is instantiated, so `[ "{{.Param.ROOTFUL}}" = true ]` becomes `[ "true" = true ]` in the `cloud-init-output.log`.

This mechanism also works better when the parameter contains quotes, which would break a simplistic `FOO="{{.Param.FOO}}"`.

Test sample:

```yaml
param:
  FOO: 'foo"bar'

provision:
- mode: system
  script: |
    echo "$PARAM_FOO"
```

Output:

```
LIMA 2024-08-30T09:13:11-07:00| Executing /mnt/lima-cidata/provision.system/00000000
foo"bar
LIMA 2024-08-30T09:13:11-07:00| Exiting with code 0
```

Example of real-life usage (from #2515) will be to replace

```diff
-     # Setting shell variable makes it easier to read cloud-init-output.log
-     readonly ROOTFUL="{{.Param.ROOTFUL}}"
-     if [ "$ROOTFUL" = true ]; then
+     if [ "$PARAM_ROOTFUL" = true ]; then
```