### PR TITLE
Revert "CI: create separate artifacts for macos-{13,14,15}"; use macOS 15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,13 @@ permissions:
 jobs:
   artifacts-darwin:
     name: Artifacts Darwin
-    runs-on: macos-12
+    # The latest release of macOS is used to enable new features.
+    # https://github.com/lima-vm/lima/issues/2767
+    #
+    # Apparently, a binary built on a newer version of macOS can still run on
+    # an older release of macOS without an error.
+    # This is quite different from Linux and glibc.
+    runs-on: macos-15
     timeout-minutes: 20
     steps:
     - name: "Show xcode and SDK version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,13 @@ on:
     - 'master'
 env:
   GO111MODULE: on
-  MACOS_LATEST_PRODUCT_VERSION: 15
 permissions:
   contents: read
 
 jobs:
   artifacts-darwin:
     name: Artifacts Darwin
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # When you update this list, make sure to update MACOS_LATEST_PRODUCT_VERSION too
-        runner: ["macos-13", "macos-14", "macos-15"]
+    runs-on: macos-12
     timeout-minutes: 20
     steps:
     - name: "Show xcode and SDK version"
@@ -41,23 +35,11 @@ jobs:
       with:
         go-version: 1.23.x
     - name: Make darwin artifacts
-      run: |
-        make artifacts-darwin
-        product_version="$(sw_vers --productVersion | cut -d. -f1)"
-        # Rename lima-VERSION-Darwin-arm64.tar.gz to lima-VERSION-Darwin_macOS15-arm64.tar.gz
-        for f in _artifacts/*; do
-          dst=${f/Darwin/Darwin_macOS${product_version}}
-          if [ ${product_version} = ${MACOS_LATEST_PRODUCT_VERSION} ]; then
-            # For the latest macOS release, preserve lima-VERSION-Darwin-arm64.tar.gz
-            cp -a "${f}" "${dst}"
-          else
-            mv "${f}" "${dst}"
-          fi
-        done
+      run: make artifacts-darwin
     - name: "Upload artifacts"
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
       with:
-        name: artifacts-darwin-${{ matrix.runner }}
+        name: artifacts-darwin
         path: _artifacts/
   release:
     # An old release of Ubuntu is chosen for glibc compatibility
@@ -74,8 +56,7 @@ jobs:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871  # v4.2.1
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        pattern: artifacts-darwin-*
-        merge-multiple: true
+        name: artifacts-darwin
         path: _artifacts/
     - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32  # v5.0.2
       with:


### PR DESCRIPTION
Revert #2762
Fix #2767


Apparently, a binary built on a newer version of macOS can still run on an older release of macOS without an error.
This is quite different from Linux and glibc.