### PR TITLE
Fix OVMF location for openSUSE

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -1119,7 +1119,7 @@ func getFirmware(qemuExe string, arch limayaml.Arch) (string, error) {
 		// Fedora package "edk2-ovmf"
 		candidates = append(candidates, "/usr/share/edk2/ovmf/OVMF_CODE.fd")
 		// openSUSE package "qemu-ovmf-x86_64"
-		candidates = append(candidates, "/usr/share/qemu/ovmf-x86_64-code.bin")
+		candidates = append(candidates, "/usr/share/qemu/ovmf-x86_64.bin")
 		// Archlinux package "edk2-ovmf"
 		candidates = append(candidates, "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd")
 	case limayaml.AARCH64:


### PR DESCRIPTION
The split firmware requires that both the CODE and the VARS parts are mounted. Otherwise the combined firmware should be used.

This should apply to the other Linux distributions too, but I have not checked the filenames there.

Ref: https://bugzilla.suse.com/show_bug.cgi?id=1230291#c5