### PR TITLE
Avoid spamming the log when /dev/rtc does not exist

### DIFF
--- a/pkg/guestagent/guestagent_linux.go
+++ b/pkg/guestagent/guestagent_linux.go
@@ -324,6 +324,11 @@ const deltaLimit = 2 * time.Second
 
 func (a *agent) fixSystemTimeSkew() {
 	for {
+		ok, err := timesync.HasRTC()
+		if !ok {
+			logrus.Warnf("fixSystemTimeSkew: error: %s", err.Error())
+			break
+		}
 		ticker := time.NewTicker(10 * time.Second)
 		for now := range ticker.C {
 			rtc, err := timesync.GetRTCTime()

--- a/pkg/guestagent/timesync/timesync_linux.go
+++ b/pkg/guestagent/timesync/timesync_linux.go
@@ -1,6 +1,7 @@
 package timesync
 
 import (
+	"errors"
 	"os"
 	"time"
 
@@ -8,6 +9,11 @@ import (
 )
 
 const rtc = "/dev/rtc"
+
+func HasRTC() (bool, error) {
+	_, err := os.Stat(rtc)
+	return !errors.Is(err, os.ErrNotExist), err
+}
 
 func GetRTCTime() (t time.Time, err error) {
 	f, err := os.Open(rtc)


### PR DESCRIPTION
For instance the Raspberry Pi does not have any real-time clock, so rely on network time synchronization instead (systemd-timesyncd).

----

Currently you get a warning every 10 seconds in the guestagent log

```
2024-10-24T16:01:43.502852+00:00 keylimepi lima-guestagent[726]: time="2024-10-24T16:01:43Z" level=warning msg="fixSystemTimeSkew: lookup error: open /dev/rtc: no such file or directory"
2024-10-24T16:01:53.512171+00:00 keylimepi lima-guestagent[726]: time="2024-10-24T16:01:53Z" level=warning msg="fixSystemTimeSkew: lookup error: open /dev/rtc: no such file or directory"
```

But it only needs to be logged once, that there is no `/dev/rtc` file.