### PR TITLE
Show progress only when logging to terminal

### DIFF
--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -29,8 +29,7 @@ var HideProgress bool
 
 // hideBar is used only for testing.
 func hideBar(bar *pb.ProgressBar) {
-	bar.Set(pb.ReturnSymbol, "")
-	bar.SetTemplateString("")
+	bar.Set(pb.Static, true)
 }
 
 type Status = string

--- a/pkg/progressbar/progressbar.go
+++ b/pkg/progressbar/progressbar.go
@@ -12,15 +12,18 @@ func New(size int64) (*pb.ProgressBar, error) {
 	bar := pb.New64(size)
 
 	bar.Set(pb.Bytes, true)
-	if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+
+	// Both logrous and pb use stderr by default.
+	logFd := os.Stderr.Fd()
+
+	// Show progress only when logging to terminal.
+	if isatty.IsTerminal(logFd) || isatty.IsCygwinTerminal(logFd) {
 		bar.SetTemplateString(`{{counters . }} {{bar . | green }} {{percent .}} {{speed . "%s/s"}}`)
 		bar.SetRefreshRate(200 * time.Millisecond)
 	} else {
-		bar.Set(pb.Terminal, false)
-		bar.Set(pb.ReturnSymbol, "\n")
-		bar.SetTemplateString(`{{counters . }} ({{percent .}}) {{speed . "%s/s"}}`)
-		bar.SetRefreshRate(5 * time.Second)
+		bar.Set(pb.Static, true)
 	}
+
 	bar.SetWidth(80)
 	if err := bar.Err(); err != nil {
 		return nil, err


### PR DESCRIPTION
Fix the terminal check so we use the right configuration when logging to file, and hide the progress in this case.

Fixes #2581 