### PR TITLE
Always delete downloader temporary data file

### DIFF
--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -599,13 +599,6 @@ func downloadHTTP(ctx context.Context, localPath, lastModified, contentType, url
 	}
 	logrus.Debugf("downloading %q into %q", url, localPath)
 
-	localPathTmp := perProcessTempfile(localPath)
-	fileWriter, err := os.Create(localPathTmp)
-	if err != nil {
-		return err
-	}
-	defer fileWriter.Close()
-
 	resp, err := httpclientutil.Get(ctx, http.DefaultClient, url)
 	if err != nil {
 		return err
@@ -630,6 +623,14 @@ func downloadHTTP(ctx context.Context, localPath, lastModified, contentType, url
 	if HideProgress {
 		hideBar(bar)
 	}
+
+	localPathTmp := perProcessTempfile(localPath)
+	fileWriter, err := os.Create(localPathTmp)
+	if err != nil {
+		return err
+	}
+	defer fileWriter.Close()
+	defer os.RemoveAll(localPathTmp)
 
 	writers := []io.Writer{fileWriter}
 	var digester digest.Digester


### PR DESCRIPTION
If the download failed, the temporary data file (data.tmp.pid) was not deleted. Ensure it is delete in all cases.

Also move the creation of the temporary file right before we need it. The chance that creating a temporary file will fail is practically zero so there is no need to do this upfront. This makes the code easier to follow and maintain.