### PR TITLE
Make it possible to call instance.Start() from another program

### DIFF
--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -154,7 +154,7 @@ func editAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return instance.Start(ctx, inst, false)
+	return instance.Start(ctx, inst, "", false)
 }
 
 func askWhetherToStart() (bool, error) {

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -501,7 +501,7 @@ func startAction(cmd *cobra.Command, args []string) error {
 		ctx = instance.WithWatchHostAgentTimeout(ctx, timeout)
 	}
 
-	return instance.Start(ctx, inst, launchHostAgentForeground)
+	return instance.Start(ctx, inst, "", launchHostAgentForeground)
 }
 
 func createBashComplete(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/hostagent/events/watcher.go
+++ b/pkg/hostagent/events/watcher.go
@@ -22,7 +22,7 @@ func Watch(ctx context.Context, haStdoutPath, haStderrPath string, begin time.Ti
 	}
 	defer func() {
 		_ = haStdoutTail.Stop()
-		haStdoutTail.Cleanup()
+		// Do NOT call haStdoutTail.Cleanup(), it prevents the process from ever tailing the file again
 	}()
 
 	haStderrTail, err := tail.TailFile(haStderrPath,
@@ -35,7 +35,7 @@ func Watch(ctx context.Context, haStdoutPath, haStderrPath string, begin time.Ti
 	}
 	defer func() {
 		_ = haStderrTail.Stop()
-		haStderrTail.Cleanup()
+		// Do NOT call haStderrTail.Cleanup(), it prevents the process from ever tailing the file again
 	}()
 
 loop:

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -115,7 +115,18 @@ func Prepare(ctx context.Context, inst *store.Instance) (*Prepared, error) {
 	}, nil
 }
 
-// Start starts the instance.
+// Start starts the hostagent in the background, which in turn will start the instance.
+// Start will listen to hostagent events and log them to STDOUT until either the instance
+// is running, or has failed to start.
+//
+// The `limactl` argument allows the caller to specify the full path of the `limactl` executable.
+// When called from inside limactl itself it will always be the empty string which uses the name
+// of the current executable instead.
+//
+// The `launchHostAgentForeground` argument makes the hostagent run in the foreground.
+// The function will continue to listen and log hostagent events until the instance is
+// shut down again.
+//
 // Start calls Prepare by itself, so you do not need to call Prepare manually before calling Start.
 func Start(ctx context.Context, inst *store.Instance, limactl string, launchHostAgentForeground bool) error {
 	haPIDPath := filepath.Join(inst.Dir, filenames.HostAgentPID)


### PR DESCRIPTION
`instance.Start` runs the host-agent as a subprocess using `limactl`. This code currently only works when it is invoked by `limactl` itself. Adding a parameter to allow a caller to pass in the path to the `limactl` binary to use.

The `tail.Cleanup` function prevents the process from tailing the same file again (at least on macOS), which breaks `instance.Stop` because it can no longer receive the `exited` event by tailing `ha.stdout.log`.

A hint has been added to the module docs (without further context or explanation) in https://github.com/nxadm/tail/commit/2efc79c:

> If you plan to re-read a file, don't call Cleanup in between.

Eventually I would like to be able to (optionally) also run the host-agent in-process and not rely on tailing a log file for IPC, but that is a bigger change for another time.

<hr>

PS: I think in this case the 2 commits shouldn't be squashed, as they have a common purpose, but address separate issues. It just feels like overkill to create a separate PR just to remove the 2 `Cleanup` calls.