### PR TITLE
Simplify initialization of bool variables

### DIFF
--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -65,10 +65,7 @@ func copyAction(cmd *cobra.Command, args []string) error {
 	if recursive {
 		scpFlags = append(scpFlags, "-r")
 	}
-	legacySSH := false
-	if sshutil.DetectOpenSSHVersion().LessThan(*semver.New("8.0.0")) {
-		legacySSH = true
-	}
+	legacySSH := sshutil.DetectOpenSSHVersion().LessThan(*semver.New("8.0.0"))
 	for _, arg := range args {
 		path := strings.Split(arg, ":")
 		switch len(path) {

--- a/pkg/guestagent/iptables/iptables.go
+++ b/pkg/guestagent/iptables/iptables.go
@@ -72,10 +72,7 @@ func parsePortsFromRules(rules []string) ([]Entry, error) {
 					return nil, err
 				}
 
-				istcp := false
-				if found[2] == "tcp" {
-					istcp = true
-				}
+				istcp := found[2] == "tcp"
 
 				// When no IP is present the rule applies to all interfaces.
 				ip := found[1]

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -97,11 +97,10 @@ func Prepare(ctx context.Context, inst *store.Instance) (*Prepared, error) {
 	}
 
 	// Check if the instance has been created (the base disk already exists)
-	created := false
 	baseDisk := filepath.Join(inst.Dir, filenames.BaseDisk)
-	if _, err := os.Stat(baseDisk); err == nil {
-		created = true
-	}
+	_, err = os.Stat(baseDisk)
+	created := err == nil
+
 	if err := limaDriver.CreateDisk(ctx); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR removes redundant `if` statements when initializing bool variables.