### PR TITLE
limactl: make sure to remove "." from instance names

### DIFF
--- a/cmd/limactl/guessarg/guessarg.go
+++ b/cmd/limactl/guessarg/guessarg.go
@@ -45,6 +45,16 @@ func SeemsYAMLPath(arg string) bool {
 	return strings.HasSuffix(lower, ".yml") || strings.HasSuffix(lower, ".yaml")
 }
 
+func InstNameFromTemplateName(templateName string) (string, error) {
+	s := filepath.Base(templateName)
+	s = strings.ReplaceAll(s, ".", "-")
+	if err := identifiers.Validate(s); err != nil {
+		return "", fmt.Errorf("instance name %q (from template name %qI is invalid: %w",
+			s, templateName, err)
+	}
+	return s, nil
+}
+
 func InstNameFromURL(urlStr string) (string, error) {
 	u, err := url.Parse(urlStr)
 	if err != nil {

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -149,7 +149,11 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 		}
 		if st.instName == "" {
 			// e.g., templateName = "deprecated/centos-7" , st.instName = "centos-7"
-			st.instName = filepath.Base(templateName)
+			// e.g., templateName = "ubuntu-24.10" , st.instName = "ubuntu-24-10"
+			st.instName, err = guessarg.InstNameFromTemplateName(templateName)
+			if err != nil {
+				return nil, err
+			}
 		}
 		st.yBytes, err = templatestore.Read(templateName)
 		if err != nil {


### PR DESCRIPTION
Now `limactl create template://ubuntu-24.10` creates `ubuntu-24-10`.

Fix #2813