### PR TITLE
Validate the jsonschema against default.yaml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,6 +186,8 @@ jobs:
       run: make
     - name: Install
       run: make install
+    - name: Validate jsonschema
+      run: make schema-limayaml.json
     - name: Validate templates
       run: find -L templates -name '*.yaml' | xargs limactl validate
     - name: Install test dependencies

--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,9 @@ endif
 
 ################################################################################
 schema-limayaml.json: _output/bin/limactl$(exe)
-	$< generate-jsonschema >$@
+ifeq ($(native_compiling),true)
+	$< generate-jsonschema --schemafile $@ examples/default.yaml
+endif
 
 .PHONY: check-jsonschema
 check-jsonschema: schema-limayaml.json

--- a/cmd/limactl/genschema.go
+++ b/cmd/limactl/genschema.go
@@ -3,21 +3,27 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
+	"github.com/goccy/go-yaml"
 	"github.com/invopop/jsonschema"
 	"github.com/lima-vm/lima/pkg/limayaml"
+	jsonschema2 "github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/spf13/cobra"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
+
+	"github.com/sirupsen/logrus"
 )
 
 func newGenSchemaCommand() *cobra.Command {
 	genschemaCommand := &cobra.Command{
 		Use:    "generate-jsonschema",
 		Short:  "Generate json-schema document",
-		Args:   WrapArgsError(cobra.NoArgs),
+		Args:   WrapArgsError(cobra.ArbitraryArgs),
 		RunE:   genschemaAction,
 		Hidden: true,
 	}
+	genschemaCommand.Flags().String("schemafile", "", "Output file")
 	return genschemaCommand
 }
 
@@ -37,7 +43,12 @@ func getProp(props *orderedmap.OrderedMap[string, *jsonschema.Schema], key strin
 	return value
 }
 
-func genschemaAction(cmd *cobra.Command, _ []string) error {
+func genschemaAction(cmd *cobra.Command, args []string) error {
+	file, err := cmd.Flags().GetString("schemafile")
+	if err != nil {
+		return err
+	}
+
 	schema := jsonschema.Reflect(&limayaml.LimaYAML{})
 	// allow Disk to be either string (name) or object (struct)
 	schema.Definitions["Disk"].Type = "" // was: "object"
@@ -54,6 +65,39 @@ func genschemaAction(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintln(cmd.OutOrStdout(), string(j))
+	if len(args) == 0 {
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), string(j))
+		return err
+	}
+
+	if file == "" {
+		return fmt.Errorf("need --schemafile to validate")
+	}
+	err = os.WriteFile(file, j, 0o644)
+	if err != nil {
+		return err
+	}
+	compiler := jsonschema2.NewCompiler()
+	schema2, err := compiler.Compile(file)
+	if err != nil {
+		return err
+	}
+	for _, f := range args {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			return err
+		}
+		var y interface{}
+		err = yaml.Unmarshal(b, &y)
+		if err != nil {
+			return err
+		}
+		err = schema2.Validate(y)
+		if err != nil {
+			return fmt.Errorf("%q: %w", f, err)
+		}
+		logrus.Infof("%q: OK", f)
+	}
+
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/rjeczalik/notify v0.9.3
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/sethvargo/go-password v0.3.1
 	github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/diskfs/go-diskfs v1.4.1 h1:iODgkzHLmvXS+1VDztpW53T+dQm8GQzi20y9yUd5UC
 github.com/diskfs/go-diskfs v1.4.1/go.mod h1:+tOkQs8CMMog6Nvljg8DGIxEXrgL48iyT3OM3IlSz74=
 github.com/djherbis/times v1.6.0 h1:w2ctJ92J8fBvWPxugmXIv7Nz7Q3iDMKNx9v5ocVH20c=
 github.com/djherbis/times v1.6.0/go.mod h1:gOHeRAz2h+VJNZ5Gmc/o7iD9k4wW7NMVqieYCY99oc0=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/elastic/go-libaudit/v2 v2.5.0 h1:5OK919QRnGtcjVBz3n/cs5F42im1mPlVTA9TyIn2K54=
@@ -253,6 +255,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sethvargo/go-password v0.3.1 h1:WqrLTjo7X6AcVYfC6R7GtSyuUQR9hGyAj/f1PYQZCJU=
 github.com/sethvargo/go-password v0.3.1/go.mod h1:rXofC1zT54N7R8K/h1WDUdkf9BOx5OptoxrMBcrXzvs=
 github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af h1:Sp5TG9f7K39yfB+If0vjp97vuT74F72r8hfRpP8jLU0=


### PR DESCRIPTION
We don't want to use the external location of the schema*, and prefer to not use the external python tool.

\* that doesn't even exist yet https://www.schemastore.org/json/

https://pypi.org/project/check-jsonschema/ `check-jsonschema`

So make it possible for the generator to validate that the generated schema matches the `default.yaml`.

Closes #2768