### PR TITLE
Makefile: exclude `.git` in `make lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,8 +444,8 @@ lint: check-generated
 	golangci-lint run ./...
 	yamllint .
 	ls-lint
-	find . -name '*.sh' | xargs shellcheck
-	find . -name '*.sh' | xargs shfmt -s -d
+	find . -name '*.sh' ! -path "./.git/*" | xargs shellcheck
+	find . -name '*.sh' ! -path "./.git/*" | xargs shfmt -s -d
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Branch names ending with `.sh` may lead to false positives.

e.g.:
```console
$ git checkout -b update-injectcmdline-to-template.sh
Switched to a new branch 'update-injectcmdline-to-template.sh'
$ make -i lint
golangci-lint run ./...
yamllint .
ls-lint
2024/10/08 12:34:29 .check_location-response-cache.yaml failed for rules: kebabcase
2024/10/08 12:34:29 .vscode failed for rules: kebabcase
2024/10/08 12:34:29 .yamlfmt.yml failed for rules: kebabcase
make: [lint] Error 1 (ignored)
find . -name '*.sh' | xargs shellcheck

In ./.git/logs/refs/heads/update-injectcmdline-to-template.sh line 1:
0000000000000000000000000000000000000000 0ac8438fa0098dc77a5d09ee24f5753b2a0bed89 Norio Nomura <norio.nomura@gmail.com> 1728358459 +0900	branch: Created from HEAD
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.
                                                                                                                      ^----------^ SC2210 (warning): This is a file redirection. Was it supposed to be a comparison or fd operation?


In ./.git/refs/heads/update-injectcmdline-to-template.sh line 1:
0ac8438fa0098dc77a5d09ee24f5753b2a0bed89
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.

For more information:
  https://www.shellcheck.net/wiki/SC2148 -- Tips depend on target shell and y...
  https://www.shellcheck.net/wiki/SC2210 -- This is a file redirection. Was i...
make: [lint] Error 1 (ignored)
find . -name '*.sh' | xargs shfmt -s -d
diff ./.git/logs/refs/heads/update-injectcmdline-to-template.sh.orig ./.git/logs/refs/heads/update-injectcmdline-to-template.sh
--- ./.git/logs/refs/heads/update-injectcmdline-to-template.sh.orig
+++ ./.git/logs/refs/heads/update-injectcmdline-to-template.sh
@@ -1,1 +1,1 @@
-0000000000000000000000000000000000000000 0ac8438fa0098dc77a5d09ee24f5753b2a0bed89 Norio Nomura <norio.nomura@gmail.com> 1728358459 +0900	branch: Created from HEAD
+0000000000000000000000000000000000000000 0ac8438fa0098dc77a5d09ee24f5753b2a0bed89 Norio Nomura +0900 branch: Created from HEAD <norio.nomura@gmail.com >1728358459
make: [lint] Error 1 (ignored)
```

This change prevents such issues from occurring.