### PR TITLE
Add --log-format json option

### DIFF
--- a/pkg/progressbar/progressbar.go
+++ b/pkg/progressbar/progressbar.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cheggaaa/pb/v3"
 	"github.com/mattn/go-isatty"
+	"github.com/sirupsen/logrus"
 )
 
 func New(size int64) (*pb.ProgressBar, error) {
@@ -13,11 +14,7 @@ func New(size int64) (*pb.ProgressBar, error) {
 
 	bar.Set(pb.Bytes, true)
 
-	// Both logrous and pb use stderr by default.
-	logFd := os.Stderr.Fd()
-
-	// Show progress only when logging to terminal.
-	if isatty.IsTerminal(logFd) || isatty.IsCygwinTerminal(logFd) {
+	if showProgress() {
 		bar.SetTemplateString(`{{counters . }} {{bar . | green }} {{percent .}} {{speed . "%s/s"}}`)
 		bar.SetRefreshRate(200 * time.Millisecond)
 	} else {
@@ -30,4 +27,15 @@ func New(size int64) (*pb.ProgressBar, error) {
 	}
 
 	return bar, nil
+}
+
+func showProgress() bool {
+	// Progress supports only text format fow now.
+	if _, ok := logrus.StandardLogger().Formatter.(*logrus.TextFormatter); !ok {
+		return false
+	}
+
+	// Both logrous and pb use stderr by default.
+	logFd := os.Stderr.Fd()
+	return isatty.IsTerminal(logFd) || isatty.IsCygwinTerminal(logFd)
 }


### PR DESCRIPTION
When using --log-format json we use machine friendly flogs to make limactl easier to consume by other programs.

Since we don't have a json format for the progress bar, the progress is also hidden when using json log format.

Here is an example usage of the new option in drenv:
https://github.com/nirs/ramen/commit/b0001198f5c04b7eca97162f42e9dafceb8723b4

Fixes #2583 