### PR TITLE
Rename instConfig → instCfg and inst.Config → inst.Cfg

### DIFF
--- a/cmd/limactl/prune.go
+++ b/cmd/limactl/prune.go
@@ -70,7 +70,7 @@ func knownLocations() (map[string]limayaml.File, error) {
 		if err != nil {
 			return nil, err
 		}
-		for k, v := range locationsFromLimaYAML(instance.Config) {
+		for k, v := range locationsFromLimaYAML(instance.Cfg) {
 			locations[k] = v
 		}
 	}

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -91,7 +91,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	if workDir != "" {
 		changeDirCmd = fmt.Sprintf("cd %s || exit 1", shellescape.Quote(workDir))
 		// FIXME: check whether y.Mounts contains the home, not just len > 0
-	} else if len(inst.Config.Mounts) > 0 {
+	} else if len(inst.Cfg.Mounts) > 0 {
 		hostCurrentDir, err := os.Getwd()
 		if err == nil {
 			changeDirCmd = fmt.Sprintf("cd %s", shellescape.Quote(hostCurrentDir))
@@ -167,10 +167,10 @@ func shellAction(cmd *cobra.Command, args []string) error {
 
 	sshOpts, err := sshutil.SSHOpts(
 		inst.Dir,
-		*inst.Config.SSH.LoadDotSSHPubKeys,
-		*inst.Config.SSH.ForwardAgent,
-		*inst.Config.SSH.ForwardX11,
-		*inst.Config.SSH.ForwardX11Trusted)
+		*inst.Cfg.SSH.LoadDotSSHPubKeys,
+		*inst.Cfg.SSH.ForwardAgent,
+		*inst.Cfg.SSH.ForwardX11,
+		*inst.Cfg.SSH.ForwardX11Trusted)
 	if err != nil {
 		return err
 	}

--- a/cmd/limactl/show-ssh.go
+++ b/cmd/limactl/show-ssh.go
@@ -90,10 +90,10 @@ func showSSHAction(cmd *cobra.Command, args []string) error {
 		filepath.Join(inst.Dir, filenames.SSHConfig), inst.Name)
 	opts, err := sshutil.SSHOpts(
 		inst.Dir,
-		*inst.Config.SSH.LoadDotSSHPubKeys,
-		*inst.Config.SSH.ForwardAgent,
-		*inst.Config.SSH.ForwardX11,
-		*inst.Config.SSH.ForwardX11Trusted)
+		*inst.Cfg.SSH.LoadDotSSHPubKeys,
+		*inst.Cfg.SSH.ForwardAgent,
+		*inst.Cfg.SSH.ForwardX11,
+		*inst.Cfg.SSH.ForwardX11Trusted)
 	if err != nil {
 		return err
 	}

--- a/pkg/driverutil/instance.go
+++ b/pkg/driverutil/instance.go
@@ -9,7 +9,7 @@ import (
 )
 
 func CreateTargetDriverInstance(base *driver.BaseDriver) driver.Driver {
-	limaDriver := base.Instance.Config.VMType
+	limaDriver := base.Instance.Cfg.VMType
 	if *limaDriver == limayaml.VZ {
 		return vz.New(base)
 	}

--- a/pkg/hostagent/inotify.go
+++ b/pkg/hostagent/inotify.go
@@ -67,7 +67,7 @@ func (a *HostAgent) startInotify(ctx context.Context) error {
 }
 
 func (a *HostAgent) setupWatchers(events chan notify.EventInfo) error {
-	for _, m := range a.instConfig.Mounts {
+	for _, m := range a.instCfg.Mounts {
 		if !*m.Writable {
 			continue
 		}

--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -20,7 +20,7 @@ func (a *HostAgent) setupMounts() ([]*mount, error) {
 		res  []*mount
 		errs []error
 	)
-	for _, f := range a.instConfig.Mounts {
+	for _, f := range a.instCfg.Mounts {
 		m, err := a.setupMount(f)
 		if err != nil {
 			errs = append(errs, err)

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -114,7 +114,7 @@ Make sure that the YAML field "ssh.localPort" is not used by other processes on 
 If any private key under ~/.ssh is protected with a passphrase, you need to have ssh-agent to be running.
 `,
 		})
-	if *a.instConfig.Plain {
+	if *a.instCfg.Plain {
 		return req
 	}
 	req = append(req,
@@ -134,7 +134,7 @@ it must not be created until the session reset is done.
 `,
 		})
 
-	if *a.instConfig.MountType == limayaml.REVSSHFS && len(a.instConfig.Mounts) > 0 {
+	if *a.instCfg.MountType == limayaml.REVSSHFS && len(a.instCfg.Mounts) > 0 {
 		req = append(req, requirement{
 			description: "sshfs binary to be installed",
 			script: `#!/bin/bash
@@ -167,7 +167,7 @@ fi
 
 func (a *HostAgent) optionalRequirements() []requirement {
 	req := make([]requirement, 0)
-	if (*a.instConfig.Containerd.System || *a.instConfig.Containerd.User) && !*a.instConfig.Plain {
+	if (*a.instCfg.Containerd.System || *a.instCfg.Containerd.User) && !*a.instCfg.Plain {
 		req = append(req,
 			requirement{
 				description: "systemd must be available",
@@ -189,7 +189,7 @@ are set to 'false' in the config file.
 				description: "containerd binaries to be installed",
 				script: `#!/bin/bash
 set -eux -o pipefail
-if ! timeout 30s bash -c "until command -v nerdctl || test -x ` + *a.instConfig.GuestInstallPrefix + `/bin/nerdctl; do sleep 3; done"; then
+if ! timeout 30s bash -c "until command -v nerdctl || test -x ` + *a.instCfg.GuestInstallPrefix + `/bin/nerdctl; do sleep 3; done"; then
 	echo >&2 "nerdctl is not installed yet"
 	exit 1
 fi
@@ -200,7 +200,7 @@ Also see "/var/log/cloud-init-output.log" in the guest.
 `,
 			})
 	}
-	for _, probe := range a.instConfig.Probes {
+	for _, probe := range a.instCfg.Probes {
 		if probe.Mode == limayaml.ProbeModeReadiness {
 			req = append(req, requirement{
 				description: probe.Description,

--- a/pkg/instance/ansible.go
+++ b/pkg/instance/ansible.go
@@ -14,7 +14,7 @@ import (
 )
 
 func runAnsibleProvision(ctx context.Context, inst *store.Instance) error {
-	for _, f := range inst.Config.Provision {
+	for _, f := range inst.Cfg.Provision {
 		if f.Mode == limayaml.ProvisionModeAnsible {
 			logrus.Infof("Waiting for ansible playbook %q", f.Playbook)
 			if err := runAnsiblePlaybook(ctx, inst, f.Playbook); err != nil {

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -98,7 +98,7 @@ func Prepare(ctx context.Context, inst *store.Instance) (*Prepared, error) {
 	if err := limaDriver.CreateDisk(ctx); err != nil {
 		return nil, err
 	}
-	nerdctlArchiveCache, err := ensureNerdctlArchiveCache(ctx, inst.Config, created)
+	nerdctlArchiveCache, err := ensureNerdctlArchiveCache(ctx, inst.Cfg, created)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func watchHostAgentEvents(ctx context.Context, inst *store.Instance, haStdoutPat
 				err = xerr
 				return true
 			}
-			if *inst.Config.Plain {
+			if *inst.Cfg.Plain {
 				logrus.Infof("READY. Run `ssh -F %q lima-%s` to open the shell.", inst.SSHConfigFile, inst.Name)
 			} else {
 				logrus.Infof("READY. Run `%s` to open the shell.", LimactlShellCmd(inst.Name))

--- a/pkg/networks/usernet/client.go
+++ b/pkg/networks/usernet/client.go
@@ -38,7 +38,7 @@ func (c *Client) ConfigureDriver(ctx context.Context, driver *driver.BaseDriver)
 	if err != nil {
 		return err
 	}
-	hosts := driver.Instance.Config.HostResolver.Hosts
+	hosts := driver.Instance.Cfg.HostResolver.Hosts
 	hosts[fmt.Sprintf("lima-%s.internal", driver.Instance.Name)] = ipAddress
 	err = c.AddDNSHosts(hosts)
 	return err

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -55,7 +55,7 @@ type Instance struct {
 	HostAgentPID    int                `json:"hostAgentPID,omitempty"`
 	DriverPID       int                `json:"driverPID,omitempty"`
 	Errors          []error            `json:"errors,omitempty"`
-	Config          *limayaml.LimaYAML `json:"config,omitempty"`
+	Cfg             *limayaml.LimaYAML `json:"config,omitempty"`
 	SSHAddress      string             `json:"sshAddress,omitempty"`
 	Protected       bool               `json:"protected"`
 	LimaVersion     string             `json:"limaVersion"`
@@ -85,7 +85,7 @@ func Inspect(instName string) (*Instance, error) {
 		inst.Errors = append(inst.Errors, err)
 		return inst, nil
 	}
-	inst.Config = y
+	inst.Cfg = y
 	inst.Arch = *y.Arch
 	inst.VMType = *y.VMType
 	inst.CPUType = y.CPUType[*y.Arch]

--- a/pkg/vz/disk.go
+++ b/pkg/vz/disk.go
@@ -28,15 +28,15 @@ func EnsureDisk(ctx context.Context, driver *driver.BaseDriver) error {
 	initrd := filepath.Join(driver.Instance.Dir, filenames.Initrd)
 	if _, err := os.Stat(baseDisk); errors.Is(err, os.ErrNotExist) {
 		var ensuredBaseDisk bool
-		errs := make([]error, len(driver.Instance.Config.Images))
-		for i, f := range driver.Instance.Config.Images {
-			if _, err := fileutils.DownloadFile(ctx, baseDisk, f.File, true, "the image", *driver.Instance.Config.Arch); err != nil {
+		errs := make([]error, len(driver.Instance.Cfg.Images))
+		for i, f := range driver.Instance.Cfg.Images {
+			if _, err := fileutils.DownloadFile(ctx, baseDisk, f.File, true, "the image", *driver.Instance.Cfg.Arch); err != nil {
 				errs[i] = err
 				continue
 			}
 			if f.Kernel != nil {
 				// ensure decompress kernel because vz expects it to be decompressed
-				if _, err := fileutils.DownloadFile(ctx, kernel, f.Kernel.File, true, "the kernel", *driver.Instance.Config.Arch); err != nil {
+				if _, err := fileutils.DownloadFile(ctx, kernel, f.Kernel.File, true, "the kernel", *driver.Instance.Cfg.Arch); err != nil {
 					errs[i] = err
 					continue
 				}
@@ -48,7 +48,7 @@ func EnsureDisk(ctx context.Context, driver *driver.BaseDriver) error {
 				}
 			}
 			if f.Initrd != nil {
-				if _, err := fileutils.DownloadFile(ctx, initrd, *f.Initrd, false, "the initrd", *driver.Instance.Config.Arch); err != nil {
+				if _, err := fileutils.DownloadFile(ctx, initrd, *f.Initrd, false, "the initrd", *driver.Instance.Cfg.Arch); err != nil {
 					errs[i] = err
 					continue
 				}
@@ -60,7 +60,7 @@ func EnsureDisk(ctx context.Context, driver *driver.BaseDriver) error {
 			return fileutils.Errors(errs)
 		}
 	}
-	diskSize, _ := units.RAMInBytes(*driver.Instance.Config.Disk)
+	diskSize, _ := units.RAMInBytes(*driver.Instance.Cfg.Disk)
 	if diskSize == 0 {
 		return nil
 	}

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -76,70 +76,70 @@ func (l *LimaVzDriver) Validate() error {
 	if errors.Is(err, vz.ErrUnsupportedOSVersion) {
 		return fmt.Errorf("VZ driver requires macOS 13 or higher to run")
 	}
-	if *l.Instance.Config.MountType == limayaml.NINEP {
-		return fmt.Errorf("field `mountType` must be %q or %q for VZ driver , got %q", limayaml.REVSSHFS, limayaml.VIRTIOFS, *l.Instance.Config.MountType)
+	if *l.Instance.Cfg.MountType == limayaml.NINEP {
+		return fmt.Errorf("field `mountType` must be %q or %q for VZ driver , got %q", limayaml.REVSSHFS, limayaml.VIRTIOFS, *l.Instance.Cfg.MountType)
 	}
-	if *l.Instance.Config.Firmware.LegacyBIOS {
-		logrus.Warnf("vmType %s: ignoring `firmware.legacyBIOS`", *l.Instance.Config.VMType)
+	if *l.Instance.Cfg.Firmware.LegacyBIOS {
+		logrus.Warnf("vmType %s: ignoring `firmware.legacyBIOS`", *l.Instance.Cfg.VMType)
 	}
-	for _, f := range l.Instance.Config.Firmware.Images {
+	for _, f := range l.Instance.Cfg.Firmware.Images {
 		switch f.VMType {
 		case "", limayaml.VZ:
-			if f.Arch == *l.Instance.Config.Arch {
+			if f.Arch == *l.Instance.Cfg.Arch {
 				return fmt.Errorf("`firmware.images` configuration is not supported for VZ driver")
 			}
 		}
 	}
-	if unknown := reflectutil.UnknownNonEmptyFields(l.Instance.Config, knownYamlProperties...); len(unknown) > 0 {
-		logrus.Warnf("vmType %s: ignoring %+v", *l.Instance.Config.VMType, unknown)
+	if unknown := reflectutil.UnknownNonEmptyFields(l.Instance.Cfg, knownYamlProperties...); len(unknown) > 0 {
+		logrus.Warnf("vmType %s: ignoring %+v", *l.Instance.Cfg.VMType, unknown)
 	}
 
-	if !limayaml.IsNativeArch(*l.Instance.Config.Arch) {
-		return fmt.Errorf("unsupported arch: %q", *l.Instance.Config.Arch)
+	if !limayaml.IsNativeArch(*l.Instance.Cfg.Arch) {
+		return fmt.Errorf("unsupported arch: %q", *l.Instance.Cfg.Arch)
 	}
 
-	for k, v := range l.Instance.Config.CPUType {
+	for k, v := range l.Instance.Cfg.CPUType {
 		if v != "" {
-			logrus.Warnf("vmType %s: ignoring cpuType[%q]: %q", *l.Instance.Config.VMType, k, v)
+			logrus.Warnf("vmType %s: ignoring cpuType[%q]: %q", *l.Instance.Cfg.VMType, k, v)
 		}
 	}
 
-	for i, image := range l.Instance.Config.Images {
+	for i, image := range l.Instance.Cfg.Images {
 		if unknown := reflectutil.UnknownNonEmptyFields(image, "File"); len(unknown) > 0 {
-			logrus.Warnf("vmType %s: ignoring images[%d]: %+v", *l.Instance.Config.VMType, i, unknown)
+			logrus.Warnf("vmType %s: ignoring images[%d]: %+v", *l.Instance.Cfg.VMType, i, unknown)
 		}
 	}
 
-	for i, mount := range l.Instance.Config.Mounts {
+	for i, mount := range l.Instance.Cfg.Mounts {
 		if unknown := reflectutil.UnknownNonEmptyFields(mount, "Location",
 			"MountPoint",
 			"Writable",
 			"SSHFS",
 			"NineP",
 		); len(unknown) > 0 {
-			logrus.Warnf("vmType %s: ignoring mounts[%d]: %+v", *l.Instance.Config.VMType, i, unknown)
+			logrus.Warnf("vmType %s: ignoring mounts[%d]: %+v", *l.Instance.Cfg.VMType, i, unknown)
 		}
 	}
 
-	for i, network := range l.Instance.Config.Networks {
+	for i, network := range l.Instance.Cfg.Networks {
 		if unknown := reflectutil.UnknownNonEmptyFields(network, "VZNAT",
 			"Lima",
 			"Socket",
 			"MACAddress",
 			"Interface",
 		); len(unknown) > 0 {
-			logrus.Warnf("vmType %s: ignoring networks[%d]: %+v", *l.Instance.Config.VMType, i, unknown)
+			logrus.Warnf("vmType %s: ignoring networks[%d]: %+v", *l.Instance.Cfg.VMType, i, unknown)
 		}
 	}
 
-	switch audioDevice := *l.Instance.Config.Audio.Device; audioDevice {
+	switch audioDevice := *l.Instance.Cfg.Audio.Device; audioDevice {
 	case "":
 	case "vz", "default", "none":
 	default:
 		logrus.Warnf("field `audio.device` must be \"vz\", \"default\", or \"none\" for VZ driver, got %q", audioDevice)
 	}
 
-	switch videoDisplay := *l.Instance.Config.Video.Display; videoDisplay {
+	switch videoDisplay := *l.Instance.Cfg.Video.Display; videoDisplay {
 	case "vz", "default", "none":
 	default:
 		logrus.Warnf("field `video.display` must be \"vz\", \"default\", or \"none\" for VZ driver , got %q", videoDisplay)
@@ -171,7 +171,7 @@ func (l *LimaVzDriver) Start(ctx context.Context) (chan error, error) {
 }
 
 func (l *LimaVzDriver) CanRunGUI() bool {
-	switch *l.Instance.Config.Video.Display {
+	switch *l.Instance.Cfg.Video.Display {
 	case "vz", "default":
 		return true
 	default:
@@ -184,7 +184,7 @@ func (l *LimaVzDriver) RunGUI() error {
 		return l.machine.StartGraphicApplication(1920, 1200)
 	}
 	//nolint:revive // error-strings
-	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "vz", *l.Instance.Config.Video.Display)
+	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "vz", *l.Instance.Cfg.Video.Display)
 }
 
 func (l *LimaVzDriver) Stop(_ context.Context) error {

--- a/pkg/wsl2/fs.go
+++ b/pkg/wsl2/fs.go
@@ -17,9 +17,9 @@ func EnsureFs(ctx context.Context, driver *driver.BaseDriver) error {
 	baseDisk := filepath.Join(driver.Instance.Dir, filenames.BaseDisk)
 	if _, err := os.Stat(baseDisk); errors.Is(err, os.ErrNotExist) {
 		var ensuredBaseDisk bool
-		errs := make([]error, len(driver.Instance.Config.Images))
-		for i, f := range driver.Instance.Config.Images {
-			if _, err := fileutils.DownloadFile(ctx, baseDisk, f.File, true, "the image", *driver.Instance.Config.Arch); err != nil {
+		errs := make([]error, len(driver.Instance.Cfg.Images))
+		for i, f := range driver.Instance.Cfg.Images {
+			if _, err := fileutils.DownloadFile(ctx, baseDisk, f.File, true, "the image", *driver.Instance.Cfg.Arch); err != nil {
 				errs[i] = err
 				continue
 			}

--- a/pkg/wsl2/wsl_driver_windows.go
+++ b/pkg/wsl2/wsl_driver_windows.go
@@ -52,51 +52,51 @@ func New(driver *driver.BaseDriver) *LimaWslDriver {
 }
 
 func (l *LimaWslDriver) Validate() error {
-	if *l.Instance.Config.MountType != limayaml.WSLMount {
-		return fmt.Errorf("field `mountType` must be %q for WSL2 driver, got %q", limayaml.WSLMount, *l.Instance.Config.MountType)
+	if *l.Instance.Cfg.MountType != limayaml.WSLMount {
+		return fmt.Errorf("field `mountType` must be %q for WSL2 driver, got %q", limayaml.WSLMount, *l.Instance.Cfg.MountType)
 	}
 	// TODO: revise this list for WSL2
-	if unknown := reflectutil.UnknownNonEmptyFields(l.Instance.Config, knownYamlProperties...); len(unknown) > 0 {
-		logrus.Warnf("Ignoring: vmType %s: %+v", *l.Instance.Config.VMType, unknown)
+	if unknown := reflectutil.UnknownNonEmptyFields(l.Instance.Cfg, knownYamlProperties...); len(unknown) > 0 {
+		logrus.Warnf("Ignoring: vmType %s: %+v", *l.Instance.Cfg.VMType, unknown)
 	}
 
-	if !limayaml.IsNativeArch(*l.Instance.Config.Arch) {
-		return fmt.Errorf("unsupported arch: %q", *l.Instance.Config.Arch)
+	if !limayaml.IsNativeArch(*l.Instance.Cfg.Arch) {
+		return fmt.Errorf("unsupported arch: %q", *l.Instance.Cfg.Arch)
 	}
 
-	for k, v := range l.Instance.Config.CPUType {
+	for k, v := range l.Instance.Cfg.CPUType {
 		if v != "" {
-			logrus.Warnf("Ignoring: vmType %s: cpuType[%q]: %q", *l.Instance.Config.VMType, k, v)
+			logrus.Warnf("Ignoring: vmType %s: cpuType[%q]: %q", *l.Instance.Cfg.VMType, k, v)
 		}
 	}
 
 	// TODO: real filetype checks
 	tarFileRegex := regexp.MustCompile(`.*tar\.*`)
-	for i, image := range l.Instance.Config.Images {
+	for i, image := range l.Instance.Cfg.Images {
 		if unknown := reflectutil.UnknownNonEmptyFields(image, "File"); len(unknown) > 0 {
-			logrus.Warnf("Ignoring: vmType %s: images[%d]: %+v", *l.Instance.Config.VMType, i, unknown)
+			logrus.Warnf("Ignoring: vmType %s: images[%d]: %+v", *l.Instance.Cfg.VMType, i, unknown)
 		}
 		match := tarFileRegex.MatchString(image.Location)
-		if image.Arch == *l.Instance.Config.Arch && !match {
-			return fmt.Errorf("unsupported image type for vmType: %s, tarball root file system required: %q", *l.Instance.Config.VMType, image.Location)
+		if image.Arch == *l.Instance.Cfg.Arch && !match {
+			return fmt.Errorf("unsupported image type for vmType: %s, tarball root file system required: %q", *l.Instance.Cfg.VMType, image.Location)
 		}
 	}
 
-	for i, mount := range l.Instance.Config.Mounts {
+	for i, mount := range l.Instance.Cfg.Mounts {
 		if unknown := reflectutil.UnknownNonEmptyFields(mount); len(unknown) > 0 {
-			logrus.Warnf("Ignoring: vmType %s: mounts[%d]: %+v", *l.Instance.Config.VMType, i, unknown)
+			logrus.Warnf("Ignoring: vmType %s: mounts[%d]: %+v", *l.Instance.Cfg.VMType, i, unknown)
 		}
 	}
 
-	for i, network := range l.Instance.Config.Networks {
+	for i, network := range l.Instance.Cfg.Networks {
 		if unknown := reflectutil.UnknownNonEmptyFields(network); len(unknown) > 0 {
-			logrus.Warnf("Ignoring: vmType %s: networks[%d]: %+v", *l.Instance.Config.VMType, i, unknown)
+			logrus.Warnf("Ignoring: vmType %s: networks[%d]: %+v", *l.Instance.Cfg.VMType, i, unknown)
 		}
 	}
 
-	audioDevice := *l.Instance.Config.Audio.Device
+	audioDevice := *l.Instance.Cfg.Audio.Device
 	if audioDevice != "" {
-		logrus.Warnf("Ignoring: vmType %s: `audio.device`: %+v", *l.Instance.Config.VMType, audioDevice)
+		logrus.Warnf("Ignoring: vmType %s: `audio.device`: %+v", *l.Instance.Cfg.VMType, audioDevice)
 	}
 
 	return nil
@@ -149,7 +149,7 @@ func (l *LimaWslDriver) CanRunGUI() bool {
 }
 
 func (l *LimaWslDriver) RunGUI() error {
-	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "wsl", *l.Instance.Config.Video.Display)
+	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "wsl", *l.Instance.Cfg.Video.Display)
 }
 
 func (l *LimaWslDriver) Stop(ctx context.Context) error {


### PR DESCRIPTION
Once this is merged I plan to also rename all `Instance` fields and variables to `Inst`.

Mostly for consistency, but I think the shorter field names also make the code easier to read.