### PR TITLE
Use script to pick the qemu formula for the desired version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -370,7 +370,6 @@ jobs:
 
   upgrade:
     name: "Upgrade test"
-    # The QEMU bottle URL needs to be updated when the runner is upgraded from Monterey
     runs-on: macos-12
     timeout-minutes: 120
     strategy:
@@ -388,15 +387,14 @@ jobs:
       with:
         template: https://raw.githubusercontent.com/lima-vm/lima/${{ matrix.oldver }}/examples/ubuntu-lts.yaml
     - name: Install test dependencies
+      env:
+        # brew-install-version.sh calls `gh`, which needs the token
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         brew install bash coreutils
         # QEMU 9.1.0 seems to break on GitHub runners, both on Monterey and Ventura
         # We revert back to 8.2.1, which seems to work fine
-        # The SHA1 for the Monterey bottle comes from https://github.com/Homebrew/homebrew-core/blob/4c7ffca/Formula/q/qemu.rb
-        brew uninstall --ignore-dependencies --force qemu
-        curl -L -o qemu-8.2.1.monterey.bottle.tar.gz -H "Authorization: Bearer QQ==" \
-            https://ghcr.io/v2/homebrew/core/qemu/blobs/sha256:41c77f6bac3e8c1664c665fbe2b19b19ee9da57f8e1ad6697348286710cc3575
-        brew install --ignore-dependencies ./qemu-8.2.1.monterey.bottle.tar.gz
+        ./hack/brew-install-version.sh qemu 8.2.1
     - name: Test
       uses: nick-fields/retry@v3
       with:

--- a/hack/brew-install-version.sh
+++ b/hack/brew-install-version.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# This script only works for formulas in the homebrew-core
+
+set -eu -o pipefail
+
+FORMULA=$1
+VERSION=$2
+
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_INSTALL_UPGRADE=1
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+
+TAP=lima/tap
+if ! brew tap | grep -q "^${TAP}\$"; then
+	brew tap-new "$TAP"
+fi
+
+# Get the commit id for the commit that updated this bottle
+SHA=$(gh search commits --repo homebrew/homebrew-core "${FORMULA}: update ${VERSION} bottle" --json sha --jq "last|.sha")
+if [[ -z $SHA ]]; then
+	echo "${FORMULA} ${VERSION} not found"
+	exit 1
+fi
+
+OUTPUT="$(brew --repo "$TAP")/Formula/${FORMULA}.rb"
+RAW="https://raw.githubusercontent.com/Homebrew/homebrew-core"
+curl -s "${RAW}/${SHA}/Formula/${FORMULA::1}/${FORMULA}.rb" -o "$OUTPUT"
+
+if brew ls -1 | grep -q "^${FORMULA}\$"; then
+	brew uninstall "$FORMULA" --ignore-dependencies
+fi
+brew install "${TAP}/${FORMULA}"


### PR DESCRIPTION
This will automatically pick the right bottle for the OS of the runner, and we can easily change the QEMU version number without having to look up commit ids manually.

Based on discussion at https://github.com/lima-vm/lima/pull/2640#pullrequestreview-2317320994