### PR TITLE
limactl: add `tunnel` command (experimental)

### DIFF
--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -154,6 +154,7 @@ func newApp() *cobra.Command {
 		newSnapshotCommand(),
 		newProtectCommand(),
 		newUnprotectCommand(),
+		newTunnelCommand(),
 	)
 	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
 		rootCmd.AddCommand(startAtLoginCommand())

--- a/cmd/limactl/tunnel.go
+++ b/cmd/limactl/tunnel.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+
+	"github.com/lima-vm/lima/pkg/freeport"
+	"github.com/lima-vm/lima/pkg/sshutil"
+	"github.com/lima-vm/lima/pkg/store"
+	"github.com/mattn/go-shellwords"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const tunnelHelp = `Create a tunnel for Lima
+
+Create a SOCKS tunnel so that the host can join the guest network.
+`
+
+func newTunnelCommand() *cobra.Command {
+	tunnelCmd := &cobra.Command{
+		Use:   "tunnel [flags] INSTANCE",
+		Short: "Create a tunnel for Lima",
+		PersistentPreRun: func(*cobra.Command, []string) {
+			logrus.Warn("`limactl tunnel` is experimental")
+		},
+		Long:              tunnelHelp,
+		Args:              WrapArgsError(cobra.ExactArgs(1)),
+		RunE:              tunnelAction,
+		ValidArgsFunction: tunnelBashComplete,
+		SilenceErrors:     true,
+		GroupID:           advancedCommand,
+	}
+
+	tunnelCmd.Flags().SetInterspersed(false)
+	// TODO: implement l2tp, ikev2, masque, ...
+	tunnelCmd.Flags().String("type", "socks", "Tunnel type, currently only \"socks\" is implemented")
+	tunnelCmd.Flags().Int("socks-port", 0, "SOCKS port, defaults to a random port")
+	return tunnelCmd
+}
+
+func tunnelAction(cmd *cobra.Command, args []string) error {
+	flags := cmd.Flags()
+	tunnelType, err := flags.GetString("type")
+	if err != nil {
+		return err
+	}
+	if tunnelType != "socks" {
+		return fmt.Errorf("unknown tunnel type: %q", tunnelType)
+	}
+	port, err := flags.GetInt("socks-port")
+	if err != nil {
+		return err
+	}
+	if port != 0 && (port < 1024 || port > 65535) {
+		return fmt.Errorf("invalid socks port %d", port)
+	}
+	stdout, stderr := cmd.OutOrStdout(), cmd.ErrOrStderr()
+	instName := args[0]
+	inst, err := store.Inspect(instName)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("instance %q does not exist, run `limactl create %s` to create a new instance", instName, instName)
+		}
+		return err
+	}
+	if inst.Status == store.StatusStopped {
+		return fmt.Errorf("instance %q is stopped, run `limactl start %s` to start the instance", instName, instName)
+	}
+
+	if port == 0 {
+		port, err = freeport.TCP()
+		if err != nil {
+			return err
+		}
+	}
+
+	var (
+		arg0     string
+		arg0Args []string
+	)
+	// FIXME: deduplicate the code clone across `limactl shell` and `limactl tunnel`
+	if sshShell := os.Getenv(envShellSSH); sshShell != "" {
+		sshShellFields, err := shellwords.Parse(sshShell)
+		switch {
+		case err != nil:
+			logrus.WithError(err).Warnf("Failed to split %s variable into shell tokens. "+
+				"Falling back to 'ssh' command", envShellSSH)
+		case len(sshShellFields) > 0:
+			arg0 = sshShellFields[0]
+			if len(sshShellFields) > 1 {
+				arg0Args = sshShellFields[1:]
+			}
+		}
+	}
+
+	if arg0 == "" {
+		arg0, err = exec.LookPath("ssh")
+		if err != nil {
+			return err
+		}
+	}
+
+	sshOpts, err := sshutil.SSHOpts(
+		inst.Dir,
+		*inst.Config.SSH.LoadDotSSHPubKeys,
+		*inst.Config.SSH.ForwardAgent,
+		*inst.Config.SSH.ForwardX11,
+		*inst.Config.SSH.ForwardX11Trusted)
+	if err != nil {
+		return err
+	}
+	sshArgs := sshutil.SSHArgsFromOpts(sshOpts)
+	sshArgs = append(sshArgs, []string{
+		"-q", // quiet
+		"-f", // background
+		"-N", // no command
+		"-D", fmt.Sprintf("127.0.0.1:%d", port),
+		"-p", strconv.Itoa(inst.SSHLocalPort),
+		inst.SSHAddress,
+	}...)
+	sshCmd := exec.Command(arg0, append(arg0Args, sshArgs...)...)
+	sshCmd.Stdout = stderr
+	sshCmd.Stderr = stderr
+	logrus.Debugf("executing ssh (may take a long)): %+v", sshCmd.Args)
+
+	if err := sshCmd.Run(); err != nil {
+		return err
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		fmt.Fprintf(stdout, "Open <System Settings> → <Network> → <Wi-Fi> (or whatever) → <Details> → <Proxies> → <SOCKS proxy>,\n")
+		fmt.Fprintf(stdout, "and specify the following configuration:\n")
+		fmt.Fprintf(stdout, "- Server: 127.0.0.1\n")
+		fmt.Fprintf(stdout, "- Port: %d\n", port)
+	case "windows":
+		fmt.Fprintf(stdout, "Open <Settings> → <Network & Internet> → <Proxy>,\n")
+		fmt.Fprintf(stdout, "and specify the following configuration:\n")
+		fmt.Fprintf(stdout, "- Address: socks=127.0.0.1\n")
+		fmt.Fprintf(stdout, "- Port: %d\n", port)
+	default:
+		fmt.Fprintf(stdout, "Set `ALL_PROXY=socks5h://127.0.0.1:%d`, etc.\n", port)
+	}
+	fmt.Fprintf(stdout, "The instance can be connected from the host as <http://lima-%s.internal> via a web browser.\n", inst.Name)
+
+	// TODO: show the port in `limactl list --json` ?
+	// TODO: add `--stop` flag to shut down the tunnel
+	return nil
+}
+
+func tunnelBashComplete(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return bashCompleteInstanceNames(cmd)
+}

