### PR TITLE
CI: vz: try macos-15-large (Intel)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -423,8 +423,8 @@ jobs:
 
   vz:
     name: "vz"
-    # on macOS 13, the default vmType is VZ
-    runs-on: macos-13
+    # on macOS >= 13, the default vmType is VZ
+    runs-on: macos-15-large  # Intel
     timeout-minutes: 120
     strategy:
       fail-fast: false


### PR DESCRIPTION
This might be less flaky than the current macos-13?