### PR TITLE
Suppress error if file is already deleted

### DIFF
--- a/pkg/instance/stop.go
+++ b/pkg/instance/stop.go
@@ -93,7 +93,9 @@ func StopForcibly(inst *store.Instance) {
 	}
 
 	suffixesToBeRemoved := []string{".pid", ".sock", ".tmp"}
-	logrus.Infof("Removing %s under %q", inst.Dir, strings.ReplaceAll(strings.Join(suffixesToBeRemoved, " "), ".", "*."))
+	globPatterns := strings.ReplaceAll(strings.Join(suffixesToBeRemoved, " "), ".", "*.")
+	logrus.Infof("Removing %s under %q", globPatterns, inst.Dir)
+
 	fi, err := os.ReadDir(inst.Dir)
 	if err != nil {
 		logrus.Error(err)

--- a/pkg/instance/stop.go
+++ b/pkg/instance/stop.go
@@ -107,7 +107,11 @@ func StopForcibly(inst *store.Instance) {
 			if strings.HasSuffix(path, suffix) {
 				logrus.Infof("Removing %q", path)
 				if err := os.Remove(path); err != nil {
-					logrus.Error(err)
+					if errors.Is(err, os.ErrNotExist) {
+						logrus.Debug(err.Error())
+					} else {
+						logrus.Error(err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
We have a race (time of check, time of use) when deleting a vm with
--force. We first list the file in the instance dir, and then delete
matching files. "ssh.sock" is consistently already deleted when we try
to remove it, creating unwanted noise in the log.
    
"ssh.sock" is probably removed by other code that may need need to
remove it. To make this easy to improve we still log the event in debug
level.

Also fix a log issue in this same function.
    
Fixes: #2635
