### PR TITLE
CI: temporarily remove ArchLinux (and demote it from Tier 1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,8 @@ jobs:
         - alpine.yaml
         - debian.yaml
         - fedora.yaml
-        - archlinux.yaml
+        # cloud-init 24.3.1-1 package has a regression: https://github.com/lima-vm/lima/issues/2714
+        # - archlinux.yaml
         - opensuse.yaml
         - experimental/net-user-v2.yaml
         - experimental/9p.yaml

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,7 +15,7 @@ Distro:
 - [`almalinux-9`](./almalinux-9.yaml), `almalinux.yaml`: AlmaLinux 9
 - [`alpine`](./alpine.yaml): ☆Alpine Linux
 - [`alpine-iso`](./alpine-iso.yaml): ☆Alpine Linux (ISO9660 image). Compatible with the `alpine` template used in Lima prior to v1.0.
-- [`archlinux`](./archlinux.yaml): ⭐Arch Linux
+- [`archlinux`](./archlinux.yaml): Arch Linux
 - [`centos-stream-9`](./centos-stream-9.yaml), `centos-stream.yaml`: CentOS Stream 9
 - [`debian-11`](./debian-11.yaml): Debian GNU/Linux 11(bullseye)
 - [`debian-12`](./debian-12.yaml), `debian.yaml`: ⭐Debian GNU/Linux 12(bookworm)


### PR DESCRIPTION
Workaround for:
- #2714

The "user session is ready for ssh" phase can never finishes with the cloud-init 24.3.1-1 package due to a regression that breaks execution of `/var/lib/cloud/scripts/per-boot/` scripts.

This commit also demotes ArchLinux from Tier 1; it is practically impossible to maintain good stability as the packages are too frequently updated.

After the regression is fixed we may bring ArchLinux to Tier 2, but probably never to Tier 1 again.