### PR TITLE
CI: add spell checker

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,12 @@
+# https://github.com/codespell-project/codespell#using-a-config-file
+
+[codespell]
+
+# Comma separated list of dirs to be skipped.
+skip = .git,*.pb.desc,*/node_modules/*,*/public/js/*,*/public/scss/*
+
+# Comma separated list of words to be ignored. Words must be lowercased.
+ignore-words-list = ans,distroname,testof,hda,ststr
+
+# Check file names as well.
+check-filenames = true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,20 @@ jobs:
       # the allow list corresponds to https://github.com/cncf/foundation/blob/e5db022a0009f4db52b89d9875640cf3137153fe/allowed-third-party-license-policy.md
       run: go-licenses check --include_tests  ./... --allowed_licenses=Apache-2.0,BSD-2-Clause,BSD-2-Clause-FreeBSD,BSD-3-Clause,MIT,ISC,Python-2.0,PostgreSQL,X11,Zlib
 
+  spell:
+    name: "Spell check"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871  # v4.2.1
+      with:
+        fetch-depth: 1
+    - uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630  # v2.1
+      with:
+        check_filenames: true
+        check_hidden: true
+        # by default, codespell uses configuration from the .codespellrc
+
   unit:
     name: "Unit tests"
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The PR integrates [`codespell`](https://github.com/codespell-project/codespell) spell checker into CI. `codespell` is executed via [actions-codespell](https://github.com/codespell-project/actions-codespell) with the `.codespellrc` config.

Follows: https://github.com/lima-vm/lima/pull/2754#issuecomment-2419083339