### PR TITLE
Get qemu bottle commit from git checkout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -379,6 +379,14 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Fetch homebrew-core commit messages
+      uses: actions/checkout@v4
+      with:
+        # needed by ./hack/brew-install-version.sh
+        repository: homebrew/homebrew-core
+        path: homebrew-core
+        fetch-depth: 0
+        filter: tree:0
     - uses: actions/setup-go@v5
       with:
         go-version: 1.23.x
@@ -387,9 +395,6 @@ jobs:
       with:
         template: https://raw.githubusercontent.com/lima-vm/lima/${{ matrix.oldver }}/examples/ubuntu-lts.yaml
     - name: Install test dependencies
-      env:
-        # brew-install-version.sh calls `gh`, which needs the token
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         brew install bash coreutils
         # QEMU 9.1.0 seems to break on GitHub runners, both on Monterey and Ventura

--- a/hack/brew-install-version.sh
+++ b/hack/brew-install-version.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# This script only works for formulas in the homebrew-core
+# This script only works for formulas in the homebrew-core.
+# It assumes the homebrew-core has been checked out into ./homebrew-core.
+# It only needs commit messages, so the checkout can be filtered with tree:0.
 
 set -eu -o pipefail
 
@@ -15,8 +17,8 @@ if ! brew tap | grep -q "^${TAP}\$"; then
 	brew tap-new "$TAP"
 fi
 
-# Get the commit id for the commit that updated this bottle
-SHA=$(gh search commits --repo homebrew/homebrew-core "${FORMULA}: update ${VERSION} bottle" --json sha --jq "last|.sha")
+# Get the latest commit id for the commit that updated this bottle
+SHA=$(git -C homebrew-core log --max-count 1 --grep "^${FORMULA}: update ${VERSION} bottle" --format="%H")
 if [[ -z $SHA ]]; then
 	echo "${FORMULA} ${VERSION} not found"
 	exit 1


### PR DESCRIPTION
Running `gh search` sometimes runs into secondary rate limits.

See also https://github.com/cli/cli/issues/3292