### PR TITLE
Refactor fuzz tests

### DIFF
--- a/pkg/cidata/fuzz_test.go
+++ b/pkg/cidata/fuzz_test.go
@@ -1,27 +1,23 @@
 package cidata
 
 import (
-	"fmt"
 	"testing"
 
+	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/ptr"
-
-	"github.com/lima-vm/lima/pkg/limayaml"
 )
 
 func FuzzSetupEnv(f *testing.F) {
 	f.Fuzz(func(_ *testing.T, suffix string, localhost bool) {
-		var prefix string
+		prefix := "http://127.0.0.1:8080/"
 		if localhost {
 			prefix = "http://localhost:8080/"
-		} else {
-			prefix = "http://127.0.0.1:8080/"
 		}
-		envKey := "http_proxy"
-		envValue := fmt.Sprintf("%s%s", prefix, suffix)
 		templateArgs := TemplateArgs{SlirpGateway: networks.SlirpGateway}
-		envAttr := map[string]string{envKey: envValue}
-		_, _ = setupEnv(&limayaml.LimaYAML{PropagateProxyEnv: ptr.Of(false), Env: envAttr}, templateArgs)
+		_, _ = setupEnv(&limayaml.LimaYAML{
+			PropagateProxyEnv: ptr.Of(false),
+			Env:               map[string]string{"http_proxy": prefix + suffix},
+		}, templateArgs)
 	})
 }

--- a/pkg/downloader/fuzz_test.go
+++ b/pkg/downloader/fuzz_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
-var a = digest.Algorithm("sha256")
+var algorithm = digest.Algorithm("sha256")
 
 func FuzzDownload(f *testing.F) {
 	f.Fuzz(func(t *testing.T, fileContents []byte, checkDigest bool) {
@@ -21,15 +21,10 @@ func FuzzDownload(f *testing.F) {
 		}
 		testLocalFileURL := "file://" + remoteFile
 		if checkDigest {
-			d := a.FromBytes(fileContents)
-			_, _ = Download(context.Background(),
-				localFile,
-				testLocalFileURL,
-				WithExpectedDigest(d))
+			d := algorithm.FromBytes(fileContents)
+			_, _ = Download(context.Background(), localFile, testLocalFileURL, WithExpectedDigest(d))
 		} else {
-			_, _ = Download(context.Background(),
-				localFile,
-				testLocalFileURL)
+			_, _ = Download(context.Background(), localFile, testLocalFileURL)
 		}
 	})
 }

--- a/pkg/guestagent/procnettcp/fuzz_test.go
+++ b/pkg/guestagent/procnettcp/fuzz_test.go
@@ -7,11 +7,9 @@ import (
 
 func FuzzParse(f *testing.F) {
 	f.Fuzz(func(_ *testing.T, data []byte, tcp6 bool) {
-		var kind Kind
+		kind := TCP
 		if tcp6 {
 			kind = TCP6
-		} else {
-			kind = TCP
 		}
 		_, _ = Parse(bytes.NewReader(data), kind)
 	})

--- a/pkg/iso9660util/fuzz_test.go
+++ b/pkg/iso9660util/fuzz_test.go
@@ -13,7 +13,6 @@ func FuzzIsISO9660(f *testing.F) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		//nolint:errcheck // The test doesn't check the return value
-		IsISO9660(imageFile)
+		_, _ = IsISO9660(imageFile)
 	})
 }

--- a/pkg/nativeimgutil/fuzz_test.go
+++ b/pkg/nativeimgutil/fuzz_test.go
@@ -12,7 +12,7 @@ func FuzzConvertToRaw(f *testing.F) {
 		destPath := filepath.Join(t.TempDir(), "dest.img")
 		err := os.WriteFile(srcPath, imgData, 0o600)
 		if err != nil {
-			return
+			t.Fatal(err)
 		}
 		_ = ConvertToRaw(srcPath, destPath, &size, withBacking)
 	})

--- a/pkg/store/fuzz_test.go
+++ b/pkg/store/fuzz_test.go
@@ -15,29 +15,27 @@ func FuzzLoadYAMLByFilePath(f *testing.F) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		//nolint:errcheck // The test doesn't check the return value
-		LoadYAMLByFilePath(localFile)
+		_, _ = LoadYAMLByFilePath(localFile)
 	})
 }
 
 func FuzzInspect(f *testing.F) {
 	f.Fuzz(func(t *testing.T, yml, limaVersion []byte) {
 		limaDir := t.TempDir()
-		os.Setenv("LIMA_HOME", limaDir)
+		t.Setenv("LIMA_HOME", limaDir)
 		err := os.MkdirAll(filepath.Join(limaDir, "fuzz-instance"), 0o700)
 		if err != nil {
-			// panic so that we know of problems here
-			panic(err)
+			t.Fatal(err)
 		}
 		ymlFile := filepath.Join(limaDir, "fuzz-instance", filenames.LimaYAML)
 		limaVersionFile := filepath.Join(limaDir, filenames.LimaVersion)
 		err = os.WriteFile(ymlFile, yml, 0o600)
 		if err != nil {
-			return
+			t.Fatal(err)
 		}
 		err = os.WriteFile(limaVersionFile, limaVersion, 0o600)
 		if err != nil {
-			return
+			t.Fatal(err)
 		}
 		_, _ = Inspect("fuzz-instance")
 	})


### PR DESCRIPTION
The PR simplifies fuzz tests:

- Use `_` instead of `//nolint:errcheck`
- Remove redundant `else`
- `t.Fatal(err)` instead of `panic(err)`
- `t.Setenv` instead of `os.Setenv`