### PR TITLE
Disable `ssh.loadDotSSHPubKeys` by default

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -148,7 +148,7 @@ ssh:
   # This option is useful when you want to use other SSH-based
   # applications such as rsync with the Lima instance.
   # If you have an insecure key under ~/.ssh, do not use this option.
-  # 🟢 Builtin default: true
+  # 🟢 Builtin default: false (since Lima v1.0)
   loadDotSSHPubKeys: null
   # Forward ssh agent into the instance.
   # The ssh agent socket can be mounted in a container at the path `/run/host-services/ssh-auth.sock`.

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -350,7 +350,7 @@ func FillDefault(y, d, o *LimaYAML, filePath string) {
 		y.SSH.LoadDotSSHPubKeys = o.SSH.LoadDotSSHPubKeys
 	}
 	if y.SSH.LoadDotSSHPubKeys == nil {
-		y.SSH.LoadDotSSHPubKeys = ptr.Of(true)
+		y.SSH.LoadDotSSHPubKeys = ptr.Of(false) // was true before Lima v1.0
 	}
 
 	if y.SSH.ForwardAgent == nil {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -80,7 +80,7 @@ func TestFillDefault(t *testing.T) {
 		},
 		SSH: SSH{
 			LocalPort:         ptr.Of(0),
-			LoadDotSSHPubKeys: ptr.Of(true),
+			LoadDotSSHPubKeys: ptr.Of(false),
 			ForwardAgent:      ptr.Of(false),
 			ForwardX11:        ptr.Of(false),
 			ForwardX11Trusted: ptr.Of(false),

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -154,7 +154,7 @@ type SSH struct {
 	LocalPort *int `yaml:"localPort,omitempty" json:"localPort,omitempty"`
 
 	// LoadDotSSHPubKeys loads ~/.ssh/*.pub in addition to $LIMA_HOME/_config/user.pub .
-	LoadDotSSHPubKeys *bool `yaml:"loadDotSSHPubKeys,omitempty" json:"loadDotSSHPubKeys,omitempty"` // default: true
+	LoadDotSSHPubKeys *bool `yaml:"loadDotSSHPubKeys,omitempty" json:"loadDotSSHPubKeys,omitempty"` // default: false
 	ForwardAgent      *bool `yaml:"forwardAgent,omitempty" json:"forwardAgent,omitempty"`           // default: false
 	ForwardX11        *bool `yaml:"forwardX11,omitempty" json:"forwardX11,omitempty"`               // default: false
 	ForwardX11Trusted *bool `yaml:"forwardX11Trusted,omitempty" json:"forwardX11Trusted,omitempty"` // default: false


### PR DESCRIPTION
https://github.com/lima-vm/lima/blob/9d29da396c164fea261bc547b4537d470aa3a824/examples/default.yaml#L111-L122

This might be a breaking change for new instances, but does not affect existing instances.

Fix #1617