### PR TITLE
Improve debugging with `dlv dap` (in VSCode, for example)

### DIFF
--- a/hack/toolexec-for-codesign.sh
+++ b/hack/toolexec-for-codesign.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# This script is used to wrap the compiler and linker commands in the build
+# process. It captures the output of the command and logs it to a file.
+# The script's primary purpose is codesigning the output of the linker command
+# with the entitlements file if it exists.
+# If the OS is macOS, the result of the command is 0, the entitlements file
+# exists, and codesign is available, sign the output of the linker command with
+# the entitlements file.
+#
+# Usage:
+#   go build -toolexec hack/toolexec-to-codesign.sh
+
+repository_root="$(dirname "$(dirname "$0")")"
+logfile="${repository_root}/.toolexec-to-codesign.log"
+
+echo $$: cmd: "$@" >>"${logfile}"
+
+output="$("$@")"
+result=$?
+
+echo $$: output: "${output}" >>"${logfile}"
+
+entitlements="${repository_root}/vz.entitlements"
+
+# If the OS is macOS, the result of the command is 0, the entitlements file
+# exists, and codesign is available, sign the output of the linker command.
+if OS=$(uname -s) && [ "${OS}" = "Darwin" ] && [ "${result}" -eq 0 ] && [ -f "${entitlements}" ] && command -v codesign >/dev/null 2>&1; then
+	# Check if the command is a linker command.
+	case "$1" in
+	*link)
+		shift
+		# Find a parameter that is a output file.
+		while [ $# -gt 1 ]; do
+			case "$1" in
+			-o)
+				# If the output file is a executable, sign it with the entitlements file.
+				if [ -x "$2" ]; then
+					codesign_output="$(codesign -v --entitlements "${entitlements}" -s - "$2" 2>&1)"
+					echo "$$: ${codesign_output}" >>"${logfile}"
+				fi
+				break
+				;;
+			*) shift ;;
+			esac
+		done
+		;;
+	*) ;;
+	esac
+fi
+
+# Print the output of the command and exit with the result of the command.
+echo "${output}"
+exit "${result}"

--- a/pkg/usrlocalsharelima/usrlocalsharelima.go
+++ b/pkg/usrlocalsharelima/usrlocalsharelima.go
@@ -36,6 +36,7 @@ func Dir() (string, error) {
 	// self:  /usr/local/bin/limactl
 	selfDir := filepath.Dir(self)
 	selfDirDir := filepath.Dir(selfDir)
+	selfDirDirDir := filepath.Dir(selfDirDir)
 	gaCandidates := []string{
 		// candidate 0:
 		// - self:  /Applications/Lima.app/Contents/MacOS/limactl
@@ -47,6 +48,11 @@ func Dir() (string, error) {
 		// - agent: /usr/local/share/lima/lima-guestagent.Linux-x86_64
 		// - dir:   /usr/local/share/lima
 		filepath.Join(selfDirDir, "share/lima/lima-guestagent."+ostype+"-"+arch),
+		// candidate 2: lauched by `~/go/bin/dlv dap`
+		// - self: ${workspaceFolder}/cmd/limactl/__debug_bin_XXXXXX
+		// - agent: ${workspaceFolder}/_output/share/lima/lima-guestagent.Linux-x86_64
+		// - dir:  ${workspaceFolder}/_output/share/lima
+		filepath.Join(selfDirDirDir, "_output/share/lima/lima-guestagent."+ostype+"-"+arch),
 		// TODO: support custom path
 	}
 	for _, gaCandidate := range gaCandidates {


### PR DESCRIPTION
### - `hack/toolexec-for-codesign.sh`: add a wrapper script for `-toolexec` to `codesign` an executable produced by linker

By passing `-toolexec hack/toolexec-for-codesign.sh` to the Go build options, the executable will be `codesign`ed with `vz.entitlements` after linking. This eliminates the need to prepare a pre-signed debug binary when running `dlv dap` (in VSCode, for example) for debugging.  
usage in `launch.json`:
```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Debug limactl hostagent for debug instance",
            "type": "go",
            "request": "launch",
            "mode": "debug",
            "program": "${workspaceFolder}/cmd/limactl",
            "buildFlags": [
                "-toolexec",
                "${workspaceFolder}/hack/toolexec-for-codesign.sh",
            ],
            "env": {
                "CGO_ENABLED": "1"
            },
            "cwd": "${userHome}/.lima/debug",
            "args": [
                "hostagent",
                "--pidfile",
                "ha.pid",
                "--socket",
                "ha.sock",
                "debug"
            ],
            "preLaunchTask": "prepare launching hostagent for debug instance",
            "postDebugTask": "clean up after stopping hostagent for debug instance"
        },
    ]
}
```

### - pkg/usrlocalsharelima: add a candidate directory to searching `lima-guestagent`

When debugging `cmd/limactl` with `dlv dap`, the executable appears as follows:
`cmd/limactl/__debug_bin2611107549`.
In this case, `limactl` fails to locate `lima-guestagent` relative to the expected executable path and results in the following error:
```json
{
  "level": "fatal",
  "msg": "failed to find \"lima-guestagent.Linux-aarch64\" binary for \"/Users/norio/ghq/github.com/lima-vm/lima/cmd/limactl/__debug_bin2611107549\", attempted [/Users/norio/ghq/github.com/lima-vm/lima/cmd/limactl/lima-guestagent.Linux-aarch64 /Users/norio/ghq/github.com/lima-vm/lima/cmd/share/lima/lima-guestagent.Linux-aarch64]",
  "time": "2024-09-24T15:02:23+09:00"
}
```
To avoid this error, it was necessary to create a symbolic link (`ln -sf ../_output/share cmd/share`) so that `lima-guestagent*` exists at the expected relative path.
This change adds `_output/share/lima/lima-guestagent.*` to the search directories, making the symbolic link creation unnecessary before running `dlv dap` for debugging.
