### PR TITLE
Change "Not forwarding" messages to debug level

### DIFF
--- a/hack/test-port-forwarding.pl
+++ b/hack/test-port-forwarding.pl
@@ -6,7 +6,7 @@
 # running to perform the tests:
 #
 # ./hack/test-port-forwarding.pl templates/default.yaml
-# limactl --tty=false start templates/default.yaml
+# limactl --tty=false --log-level debug start templates/default.yaml
 # git restore templates/default.yaml
 # ./hack/test-port-forwarding.pl default
 #

--- a/pkg/hostagent/port.go
+++ b/pkg/hostagent/port.go
@@ -94,7 +94,7 @@ func (pf *portForwarder) OnEvent(ctx context.Context, ev *api.Event) {
 		}
 		local, remote := pf.forwardingAddresses(f)
 		if local == "" {
-			logrus.Infof("Not forwarding TCP %s", remote)
+			logrus.Debugf("Not forwarding TCP %s", remote)
 			continue
 		}
 		logrus.Infof("Forwarding TCP from %s to %s", remote, local)

--- a/pkg/portfwd/forward.go
+++ b/pkg/portfwd/forward.go
@@ -26,7 +26,7 @@ func (fw *Forwarder) OnEvent(ctx context.Context, client *guestagentclient.Guest
 	for _, f := range ev.LocalPortsAdded {
 		local, remote := fw.forwardingAddresses(f)
 		if local == "" {
-			logrus.Infof("Not forwarding %s %s", strings.ToUpper(f.Protocol), remote)
+			logrus.Debugf("Not forwarding %s %s", strings.ToUpper(f.Protocol), remote)
 			continue
 		}
 		logrus.Infof("Forwarding %s from %s to %s", strings.ToUpper(f.Protocol), remote, local)


### PR DESCRIPTION
Info level should be used only for important events or changes to the system, for example when we forward a port from the guest. Not forwarding a port can be helpful when debugging port forwarding, so keeping it as debug message.

Part-of: #2577