### PR TITLE
qemu: riscv64: switch from u-boot to EDK2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1
+        # To avoid "failed to load YAML file \"templates/experimental/riscv64.yaml\": can't parse builtin Lima version \"3f3a6f6\": 3f3a6f6 is not in dotted-tri format"
+        fetch-depth: 0
     - uses: actions/setup-go@v5
       with:
         go-version: 1.23.x
@@ -158,7 +159,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1
+        # To avoid "failed to load YAML file \"templates/experimental/riscv64.yaml\": can't parse builtin Lima version \"3f3a6f6\": 3f3a6f6 is not in dotted-tri format"
+        fetch-depth: 0
     - uses: actions/setup-go@v5
       with:
         go-version: 1.23.x

--- a/examples/experimental/riscv64.yaml
+++ b/examples/experimental/riscv64.yaml
@@ -1,22 +1,18 @@
-# This template requires Lima v0.11.0 or later.
+# Lima v0.x users should use https://raw.githubusercontent.com/lima-vm/lima/v0.23.2/examples/experimental/riscv64.yaml
+minimumLimaVersion: "1.0.0"
+vmOpts:
+  qemu:
+    minimumVersion: "9.1.0"
 
 arch: "riscv64"
 images:
 - location: "https://cloud-images.ubuntu.com/releases/24.04/release-20240821/ubuntu-24.04-server-cloudimg-riscv64.img"
   arch: "riscv64"
   digest: "sha256:f5886ad4e405e689585dfef0e96c31b06478e0cb12bc7f3fae965759a32d729e"
-  kernel:
-    # Extracted from http://http.us.debian.org/debian/pool/main/u/u-boot/u-boot-qemu_2023.07+dfsg-1_all.deb (GPL-2.0)
-    location: "https://github.com/lima-vm/u-boot-qemu-mirror/releases/download/2023.07%2Bdfsg-7/qemu-riscv64_smode_uboot.elf"
-    digest: "sha256:d4b3a10c3ef04219641802a586dca905e768805f5a5164fb68520887df54f33c"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 - location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-riscv64.img"
   arch: "riscv64"
-  kernel:
-    # Extracted from http://http.us.debian.org/debian/pool/main/u/u-boot/u-boot-qemu_2023.07+dfsg-1_all.deb (GPL-2.0)
-    location: "https://github.com/lima-vm/u-boot-qemu-mirror/releases/download/2023.07%2Bdfsg-1/qemu-riscv64_smode_uboot.elf"
-    digest: "sha256:d4b3a10c3ef04219641802a586dca905e768805f5a5164fb68520887df54f33c"
 
 mounts:
 - location: "~"

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -101,8 +101,6 @@ func Validate(y *LimaYAML, warn bool) error {
 			if f.Kernel.Arch != f.Arch {
 				return fmt.Errorf("images[%d].kernel has unexpected architecture %q, must be %q", i, f.Kernel.Arch, f.Arch)
 			}
-		} else if f.Arch == RISCV64 {
-			return errors.New("riscv64 needs the kernel (e.g., \"uboot.elf\") to be specified")
 		}
 		if f.Initrd != nil {
 			if err := validateFileObject(*f.Initrd, fmt.Sprintf("images[%d].initrd", i)); err != nil {

--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -296,7 +296,8 @@ func (l *LimaQemuDriver) killVhosts() error {
 }
 
 func (l *LimaQemuDriver) shutdownQEMU(ctx context.Context, timeout time.Duration, qCmd *exec.Cmd, qWaitCh <-chan error) error {
-	logrus.Info("Shutting down QEMU with ACPI")
+	// "power button" refers to ACPI on the most archs, except RISC-V
+	logrus.Info("Shutting down QEMU with the power button")
 	if usernetIndex := limayaml.FirstUsernetIndex(l.Instance.Config); usernetIndex != -1 {
 		client := usernet.NewClientByName(l.Instance.Config.Networks[usernetIndex].Lima)
 		err := client.UnExposeSSH(l.SSHLocalPort)


### PR DESCRIPTION
u-boot no longer needs to be specified as the "kernel" image, as EDK2 (`edk2-riscv-code.fd`) is available since QEMU v9.1.

ACPI is disabled, as suggested in https://github.com/tianocore/edk2/blob/edk2-stable202408/OvmfPkg/RiscVVirt/README.md#test