### PR TITLE
yqutil: fix to preserve line breaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,10 @@ jobs:
       run: make
     - name: Install
       run: sudo make install
+    - name: Verify templates match `limactl edit` format
+      run: |
+        find examples -name '*.yaml' -exec limactl edit --set 'del(.nothing)' {} \;
+        git diff-index --exit-code HEAD
     - name: Uninstall
       run: sudo make uninstall
 

--- a/examples/buildkit.yaml
+++ b/examples/buildkit.yaml
@@ -5,11 +5,11 @@
 # $ export BUILDKIT_HOST=$(limactl list buildkit --format 'unix://{{.Dir}}/sock/buildkitd.sock')
 # $ buildctl debug workers
 message: |
- To run `buildkit` on the host (assumes buildctl is installed), run the following commands:
- -------
- export BUILDKIT_HOST="unix://{{.Dir}}/sock/buildkitd.sock"
- buildctl debug workers
- -------
+  To run `buildkit` on the host (assumes buildctl is installed), run the following commands:
+  -------
+  export BUILDKIT_HOST="unix://{{.Dir}}/sock/buildkitd.sock"
+  buildctl debug workers
+  -------
 images:
 # Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
 - location: "https://cloud-images.ubuntu.com/releases/24.04/release-20240821/ubuntu-24.04-server-cloudimg-amd64.img"

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -264,10 +264,10 @@ containerd:
 # Setting of instructions is supported like this: "qemu64,+ssse3".
 # 🟢 Builtin default: hard-coded arch map with type (see the output of `limactl info | jq .defaultTemplate.cpuType`)
 cpuType:
-  # aarch64: "cortex-a72" # (or "host" when running on aarch64 host)
-  # armv7l: "cortex-a7" # (or "host" when running on armv7l host)
-  # riscv64: "rv64" # (or "host" when running on riscv64 host)
-  # x86_64: "qemu64" # (or "host,-pdpe1gb" when running on x86_64 host)
+# aarch64: "cortex-a72" # (or "host" when running on aarch64 host)
+# armv7l: "cortex-a7" # (or "host" when running on armv7l host)
+# riscv64: "rv64" # (or "host" when running on riscv64 host)
+# x86_64: "qemu64" # (or "host,-pdpe1gb" when running on x86_64 host)
 
 rosetta:
   # Enable Rosetta for Linux (EXPERIMENTAL; will graduate from experimental in Lima v1.0).
@@ -456,8 +456,8 @@ hostResolver:
   # predefined to specify the gateway address to the host.
   # 🟢 Builtin default: null
   hosts:
-    # guest.name: 127.1.1.1
-    # host.name: host.lima.internal
+  # guest.name: 127.1.1.1
+  # host.name: host.lima.internal
 
 # If hostResolver.enabled is false, then the following rules apply for configuring dns:
 # Explicitly set DNS addresses for qemu user-mode networking. By default qemu picks *one*

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -264,10 +264,10 @@ containerd:
 # Setting of instructions is supported like this: "qemu64,+ssse3".
 # 🟢 Builtin default: hard-coded arch map with type (see the output of `limactl info | jq .defaultTemplate.cpuType`)
 cpuType:
-# aarch64: "cortex-a72" # (or "host" when running on aarch64 host)
-# armv7l: "cortex-a7" # (or "host" when running on armv7l host)
-# riscv64: "rv64" # (or "host" when running on riscv64 host)
-# x86_64: "qemu64" # (or "host,-pdpe1gb" when running on x86_64 host)
+#   aarch64: "cortex-a72" # (or "host" when running on aarch64 host)
+#   armv7l: "cortex-a7" # (or "host" when running on armv7l host)
+#   riscv64: "rv64" # (or "host" when running on riscv64 host)
+#   x86_64: "qemu64" # (or "host,-pdpe1gb" when running on x86_64 host)
 
 rosetta:
   # Enable Rosetta for Linux (EXPERIMENTAL; will graduate from experimental in Lima v1.0).
@@ -456,8 +456,8 @@ hostResolver:
   # predefined to specify the gateway address to the host.
   # 🟢 Builtin default: null
   hosts:
-  # guest.name: 127.1.1.1
-  # host.name: host.lima.internal
+  #   guest.name: 127.1.1.1
+  #   host.name: host.lima.internal
 
 # If hostResolver.enabled is false, then the following rules apply for configuring dns:
 # Explicitly set DNS addresses for qemu user-mode networking. By default qemu picks *one*

--- a/pkg/yqutil/yqutil_test.go
+++ b/pkg/yqutil/yqutil_test.go
@@ -19,6 +19,7 @@ memory: null
 	expected := `
 # CPUs
 cpus: 2
+
 # Memory size
 memory: 2GiB
 `


### PR DESCRIPTION
`yamlfmt` works by replacing line breaks with place holder strings to avoid their loss when using `gopkg.in/yaml.v3`. By replacing line breaks with place holder strings before `yqlib` uses `gopkg.in/yaml.v3`, we can ultimately prevent the loss of line breaks through `yamlfmt`.

https://github.com/lima-vm/lima/pull/2593#issuecomment-2351462571