### PR TITLE
Allow "." and "_" in instance names, disallow them in hostnames

### DIFF
--- a/cmd/limactl/guessarg/guessarg.go
+++ b/cmd/limactl/guessarg/guessarg.go
@@ -56,7 +56,8 @@ func InstNameFromURL(urlStr string) (string, error) {
 func InstNameFromYAMLPath(yamlPath string) (string, error) {
 	s := strings.ToLower(filepath.Base(yamlPath))
 	s = strings.TrimSuffix(strings.TrimSuffix(s, ".yml"), ".yaml")
-	s = strings.ReplaceAll(s, ".", "-")
+	// "." is allowed in instance names, but replaced to "-" for hostnames.
+	// e.g., yaml: "ubuntu-24.04.yaml" , instance name: "ubuntu-24.04", hostname: "lima-ubuntu-24-04"
 	if err := identifiers.Validate(s); err != nil {
 		return "", fmt.Errorf("filename %q is invalid: %w", yamlPath, err)
 	}

--- a/cmd/limactl/show-ssh.go
+++ b/cmd/limactl/show-ssh.go
@@ -86,8 +86,8 @@ func showSSHAction(cmd *cobra.Command, args []string) error {
 		}
 		return err
 	}
-	logrus.Warnf("`limactl show-ssh` is deprecated. Instead, use `ssh -F %s lima-%s`.",
-		filepath.Join(inst.Dir, filenames.SSHConfig), inst.Name)
+	logrus.Warnf("`limactl show-ssh` is deprecated. Instead, use `ssh -F %s %s`.",
+		filepath.Join(inst.Dir, filenames.SSHConfig), inst.Hostname)
 	opts, err := sshutil.SSHOpts(
 		inst.Dir,
 		*inst.Config.SSH.LoadDotSSHPubKeys,

--- a/cmd/limactl/tunnel.go
+++ b/cmd/limactl/tunnel.go
@@ -146,7 +146,7 @@ func tunnelAction(cmd *cobra.Command, args []string) error {
 	default:
 		fmt.Fprintf(stdout, "Set `ALL_PROXY=socks5h://127.0.0.1:%d`, etc.\n", port)
 	}
-	fmt.Fprintf(stdout, "The instance can be connected from the host as <http://lima-%s.internal> via a web browser.\n", inst.Name)
+	fmt.Fprintf(stdout, "The instance can be connected from the host as <http://%s.internal> via a web browser.\n", inst.Hostname)
 
 	// TODO: show the port in `limactl list --json` ?
 	// TODO: add `--stop` flag to shut down the tunnel

--- a/pkg/cidata/cidata.TEMPLATE.d/meta-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/meta-data
@@ -1,2 +1,2 @@
 instance-id: {{.IID}}
-local-hostname: lima-{{.Name}}
+local-hostname: {{.Hostname}}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/lima-vm/lima/pkg/debugutil"
+	"github.com/lima-vm/lima/pkg/identifierutil"
 	"github.com/lima-vm/lima/pkg/iso9660util"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/localpathutil"
@@ -128,6 +129,7 @@ func templateArgs(bootScripts bool, instDir, name string, instConfig *limayaml.L
 		Debug:              debugutil.Debug,
 		BootScripts:        bootScripts,
 		Name:               name,
+		Hostname:           identifierutil.HostnameFromInstName(name), // TODO: support customization
 		User:               u.Username,
 		UID:                uid,
 		Home:               fmt.Sprintf("/home/%s.linux", u.Username),

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -56,6 +56,7 @@ type Disk struct {
 type TemplateArgs struct {
 	Debug                           bool
 	Name                            string // instance name
+	Hostname                        string // instance hostname
 	IID                             string // instance id
 	User                            string // user name
 	Home                            string // home directory

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -28,6 +28,7 @@ import (
 	hostagentapi "github.com/lima-vm/lima/pkg/hostagent/api"
 	"github.com/lima-vm/lima/pkg/hostagent/dns"
 	"github.com/lima-vm/lima/pkg/hostagent/events"
+	"github.com/lima-vm/lima/pkg/identifierutil"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/osutil"
@@ -288,7 +289,8 @@ func (a *HostAgent) Run(ctx context.Context) error {
 	if limayaml.FirstUsernetIndex(a.instConfig) == -1 && *a.instConfig.HostResolver.Enabled {
 		hosts := a.instConfig.HostResolver.Hosts
 		hosts["host.lima.internal"] = networks.SlirpGateway
-		hosts[fmt.Sprintf("lima-%s", a.instName)] = networks.SlirpIPAddress
+		hostname := identifierutil.HostnameFromInstName(a.instName) // TODO: support customization
+		hosts[hostname] = networks.SlirpIPAddress
 		srvOpts := dns.ServerOptions{
 			UDPPort: a.udpDNSLocalPort,
 			TCPPort: a.tcpDNSLocalPort,

--- a/pkg/identifierutil/identifierutil.go
+++ b/pkg/identifierutil/identifierutil.go
@@ -1,0 +1,9 @@
+package identifierutil
+
+import "strings"
+
+func HostnameFromInstName(instName string) string {
+	s := strings.ReplaceAll(instName, ".", "-")
+	s = strings.ReplaceAll(s, "_", "-")
+	return "lima-" + s
+}

--- a/pkg/identifierutil/identifierutil_test.go
+++ b/pkg/identifierutil/identifierutil_test.go
@@ -1,0 +1,13 @@
+package identifierutil
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestHostnameFromInstName(t *testing.T) {
+	assert.Equal(t, "lima-default", HostnameFromInstName("default"))
+	assert.Equal(t, "lima-ubuntu-24-04", HostnameFromInstName("ubuntu-24.04"))
+	assert.Equal(t, "lima-foo-bar-baz", HostnameFromInstName("foo_bar.baz"))
+}

--- a/pkg/instance/ansible.go
+++ b/pkg/instance/ansible.go
@@ -41,7 +41,7 @@ func runAnsiblePlaybook(ctx context.Context, inst *store.Instance, playbook stri
 func createAnsibleInventory(inst *store.Instance) (string, error) {
 	vars := map[string]interface{}{
 		"ansible_connection":      "ssh",
-		"ansible_host":            "lima-" + inst.Name,
+		"ansible_host":            inst.Hostname,
 		"ansible_ssh_common_args": "-F " + inst.SSHConfigFile,
 	}
 	hosts := map[string]interface{}{

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -308,7 +308,7 @@ func watchHostAgentEvents(ctx context.Context, inst *store.Instance, haStdoutPat
 				return true
 			}
 			if *inst.Config.Plain {
-				logrus.Infof("READY. Run `ssh -F %q lima-%s` to open the shell.", inst.SSHConfigFile, inst.Name)
+				logrus.Infof("READY. Run `ssh -F %q %s` to open the shell.", inst.SSHConfigFile, inst.Hostname)
 			} else {
 				logrus.Infof("READY. Run `%s` to open the shell.", LimactlShellCmd(inst.Name))
 			}

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/cpu"
 
+	"github.com/lima-vm/lima/pkg/identifierutil"
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/ptr"
@@ -814,12 +815,14 @@ func executeGuestTemplate(format, instDir string, param map[string]string) (byte
 	tmpl, err := template.New("").Parse(format)
 	if err == nil {
 		user, _ := osutil.LimaUser(false)
+		name := filepath.Base(instDir)
 		data := map[string]interface{}{
-			"Home":  fmt.Sprintf("/home/%s.linux", user.Username),
-			"Name":  filepath.Base(instDir),
-			"UID":   user.Uid,
-			"User":  user.Username,
-			"Param": param,
+			"Home":     fmt.Sprintf("/home/%s.linux", user.Username),
+			"Name":     name,
+			"Hostname": identifierutil.HostnameFromInstName(name), // TODO: support customization
+			"UID":      user.Uid,
+			"User":     user.Username,
+			"Param":    param,
 		}
 		var out bytes.Buffer
 		if err := tmpl.Execute(&out, data); err == nil {
@@ -836,9 +839,10 @@ func executeHostTemplate(format, instDir string, param map[string]string) (bytes
 		home, _ := os.UserHomeDir()
 		limaHome, _ := dirnames.LimaDir()
 		data := map[string]interface{}{
-			"Dir":   instDir,
-			"Home":  home,
-			"Name":  filepath.Base(instDir),
+			"Dir":  instDir,
+			"Home": home,
+			"Name": filepath.Base(instDir),
+			// TODO: add hostname fields for the host and the guest
 			"UID":   user.Uid,
 			"User":  user.Username,
 			"Param": param,

--- a/pkg/networks/usernet/client.go
+++ b/pkg/networks/usernet/client.go
@@ -39,7 +39,7 @@ func (c *Client) ConfigureDriver(ctx context.Context, driver *driver.BaseDriver)
 		return err
 	}
 	hosts := driver.Instance.Config.HostResolver.Hosts
-	hosts[fmt.Sprintf("lima-%s.internal", driver.Instance.Name)] = ipAddress
+	hosts[fmt.Sprintf("%s.internal", driver.Instance.Hostname)] = ipAddress
 	err = c.AddDNSHosts(hosts)
 	return err
 }

--- a/pkg/sshutil/format.go
+++ b/pkg/sshutil/format.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/lima-vm/lima/pkg/identifierutil"
 )
 
 // FormatT specifies the format type.
@@ -57,7 +59,7 @@ func quoteOption(o string) string {
 
 // Format formats the ssh options.
 func Format(w io.Writer, instName string, format FormatT, opts []string) error {
-	fakeHostname := "lima-" + instName // corresponds to the default guest hostname
+	fakeHostname := identifierutil.HostnameFromInstName(instName) // TODO: support customization
 	switch format {
 	case FormatCmd:
 		args := []string{"ssh"}

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/docker/go-units"
 	hostagentclient "github.com/lima-vm/lima/pkg/hostagent/api/client"
+	"github.com/lima-vm/lima/pkg/identifierutil"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
@@ -38,7 +39,9 @@ const (
 )
 
 type Instance struct {
-	Name            string             `json:"name"`
+	Name string `json:"name"`
+	// Hostname, not HostName (corresponds to SSH's naming convention)
+	Hostname        string             `json:"hostname"`
 	Status          Status             `json:"status"`
 	Dir             string             `json:"dir"`
 	VMType          limayaml.VMType    `json:"vmType"`
@@ -66,8 +69,10 @@ type Instance struct {
 // Other errors are returned as *Instance.Errors.
 func Inspect(instName string) (*Instance, error) {
 	inst := &Instance{
-		Name:   instName,
-		Status: StatusUnknown,
+		Name: instName,
+		// TODO: support customizing hostname
+		Hostname: identifierutil.HostnameFromInstName(instName),
+		Status:   StatusUnknown,
 	}
 	// InstanceDir validates the instName but does not check whether the instance exists
 	instDir, err := InstanceDir(instName)

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -56,7 +56,7 @@ disk: null
 
 # Expose host directories to the guest, the mount point might be accessible from all UIDs in the guest
 # "location" can use these template variables: {{.Home}}, {{.Dir}}, {{.Name}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
-# "mountPoint" can use these template variables: {{.Home}}, {{.Name}}, {{.UID}}, {{.User}}, and {{.Param.Key}}
+# "mountPoint" can use these template variables: {{.Home}}, {{.Name}}, {{.Hostname}}, {{.UID}}, {{.User}}, and {{.Param.Key}}
 # 🟢 Builtin default: [] (Mount nothing)
 # 🔵 This file: Mount the home as read-only, /tmp/lima as writable
 mounts:
@@ -205,7 +205,7 @@ containerd:
 
 # Provisioning scripts need to be idempotent because they might be called
 # multiple times, e.g. when the host VM is being restarted.
-# The scripts can use the following template variables: {{.Home}}, {{.UID}}, {{.User}}, and {{.Param.Key}}
+# The scripts can use the following template variables: {{.Home}}, {{.Name}}, {{.Hostname}}, {{.UID}}, {{.User}}, and {{.Param.Key}}
 # 🟢 Builtin default: []
 # provision:
 # # `system` is executed with root privileges
@@ -248,7 +248,7 @@ containerd:
 
 # Probe scripts to check readiness.
 # The scripts run in user mode. They must start with a '#!' line.
-# The scripts can use the following template variables: {{.Home}}, {{.UID}}, {{.User}}, and {{.Param.Key}}
+# The scripts can use the following template variables: {{.Home}}, {{.Name}}, {{.Hostname}}, {{.UID}}, {{.User}}, and {{.Param.Key}}
 # 🟢 Builtin default: []
 # probes:
 # # Only `readiness` probes are supported right now.
@@ -407,7 +407,7 @@ networks:
 # - guestSocket: "/run/user/{{.UID}}/my.sock"
 #   hostSocket: mysocket
 # # default: reverse: false
-# # "guestSocket" can include these template variables: {{.Home}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
+# # "guestSocket" can include these template variables: {{.Home}}, {{.Name}}, {{.Hostname}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
 # # "hostSocket" can include {{.Home}}, {{.Dir}}, {{.Name}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
 # # "reverse" can only be used for unix sockets right now, not for tcp sockets.
 # # Put sockets into "{{.Dir}}/sock" to avoid collision with Lima internal sockets!
@@ -427,7 +427,7 @@ networks:
 # - guest: "/etc/myconfig.cfg"
 #   host: "{{.Dir}}/copied-from-guest/myconfig"
 # # deleteOnStop: false
-# # "guest" can include these template variables: {{.Home}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
+# # "guest" can include these template variables: {{.Home}}, {{.Name}}, {{.Hostname}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
 # # "host" can include {{.Home}}, {{.Dir}}, {{.Name}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
 # # "deleteOnStop" will delete the file from the host when the instance is stopped.
 


### PR DESCRIPTION
Now `limactl create template://ubuntu-24.10` and `limactl create ./ubuntu-24.10.yaml` creates an instance named `ubuntu-24.10` with the hostname `lima-ubuntu-24-10`.

Eventually the hostname should be customizable via the YAML, but it is beyond the scope of this commit.

Fix #2813
Alternative to:
- #2815