### PR TITLE
limactl shell: ask whether to start the instance if not running

### DIFF
--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -10,12 +10,9 @@ import (
 	"github.com/lima-vm/lima/cmd/limactl/editflags"
 	"github.com/lima-vm/lima/cmd/limactl/guessarg"
 	"github.com/lima-vm/lima/pkg/editutil"
-	"github.com/lima-vm/lima/pkg/instance"
 	"github.com/lima-vm/lima/pkg/limayaml"
-	networks "github.com/lima-vm/lima/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/lima-vm/lima/pkg/uiutil"
 	"github.com/lima-vm/lima/pkg/yqutil"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -132,34 +129,12 @@ func editAction(cmd *cobra.Command, args []string) error {
 	}
 	if inst != nil {
 		logrus.Infof("Instance %q configuration edited", inst.Name)
+		if _, err = startInteractive(cmd, inst.Name, false, false); err != nil {
+			return err
+		}
 	}
-
-	if !tty {
-		// use "start" to start it
-		return nil
-	}
-	if inst == nil {
-		// edited a limayaml file directly
-		return nil
-	}
-	startNow, err := askWhetherToStart()
-	if err != nil {
-		return err
-	}
-	if !startNow {
-		return nil
-	}
-	ctx := cmd.Context()
-	err = networks.Reconcile(ctx, inst.Name)
-	if err != nil {
-		return err
-	}
-	return instance.Start(ctx, inst, "", false)
-}
-
-func askWhetherToStart() (bool, error) {
-	message := "Do you want to start the instance now? "
-	return uiutil.Confirm(message, true)
+	// inst is nil if edited a limayaml file directly
+	return nil
 }
 
 func editBashComplete(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -307,10 +307,17 @@ func watchHostAgentEvents(ctx context.Context, inst *store.Instance, haStdoutPat
 				err = xerr
 				return true
 			}
-			if *inst.Config.Plain {
-				logrus.Infof("READY. Run `ssh -F %q %s` to open the shell.", inst.SSHConfigFile, inst.Hostname)
+			// _LIMACTL_SHELL_IN_ACTION is set if `limactl shell` invoked `limactl start`.
+			// In this case we shouldn't print "Run `lima` to open the shell",
+			// because the user has already executed the `lima` command.
+			if _, limactlShellInAction := os.LookupEnv("_LIMACTL_SHELL_IN_ACTION"); limactlShellInAction {
+				logrus.Infof("READY.")
 			} else {
-				logrus.Infof("READY. Run `%s` to open the shell.", LimactlShellCmd(inst.Name))
+				if *inst.Config.Plain {
+					logrus.Infof("READY. Run `ssh -F %q %s` to open the shell.", inst.SSHConfigFile, inst.Hostname)
+				} else {
+					logrus.Infof("READY. Run `%s` to open the shell.", LimactlShellCmd(inst.Name))
+				}
 			}
 			_ = ShowMessage(inst)
 			err = nil


### PR DESCRIPTION
Before
```console
$ lima
FATA[0000] instance "default" does not exist, run `limactl create default` to create a new instance
```

After
```console
$ lima
ERRO[0000] instance "default" does not exist, run `limactl create default` to create a new instance 
? Do you want to create and start the instance "default" using the default template now? Yes
? Creating an instance "default" Proceed with the current configuration
[...]
INFO[0114] READY.
suda@lima-default:/Users/suda/gopath/src/github.com/lima-vm/lima$
```
