### PR TITLE
networks.Validate() requires that socket_vmnet is owned by root

### DIFF
--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -3,21 +3,16 @@ package main
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"runtime"
 
 	"github.com/lima-vm/lima/pkg/networks"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
+const networksURL = "https://lima-vm.io/docs/config/network/#socket_vmnet"
+
 func newSudoersCommand() *cobra.Command {
-	networksMD := "$PREFIX/share/doc/lima/docs/network.md"
-	if exe, err := os.Executable(); err == nil {
-		binDir := filepath.Dir(exe)
-		prefixDir := filepath.Dir(binDir)
-		networksMD = filepath.Join(prefixDir, "share/doc/lima/docs/network.md")
-	}
 	sudoersCommand := &cobra.Command{
 		Use: "sudoers [--check [SUDOERSFILE-TO-CHECK]]",
 		Example: `
@@ -31,7 +26,7 @@ $ limactl sudoers --check /etc/sudoers.d/lima
 		Long: fmt.Sprintf(`Generate the content of the /etc/sudoers.d/lima file for enabling vmnet.framework support.
 The content is written to stdout, NOT to the file.
 This command must not run as the root user.
-See %s for the usage.`, networksMD),
+See %s for the usage.`, networksURL),
 		Args:    WrapArgsError(cobra.MaximumNArgs(1)),
 		RunE:    sudoersAction,
 		GroupID: advancedCommand,
@@ -52,6 +47,7 @@ func sudoersAction(cmd *cobra.Command, args []string) error {
 	}
 	// Make sure the current network configuration is secure
 	if err := nwCfg.Validate(); err != nil {
+		logrus.Infof("Please check %s for more information.", networksURL)
 		return err
 	}
 	check, err := cmd.Flags().GetBool("check")

--- a/examples/vmnet.yaml
+++ b/examples/vmnet.yaml
@@ -1,10 +1,6 @@
 # A template to enable vmnet.framework.
 
-# Usage:
-#   brew install socket_vmnet
-#   limactl sudoers >etc_sudoers.d_lima
-#   sudo install -o root etc_sudoers.d_lima /etc/sudoers.d/lima
-#   limactl start template://vmnet
+# Install socket_vmnet: https://lima-vm.io/docs/config/network/#socket_vmnet
 
 # This template requires Lima v0.7.0 or later.
 # Older versions of Lima were using a different syntax for supporting vmnet.framework.

--- a/pkg/networks/networks.TEMPLATE.yaml
+++ b/pkg/networks/networks.TEMPLATE.yaml
@@ -1,6 +1,6 @@
 # Path to socket_vmnet executable. Because socket_vmnet is invoked via sudo it should be
 # installed where only root can modify/replace it. This means also none of the
-# parent directories should be writable by the user.
+# parent directories can be writable by the user.
 #
 # The varRun directory also must not be writable by the user because it will
 # include the socket_vmnet pid file. Those will be terminated via sudo, so replacing

--- a/pkg/store/filenames/filenames.go
+++ b/pkg/store/filenames/filenames.go
@@ -1,7 +1,7 @@
 // Package filenames defines the names of the files that appear under an instance dir
 // or inside the config directory.
 //
-// See docs/internal.md .
+// See https://lima-vm.io/docs/dev/internals/
 package filenames
 
 // Instance names starting with an underscore are reserved for lima internal usage


### PR DESCRIPTION
This restriction was weakened by https://github.com/lima-vm/lima/pull/1220 to only require the file and directories to be owned by the admin user, but that configuration is not secure.

If users are willing to run an insecure configuration, then they can always enable password-less sudo, which does not need a sudoers file at all.