### PR TITLE
Setup RAM disk for vz tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -451,6 +451,11 @@ jobs:
       run: brew install bash coreutils jq
     - name: Uninstall qemu
       run: brew uninstall --ignore-dependencies --force qemu
+    - name: Setup RAM disk for ~/.lima
+      run: ./hack/setup-lima-home-ramdisk.sh
+    - name: "Adjust LIMACTL_CREATE_ARGS"
+      # use small disk that fits into the RAM disk because it will become non-sparse on conversion to raw
+      run: echo "LIMACTL_CREATE_ARGS=${LIMACTL_CREATE_ARGS} --disk 5" >>$GITHUB_ENV
     - name: Test
       run: ./hack/test-templates.sh templates/${{ matrix.template }}
     - if: failure()

--- a/hack/setup-lima-home-ramdisk.sh
+++ b/hack/setup-lima-home-ramdisk.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+: "${RAMDISK_SIZE_IN_GB:=7}"
+: "${LIMA_HOME:=$HOME/.lima}"
+
+RAMDISK_SIZE_IN_SECTORS=$((RAMDISK_SIZE_IN_GB * 1024 * 1024 * 1024 / 512))
+# hdiutil space-pads the output; strip it.
+DISK=$(hdiutil attach -nomount "ram://$RAMDISK_SIZE_IN_SECTORS" | xargs echo)
+newfs_hfs "$DISK"
+mkdir -p "$LIMA_HOME"
+mount -t hfs "$DISK" "$LIMA_HOME"

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -17,7 +17,7 @@ INFO "Validating \"$FILE\""
 limactl validate "$FILE"
 
 # --cpus=1 is needed for running vz on GHA: https://github.com/lima-vm/lima/pull/1511#issuecomment-1574937888
-LIMACTL_CREATE=(limactl --tty=false create --cpus=1 --memory=1)
+LIMACTL_CREATE=(limactl --tty=false create --cpus=2 --memory=2  )
 
 CONTAINER_ENGINE="nerdctl"
 


### PR DESCRIPTION
The GitHub runners have really slow disks, and the vz tests are very flaky. Maybe having better disk performance will make them less likely to fail.