### PR TITLE
Run in a new process group when not using --foreground

### DIFF
--- a/pkg/instance/ha_cmd_opts_others.go
+++ b/pkg/instance/ha_cmd_opts_others.go
@@ -6,4 +6,7 @@ import (
 	"syscall"
 )
 
-var SysProcAttr = &syscall.SysProcAttr{}
+var (
+	ForegroundSysProcAttr = &syscall.SysProcAttr{}
+	BackgroundSysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+)

--- a/pkg/instance/ha_cmd_opts_windows.go
+++ b/pkg/instance/ha_cmd_opts_windows.go
@@ -4,6 +4,9 @@ import (
 	"syscall"
 )
 
-var SysProcAttr = &syscall.SysProcAttr{
-	CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
-}
+var (
+	ForegroundSysProcAttr = &syscall.SysProcAttr{}
+	BackgroundSysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+)

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -189,7 +189,12 @@ func Start(ctx context.Context, inst *store.Instance, launchHostAgentForeground 
 	}
 	args = append(args, inst.Name)
 	haCmd := exec.CommandContext(ctx, self, args...)
-	haCmd.SysProcAttr = SysProcAttr
+
+	if launchHostAgentForeground {
+		haCmd.SysProcAttr = ForegroundSysProcAttr
+	} else {
+		haCmd.SysProcAttr = BackgroundSysProcAttr
+	}
 
 	haCmd.Stdout = haStdoutW
 	haCmd.Stderr = haStderrW


### PR DESCRIPTION
Previously the hostagenet process was running in the foreground even when not using the --foreground option. It was using the same pgid of limactl process. If the guest was running, but limactl was interrupted the hostagent received the signal and was killed, stopping the VM.

A simple way to fix this issue is to start the hostagent process in a new process group. This way it will be killed sending signals to the limactl process group.

Example run with this change:

    % ps -o pid,pgid,ppid,command
      PID  PGID  PPID COMMAND
    39442 39442 39440 -zsh
    63233 63233 39442 _output/bin/limactl start --vm-type vz --tty=false
    63299 63299 63233 /Users/nsoffer/src/lima/_output/bin/limactl hostagent ...

We can improve this later by adding an option to daemonize the hostagent process (like qemu --daemonize).

Fixes #2573