### PR TITLE
Refactor by applying the "Mutex hat" idiom

### DIFF
--- a/pkg/guestagent/guestagent_linux.go
+++ b/pkg/guestagent/guestagent_linux.go
@@ -90,10 +90,12 @@ type agent struct {
 	// reload /proc/net/tcp.
 	newTicker func() (<-chan time.Time, func())
 
-	worthCheckingIPTables    bool
-	worthCheckingIPTablesMu  sync.RWMutex
-	latestIPTables           []iptables.Entry
-	latestIPTablesMu         sync.RWMutex
+	worthCheckingIPTablesMu sync.RWMutex
+	worthCheckingIPTables   bool
+
+	latestIPTablesMu sync.RWMutex
+	latestIPTables   []iptables.Entry
+
 	kubernetesServiceWatcher *kubernetesservice.ServiceWatcher
 }
 

--- a/pkg/guestagent/kubernetesservice/kubernetesservice.go
+++ b/pkg/guestagent/kubernetesservice/kubernetesservice.go
@@ -34,8 +34,8 @@ type Entry struct {
 }
 
 type ServiceWatcher struct {
-	rwMutex         sync.RWMutex
-	serviceInformer cache.SharedIndexInformer
+	serviceInformerMu sync.RWMutex
+	serviceInformer   cache.SharedIndexInformer
 }
 
 func NewServiceWatcher() *ServiceWatcher {
@@ -43,14 +43,14 @@ func NewServiceWatcher() *ServiceWatcher {
 }
 
 func (s *ServiceWatcher) setServiceInformer(serviceInformer cache.SharedIndexInformer) {
-	s.rwMutex.Lock()
-	defer s.rwMutex.Unlock()
+	s.serviceInformerMu.Lock()
+	defer s.serviceInformerMu.Unlock()
 	s.serviceInformer = serviceInformer
 }
 
 func (s *ServiceWatcher) getServiceInformer() cache.SharedIndexInformer {
-	s.rwMutex.RLock()
-	defer s.rwMutex.RUnlock()
+	s.serviceInformerMu.RLock()
+	defer s.serviceInformerMu.RUnlock()
 	return s.serviceInformer
 }
 

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -56,8 +56,8 @@ type HostAgent struct {
 	driver   driver.Driver
 	signalCh chan os.Signal
 
-	eventEnc   *json.Encoder
 	eventEncMu sync.Mutex
+	eventEnc   *json.Encoder
 
 	vSockPort  int
 	virtioPort string

--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -39,8 +39,8 @@ const diskImageCachingMode = vz.DiskImageCachingModeCached
 
 type virtualMachineWrapper struct {
 	*vz.VirtualMachine
-	mu      sync.Mutex
-	stopped bool
+	stoppedMu sync.Mutex
+	stopped   bool
 }
 
 // Hold all *os.File created via socketpair() so that they won't get garbage collected. f.FD() gets invalid if f gets garbage collected.
@@ -108,9 +108,9 @@ func startVM(ctx context.Context, driver *driver.BaseDriver) (*virtualMachineWra
 					}
 				case vz.VirtualMachineStateStopped:
 					logrus.Info("[VZ] - vm state change: stopped")
-					wrapper.mu.Lock()
+					wrapper.stoppedMu.Lock()
 					wrapper.stopped = true
-					wrapper.mu.Unlock()
+					wrapper.stoppedMu.Unlock()
 					_ = usernetClient.UnExposeSSH(driver.SSHLocalPort)
 					errCh <- errors.New("vz driver state stopped")
 				default:

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -204,9 +204,9 @@ func (l *LimaVzDriver) Stop(_ context.Context) error {
 			case <-timeout:
 				return errors.New("vz timeout while waiting for stop status")
 			case <-ticker.C:
-				l.machine.mu.Lock()
+				l.machine.stoppedMu.Lock()
 				stopped := l.machine.stopped
-				l.machine.mu.Unlock()
+				l.machine.stoppedMu.Unlock()
 				if stopped {
 					return nil
 				}


### PR DESCRIPTION
The PR improves readability by applying the ["Mutex hat"](https://dmitri.shuralyov.com/idiomatic-go#mutex-hat) idiom. See also [this slide](https://go.dev/talks/2014/readability.slide#21).

Additionally, this PR renames mutexes names by using the `Mu` suffix.