### PR TITLE
Avoid calling yq when the expression is empty

### DIFF
--- a/pkg/yqutil/yqutil.go
+++ b/pkg/yqutil/yqutil.go
@@ -38,6 +38,9 @@ func ValidateContent(content []byte) error {
 
 // EvaluateExpression evaluates the yq expression, and returns the modified yaml.
 func EvaluateExpression(expression string, content []byte) ([]byte, error) {
+	if expression == "" {
+		return content, nil
+	}
 	logrus.Debugf("Evaluating yq expression: %q", expression)
 	formatter, err := yamlfmtBasicFormatter()
 	if err != nil {

--- a/pkg/yqutil/yqutil_test.go
+++ b/pkg/yqutil/yqutil_test.go
@@ -25,6 +25,17 @@ func TestValidateContentError(t *testing.T) {
 	assert.ErrorContains(t, err, "could not find expected")
 }
 
+func TestEvaluateExpressionEmpty(t *testing.T) {
+	expression := ""
+	content := `
+foo: bar
+`
+	expected := content
+	out, err := EvaluateExpression(expression, []byte(content))
+	assert.NilError(t, err)
+	assert.Equal(t, expected, string(out))
+}
+
 func TestEvaluateExpressionSimple(t *testing.T) {
 	expression := `.cpus = 2 | .memory = "2GiB"`
 	content := `


### PR DESCRIPTION
Cutting down on the debug log information