### PR TITLE
Refactor: network.YAML → network.Config

### DIFF
--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -364,14 +364,14 @@ func validateNetwork(y *LimaYAML) error {
 		field := fmt.Sprintf("networks[%d]", i)
 		switch {
 		case nw.Lima != "":
-			config, err := networks.Config()
+			nwCfg, err := networks.LoadConfig()
 			if err != nil {
 				return err
 			}
-			if config.Check(nw.Lima) != nil {
+			if nwCfg.Check(nw.Lima) != nil {
 				return fmt.Errorf("field `%s.lima` references network %q which is not defined in networks.yaml", field, nw.Lima)
 			}
-			usernet, err := config.Usernet(nw.Lima)
+			usernet, err := nwCfg.Usernet(nw.Lima)
 			if err != nil {
 				return err
 			}

--- a/pkg/networks/commands.go
+++ b/pkg/networks/commands.go
@@ -16,36 +16,36 @@ const (
 )
 
 // Commands in `sudoers` cannot use quotes, so all arguments are printed via "%s"
-// and not "%q". config.Paths.* entries must not include any whitespace!
+// and not "%q". cfg.Paths.* entries must not include any whitespace!
 
-func (config *YAML) Check(name string) error {
-	if _, ok := config.Networks[name]; ok {
+func (c *Config) Check(name string) error {
+	if _, ok := c.Networks[name]; ok {
 		return nil
 	}
 	return fmt.Errorf("network %q is not defined", name)
 }
 
 // Usernet returns true if the mode of given network is ModeUserV2.
-func (config *YAML) Usernet(name string) (bool, error) {
-	if nw, ok := config.Networks[name]; ok {
+func (c *Config) Usernet(name string) (bool, error) {
+	if nw, ok := c.Networks[name]; ok {
 		return nw.Mode == ModeUserV2, nil
 	}
 	return false, fmt.Errorf("network %q is not defined", name)
 }
 
 // DaemonPath returns the daemon path.
-func (config *YAML) DaemonPath(daemon string) (string, error) {
+func (c *Config) DaemonPath(daemon string) (string, error) {
 	switch daemon {
 	case SocketVMNet:
-		return config.Paths.SocketVMNet, nil
+		return c.Paths.SocketVMNet, nil
 	default:
 		return "", fmt.Errorf("unknown daemon type %q", daemon)
 	}
 }
 
 // IsDaemonInstalled checks whether the daemon is installed.
-func (config *YAML) IsDaemonInstalled(daemon string) (bool, error) {
-	p, err := config.DaemonPath(daemon)
+func (c *Config) IsDaemonInstalled(daemon string) (bool, error) {
+	p, err := c.DaemonPath(daemon)
 	if err != nil {
 		return false, err
 	}
@@ -62,22 +62,22 @@ func (config *YAML) IsDaemonInstalled(daemon string) (bool, error) {
 }
 
 // Sock returns a socket_vmnet socket.
-func (config *YAML) Sock(name string) string {
-	return filepath.Join(config.Paths.VarRun, fmt.Sprintf("socket_vmnet.%s", name))
+func (c *Config) Sock(name string) string {
+	return filepath.Join(c.Paths.VarRun, fmt.Sprintf("socket_vmnet.%s", name))
 }
 
-func (config *YAML) PIDFile(name, daemon string) string {
-	return filepath.Join(config.Paths.VarRun, fmt.Sprintf("%s_%s.pid", name, daemon))
+func (c *Config) PIDFile(name, daemon string) string {
+	return filepath.Join(c.Paths.VarRun, fmt.Sprintf("%s_%s.pid", name, daemon))
 }
 
-func (config *YAML) LogFile(name, daemon, stream string) string {
+func (c *Config) LogFile(name, daemon, stream string) string {
 	networksDir, _ := dirnames.LimaNetworksDir()
 	return filepath.Join(networksDir, fmt.Sprintf("%s_%s.%s.log", name, daemon, stream))
 }
 
-func (config *YAML) User(daemon string) (osutil.User, error) {
-	if ok, _ := config.IsDaemonInstalled(daemon); !ok {
-		daemonPath, _ := config.DaemonPath(daemon)
+func (c *Config) User(daemon string) (osutil.User, error) {
+	if ok, _ := c.IsDaemonInstalled(daemon); !ok {
+		daemonPath, _ := c.DaemonPath(daemon)
 		return osutil.User{}, fmt.Errorf("daemon %q (path=%q) is not available", daemon, daemonPath)
 	}
 	//nolint:gocritic // singleCaseSwitch: should rewrite switch statement to if statement
@@ -88,23 +88,23 @@ func (config *YAML) User(daemon string) (osutil.User, error) {
 	return osutil.User{}, fmt.Errorf("daemon %q not defined", daemon)
 }
 
-func (config *YAML) MkdirCmd() string {
-	return fmt.Sprintf("/bin/mkdir -m 775 -p %s", config.Paths.VarRun)
+func (c *Config) MkdirCmd() string {
+	return fmt.Sprintf("/bin/mkdir -m 775 -p %s", c.Paths.VarRun)
 }
 
-func (config *YAML) StartCmd(name, daemon string) string {
-	if ok, _ := config.IsDaemonInstalled(daemon); !ok {
+func (c *Config) StartCmd(name, daemon string) string {
+	if ok, _ := c.IsDaemonInstalled(daemon); !ok {
 		panic(fmt.Errorf("daemon %q is not available", daemon))
 	}
 	var cmd string
 	switch daemon {
 	case SocketVMNet:
-		nw := config.Networks[name]
-		if config.Paths.SocketVMNet == "" {
-			panic("config.Paths.SocketVMNet is empty")
+		nw := c.Networks[name]
+		if c.Paths.SocketVMNet == "" {
+			panic("c.Paths.SocketVMNet is empty")
 		}
 		cmd = fmt.Sprintf("%s --pidfile=%s --socket-group=%s --vmnet-mode=%s",
-			config.Paths.SocketVMNet, config.PIDFile(name, SocketVMNet), config.Group, nw.Mode)
+			c.Paths.SocketVMNet, c.PIDFile(name, SocketVMNet), c.Group, nw.Mode)
 		switch nw.Mode {
 		case ModeBridged:
 			cmd += fmt.Sprintf(" --vmnet-interface=%s", nw.Interface)
@@ -112,13 +112,13 @@ func (config *YAML) StartCmd(name, daemon string) string {
 			cmd += fmt.Sprintf(" --vmnet-gateway=%s --vmnet-dhcp-end=%s --vmnet-mask=%s",
 				nw.Gateway, nw.DHCPEnd, nw.NetMask)
 		}
-		cmd += " " + config.Sock(name)
+		cmd += " " + c.Sock(name)
 	default:
 		panic(fmt.Errorf("unexpected daemon %q", daemon))
 	}
 	return cmd
 }
 
-func (config *YAML) StopCmd(name, daemon string) string {
-	return fmt.Sprintf("/usr/bin/pkill -F %s", config.PIDFile(name, daemon))
+func (c *Config) StopCmd(name, daemon string) string {
+	return fmt.Sprintf("/usr/bin/pkill -F %s", c.PIDFile(name, daemon))
 }

--- a/pkg/networks/config_test.go
+++ b/pkg/networks/config_test.go
@@ -8,11 +8,10 @@ import (
 )
 
 func TestFillDefault(t *testing.T) {
-	nwYaml := YAML{}
-	newYaml, err := fillDefaults(nwYaml)
+	cfg, err := fillDefaults(Config{})
 	assert.NilError(t, err)
 
-	userNet := newYaml.Networks[ModeUserV2]
+	userNet := cfg.Networks[ModeUserV2]
 	assert.Equal(t, userNet.Mode, ModeUserV2)
 	assert.Equal(t, userNet.Interface, "")
 	assert.DeepEqual(t, userNet.NetMask, net.ParseIP("255.255.255.0"))
@@ -21,13 +20,13 @@ func TestFillDefault(t *testing.T) {
 }
 
 func TestFillDefaultWithV2(t *testing.T) {
-	nwYaml := YAML{Networks: map[string]Network{
+	cfg := Config{Networks: map[string]Network{
 		"user-v2": {Mode: ModeUserV2},
 	}}
-	newYaml, err := fillDefaults(nwYaml)
+	cfg, err := fillDefaults(cfg)
 	assert.NilError(t, err)
 
-	userNet := newYaml.Networks[ModeUserV2]
+	userNet := cfg.Networks[ModeUserV2]
 	assert.Equal(t, userNet.Mode, ModeUserV2)
 	assert.Equal(t, userNet.Interface, "")
 	assert.DeepEqual(t, userNet.NetMask, net.ParseIP("255.255.255.0"))
@@ -36,13 +35,13 @@ func TestFillDefaultWithV2(t *testing.T) {
 }
 
 func TestFillDefaultWithV2AndGateway(t *testing.T) {
-	nwYaml := YAML{Networks: map[string]Network{
+	cfg := Config{Networks: map[string]Network{
 		"user-v2": {Mode: ModeUserV2, Gateway: net.ParseIP("192.168.105.1")},
 	}}
-	newYaml, err := fillDefaults(nwYaml)
+	cfg, err := fillDefaults(cfg)
 	assert.NilError(t, err)
 
-	userNet := newYaml.Networks[ModeUserV2]
+	userNet := cfg.Networks[ModeUserV2]
 	assert.Equal(t, userNet.Mode, ModeUserV2)
 	assert.Equal(t, userNet.Interface, "")
 	assert.DeepEqual(t, userNet.NetMask, net.IP{})

--- a/pkg/networks/networks.go
+++ b/pkg/networks/networks.go
@@ -2,7 +2,7 @@ package networks
 
 import "net"
 
-type YAML struct {
+type Config struct {
 	Paths    Paths              `yaml:"paths"`
 	Group    string             `yaml:"group,omitempty"` // default: "everyone"
 	Networks map[string]Network `yaml:"networks"`

--- a/pkg/networks/sudoers.go
+++ b/pkg/networks/sudoers.go
@@ -12,17 +12,17 @@ import (
 )
 
 func Sudoers() (string, error) {
-	config, err := Config()
+	cfg, err := LoadConfig()
 	if err != nil {
 		return "", err
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%%%s ALL=(root:wheel) NOPASSWD:NOSETENV: %s\n", config.Group, config.MkdirCmd()))
+	sb.WriteString(fmt.Sprintf("%%%s ALL=(root:wheel) NOPASSWD:NOSETENV: %s\n", cfg.Group, cfg.MkdirCmd()))
 
 	// names must be in stable order to be able to check if sudoers file needs updating
-	names := make([]string, 0, len(config.Networks))
-	for name, nw := range config.Networks {
+	names := make([]string, 0, len(cfg.Networks))
+	for name, nw := range cfg.Networks {
 		if nw.Mode == ModeUserV2 {
 			continue // no sudo needed
 		}
@@ -34,26 +34,26 @@ func Sudoers() (string, error) {
 		sb.WriteRune('\n')
 		sb.WriteString(fmt.Sprintf("# Manage %q network daemons\n", name))
 		for _, daemon := range []string{SocketVMNet} {
-			if ok, err := config.IsDaemonInstalled(daemon); err != nil {
+			if ok, err := cfg.IsDaemonInstalled(daemon); err != nil {
 				return "", err
 			} else if !ok {
 				continue
 			}
-			user, err := config.User(daemon)
+			user, err := cfg.User(daemon)
 			if err != nil {
 				return "", err
 			}
 			sb.WriteRune('\n')
 			sb.WriteString(fmt.Sprintf("%%%s ALL=(%s:%s) NOPASSWD:NOSETENV: \\\n",
-				config.Group, user.User, user.Group))
-			sb.WriteString(fmt.Sprintf("    %s, \\\n", config.StartCmd(name, daemon)))
-			sb.WriteString(fmt.Sprintf("    %s\n", config.StopCmd(name, daemon)))
+				cfg.Group, user.User, user.Group))
+			sb.WriteString(fmt.Sprintf("    %s, \\\n", cfg.StartCmd(name, daemon)))
+			sb.WriteString(fmt.Sprintf("    %s\n", cfg.StopCmd(name, daemon)))
 		}
 	}
 	return sb.String(), nil
 }
 
-func (config *YAML) passwordLessSudo() error {
+func (c *Config) passwordLessSudo() error {
 	// Flush cached sudo password
 	cmd := exec.Command("sudo", "-k")
 	if err := cmd.Run(); err != nil {
@@ -62,12 +62,12 @@ func (config *YAML) passwordLessSudo() error {
 	// Verify that user/groups for both daemons work without a password, e.g.
 	// %admin ALL = (ALL:ALL) NOPASSWD: ALL
 	for _, daemon := range []string{SocketVMNet} {
-		if ok, err := config.IsDaemonInstalled(daemon); err != nil {
+		if ok, err := c.IsDaemonInstalled(daemon); err != nil {
 			return err
 		} else if !ok {
 			continue
 		}
-		user, err := config.User(daemon)
+		user, err := c.User(daemon)
 		if err != nil {
 			return err
 		}
@@ -79,9 +79,9 @@ func (config *YAML) passwordLessSudo() error {
 	return nil
 }
 
-func (config *YAML) VerifySudoAccess(sudoersFile string) error {
+func (c *Config) VerifySudoAccess(sudoersFile string) error {
 	if sudoersFile == "" {
-		err := config.passwordLessSudo()
+		err := c.passwordLessSudo()
 		if err == nil {
 			logrus.Debug("sudo doesn't seem to require a password")
 			return nil
@@ -95,7 +95,7 @@ func (config *YAML) VerifySudoAccess(sudoersFile string) error {
 		// Default networks.yaml specifies /etc/sudoers.d/lima file. Don't throw an error when the
 		// file doesn't exist, as long as password-less sudo still works.
 		if errors.Is(err, os.ErrNotExist) {
-			err = config.passwordLessSudo()
+			err = c.passwordLessSudo()
 			if err == nil {
 				logrus.Debugf("%q does not exist, but sudo doesn't seem to require a password", sudoersFile)
 				return nil

--- a/pkg/networks/usernet/config.go
+++ b/pkg/networks/usernet/config.go
@@ -52,15 +52,15 @@ func PIDFile(name string) (string, error) {
 
 // SubnetCIDR returns a subnet in form of net.IPNet for the given network name.
 func SubnetCIDR(name string) (*net.IPNet, error) {
-	config, err := networks.Config()
+	cfg, err := networks.LoadConfig()
 	if err != nil {
 		return nil, err
 	}
-	err = config.Check(name)
+	err = cfg.Check(name)
 	if err != nil {
 		return nil, err
 	}
-	_, ipNet, err := netmaskToCidr(config.Networks[name].Gateway, config.Networks[name].NetMask)
+	_, ipNet, err := netmaskToCidr(cfg.Networks[name].Gateway, cfg.Networks[name].NetMask)
 	if err != nil {
 		return nil, err
 	}
@@ -69,15 +69,15 @@ func SubnetCIDR(name string) (*net.IPNet, error) {
 
 // Subnet returns a subnet net.IP for the given network name.
 func Subnet(name string) (net.IP, error) {
-	config, err := networks.Config()
+	cfg, err := networks.LoadConfig()
 	if err != nil {
 		return nil, err
 	}
-	err = config.Check(name)
+	err = cfg.Check(name)
 	if err != nil {
 		return nil, err
 	}
-	_, ipNet, err := netmaskToCidr(config.Networks[name].Gateway, config.Networks[name].NetMask)
+	_, ipNet, err := netmaskToCidr(cfg.Networks[name].Gateway, cfg.Networks[name].NetMask)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/networks/validate.go
+++ b/pkg/networks/validate.go
@@ -15,9 +15,9 @@ import (
 	"github.com/lima-vm/lima/pkg/osutil"
 )
 
-func (config *YAML) Validate() error {
+func (c *Config) Validate() error {
 	// validate all paths.* values
-	paths := reflect.ValueOf(&config.Paths).Elem()
+	paths := reflect.ValueOf(&c.Paths).Elem()
 	pathsMap := make(map[string]string, paths.NumField())
 	var socketVMNetNotFound bool
 	for i := 0; i < paths.NumField(); i++ {

--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -324,7 +324,7 @@ func attachNetwork(driver *driver.BaseDriver, vmConfig *vz.VirtualMachineConfigu
 			}
 			configurations = append(configurations, networkConfig)
 		} else if nw.Lima != "" {
-			nwCfg, err := networks.Config()
+			nwCfg, err := networks.LoadConfig()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Because YAML is just the serialization format, and not what the data is used for.