--- a/pkg/freeport/freeport.go
+++ b/pkg/freeport/freeport.go
@@ -1,0 +1,51 @@
+// Package freeport provides functions to find free localhost ports.
+package freeport
+
+import (
+	"fmt"
+	"net"
+)
+
+func TCP() (int, error) {
+	lAddr0, err := net.ResolveTCPAddr("tcp4", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	l, err := net.ListenTCP("tcp4", lAddr0)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	lAddr := l.Addr()
+	lTCPAddr, ok := lAddr.(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("expected *net.TCPAddr, got %v", lAddr)
+	}
+	port := lTCPAddr.Port
+	if port <= 0 {
+		return 0, fmt.Errorf("unexpected port %d", port)
+	}
+	return port, nil
+}
+
+func UDP() (int, error) {
+	lAddr0, err := net.ResolveUDPAddr("udp4", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	l, err := net.ListenUDP("udp4", lAddr0)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	lAddr := l.LocalAddr()
+	lUDPAddr, ok := lAddr.(*net.UDPAddr)
+	if !ok {
+		return 0, fmt.Errorf("expected *net.UDPAddr, got %v", lAddr)
+	}
+	port := lUDPAddr.Port
+	if port <= 0 {
+		return 0, fmt.Errorf("unexpected port %d", port)
+	}
+	return port, nil
+}

--- a/pkg/freeport/freeport_unix.go
+++ b/pkg/freeport/freeport_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package freeport
+
+import "errors"
+
+func VSock() (int, error) {
+	return 0, errors.New("freeport.VSock is not implemented for non-Windows hosts")
+}

--- a/pkg/freeport/freeport_windows.go
+++ b/pkg/freeport/freeport_windows.go
@@ -1,0 +1,7 @@
+package freeport
+
+import "github.com/lima-vm/lima/pkg/windows"
+
+func VSock() (int, error) {
+	return windows.GetRandomFreeVSockPort(0, 2147483647)
+}

--- a/pkg/hostagent/port_darwin.go
+++ b/pkg/hostagent/port_darwin.go
@@ -155,7 +155,3 @@ func (plf *pseudoLoopbackForwarder) Close() error {
 	_ = plf.ln.Close()
 	return plf.onClose()
 }
-
-func getFreeVSockPort() (int, error) {
-	return 0, nil
-}

--- a/pkg/hostagent/port_others.go
+++ b/pkg/hostagent/port_others.go
@@ -11,7 +11,3 @@ import (
 func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote, verb string) error {
 	return forwardSSH(ctx, sshConfig, port, local, remote, verb, false)
 }
-
-func getFreeVSockPort() (int, error) {
-	return 0, nil
-}

--- a/pkg/hostagent/port_windows.go
+++ b/pkg/hostagent/port_windows.go
@@ -3,14 +3,9 @@ package hostagent
 import (
 	"context"
 
-	"github.com/lima-vm/lima/pkg/windows"
 	"github.com/lima-vm/sshocker/pkg/ssh"
 )
 
 func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, remote, verb string) error {
 	return forwardSSH(ctx, sshConfig, port, local, remote, verb, false)
-}
-
-func getFreeVSockPort() (int, error) {
-	return windows.GetRandomFreeVSockPort(0, 2147483647)
 }

--- a/website/content/en/docs/releases/experimental/_index.md
+++ b/website/content/en/docs/releases/experimental/_index.md
@@ -17,6 +17,7 @@ The following features are experimental and subject to change:
 The following commands are experimental and subject to change:
 
 - `limactl snapshot *`
+- `limactl tunnel`
 
 ## Graduated
 


### PR DESCRIPTION
```console
$ limactl tunnel --help
Create a tunnel for Lima

Create a SOCKS tunnel so that the host can join the guest network.

Usage:
  limactl tunnel [flags] INSTANCE

Flags:
  -h, --help             help for tunnel
      --socks-port int   SOCKS port, defaults to a random port
      --type string      Tunnel type, currently only "socks" is implemented (default "socks")

Global Flags:
      --debug               debug mode
      --log-format string   Set the logging format [text, json] (default "text")
      --log-level string    Set the logging level [trace, debug, info, warn, error]
      --tty                 Enable TUI interactions such as opening an editor. Defaults to true when stdout is a terminal. Set to false for automation. (default true)

$ limactl tunnel default
Open <System Settings> → <Network> → <Wi-Fi> (or whatever) → <Details> → <Proxies> → <SOCKS proxy>,
and specify the following configuration:
- Server: 127.0.0.1
- Port: 54940
The instance can be connected from the host as <http://lima-default.internal> via a web browser.

$ curl --proxy socks5h://127.0.0.1:54940 http://lima-default.internal
<!DOCTYPE html>
[...]
```