### PR TITLE
Add minimumLimaVersion and vmOpts.qemu.minimumVersion fields to lima.yaml

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -5,11 +5,23 @@
 # Default values in this YAML file are specified by `null` instead of Lima's "builtin default" values,
 # so they can be overridden by the $LIMA_HOME/_config/default.yaml mechanism documented at the end of this file.
 
+# A template should specify the minimum Lima version required to parse this template correctly.
+# It should not be set if the minimum version is less than 1.0.0
+# 🟢 Builtin default: not set
+minimumLimaVersion: null
+
 # VM type: "qemu", "vz" (on macOS 13 and later), or "default".
 # The vmType can be specified only on creating the instance.
 # The vmType of existing instances cannot be changed.
 # 🟢 Builtin default: "vz" (on macOS 13.5 and later), "qemu" (on others)
 vmType: null
+
+vmOpts:
+  qemu:
+    # Minimum version of QEMU required to create an instance of this template.
+    # Will be ignored if the vmType is not "qemu"
+    # 🟢 Builtin default: not set
+    minimumVersion: null
 
 # OS: "Linux".
 # 🟢 Builtin default: "Linux"

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -7,7 +7,9 @@ import (
 )
 
 type LimaYAML struct {
+	MinimumLimaVersion *string       `yaml:"minimumLimaVersion,omitempty" json:"minimumLimaVersion,omitempty"`
 	VMType             *VMType       `yaml:"vmType,omitempty" json:"vmType,omitempty"`
+	VMOpts             VMOpts        `yaml:"vmOpts,omitempty" json:"vmOpts,omitempty"`
 	OS                 *OS           `yaml:"os,omitempty" json:"os,omitempty"`
 	Arch               *Arch         `yaml:"arch,omitempty" json:"arch,omitempty"`
 	Images             []Image       `yaml:"images" json:"images"` // REQUIRED
@@ -71,6 +73,14 @@ const (
 	VZ   VMType = "vz"
 	WSL2 VMType = "wsl2"
 )
+
+type VMOpts struct {
+	QEMU QEMUOpts `yaml:"qemu,omitempty" json:"qemu,omitempty"`
+}
+
+type QEMUOpts struct {
+	MinimumVersion *string `yaml:"minimumVersion,omitempty" json:"minimumVersion,omitempty"`
+}
 
 type Rosetta struct {
 	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -496,6 +496,9 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 		if version.LessThan(*semver.New(MinimumQemuVersion)) {
 			logrus.Fatalf("QEMU %v is too old, %v or later required", version, MinimumQemuVersion)
 		}
+		if y.VMOpts.QEMU.MinimumVersion != nil && version.LessThan(*semver.New(*y.VMOpts.QEMU.MinimumVersion)) {
+			logrus.Fatalf("QEMU %v is too old, template requires %q or later", version, *y.VMOpts.QEMU.MinimumVersion)
+		}
 		if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" && version.Equal(*semver.New("8.2.0")) {
 			logrus.Fatal("QEMU 8.2.0 is no longer supported on ARM Mac due to <https://gitlab.com/qemu-project/qemu/-/issues/1990>. " +
 				"Please upgrade QEMU to v8.2.1 (or downgrade to v8.1.x).")


### PR DESCRIPTION
This will allow us to specify the requirements in the templates not just in a comment, but in a way that can be validated.