### PR TITLE
Make sure that ansible params check the playbook

### DIFF
--- a/hack/ansible-test.yaml
+++ b/hack/ansible-test.yaml
@@ -2,5 +2,5 @@
   tasks:
   - name: Create test file
     file:
-      path: /tmp/ansible
+      path: "/tmp/param-{{ lookup('ansible.builtin.env', 'PARAM_ANSIBLE') }}"
       state: touch

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -54,7 +54,6 @@ declare -A CHECKS=(
 	["disk"]=""
 	["user-v2"]=""
 	["mount-path-with-spaces"]=""
-	["provision-ansible"]=""
 	["provision-data"]=""
 	["param-env-variables"]=""
 	["set-user"]=""
@@ -82,7 +81,6 @@ case "$NAME" in
 	CHECKS["snapshot-online"]="1"
 	CHECKS["snapshot-offline"]="1"
 	CHECKS["mount-path-with-spaces"]="1"
-	CHECKS["provision-ansible"]="1"
 	CHECKS["provision-data"]="1"
 	CHECKS["param-env-variables"]="1"
 	CHECKS["set-user"]="1"
@@ -188,11 +186,6 @@ if [[ -n ${CHECKS["mount-path-with-spaces"]} ]]; then
 	[ "$(limactl shell "$NAME" cat "/tmp/lima test dir with spaces/test file")" = "test file content" ]
 fi
 
-if [[ -n ${CHECKS["provision-ansible"]} ]]; then
-	INFO 'Testing that /tmp/ansible was created successfully on provision'
-	limactl shell "$NAME" test -e /tmp/ansible
-fi
-
 if [[ -n ${CHECKS["provision-data"]} ]]; then
 	INFO 'Testing that /etc/sysctl.d/99-inotify.conf was created successfully on provision'
 	limactl shell "$NAME" grep -q fs.inotify.max_user_watches /etc/sysctl.d/99-inotify.conf
@@ -200,6 +193,7 @@ fi
 
 if [[ -n ${CHECKS["param-env-variables"]} ]]; then
 	INFO 'Testing that PARAM env variables are exported to all types of provisioning scripts and probes'
+	limactl shell "$NAME" test -e /tmp/param-ansible
 	limactl shell "$NAME" test -e /tmp/param-boot
 	limactl shell "$NAME" test -e /tmp/param-dependency
 	limactl shell "$NAME" test -e /tmp/param-probe

--- a/hack/test-templates/test-misc.yaml
+++ b/hack/test-templates/test-misc.yaml
@@ -14,6 +14,7 @@ mounts:
   writable: true
 
 param:
+  ANSIBLE: ansible
   BOOT: boot
   DEPENDENCY: dependency
   PROBE: probe

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -524,6 +524,16 @@ func ValidateParamIsUsed(y *LimaYAML) error {
 				keyIsUsed = true
 				break
 			}
+			if p.Playbook != "" {
+				playbook, err := os.ReadFile(p.Playbook)
+				if err != nil {
+					return err
+				}
+				if re.Match(playbook) {
+					keyIsUsed = true
+					break
+				}
+			}
 		}
 		for _, p := range y.Probes {
 			if re.MatchString(p.Script) {


### PR DESCRIPTION
The ansible provisioning supports using a separate yaml playbook,
so check this file (but only the top playbook) for any parameters...

The `ansible-playbook` command does not run remotely so it does not
use the param.env, which means that the env is set on the command.