### PR TITLE
Use "context" instead of "golang.org/x/net/context"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ run:
 linters:
   disable-all: true
   enable:
-  # - depguard # annoying since golangci-lint v1.53.1 https://github.com/golangci/golangci-lint/issues/3877
+  - depguard
   - gofmt
   - goimports
   - govet
@@ -81,6 +81,12 @@ linters:
   # - wrapcheck
   # - wsl
 linters-settings:
+  depguard:
+    rules:
+      main:
+        deny:
+        - pkg: "golang.org/x/net/context"
+          desc: "use the 'context' package from the standard library"
   gocritic:
     # See "Tags" section in https://github.com/go-critic/go-critic#usage
     enabled-tags:

--- a/pkg/portfwd/client.go
+++ b/pkg/portfwd/client.go
@@ -1,6 +1,7 @@
 package portfwd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -9,8 +10,6 @@ import (
 	"github.com/lima-vm/lima/pkg/guestagent/api"
 	guestagentclient "github.com/lima-vm/lima/pkg/guestagent/api/client"
 	"github.com/sirupsen/logrus"
-
-	"golang.org/x/net/context"
 )
 
 func HandleTCPConnection(ctx context.Context, client *guestagentclient.GuestAgentClient, conn net.Conn, guestAddr string) {


### PR DESCRIPTION
The PR refactors by replacing the import `"golang.org/x/net/context"` with `"context"`. Also, enable `depguard` linter to prevent importing `"golang.org/x/net/context"` in the future.