### PR TITLE
Test workflow should not need any write permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ on:
 env:
   LIMACTL_CREATE_ARGS: ""
 
+permissions: read-all
+
 jobs:
   lints:
     name: "Lints"


### PR DESCRIPTION
Not sure why the StepSecurity bot is ignoring the test workflow.