### PR TITLE
Make sure lima user fallback uses same validation as template

### DIFF
--- a/pkg/osutil/user_test.go
+++ b/pkg/osutil/user_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/containerd/containerd/identifiers"
 	"gotest.tools/v3/assert"
 )
 
@@ -14,7 +15,7 @@ func TestLimaUserWarn(t *testing.T) {
 }
 
 func validUsername(username string) bool {
-	return regexUsername.MatchString(username)
+	return identifiers.Validate(username) == nil
 }
 
 func TestLimaUsername(t *testing.T) {


### PR DESCRIPTION
The regex currently being used is different from the identifier's validation from containerd. The fallback test does allow a starting `_` but the validation for the identifier does not.

This results in a bug where the a user that starts with an `_` will pass fallback validation (ie not be set to lima for the user), but will then fail the cidata validation here: https://github.com/lima-vm/lima/blob/master/pkg/cidata/template.go#L95.

Error log shows as:
` ERRO[0000] [hostagent] identifier "_nixbld1" must match ^[A-Za-z0-9]+(?:[._-](?:[A-Za-z0-9]+))*$: invalid argument  fields.level=fatal`

This PR sets the same validation check in both spots to fix this and make sure they stay in sync in the future.