### PR TITLE
20-rootless-base.sh: Fix ownership of the user home directory when created by root.

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/20-rootless-base.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/20-rootless-base.sh
@@ -4,6 +4,18 @@ set -eux
 # This script does not work unless systemd is available
 command -v systemctl >/dev/null 2>&1 || exit 0
 
+if [ -O "${LIMA_CIDATA_HOME}" ]; then
+	# Fix ownership of the user home directory when created by root.
+	# In cases where mount points exist in the user's home directory, the home directory and
+	# the mount points are created by root before the user is created. This leads to the home
+	# directory being owned by root.
+	# Following commands fix the ownership of the home directory and its contents (on the same filesystem)
+	# is updated to the correct user.
+	# shellcheck disable=SC2046 # it fails if find results are quoted.
+	chown "${LIMA_CIDATA_USER}" $(find "${LIMA_CIDATA_HOME}" -xdev) ||
+		true # Ignore errors because changing owner of the mount points may fail but it is not critical.
+fi
+
 # Set up env
 for f in .profile .bashrc .zshrc; do
 	if ! grep -q "# Lima BEGIN" "${LIMA_CIDATA_HOME}/$f"; then


### PR DESCRIPTION
When mount points exist in the user's home directory, both the home directory
and the mount points are created by root before the user is created.
This results in the home directory being owned by root.

This change ensures that the ownership of the home directory and its contents 
(on the same filesystem) is updated to the correct user.

If changing the owner of any mount points fails, the error is ignored.

The following steps reproduce the issue where the owner of the user’s home directory becomes root.
```console
$ limactl create template://default --set '.mounts += [{"location": "~/go/pkg/mod", "mountPoint": "{{.Home}}/go/pkg/mod", "writable": true}]' --tty=false --log-level warn
3.50 GiB / 3.50 GiB [-------------------------------------] 100.00% 209.42 MiB/s
$ hack/inject-cmdline-to-template.sh ~/.lima/default/lima.yaml console=hvc0
kernel_location=https://cloud-images.ubuntu.com/releases/24.04/release-20240821/unpacked/ubuntu-24.04-server-cloudimg-arm64-vmlinuz-generic
kernel_digest=sha256:69e66230d6acc503082f098fd072a672a804774007209110b353d25bb7007669
cmdline=root=LABEL=cloudimg-rootfs ro console=tty1 console=ttyAMA0 console=hvc0
initrd_location=https://cloud-images.ubuntu.com/releases/24.04/release-20240821/unpacked/ubuntu-24.04-server-cloudimg-arm64-initrd-generic
initrd_digest=sha256:92acf9f2976b7a8b3b5e9e3f22211d17a6fdb3f2aed981467f91cd6dbfa16ae5
$ limactl start default --log-level=warn
WARN[0000] vmType vz: ignoring images[1]: [Kernel Initrd] 
17.39 MiB / 17.39 MiB [------------------------------------------] 100.00% ? p/s
3.50 GiB / 3.50 GiB [-------------------------------------] 100.00% 215.78 MiB/s
WARN[0018] [hostagent] GRPC port forwarding is experimental 
$ grep writable $(limactl list default --format "{{.Dir}}")
grep: /Users/norio/.lima/default: Is a directory
$ grep writable $(limactl list default --format "{{.Dir}}")/serialv.log
[   17.815317] cloud-init[2094]: [ERROR] HOME needs to be writable
```