### PR TITLE
Address CodeQL warning about converting strconv.Atoi() to int32

### DIFF
--- a/pkg/guestagent/iptables/iptables.go
+++ b/pkg/guestagent/iptables/iptables.go
@@ -67,7 +67,7 @@ func parsePortsFromRules(rules []string) ([]Entry, error) {
 	for _, rule := range rules {
 		if found := findPortRegex.FindStringSubmatch(rule); found != nil {
 			if len(found) == 4 {
-				port, err := strconv.Atoi(found[3])
+				port, err := strconv.ParseInt(found[3], 10, 32)
 				if err != nil {
 					return nil, err
 				}
@@ -81,7 +81,7 @@ func parsePortsFromRules(rules []string) ([]Entry, error) {
 				}
 				ent := Entry{
 					IP:   net.ParseIP(ip),
-					Port: port,
+					Port: int(port),
 					TCP:  istcp,
 				}
 				entries = append(entries, ent)


### PR DESCRIPTION
By using `strconv.ParseInt(…, 32)` the analyzer will know that the value will fit into 32 bits (the warning is in `guestagent_linux.go`).