### PR TITLE
pkg: improve field and variable names

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -72,8 +72,8 @@ type Driver interface {
 }
 
 type BaseDriver struct {
-	Instance *store.Instance
-	Yaml     *limayaml.LimaYAML
+	Instance   *store.Instance
+	InstConfig *limayaml.LimaYAML
 
 	SSHLocalPort int
 	VSockPort    int

--- a/pkg/driverutil/instance.go
+++ b/pkg/driverutil/instance.go
@@ -9,7 +9,7 @@ import (
 )
 
 func CreateTargetDriverInstance(base *driver.BaseDriver) driver.Driver {
-	limaDriver := base.Yaml.VMType
+	limaDriver := base.InstConfig.VMType
 	if *limaDriver == limayaml.VZ {
 		return vz.New(base)
 	}

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -40,7 +40,7 @@ import (
 )
 
 type HostAgent struct {
-	y                 *limayaml.LimaYAML
+	instConfig        *limayaml.LimaYAML
 	sshLocalPort      int
 	udpDNSLocalPort   int
 	tcpDNSLocalPort   int
@@ -97,22 +97,22 @@ func New(instName string, stdout io.Writer, signalCh chan os.Signal, opts ...Opt
 		return nil, err
 	}
 
-	y, err := inst.LoadYAML()
+	instConfig, err := inst.LoadYAML()
 	if err != nil {
 		return nil, err
 	}
 	// y is loaded with FillDefault() already, so no need to care about nil pointers.
 
-	sshLocalPort, err := determineSSHLocalPort(y, instName)
+	sshLocalPort, err := determineSSHLocalPort(instConfig, instName)
 	if err != nil {
 		return nil, err
 	}
-	if *y.VMType == limayaml.WSL2 {
+	if *instConfig.VMType == limayaml.WSL2 {
 		sshLocalPort = inst.SSHLocalPort
 	}
 
 	var udpDNSLocalPort, tcpDNSLocalPort int
-	if *y.HostResolver.Enabled {
+	if *instConfig.HostResolver.Enabled {
 		udpDNSLocalPort, err = findFreeUDPLocalPort()
 		if err != nil {
 			return nil, err
@@ -125,24 +125,24 @@ func New(instName string, stdout io.Writer, signalCh chan os.Signal, opts ...Opt
 
 	vSockPort := 0
 	virtioPort := ""
-	if *y.VMType == limayaml.VZ {
+	if *instConfig.VMType == limayaml.VZ {
 		vSockPort = 2222
-	} else if *y.VMType == limayaml.WSL2 {
+	} else if *instConfig.VMType == limayaml.WSL2 {
 		port, err := getFreeVSockPort()
 		if err != nil {
 			logrus.WithError(err).Error("failed to get free VSock port")
 		}
 		vSockPort = port
-	} else if *y.VMType == limayaml.QEMU {
+	} else if *instConfig.VMType == limayaml.QEMU {
 		// virtserialport doesn't seem to work reliably: https://github.com/lima-vm/lima/issues/2064
 		virtioPort = "" // filenames.VirtioPort
 	}
 
-	if err := cidata.GenerateISO9660(inst.Dir, instName, y, udpDNSLocalPort, tcpDNSLocalPort, o.nerdctlArchive, vSockPort, virtioPort); err != nil {
+	if err := cidata.GenerateISO9660(inst.Dir, instName, instConfig, udpDNSLocalPort, tcpDNSLocalPort, o.nerdctlArchive, vSockPort, virtioPort); err != nil {
 		return nil, err
 	}
 
-	sshOpts, err := sshutil.SSHOpts(inst.Dir, *y.SSH.LoadDotSSHPubKeys, *y.SSH.ForwardAgent, *y.SSH.ForwardX11, *y.SSH.ForwardX11Trusted)
+	sshOpts, err := sshutil.SSHOpts(inst.Dir, *instConfig.SSH.LoadDotSSHPubKeys, *instConfig.SSH.ForwardAgent, *instConfig.SSH.ForwardX11, *instConfig.SSH.ForwardX11Trusted)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func New(instName string, stdout io.Writer, signalCh chan os.Signal, opts ...Opt
 
 	ignoreTCP := false
 	ignoreUDP := false
-	for _, rule := range y.PortForwards {
+	for _, rule := range instConfig.PortForwards {
 		if rule.Ignore && rule.GuestPortRange[0] == 1 && rule.GuestPortRange[1] == 65535 {
 			switch rule.Proto {
 			case limayaml.TCP:
@@ -169,14 +169,14 @@ func New(instName string, stdout io.Writer, signalCh chan os.Signal, opts ...Opt
 			break
 		}
 	}
-	rules := make([]limayaml.PortForward, 0, 3+len(y.PortForwards))
+	rules := make([]limayaml.PortForward, 0, 3+len(instConfig.PortForwards))
 	// Block ports 22 and sshLocalPort on all IPs
 	for _, port := range []int{sshGuestPort, sshLocalPort} {
 		rule := limayaml.PortForward{GuestIP: net.IPv4zero, GuestPort: port, Ignore: true}
 		limayaml.FillPortForwardDefaults(&rule, inst.Dir, inst.Param)
 		rules = append(rules, rule)
 	}
-	rules = append(rules, y.PortForwards...)
+	rules = append(rules, instConfig.PortForwards...)
 	// Default forwards for all non-privileged ports from "127.0.0.1" and "::1"
 	rule := limayaml.PortForward{}
 	limayaml.FillPortForwardDefaults(&rule, inst.Dir, inst.Param)
@@ -189,14 +189,14 @@ func New(instName string, stdout io.Writer, signalCh chan os.Signal, opts ...Opt
 
 	limaDriver := driverutil.CreateTargetDriverInstance(&driver.BaseDriver{
 		Instance:     inst,
-		Yaml:         y,
+		InstConfig:   instConfig,
 		SSHLocalPort: sshLocalPort,
 		VSockPort:    vSockPort,
 		VirtioPort:   virtioPort,
 	})
 
 	a := &HostAgent{
-		y:                 y,
+		instConfig:        instConfig,
 		sshLocalPort:      sshLocalPort,
 		udpDNSLocalPort:   udpDNSLocalPort,
 		tcpDNSLocalPort:   tcpDNSLocalPort,
@@ -329,8 +329,8 @@ func (a *HostAgent) Run(ctx context.Context) error {
 	}()
 	adjustNofileRlimit()
 
-	if limayaml.FirstUsernetIndex(a.y) == -1 && *a.y.HostResolver.Enabled {
-		hosts := a.y.HostResolver.Hosts
+	if limayaml.FirstUsernetIndex(a.instConfig) == -1 && *a.instConfig.HostResolver.Enabled {
+		hosts := a.instConfig.HostResolver.Hosts
 		hosts["host.lima.internal"] = networks.SlirpGateway
 		hosts[fmt.Sprintf("lima-%s", a.instName)] = networks.SlirpIPAddress
 		srvOpts := dns.ServerOptions{
@@ -338,7 +338,7 @@ func (a *HostAgent) Run(ctx context.Context) error {
 			TCPPort: a.tcpDNSLocalPort,
 			Address: "127.0.0.1",
 			HandlerOptions: dns.HandlerOptions{
-				IPv6:        *a.y.HostResolver.IPv6,
+				IPv6:        *a.instConfig.HostResolver.IPv6,
 				StaticHosts: hosts,
 			},
 		}
@@ -355,7 +355,7 @@ func (a *HostAgent) Run(ctx context.Context) error {
 	}
 
 	// WSL instance SSH address isn't known until after VM start
-	if *a.y.VMType == limayaml.WSL2 {
+	if *a.instConfig.VMType == limayaml.WSL2 {
 		sshAddr, err := store.GetSSHAddress(a.instName)
 		if err != nil {
 			return err
@@ -363,8 +363,8 @@ func (a *HostAgent) Run(ctx context.Context) error {
 		a.instSSHAddress = sshAddr
 	}
 
-	if a.y.Video.Display != nil && *a.y.Video.Display == "vnc" {
-		vncdisplay, vncoptions, _ := strings.Cut(*a.y.Video.VNC.Display, ",")
+	if a.instConfig.Video.Display != nil && *a.instConfig.Video.Display == "vnc" {
+		vncdisplay, vncoptions, _ := strings.Cut(*a.instConfig.Video.VNC.Display, ",")
 		vnchost, vncnum, err := net.SplitHostPort(vncdisplay)
 		if err != nil {
 			return err
@@ -465,7 +465,7 @@ func (a *HostAgent) Info(_ context.Context) (*hostagentapi.Info, error) {
 }
 
 func (a *HostAgent) startHostAgentRoutines(ctx context.Context) error {
-	if *a.y.Plain {
+	if *a.instConfig.Plain {
 		logrus.Info("Running in plain mode. Mounts, port forwarding, containerd, etc. will be ignored. Guest agent will not be running.")
 	}
 	a.onClose = append(a.onClose, func() error {
@@ -479,7 +479,7 @@ func (a *HostAgent) startHostAgentRoutines(ctx context.Context) error {
 	if err := a.waitForRequirements("essential", a.essentialRequirements()); err != nil {
 		errs = append(errs, err)
 	}
-	if *a.y.SSH.ForwardAgent {
+	if *a.instConfig.SSH.ForwardAgent {
 		faScript := `#!/bin/bash
 set -eux -o pipefail
 sudo mkdir -p -m 700 /run/host-services
@@ -492,7 +492,7 @@ sudo chown -R "${USER}" /run/host-services`
 			errs = append(errs, fmt.Errorf("stdout=%q, stderr=%q: %w", stdout, stderr, err))
 		}
 	}
-	if *a.y.MountType == limayaml.REVSSHFS && !*a.y.Plain {
+	if *a.instConfig.MountType == limayaml.REVSSHFS && !*a.instConfig.Plain {
 		mounts, err := a.setupMounts()
 		if err != nil {
 			errs = append(errs, err)
@@ -507,10 +507,10 @@ sudo chown -R "${USER}" /run/host-services`
 			return errors.Join(unmountErrs...)
 		})
 	}
-	if len(a.y.AdditionalDisks) > 0 {
+	if len(a.instConfig.AdditionalDisks) > 0 {
 		a.onClose = append(a.onClose, func() error {
 			var unlockErrs []error
-			for _, d := range a.y.AdditionalDisks {
+			for _, d := range a.instConfig.AdditionalDisks {
 				disk, inspectErr := store.InspectDisk(d.Name)
 				if inspectErr != nil {
 					unlockErrs = append(unlockErrs, inspectErr)
@@ -524,13 +524,13 @@ sudo chown -R "${USER}" /run/host-services`
 			return errors.Join(unlockErrs...)
 		})
 	}
-	if !*a.y.Plain {
+	if !*a.instConfig.Plain {
 		go a.watchGuestAgentEvents(ctx)
 	}
 	if err := a.waitForRequirements("optional", a.optionalRequirements()); err != nil {
 		errs = append(errs, err)
 	}
-	if !*a.y.Plain {
+	if !*a.instConfig.Plain {
 		logrus.Info("Waiting for the guest agent to be running")
 		select {
 		case <-a.guestAgentAliveCh:
@@ -543,14 +543,14 @@ sudo chown -R "${USER}" /run/host-services`
 		errs = append(errs, err)
 	}
 	// Copy all config files _after_ the requirements are done
-	for _, rule := range a.y.CopyToHost {
+	for _, rule := range a.instConfig.CopyToHost {
 		if err := copyToHost(ctx, a.sshConfig, a.sshLocalPort, rule.HostFile, rule.GuestFile); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	a.onClose = append(a.onClose, func() error {
 		var rmErrs []error
-		for _, rule := range a.y.CopyToHost {
+		for _, rule := range a.instConfig.CopyToHost {
 			if rule.DeleteOnStop {
 				logrus.Infof("Deleting %s", rule.HostFile)
 				if err := os.RemoveAll(rule.HostFile); err != nil {
@@ -579,9 +579,9 @@ func (a *HostAgent) watchGuestAgentEvents(ctx context.Context) {
 	// TODO: use vSock (when QEMU for macOS gets support for vSock)
 
 	// Setup all socket forwards and defer their teardown
-	if *a.y.VMType != limayaml.WSL2 {
+	if *a.instConfig.VMType != limayaml.WSL2 {
 		logrus.Debugf("Forwarding unix sockets")
-		for _, rule := range a.y.PortForwards {
+		for _, rule := range a.instConfig.PortForwards {
 			if rule.GuestSocket != "" {
 				local := hostAddress(rule, &guestagentapi.IPPort{})
 				_ = forwardSSH(ctx, a.sshConfig, a.sshLocalPort, local, rule.GuestSocket, verbForward, rule.Reverse)
@@ -595,7 +595,7 @@ func (a *HostAgent) watchGuestAgentEvents(ctx context.Context) {
 	a.onClose = append(a.onClose, func() error {
 		logrus.Debugf("Stop forwarding unix sockets")
 		var errs []error
-		for _, rule := range a.y.PortForwards {
+		for _, rule := range a.instConfig.PortForwards {
 			if rule.GuestSocket != "" {
 				local := hostAddress(rule, &guestagentapi.IPPort{})
 				// using ctx.Background() because ctx has already been cancelled
@@ -613,7 +613,7 @@ func (a *HostAgent) watchGuestAgentEvents(ctx context.Context) {
 	})
 
 	go func() {
-		if a.y.MountInotify != nil && *a.y.MountInotify {
+		if a.instConfig.MountInotify != nil && *a.instConfig.MountInotify {
 			if a.client == nil || !isGuestAgentSocketAccessible(ctx, a.client) {
 				if a.driver.ForwardGuestAgent() {
 					_ = forwardSSH(ctx, a.sshConfig, a.sshLocalPort, localUnix, remoteUnix, verbForward, false)

--- a/pkg/hostagent/inotify.go
+++ b/pkg/hostagent/inotify.go
@@ -67,7 +67,7 @@ func (a *HostAgent) startInotify(ctx context.Context) error {
 }
 
 func (a *HostAgent) setupWatchers(events chan notify.EventInfo) error {
-	for _, m := range a.y.Mounts {
+	for _, m := range a.instConfig.Mounts {
 		if !*m.Writable {
 			continue
 		}

--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -20,7 +20,7 @@ func (a *HostAgent) setupMounts() ([]*mount, error) {
 		res  []*mount
 		errs []error
 	)
-	for _, f := range a.y.Mounts {
+	for _, f := range a.instConfig.Mounts {
 		m, err := a.setupMount(f)
 		if err != nil {
 			errs = append(errs, err)

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -114,7 +114,7 @@ Make sure that the YAML field "ssh.localPort" is not used by other processes on 
 If any private key under ~/.ssh is protected with a passphrase, you need to have ssh-agent to be running.
 `,
 		})
-	if *a.y.Plain {
+	if *a.instConfig.Plain {
 		return req
 	}
 	req = append(req,
@@ -134,7 +134,7 @@ it must not be created until the session reset is done.
 `,
 		})
 
-	if *a.y.MountType == limayaml.REVSSHFS && len(a.y.Mounts) > 0 {
+	if *a.instConfig.MountType == limayaml.REVSSHFS && len(a.instConfig.Mounts) > 0 {
 		req = append(req, requirement{
 			description: "sshfs binary to be installed",
 			script: `#!/bin/bash
@@ -167,7 +167,7 @@ fi
 
 func (a *HostAgent) optionalRequirements() []requirement {
 	req := make([]requirement, 0)
-	if (*a.y.Containerd.System || *a.y.Containerd.User) && !*a.y.Plain {
+	if (*a.instConfig.Containerd.System || *a.instConfig.Containerd.User) && !*a.instConfig.Plain {
 		req = append(req,
 			requirement{
 				description: "systemd must be available",
@@ -189,7 +189,7 @@ are set to 'false' in the config file.
 				description: "containerd binaries to be installed",
 				script: `#!/bin/bash
 set -eux -o pipefail
-if ! timeout 30s bash -c "until command -v nerdctl || test -x ` + *a.y.GuestInstallPrefix + `/bin/nerdctl; do sleep 3; done"; then
+if ! timeout 30s bash -c "until command -v nerdctl || test -x ` + *a.instConfig.GuestInstallPrefix + `/bin/nerdctl; do sleep 3; done"; then
 	echo >&2 "nerdctl is not installed yet"
 	exit 1
 fi
@@ -200,7 +200,7 @@ Also see "/var/log/cloud-init-output.log" in the guest.
 `,
 			})
 	}
-	for _, probe := range a.y.Probes {
+	for _, probe := range a.instConfig.Probes {
 		if probe.Mode == limayaml.ProbeModeReadiness {
 			req = append(req, requirement{
 				description: probe.Description,

--- a/pkg/instance/create.go
+++ b/pkg/instance/create.go
@@ -16,12 +16,12 @@ import (
 	"github.com/lima-vm/lima/pkg/version"
 )
 
-func Create(ctx context.Context, instName string, yBytes []byte, saveBrokenYAML bool) (*store.Instance, error) {
+func Create(ctx context.Context, instName string, instConfig []byte, saveBrokenYAML bool) (*store.Instance, error) {
 	if instName == "" {
 		return nil, errors.New("got empty instName")
 	}
-	if len(yBytes) == 0 {
-		return nil, errors.New("got empty yBytes")
+	if len(instConfig) == 0 {
+		return nil, errors.New("got empty instConfig")
 	}
 
 	instDir, err := store.InstanceDir(instName)
@@ -40,16 +40,16 @@ func Create(ctx context.Context, instName string, yBytes []byte, saveBrokenYAML 
 	}
 	// limayaml.Load() needs to pass the store file path to limayaml.FillDefault() to calculate default MAC addresses
 	filePath := filepath.Join(instDir, filenames.LimaYAML)
-	y, err := limayaml.Load(yBytes, filePath)
+	loadedInstConfig, err := limayaml.Load(instConfig, filePath)
 	if err != nil {
 		return nil, err
 	}
-	if err := limayaml.Validate(y, true); err != nil {
+	if err := limayaml.Validate(loadedInstConfig, true); err != nil {
 		if !saveBrokenYAML {
 			return nil, err
 		}
 		rejectedYAML := "lima.REJECTED.yaml"
-		if writeErr := os.WriteFile(rejectedYAML, yBytes, 0o644); writeErr != nil {
+		if writeErr := os.WriteFile(rejectedYAML, instConfig, 0o644); writeErr != nil {
 			return nil, fmt.Errorf("the YAML is invalid, attempted to save the buffer as %q but failed: %w: %w", rejectedYAML, writeErr, err)
 		}
 		return nil, fmt.Errorf("the YAML is invalid, saved the buffer as %q: %w", rejectedYAML, err)
@@ -57,7 +57,7 @@ func Create(ctx context.Context, instName string, yBytes []byte, saveBrokenYAML 
 	if err := os.MkdirAll(instDir, 0o700); err != nil {
 		return nil, err
 	}
-	if err := os.WriteFile(filePath, yBytes, 0o644); err != nil {
+	if err := os.WriteFile(filePath, instConfig, 0o644); err != nil {
 		return nil, err
 	}
 	if err := os.WriteFile(filepath.Join(instDir, filenames.LimaVersion), []byte(version.Version), 0o444); err != nil {
@@ -70,8 +70,8 @@ func Create(ctx context.Context, instName string, yBytes []byte, saveBrokenYAML 
 	}
 
 	limaDriver := driverutil.CreateTargetDriverInstance(&driver.BaseDriver{
-		Instance: inst,
-		Yaml:     y,
+		Instance:   inst,
+		InstConfig: loadedInstConfig,
 	})
 
 	if err := limaDriver.Register(ctx); err != nil {

--- a/pkg/instance/delete.go
+++ b/pkg/instance/delete.go
@@ -32,14 +32,14 @@ func Delete(ctx context.Context, inst *store.Instance, force bool) error {
 }
 
 func unregister(ctx context.Context, inst *store.Instance) error {
-	y, err := inst.LoadYAML()
+	instConfig, err := inst.LoadYAML()
 	if err != nil {
 		return err
 	}
 
 	limaDriver := driverutil.CreateTargetDriverInstance(&driver.BaseDriver{
-		Instance: inst,
-		Yaml:     y,
+		Instance:   inst,
+		InstConfig: instConfig,
 	})
 
 	return limaDriver.Unregister(ctx)

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -78,14 +78,14 @@ type Prepared struct {
 
 // Prepare ensures the disk, the nerdctl archive, etc.
 func Prepare(ctx context.Context, inst *store.Instance) (*Prepared, error) {
-	y, err := inst.LoadYAML()
+	instConfig, err := inst.LoadYAML()
 	if err != nil {
 		return nil, err
 	}
 
 	limaDriver := driverutil.CreateTargetDriverInstance(&driver.BaseDriver{
-		Instance: inst,
-		Yaml:     y,
+		Instance:   inst,
+		InstConfig: instConfig,
 	})
 
 	if err := limaDriver.Validate(); err != nil {
@@ -104,7 +104,7 @@ func Prepare(ctx context.Context, inst *store.Instance) (*Prepared, error) {
 	if err := limaDriver.CreateDisk(ctx); err != nil {
 		return nil, err
 	}
-	nerdctlArchiveCache, err := ensureNerdctlArchiveCache(ctx, y, created)
+	nerdctlArchiveCache, err := ensureNerdctlArchiveCache(ctx, instConfig, created)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/networks/usernet/client.go
+++ b/pkg/networks/usernet/client.go
@@ -38,7 +38,7 @@ func (c *Client) ConfigureDriver(ctx context.Context, driver *driver.BaseDriver)
 	if err != nil {
 		return err
 	}
-	hosts := driver.Yaml.HostResolver.Hosts
+	hosts := driver.InstConfig.HostResolver.Hosts
 	hosts[fmt.Sprintf("lima-%s.internal", driver.Instance.Name)] = ipAddress
 	err = c.AddDNSHosts(hosts)
 	return err

--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -43,9 +43,9 @@ func New(driver *driver.BaseDriver) *LimaQemuDriver {
 }
 
 func (l *LimaQemuDriver) Validate() error {
-	if *l.Yaml.MountType == limayaml.VIRTIOFS && runtime.GOOS != "linux" {
+	if *l.InstConfig.MountType == limayaml.VIRTIOFS && runtime.GOOS != "linux" {
 		return fmt.Errorf("field `mountType` must be %q or %q for QEMU driver on non-Linux, got %q",
-			limayaml.REVSSHFS, limayaml.NINEP, *l.Yaml.MountType)
+			limayaml.REVSSHFS, limayaml.NINEP, *l.InstConfig.MountType)
 	}
 	return nil
 }
@@ -54,7 +54,7 @@ func (l *LimaQemuDriver) CreateDisk(ctx context.Context) error {
 	qCfg := Config{
 		Name:        l.Instance.Name,
 		InstanceDir: l.Instance.Dir,
-		LimaYAML:    l.Yaml,
+		LimaYAML:    l.InstConfig,
 	}
 	return EnsureDisk(ctx, qCfg)
 }
@@ -70,7 +70,7 @@ func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
 	qCfg := Config{
 		Name:         l.Instance.Name,
 		InstanceDir:  l.Instance.Dir,
-		LimaYAML:     l.Yaml,
+		LimaYAML:     l.InstConfig,
 		SSHLocalPort: l.SSHLocalPort,
 	}
 	qExe, qArgs, err := Cmdline(ctx, qCfg)
@@ -79,13 +79,13 @@ func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
 	}
 
 	var vhostCmds []*exec.Cmd
-	if *l.Yaml.MountType == limayaml.VIRTIOFS {
+	if *l.InstConfig.MountType == limayaml.VIRTIOFS {
 		vhostExe, err := FindVirtiofsd(qExe)
 		if err != nil {
 			return nil, err
 		}
 
-		for i := range l.Yaml.Mounts {
+		for i := range l.InstConfig.Mounts {
 			args, err := VirtiofsdCmdline(qCfg, i)
 			if err != nil {
 				return nil, err
@@ -189,8 +189,8 @@ func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
 	}()
 	l.vhostCmds = vhostCmds
 	go func() {
-		if usernetIndex := limayaml.FirstUsernetIndex(l.Yaml); usernetIndex != -1 {
-			client := usernet.NewClientByName(l.Yaml.Networks[usernetIndex].Lima)
+		if usernetIndex := limayaml.FirstUsernetIndex(l.InstConfig); usernetIndex != -1 {
+			client := usernet.NewClientByName(l.InstConfig.Networks[usernetIndex].Lima)
 			err := client.ConfigureDriver(ctx, l.BaseDriver)
 			if err != nil {
 				l.qWaitCh <- err
@@ -297,8 +297,8 @@ func (l *LimaQemuDriver) killVhosts() error {
 
 func (l *LimaQemuDriver) shutdownQEMU(ctx context.Context, timeout time.Duration, qCmd *exec.Cmd, qWaitCh <-chan error) error {
 	logrus.Info("Shutting down QEMU with ACPI")
-	if usernetIndex := limayaml.FirstUsernetIndex(l.Yaml); usernetIndex != -1 {
-		client := usernet.NewClientByName(l.Yaml.Networks[usernetIndex].Lima)
+	if usernetIndex := limayaml.FirstUsernetIndex(l.InstConfig); usernetIndex != -1 {
+		client := usernet.NewClientByName(l.InstConfig.Networks[usernetIndex].Lima)
 		err := client.UnExposeSSH(l.SSHLocalPort)
 		if err != nil {
 			logrus.Warnf("Failed to remove SSH binding for port %d", l.SSHLocalPort)
@@ -348,7 +348,7 @@ func (l *LimaQemuDriver) killQEMU(_ context.Context, _ time.Duration, qCmd *exec
 	} else {
 		logrus.Info("QEMU has already exited")
 	}
-	qemuPIDPath := filepath.Join(l.Instance.Dir, filenames.PIDFile(*l.Yaml.VMType))
+	qemuPIDPath := filepath.Join(l.Instance.Dir, filenames.PIDFile(*l.InstConfig.VMType))
 	_ = os.RemoveAll(qemuPIDPath)
 	_ = l.removeVNCFiles()
 	return errors.Join(qWaitErr, l.killVhosts())
@@ -366,7 +366,7 @@ func (l *LimaQemuDriver) DeleteSnapshot(_ context.Context, tag string) error {
 	qCfg := Config{
 		Name:        l.Instance.Name,
 		InstanceDir: l.Instance.Dir,
-		LimaYAML:    l.Yaml,
+		LimaYAML:    l.InstConfig,
 	}
 	return Del(qCfg, l.Instance.Status == store.StatusRunning, tag)
 }
@@ -375,7 +375,7 @@ func (l *LimaQemuDriver) CreateSnapshot(_ context.Context, tag string) error {
 	qCfg := Config{
 		Name:        l.Instance.Name,
 		InstanceDir: l.Instance.Dir,
-		LimaYAML:    l.Yaml,
+		LimaYAML:    l.InstConfig,
 	}
 	return Save(qCfg, l.Instance.Status == store.StatusRunning, tag)
 }
@@ -384,7 +384,7 @@ func (l *LimaQemuDriver) ApplySnapshot(_ context.Context, tag string) error {
 	qCfg := Config{
 		Name:        l.Instance.Name,
 		InstanceDir: l.Instance.Dir,
-		LimaYAML:    l.Yaml,
+		LimaYAML:    l.InstConfig,
 	}
 	return Load(qCfg, l.Instance.Status == store.StatusRunning, tag)
 }
@@ -393,7 +393,7 @@ func (l *LimaQemuDriver) ListSnapshots(_ context.Context) (string, error) {
 	qCfg := Config{
 		Name:        l.Instance.Name,
 		InstanceDir: l.Instance.Dir,
-		LimaYAML:    l.Yaml,
+		LimaYAML:    l.InstConfig,
 	}
 	return List(qCfg, l.Instance.Status == store.StatusRunning)
 }

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -9,37 +9,37 @@ import (
 )
 
 func Del(ctx context.Context, inst *store.Instance, tag string) error {
-	y, err := inst.LoadYAML()
+	instConfig, err := inst.LoadYAML()
 	if err != nil {
 		return err
 	}
 	limaDriver := driverutil.CreateTargetDriverInstance(&driver.BaseDriver{
-		Instance: inst,
-		Yaml:     y,
+		Instance:   inst,
+		InstConfig: instConfig,
 	})
 	return limaDriver.DeleteSnapshot(ctx, tag)
 }
 
 func Save(ctx context.Context, inst *store.Instance, tag string) error {
-	y, err := inst.LoadYAML()
+	instConfig, err := inst.LoadYAML()
 	if err != nil {
 		return err
 	}
 	limaDriver := driverutil.CreateTargetDriverInstance(&driver.BaseDriver{
-		Instance: inst,
-		Yaml:     y,
+		Instance:   inst,
+		InstConfig: instConfig,
 	})
 	return limaDriver.CreateSnapshot(ctx, tag)
 }
 
 func Load(ctx context.Context, inst *store.Instance, tag string) error {
-	y, err := inst.LoadYAML()
+	instConfig, err := inst.LoadYAML()
 	if err != nil {
 		return err
 	}
 	limaDriver := driverutil.CreateTargetDriverInstance(&driver.BaseDriver{
-		Instance: inst,
-		Yaml:     y,
+		Instance:   inst,
+		InstConfig: instConfig,
 	})
 	return limaDriver.ApplySnapshot(ctx, tag)
 }
@@ -50,8 +50,8 @@ func List(ctx context.Context, inst *store.Instance) (string, error) {
 		return "", err
 	}
 	limaDriver := driverutil.CreateTargetDriverInstance(&driver.BaseDriver{
-		Instance: inst,
-		Yaml:     y,
+		Instance:   inst,
+		InstConfig: y,
 	})
 	return limaDriver.ListSnapshots(ctx)
 }

--- a/pkg/vz/disk.go
+++ b/pkg/vz/disk.go
@@ -28,15 +28,15 @@ func EnsureDisk(ctx context.Context, driver *driver.BaseDriver) error {
 	initrd := filepath.Join(driver.Instance.Dir, filenames.Initrd)
 	if _, err := os.Stat(baseDisk); errors.Is(err, os.ErrNotExist) {
 		var ensuredBaseDisk bool
-		errs := make([]error, len(driver.Yaml.Images))
-		for i, f := range driver.Yaml.Images {
-			if _, err := fileutils.DownloadFile(ctx, baseDisk, f.File, true, "the image", *driver.Yaml.Arch); err != nil {
+		errs := make([]error, len(driver.InstConfig.Images))
+		for i, f := range driver.InstConfig.Images {
+			if _, err := fileutils.DownloadFile(ctx, baseDisk, f.File, true, "the image", *driver.InstConfig.Arch); err != nil {
 				errs[i] = err
 				continue
 			}
 			if f.Kernel != nil {
 				// ensure decompress kernel because vz expects it to be decompressed
-				if _, err := fileutils.DownloadFile(ctx, kernel, f.Kernel.File, true, "the kernel", *driver.Yaml.Arch); err != nil {
+				if _, err := fileutils.DownloadFile(ctx, kernel, f.Kernel.File, true, "the kernel", *driver.InstConfig.Arch); err != nil {
 					errs[i] = err
 					continue
 				}
@@ -48,7 +48,7 @@ func EnsureDisk(ctx context.Context, driver *driver.BaseDriver) error {
 				}
 			}
 			if f.Initrd != nil {
-				if _, err := fileutils.DownloadFile(ctx, initrd, *f.Initrd, false, "the initrd", *driver.Yaml.Arch); err != nil {
+				if _, err := fileutils.DownloadFile(ctx, initrd, *f.Initrd, false, "the initrd", *driver.InstConfig.Arch); err != nil {
 					errs[i] = err
 					continue
 				}
@@ -60,7 +60,7 @@ func EnsureDisk(ctx context.Context, driver *driver.BaseDriver) error {
 			return fileutils.Errors(errs)
 		}
 	}
-	diskSize, _ := units.RAMInBytes(*driver.Yaml.Disk)
+	diskSize, _ := units.RAMInBytes(*driver.InstConfig.Disk)
 	if diskSize == 0 {
 		return nil
 	}

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -76,70 +76,70 @@ func (l *LimaVzDriver) Validate() error {
 	if errors.Is(err, vz.ErrUnsupportedOSVersion) {
 		return fmt.Errorf("VZ driver requires macOS 13 or higher to run")
 	}
-	if *l.Yaml.MountType == limayaml.NINEP {
-		return fmt.Errorf("field `mountType` must be %q or %q for VZ driver , got %q", limayaml.REVSSHFS, limayaml.VIRTIOFS, *l.Yaml.MountType)
+	if *l.InstConfig.MountType == limayaml.NINEP {
+		return fmt.Errorf("field `mountType` must be %q or %q for VZ driver , got %q", limayaml.REVSSHFS, limayaml.VIRTIOFS, *l.InstConfig.MountType)
 	}
-	if *l.Yaml.Firmware.LegacyBIOS {
-		logrus.Warnf("vmType %s: ignoring `firmware.legacyBIOS`", *l.Yaml.VMType)
+	if *l.InstConfig.Firmware.LegacyBIOS {
+		logrus.Warnf("vmType %s: ignoring `firmware.legacyBIOS`", *l.InstConfig.VMType)
 	}
-	for _, f := range l.Yaml.Firmware.Images {
+	for _, f := range l.InstConfig.Firmware.Images {
 		switch f.VMType {
 		case "", limayaml.VZ:
-			if f.Arch == *l.Yaml.Arch {
+			if f.Arch == *l.InstConfig.Arch {
 				return fmt.Errorf("`firmware.images` configuration is not supported for VZ driver")
 			}
 		}
 	}
-	if unknown := reflectutil.UnknownNonEmptyFields(l.Yaml, knownYamlProperties...); len(unknown) > 0 {
-		logrus.Warnf("vmType %s: ignoring %+v", *l.Yaml.VMType, unknown)
+	if unknown := reflectutil.UnknownNonEmptyFields(l.InstConfig, knownYamlProperties...); len(unknown) > 0 {
+		logrus.Warnf("vmType %s: ignoring %+v", *l.InstConfig.VMType, unknown)
 	}
 
-	if !limayaml.IsNativeArch(*l.Yaml.Arch) {
-		return fmt.Errorf("unsupported arch: %q", *l.Yaml.Arch)
+	if !limayaml.IsNativeArch(*l.InstConfig.Arch) {
+		return fmt.Errorf("unsupported arch: %q", *l.InstConfig.Arch)
 	}
 
-	for k, v := range l.Yaml.CPUType {
+	for k, v := range l.InstConfig.CPUType {
 		if v != "" {
-			logrus.Warnf("vmType %s: ignoring cpuType[%q]: %q", *l.Yaml.VMType, k, v)
+			logrus.Warnf("vmType %s: ignoring cpuType[%q]: %q", *l.InstConfig.VMType, k, v)
 		}
 	}
 
-	for i, image := range l.Yaml.Images {
+	for i, image := range l.InstConfig.Images {
 		if unknown := reflectutil.UnknownNonEmptyFields(image, "File"); len(unknown) > 0 {
-			logrus.Warnf("vmType %s: ignoring images[%d]: %+v", *l.Yaml.VMType, i, unknown)
+			logrus.Warnf("vmType %s: ignoring images[%d]: %+v", *l.InstConfig.VMType, i, unknown)
 		}
 	}
 
-	for i, mount := range l.Yaml.Mounts {
+	for i, mount := range l.InstConfig.Mounts {
 		if unknown := reflectutil.UnknownNonEmptyFields(mount, "Location",
 			"MountPoint",
 			"Writable",
 			"SSHFS",
 			"NineP",
 		); len(unknown) > 0 {
-			logrus.Warnf("vmType %s: ignoring mounts[%d]: %+v", *l.Yaml.VMType, i, unknown)
+			logrus.Warnf("vmType %s: ignoring mounts[%d]: %+v", *l.InstConfig.VMType, i, unknown)
 		}
 	}
 
-	for i, network := range l.Yaml.Networks {
+	for i, network := range l.InstConfig.Networks {
 		if unknown := reflectutil.UnknownNonEmptyFields(network, "VZNAT",
 			"Lima",
 			"Socket",
 			"MACAddress",
 			"Interface",
 		); len(unknown) > 0 {
-			logrus.Warnf("vmType %s: ignoring networks[%d]: %+v", *l.Yaml.VMType, i, unknown)
+			logrus.Warnf("vmType %s: ignoring networks[%d]: %+v", *l.InstConfig.VMType, i, unknown)
 		}
 	}
 
-	switch audioDevice := *l.Yaml.Audio.Device; audioDevice {
+	switch audioDevice := *l.InstConfig.Audio.Device; audioDevice {
 	case "":
 	case "vz", "default", "none":
 	default:
 		logrus.Warnf("field `audio.device` must be \"vz\", \"default\", or \"none\" for VZ driver, got %q", audioDevice)
 	}
 
-	switch videoDisplay := *l.Yaml.Video.Display; videoDisplay {
+	switch videoDisplay := *l.InstConfig.Video.Display; videoDisplay {
 	case "vz", "default", "none":
 	default:
 		logrus.Warnf("field `video.display` must be \"vz\", \"default\", or \"none\" for VZ driver , got %q", videoDisplay)
@@ -171,7 +171,7 @@ func (l *LimaVzDriver) Start(ctx context.Context) (chan error, error) {
 }
 
 func (l *LimaVzDriver) CanRunGUI() bool {
-	switch *l.Yaml.Video.Display {
+	switch *l.InstConfig.Video.Display {
 	case "vz", "default":
 		return true
 	default:
@@ -184,7 +184,7 @@ func (l *LimaVzDriver) RunGUI() error {
 		return l.machine.StartGraphicApplication(1920, 1200)
 	}
 	//nolint:revive // error-strings
-	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "vz", *l.Yaml.Video.Display)
+	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "vz", *l.InstConfig.Video.Display)
 }
 
 func (l *LimaVzDriver) Stop(_ context.Context) error {

--- a/pkg/wsl2/fs.go
+++ b/pkg/wsl2/fs.go
@@ -17,9 +17,9 @@ func EnsureFs(ctx context.Context, driver *driver.BaseDriver) error {
 	baseDisk := filepath.Join(driver.Instance.Dir, filenames.BaseDisk)
 	if _, err := os.Stat(baseDisk); errors.Is(err, os.ErrNotExist) {
 		var ensuredBaseDisk bool
-		errs := make([]error, len(driver.Yaml.Images))
-		for i, f := range driver.Yaml.Images {
-			if _, err := fileutils.DownloadFile(ctx, baseDisk, f.File, true, "the image", *driver.Yaml.Arch); err != nil {
+		errs := make([]error, len(driver.InstConfig.Images))
+		for i, f := range driver.InstConfig.Images {
+			if _, err := fileutils.DownloadFile(ctx, baseDisk, f.File, true, "the image", *driver.InstConfig.Arch); err != nil {
 				errs[i] = err
 				continue
 			}

--- a/pkg/wsl2/wsl_driver_windows.go
+++ b/pkg/wsl2/wsl_driver_windows.go
@@ -52,51 +52,51 @@ func New(driver *driver.BaseDriver) *LimaWslDriver {
 }
 
 func (l *LimaWslDriver) Validate() error {
-	if *l.Yaml.MountType != limayaml.WSLMount {
-		return fmt.Errorf("field `mountType` must be %q for WSL2 driver, got %q", limayaml.WSLMount, *l.Yaml.MountType)
+	if *l.InstConfig.MountType != limayaml.WSLMount {
+		return fmt.Errorf("field `mountType` must be %q for WSL2 driver, got %q", limayaml.WSLMount, *l.InstConfig.MountType)
 	}
 	// TODO: revise this list for WSL2
-	if unknown := reflectutil.UnknownNonEmptyFields(l.Yaml, knownYamlProperties...); len(unknown) > 0 {
-		logrus.Warnf("Ignoring: vmType %s: %+v", *l.Yaml.VMType, unknown)
+	if unknown := reflectutil.UnknownNonEmptyFields(l.InstConfig, knownYamlProperties...); len(unknown) > 0 {
+		logrus.Warnf("Ignoring: vmType %s: %+v", *l.InstConfig.VMType, unknown)
 	}
 
-	if !limayaml.IsNativeArch(*l.Yaml.Arch) {
-		return fmt.Errorf("unsupported arch: %q", *l.Yaml.Arch)
+	if !limayaml.IsNativeArch(*l.InstConfig.Arch) {
+		return fmt.Errorf("unsupported arch: %q", *l.InstConfig.Arch)
 	}
 
-	for k, v := range l.Yaml.CPUType {
+	for k, v := range l.InstConfig.CPUType {
 		if v != "" {
-			logrus.Warnf("Ignoring: vmType %s: cpuType[%q]: %q", *l.Yaml.VMType, k, v)
+			logrus.Warnf("Ignoring: vmType %s: cpuType[%q]: %q", *l.InstConfig.VMType, k, v)
 		}
 	}
 
 	// TODO: real filetype checks
 	tarFileRegex := regexp.MustCompile(`.*tar\.*`)
-	for i, image := range l.Yaml.Images {
+	for i, image := range l.InstConfig.Images {
 		if unknown := reflectutil.UnknownNonEmptyFields(image, "File"); len(unknown) > 0 {
-			logrus.Warnf("Ignoring: vmType %s: images[%d]: %+v", *l.Yaml.VMType, i, unknown)
+			logrus.Warnf("Ignoring: vmType %s: images[%d]: %+v", *l.InstConfig.VMType, i, unknown)
 		}
 		match := tarFileRegex.MatchString(image.Location)
-		if image.Arch == *l.Yaml.Arch && !match {
-			return fmt.Errorf("unsupported image type for vmType: %s, tarball root file system required: %q", *l.Yaml.VMType, image.Location)
+		if image.Arch == *l.InstConfig.Arch && !match {
+			return fmt.Errorf("unsupported image type for vmType: %s, tarball root file system required: %q", *l.InstConfig.VMType, image.Location)
 		}
 	}
 
-	for i, mount := range l.Yaml.Mounts {
+	for i, mount := range l.InstConfig.Mounts {
 		if unknown := reflectutil.UnknownNonEmptyFields(mount); len(unknown) > 0 {
-			logrus.Warnf("Ignoring: vmType %s: mounts[%d]: %+v", *l.Yaml.VMType, i, unknown)
+			logrus.Warnf("Ignoring: vmType %s: mounts[%d]: %+v", *l.InstConfig.VMType, i, unknown)
 		}
 	}
 
-	for i, network := range l.Yaml.Networks {
+	for i, network := range l.InstConfig.Networks {
 		if unknown := reflectutil.UnknownNonEmptyFields(network); len(unknown) > 0 {
-			logrus.Warnf("Ignoring: vmType %s: networks[%d]: %+v", *l.Yaml.VMType, i, unknown)
+			logrus.Warnf("Ignoring: vmType %s: networks[%d]: %+v", *l.InstConfig.VMType, i, unknown)
 		}
 	}
 
-	audioDevice := *l.Yaml.Audio.Device
+	audioDevice := *l.InstConfig.Audio.Device
 	if audioDevice != "" {
-		logrus.Warnf("Ignoring: vmType %s: `audio.device`: %+v", *l.Yaml.VMType, audioDevice)
+		logrus.Warnf("Ignoring: vmType %s: `audio.device`: %+v", *l.InstConfig.VMType, audioDevice)
 	}
 
 	return nil
@@ -144,12 +144,12 @@ func (l *LimaWslDriver) Start(ctx context.Context) (chan error, error) {
 // Requires WSLg, which requires specific version of WSL2 to be installed.
 // TODO: Add check and add support for WSLg (instead of VNC) to hostagent.
 func (l *LimaWslDriver) CanRunGUI() bool {
-	// return *l.Yaml.Video.Display == "wsl"
+	// return *l.InstConfig.Video.Display == "wsl"
 	return false
 }
 
 func (l *LimaWslDriver) RunGUI() error {
-	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "wsl", *l.Yaml.Video.Display)
+	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "wsl", *l.InstConfig.Video.Display)
 }
 
 func (l *LimaWslDriver) Stop(ctx context.Context) error {


### PR DESCRIPTION
This PR renames `y` to `instConfig` because `y` is too short for its usage scope, which broke the [CodeReviewComments#variable-names](https://go.dev/wiki/CodeReviewComments#variable-names) statement:

> The basic rule: the further from its declaration that a name is used, the more descriptive the name must be