### PR TITLE
Run usernet process in background

### DIFF
--- a/pkg/executil/opts_others.go
+++ b/pkg/executil/opts_others.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package instance
+package executil
 
 import (
 	"syscall"

--- a/pkg/executil/opts_windows.go
+++ b/pkg/executil/opts_windows.go
@@ -1,4 +1,4 @@
-package instance
+package executil
 
 import (
 	"syscall"

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -17,6 +17,7 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/lima-vm/lima/pkg/driver"
 	"github.com/lima-vm/lima/pkg/driverutil"
+	"github.com/lima-vm/lima/pkg/executil"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/qemu"
 	"github.com/lima-vm/lima/pkg/qemu/entitlementutil"
@@ -191,9 +192,9 @@ func Start(ctx context.Context, inst *store.Instance, launchHostAgentForeground 
 	haCmd := exec.CommandContext(ctx, self, args...)
 
 	if launchHostAgentForeground {
-		haCmd.SysProcAttr = ForegroundSysProcAttr
+		haCmd.SysProcAttr = executil.ForegroundSysProcAttr
 	} else {
-		haCmd.SysProcAttr = BackgroundSysProcAttr
+		haCmd.SysProcAttr = executil.BackgroundSysProcAttr
 	}
 
 	haCmd.Stdout = haStdoutW

--- a/pkg/networks/usernet/recoincile.go
+++ b/pkg/networks/usernet/recoincile.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lima-vm/lima/pkg/executil"
 	"github.com/lima-vm/lima/pkg/lockutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
@@ -81,6 +82,7 @@ func Start(ctx context.Context, name string) error {
 				args = append(args, "--leases", leasesString)
 			}
 			cmd := exec.CommandContext(ctx, self, args...)
+			cmd.SysProcAttr = executil.BackgroundSysProcAttr
 
 			stdoutPath := filepath.Join(usernetDir, fmt.Sprintf("%s.%s.%s.log", "usernet", name, "stdout"))
 			stderrPath := filepath.Join(usernetDir, fmt.Sprintf("%s.%s.%s.log", "usernet", name, "stderr"))


### PR DESCRIPTION
Similar to the how we run the hostagent process[1], we want to run the
usernet process in the background. Now a program using killpg to cleanup
child processes will not terminate the usernet process.

Example run with this change:

    % ps -o pid,pgid,ppid,command
      PID  PGID  PPID COMMAND
    55768 55768 55767 -zsh
    56126 56126 55768 limactl start userv2.yaml --tty=0
    56128 56128 56126 /Users/nsoffer/src/lima/_output/bin/limactl usernet ...
    56131 56131 56126 /Users/nsoffer/src/lima/_output/bin/limactl hostagent ...

    % ps -o pid,pgid,ppid,command
      PID  PGID  PPID COMMAND
    55768 55768 55767 -zsh
    56128 56128     1 /Users/nsoffer/src/lima/_output/bin/limactl usernet ...
    56131 56131     1 /Users/nsoffer/src/lima/_output/bin/limactl hostagent ...

[1] https://github.com/lima-vm/lima/pull/2574