### PR TITLE
website: network: move socket_vmnet to the bottom of the page; fix wording

### DIFF
--- a/website/content/en/docs/config/network/_index.md
+++ b/website/content/en/docs/config/network/_index.md
@@ -33,8 +33,6 @@ The loopback addresses of the host is `192.168.5.2` and is accessible from the g
 
 ### DNS (192.168.5.3)
 
-The DNS.
-
 If `hostResolver.enabled` in `lima.yaml` is true, then the hostagent is going to run a DNS server over tcp and udp - each on a separate randomly selected free port. This server does a local lookup using the native host resolver, so it will deal correctly with VPN configurations and split-DNS setups, as well as mDNS, local `/etc/hosts` etc. For this the hostagent has to be compiled with `CGO_ENABLED=1` as default Go resolver is [broken](https://github.com/golang/go/issues/12524).
 
 These tcp and udp ports are then forwarded via iptables rules to `192.168.5.3:53`, overriding the DNS provided by QEMU via slirp.
@@ -135,7 +133,8 @@ The "vzNAT" network does not need the `socket_vmnet` binary and the `sudoers` fi
 ### socket_vmnet
 #### Managed (192.168.105.0/24)
 
-[`socket_vmnet`](https://github.com/lima-vm/socket_vmnet) is required for adding another guest IP that is accessible from the host and other guests.
+[`socket_vmnet`](https://github.com/lima-vm/socket_vmnet) can be used for adding another guest IP that is accessible from the host and other guests,
+without depending on vz.
 It must be installed according to the instruction provided on https://github.com/lima-vm/socket_vmnet.
 
 Note that installation using Homebrew is not secure and not recommended by the Lima project.
@@ -264,11 +263,12 @@ sudo /usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/boot
 ```
 
 #### Unmanaged
+Lima can also connect to "unmanaged" networks addressed by "socket". This
+means that the daemons will not be controlled by Lima, but must be started
+before the instance.  The interface type (host, shared, or bridged) is
+configured in `socket_vmnet` and not in lima.
+
 ```yaml
 networks:
-  # Lima can also connect to "unmanaged" networks addressed by "socket". This
-  # means that the daemons will not be controlled by Lima, but must be started
-  # before the instance.  The interface type (host, shared, or bridged) is
-  # configured in socket_vmnet and not in lima.
-  # - socket: "/var/run/socket_vmnet"
+  - socket: "/var/run/socket_vmnet"
 ```

--- a/website/content/en/docs/config/network/_index.md
+++ b/website/content/en/docs/config/network/_index.md
@@ -57,13 +57,80 @@ During initial cloud-init bootstrap, `iptables` may not yet be installed. In tha
 
 If `hostResolver.enabled` is false, then DNS servers can be configured manually in `lima.yaml` via the `dns` setting. If that list is empty, then Lima will either use the slirp DNS (on Linux), or the nameservers from the first host interface in service order that has an assigned IPv4 address (on macOS).
 
+## Lima user-v2 network
+
+| ⚡ Requirement | Lima >= 0.16.0 |
+|-------------------|----------------|
+
+user-v2 network provides a user-mode networking similar to the [default user-mode network](#user-mode-network--1921685024-) and also provides support for `vm -> vm` communication.
+
+To enable this network mode, define a network with `mode: user-v2` in networks.yaml
+
+By default, the below network configuration is already applied (Since v0.18).
+
+```yaml
+...
+networks:
+  user-v2:
+    mode: user-v2
+    gateway: 192.168.104.1
+    netmask: 255.255.255.0
+...
+```
+
+Instances can then reference these networks from their `lima.yaml` file:
+
+{{< tabpane text=true >}}
+{{% tab header="CLI" %}}
+```bash
+limactl start --network=lima:user-v2
+```
+{{% /tab %}}
+{{% tab header="YAML" %}}
+```yaml
+networks:
+   - lima: user-v2
+```
+{{% /tab %}}
+{{< /tabpane >}}
+
+An instance's IP address is resolvable from another instance as `lima-<NAME>.internal.` (e.g., `lima-default.internal.`).
+
+_Note_
+
+- Enabling this network will disable the [default user-mode network](#user-mode-network--1921685024-)
+
 ## VMNet networks
 
 VMNet assigns a "real" IP address that is reachable from the host.
 
 The configuration steps are different for each network type:
-- [socket_vmnet](#socket_vmnet)
 - [vzNAT](#vzNAT)
+- [socket_vmnet](#socket_vmnet)
+
+### vzNAT
+
+| ⚡ Requirement | Lima >= 0.14, macOS >= 13.0 |
+|-------------------|-----------------------------|
+
+For [VZ](../vmtype/#vz) instances, the "vzNAT" network can be configured as follows:
+{{< tabpane text=true >}}
+{{% tab header="CLI" %}}
+```bash
+limactl start --vm-type=vz --network=vzNAT
+```
+{{% /tab %}}
+{{% tab header="YAML" %}}
+```yaml
+networks:
+- vzNAT: true
+```
+{{% /tab %}}
+{{< /tabpane >}}
+
+The range of the IP address is not specifiable.
+
+The "vzNAT" network does not need the `socket_vmnet` binary and the `sudoers` file.
 
 ### socket_vmnet
 #### Managed (192.168.105.0/24)
@@ -205,70 +272,3 @@ networks:
   # configured in socket_vmnet and not in lima.
   # - socket: "/var/run/socket_vmnet"
 ```
-
-### vzNAT
-
-| ⚡ Requirement | Lima >= 0.14, macOS >= 13.0 |
-|-------------------|-----------------------------|
-
-For [VZ](../vmtype/#vz) instances, the "vzNAT" network can be configured as follows:
-{{< tabpane text=true >}}
-{{% tab header="CLI" %}}
-```bash
-limactl start --vm-type=vz --network=vzNAT
-```
-{{% /tab %}}
-{{% tab header="YAML" %}}
-```yaml
-networks:
-- vzNAT: true
-```
-{{% /tab %}}
-{{< /tabpane >}}
-
-The range of the IP address is not specifiable.
-
-The "vzNAT" network does not need the `socket_vmnet` binary and the `sudoers` file.
-
-## Lima user-v2 network
-
-| ⚡ Requirement | Lima >= 0.16.0 |
-|-------------------|----------------|
-
-user-v2 network provides a user-mode networking similar to the [default user-mode network](#user-mode-network--1921685024-) and also provides support for `vm -> vm` communication.
-
-To enable this network mode, define a network with `mode: user-v2` in networks.yaml
-
-By default, the below network configuration is already applied (Since v0.18).
-
-```yaml
-...
-networks:
-  user-v2:
-    mode: user-v2
-    gateway: 192.168.104.1
-    netmask: 255.255.255.0
-...
-```
-
-Instances can then reference these networks from their `lima.yaml` file:
-
-{{< tabpane text=true >}}
-{{% tab header="CLI" %}}
-```bash
-limactl start --network=lima:user-v2
-```
-{{% /tab %}}
-{{% tab header="YAML" %}}
-```yaml
-networks:
-   - lima: user-v2
-```
-{{% /tab %}}
-{{< /tabpane >}}
-
-An instance's IP address is resolvable from another instance as `lima-<NAME>.internal.` (e.g., `lima-default.internal.`).
-
-_Note_
-
-- Enabling this network will disable the [default user-mode network](#user-mode-network--1921685024-)


### PR DESCRIPTION
`socket_vmnet` is quite complex and should be considered as the "last resort" option.

- The first commit moves the `socket_vmnet` section to the bottom of the page.
- The second commit fixes wording
