### PR TITLE
Fix code scanning alert no. 42: Incorrect conversion between integer types

### DIFF
--- a/pkg/guestagent/guestagent_linux.go
+++ b/pkg/guestagent/guestagent_linux.go
@@ -279,7 +279,7 @@ func (a *agent) LocalPorts(_ context.Context) ([]*api.IPPort, error) {
 				res = append(res,
 					&api.IPPort{
 						Ip:       ipt.IP.String(),
-						Port:     int32(ipt.Port),
+						Port:     int32(ipt.Port), // The port value is already ensured to be within int32 bounds in iptables.go
 						Protocol: "tcp",
 					})
 			}

--- a/pkg/guestagent/iptables/iptables.go
+++ b/pkg/guestagent/iptables/iptables.go
@@ -67,10 +67,11 @@ func parsePortsFromRules(rules []string) ([]Entry, error) {
 	for _, rule := range rules {
 		if found := findPortRegex.FindStringSubmatch(rule); found != nil {
 			if len(found) == 4 {
-				port, err := strconv.Atoi(found[3])
+				port64, err := strconv.ParseInt(found[3], 10, 32)
 				if err != nil {
 					return nil, err
 				}
+				port := int(port64)
 
 				istcp := found[2] == "tcp"
 


### PR DESCRIPTION
Fixes [https://github.com/lima-vm/lima/security/code-scanning/42](https://github.com/lima-vm/lima/security/code-scanning/42)

To fix the problem, we need to ensure that the integer value parsed from the string does not exceed the bounds of `int32` before converting it. This can be achieved by using `strconv.ParseInt` with a specified bit size of 32, which directly parses the string into an `int32` value. Alternatively, we can add explicit bounds checking after parsing the integer.

The best way to fix this without changing existing functionality is to replace the `strconv.Atoi` call with `strconv.ParseInt` specifying a 32-bit size. This ensures that the parsed value is within the bounds of `int32`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

- - -
This is not a security issue, as the port number is limited to 16-bit anyway.