### PR TITLE
Refactor pkg/cidata: avoid y, simplify private func

### DIFF
--- a/pkg/cidata/cidata_test.go
+++ b/pkg/cidata/cidata_test.go
@@ -7,9 +7,7 @@ import (
 	"testing"
 
 	"github.com/lima-vm/lima/pkg/networks"
-	"github.com/lima-vm/lima/pkg/ptr"
 
-	"github.com/lima-vm/lima/pkg/limayaml"
 	"gotest.tools/v3/assert"
 )
 
@@ -45,8 +43,7 @@ func TestSetupEnv(t *testing.T) {
 		t.Run(httpProxy.Host, func(t *testing.T) {
 			envKey := "http_proxy"
 			envValue := httpProxy.String()
-			templateArgs := TemplateArgs{SlirpGateway: networks.SlirpGateway}
-			envs, err := setupEnv(&limayaml.LimaYAML{PropagateProxyEnv: ptr.Of(false), Env: map[string]string{envKey: envValue}}, templateArgs)
+			envs, err := setupEnv(map[string]string{envKey: envValue}, false, networks.SlirpGateway)
 			assert.NilError(t, err)
 			assert.Equal(t, envs[envKey], strings.ReplaceAll(envValue, httpProxy.Hostname(), networks.SlirpGateway))
 		})
@@ -56,8 +53,7 @@ func TestSetupEnv(t *testing.T) {
 func TestSetupInvalidEnv(t *testing.T) {
 	envKey := "http_proxy"
 	envValue := "://localhost:8080"
-	templateArgs := TemplateArgs{SlirpGateway: networks.SlirpGateway}
-	envs, err := setupEnv(&limayaml.LimaYAML{PropagateProxyEnv: ptr.Of(false), Env: map[string]string{envKey: envValue}}, templateArgs)
+	envs, err := setupEnv(map[string]string{envKey: envValue}, false, networks.SlirpGateway)
 	assert.NilError(t, err)
 	assert.Equal(t, envs[envKey], envValue)
 }

--- a/pkg/cidata/fuzz_test.go
+++ b/pkg/cidata/fuzz_test.go
@@ -3,9 +3,7 @@ package cidata
 import (
 	"testing"
 
-	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/networks"
-	"github.com/lima-vm/lima/pkg/ptr"
 )
 
 func FuzzSetupEnv(f *testing.F) {
@@ -14,10 +12,6 @@ func FuzzSetupEnv(f *testing.F) {
 		if localhost {
 			prefix = "http://localhost:8080/"
 		}
-		templateArgs := TemplateArgs{SlirpGateway: networks.SlirpGateway}
-		_, _ = setupEnv(&limayaml.LimaYAML{
-			PropagateProxyEnv: ptr.Of(false),
-			Env:               map[string]string{"http_proxy": prefix + suffix},
-		}, templateArgs)
+		_, _ = setupEnv(map[string]string{"http_proxy": prefix + suffix}, false, networks.SlirpGateway)
 	})
 }


### PR DESCRIPTION
The PR refactors code in the `pkg/cidata`:

- rename `y` to `instConfig`;
- pass only necessary params to the `setupEnv` function.