### PR TITLE
Add `hack/update-template-oraclelinux.sh`

### DIFF
--- a/hack/update-template-almalinux.sh
+++ b/hack/update-template-almalinux.sh
@@ -130,8 +130,8 @@ function almalinux_latest_image_entry_for_url_spec() {
 }
 
 function almalinux_cache_key_for_image_kernel() {
-	local location=$1 overriding=${3:-"{}"} url_spec
-	url_spec=$(almalinux_url_spec_from_location "${location}" | jq -r ". + ${overriding}")
+	local location=$1 url_spec
+	url_spec=$(almalinux_url_spec_from_location "${location}")
 	jq -r '["almalinux", .major_minor_version // .major_version, .target_vendor,
 		if .date then "timestamped" else "latest" end,
 		.arch, .file_extension] | join(":")' <<<"${url_spec}"
@@ -254,7 +254,7 @@ for template in "${templates[@]}"; do
 		set +e # Disable 'set -e' to avoid exiting on error for the next assignment.
 		cache_key=$(
 			set -e # Enable 'set -e' for the next command.
-			almalinux_cache_key_for_image_kernel "${location}" "${kernel_location}" "${overriding}"
+			almalinux_cache_key_for_image_kernel "${location}" "${kernel_location}"
 		) # Check exit status separately to prevent disabling 'set -e' by using the function call in the condition.
 		# shellcheck disable=2181
 		[[ $? -eq 0 ]] || continue

--- a/hack/update-template-archlinux.sh
+++ b/hack/update-template-archlinux.sh
@@ -261,7 +261,7 @@ for template in "${templates[@]}"; do
 		set +e # Disable 'set -e' to avoid exiting on error for the next assignment.
 		cache_key=$(
 			set -e # Enable 'set -e' for the next command.
-			archlinux_cache_key_for_image_kernel "${location}" "${kernel_location}" "${overriding}"
+			archlinux_cache_key_for_image_kernel "${location}" "${kernel_location}"
 		) # Check exit status separately to prevent disabling 'set -e' by using the function call in the condition.
 		# shellcheck disable=2181
 		[[ $? -eq 0 ]] || continue

--- a/hack/update-template-centos-stream.sh
+++ b/hack/update-template-centos-stream.sh
@@ -20,7 +20,7 @@ Description:
   This script updates the CentOS Stream image location in the specified templates.
   If the image location in the template contains a release date in the URL, the script replaces it with the latest available date.
 
-  Image location basename format: CentOS[Stream-GenericCloud-<version>-[latest|<date>.0].<arch>.qcow2
+  Image location basename format: CentOS-Stream-GenericCloud-<version>-[latest|<date>.0].<arch>.qcow2
 
   Published CentOS Stream image information is fetched from the following URLs:
 
@@ -121,8 +121,8 @@ function centos_latest_image_entry_for_url_spec() {
 }
 
 function centos_cache_key_for_image_kernel() {
-	local location=$1 overriding=${3:-"{}"} url_spec
-	url_spec=$(centos_url_spec_from_location "${location}" | jq -r ". + ${overriding}")
+	local location=$1 url_spec
+	url_spec=$(centos_url_spec_from_location "${location}")
 	jq -r '["centos", .version, .target_vendor,
 		if .date_and_ci_job_id then "timestamped" else "latest" end,
 		.arch, .file_extension] | join(":")' <<<"${url_spec}"
@@ -241,7 +241,7 @@ for template in "${templates[@]}"; do
 		set +e # Disable 'set -e' to avoid exiting on error for the next assignment.
 		cache_key=$(
 			set -e # Enable 'set -e' for the next command.
-			centos_cache_key_for_image_kernel "${location}" "${kernel_location}" "${overriding}"
+			centos_cache_key_for_image_kernel "${location}" "${kernel_location}"
 		) # Check exit status separately to prevent disabling 'set -e' by using the function call in the condition.
 		# shellcheck disable=2181
 		[[ $? -eq 0 ]] || continue

--- a/hack/update-template-debian.sh
+++ b/hack/update-template-debian.sh
@@ -285,8 +285,8 @@ function debian_location_from_url_spec() {
 # debian_release_24.04-server-amd64-.img
 # ```
 function debian_cache_key_for_image_kernel_overriding() {
-	local location=$1 kernel_location=${2:-null} overriding=${3:-"{}"} url_spec with_kernel='' version backports arch daily timestamped file_extension
-	url_spec=$(debian_url_spec_from_location "${location}" | jq -r ". + ${overriding}")
+	local location=$1 kernel_location=${2:-null} url_spec with_kernel='' version backports arch daily timestamped file_extension
+	url_spec=$(debian_url_spec_from_location "${location}")
 	[[ ${kernel_location} != "null" ]] && with_kernel=_with_kernel
 	version=$(jq -r '.version|if . then "-\(.)" else empty end' <<<"${url_spec}")
 	backports=$(jq -r 'if .backports then "-backports" else empty end' <<<"${url_spec}")
@@ -407,7 +407,7 @@ for template in "${templates[@]}"; do
 		set +e # Disable 'set -e' to avoid exiting on error for the next assignment.
 		cache_key=$(
 			set -e # Enable 'set -e' for the next command.
-			debian_cache_key_for_image_kernel_overriding "${location}" "${kernel_location}" "${overriding}"
+			debian_cache_key_for_image_kernel_overriding "${location}" "${kernel_location}"
 		) # Check exit status separately to prevent disabling 'set -e' by using the function call in the condition.
 		# shellcheck disable=2181
 		[[ $? -eq 0 ]] || continue

--- a/hack/update-template-oraclelinux.sh
+++ b/hack/update-template-oraclelinux.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# Functions in this script assume error handling with 'set -e'.
+# To ensure 'set -e' works correctly:
+# - Use 'set +e' before assignments and '$(set -e; <function>)' to capture output without exiting on errors.
+# - Avoid calling functions directly in conditions to prevent disabling 'set -e'.
+# - Use 'shopt -s inherit_errexit' (Bash 4.4+) to avoid repeated 'set -e' in all '$(...)'.
+shopt -s inherit_errexit || error_exit "inherit_errexit not supported. Please use bash 4.4 or later."
+
+function oraclelinux_print_help() {
+	cat <<HELP
+$(basename "${BASH_SOURCE[0]}"): Update the Oracle Linux image location in the specified templates
+
+Usage:
+  $(basename "${BASH_SOURCE[0]}") [--version <version>] <template.yaml>...
+
+Description:
+  This script updates the Oracle Linux image location in the specified templates.
+  Image location basename format:
+
+	OL<version>U<release>_<arch>-kvm[-cloud]-b<build number>.qcow2
+
+  Published Oracle Linux image information is fetched from the following URLs:
+
+    OL8:
+	  x86_64: https://yum.oracle.com/templates/OracleLinux/ol8-template.json
+	  aarch64: https://yum.oracle.com/templates/OracleLinux/ol8_aarch64-cloud-template.json
+	  
+	OL9:
+	  x86_64: https://yum.oracle.com/templates/OracleLinux/ol9-template.json
+	  aarch64: https://yum.oracle.com/templates/OracleLinux/ol9_aarch64-cloud-template.json
+
+  The downloaded files will be cached in the Lima cache directory.
+
+Examples:
+  Update the Oracle Linux image location in templates/**.yaml:
+  $ $(basename "${BASH_SOURCE[0]}") templates/**.yaml
+
+  Update the Oracle Linux image location to version 9 in ~/.lima/oraclelinux/lima.yaml:
+  $ $(basename "${BASH_SOURCE[0]}") --version 9 ~/.lima/oraclelinux/lima.yaml
+  $ limactl factory-reset oraclelinux
+
+Flags:
+  --version <version>  Use the specified Oracle Linux <version>.
+                       The version must be 7+ for x86_64 or 8+ for aarch64.
+  -h, --help           Print this help message
+HELP
+}
+
+# print the URL spec for the given location
+function oraclelinux_url_spec_from_location() {
+	local location=$1 jq_filter url_spec
+	jq_filter='capture("
+		^https://yum\\.oracle\\.com/templates/OracleLinux/OL(?<path_version>\\d+)/u(?<path_release>\\d+)/(?<path_arch>[^/]+)/
+		OL(?<version>\\d+)U(?<release>\\d+)_(?<arch>[^-]+)-(?<type>[^-]+)(?<cloud>-cloud)?-b(?<build_number>\\d+)\\.(?<file_extension>.*)$
+	";"x")
+	'
+	url_spec=$(jq -e -r "${jq_filter}" <<<"\"${location}\"")
+	echo "${url_spec}"
+}
+
+readonly oraclelinux_jq_filter_json_url='
+	"https://yum.oracle.com/templates/OracleLinux/" +
+	"ol\(.path_version)\(if .path_arch != "x86_64" then "_" + .path_arch else "" end)\(.cloud // "")-template.json"
+'
+
+function oraclelinux_json_url_from_url_spec() {
+	local -r url_spec=$1
+	jq -e -r "${oraclelinux_jq_filter_json_url}" <<<"${url_spec}" ||
+		error_exit "Failed to get the JSON url for ${url_spec}"
+}
+
+function oraclelinux_latest_image_entry_for_url_spec() {
+	local url_spec=$1 arch json_url downloaded_json latest_version_info
+	# shellcheck disable=SC2034
+	arch=$(jq -r '.arch' <<<"${url_spec}")
+	json_url=$(oraclelinux_json_url_from_url_spec "${url_spec}")
+	downloaded_json=$(download_to_cache "${json_url}")
+	latest_version_info="$(jq -e -r --argjson spec "${url_spec}" '{
+		location: ("https://yum.oracle.com" + .base_url + "/" + .[$spec.type].image),
+		sha256: ("sha256:" + .[$spec.type].sha256)
+	}' <"${downloaded_json}")"
+	[[ -n ${latest_version_info} ]] || return
+	local location digest
+	# prefer the v<major>.<minor> in the path
+	location=$(jq -e -r '.location' <<<"${latest_version_info}")
+	location=$(validate_url_without_redirect "${location}")
+	# shellcheck disable=SC2034
+	digest=$(jq -e -r '.sha256' <<<"${latest_version_info}")
+	json_vars location arch digest
+}
+
+function oraclelinux_cache_key_for_image_kernel() {
+	local location=$1 overriding=${3:-"{}"} url_spec
+	url_spec=$(oraclelinux_url_spec_from_location "${location}" | jq -r ". + ${overriding}")
+	jq -r '["oraclelinux", .path_version, .type, .cloud // empty, .arch, .file_extension] | join(":")' <<<"${url_spec}"
+}
+
+function oraclelinux_image_entry_for_image_kernel() {
+	local location=$1 kernel_is_not_supported=$2 overriding=${3:-"{}"} url_spec image_entry=''
+	[[ ${kernel_is_not_supported} == "null" ]] || echo "Updating kernel information is not supported on Oracle Linux" >&2
+	url_spec=$(oraclelinux_url_spec_from_location "${location}" | jq -r ". + ${overriding}")
+	image_entry=$(oraclelinux_latest_image_entry_for_url_spec "${url_spec}")
+	# shellcheck disable=SC2031
+	if [[ -z ${image_entry} ]]; then
+		error_exit "Failed to get the ${url_spec} image location for ${location}"
+	elif jq -e ".location == \"${location}\"" <<<"${image_entry}" >/dev/null; then
+		echo "Image location is up-to-date: ${location}" >&2
+	else
+		echo "${image_entry}"
+	fi
+}
+
+# check if the script is executed or sourced
+# shellcheck disable=SC1091
+if [[ ${BASH_SOURCE[0]} == "${0}" ]]; then
+	scriptdir=$(dirname "${BASH_SOURCE[0]}")
+	# shellcheck source=./cache-common-inc.sh
+	. "${scriptdir}/cache-common-inc.sh"
+
+	# shellcheck source=/dev/null # avoid shellcheck hangs on source looping
+	. "${scriptdir}/update-template.sh"
+else
+	# this script is sourced
+	if [[ -v SUPPORTED_DISTRIBUTIONS ]]; then
+		SUPPORTED_DISTRIBUTIONS+=("oraclelinux")
+	else
+		declare -a SUPPORTED_DISTRIBUTIONS=("oraclelinux")
+	fi
+	return 0
+fi
+
+declare -a templates=()
+declare overriding='{}'
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	-h | --help)
+		oraclelinux_print_help
+		exit 0
+		;;
+	-d | --debug) set -x ;;
+	--version)
+		if [[ -n $2 && $2 != -* ]]; then
+			overriding=$(
+				path_version="${2}"
+				[[ ${path_version} =~ ^[0-9]+$ ]] || error_exit "Oracle Linux version must be a number"
+				[[ ${path_version} -eq 7 ]] && echo 'Oracle Linux version 7 exists only for x86_64. It may fail for aarch64.' >&2
+				[[ ${path_version} -gt 7 ]] || error_exit "Oracle Linux version must be 7+ for x86_64 or 8+ for aarch64"
+				json_vars path_version <<<"${overriding}"
+			)
+			shift
+		else
+			error_exit "--version requires a value"
+		fi
+		;;
+	--version=*)
+		overriding=$(
+			path_version="${1#*=}"
+			[[ ${path_version} =~ ^[0-9]+$ ]] || error_exit "Oracle Linux version must be a number"
+			[[ ${path_version} -eq 7 ]] && echo 'Oracle Linux version 7 exists only for x86_64. It may fail for aarch64.' >&2
+			[[ ${path_version} -gt 7 ]] || error_exit "Oracle Linux version must be 7+ for x86_64 or 8+ for aarch64"
+			json_vars path_version <<<"${overriding}"
+		)
+		;;
+	*.yaml) templates+=("$1") ;;
+	*)
+		error_exit "Unknown argument: $1"
+		;;
+	esac
+	shift
+	[[ -z ${overriding} ]] && overriding="{}"
+done
+
+if [[ ${#templates[@]} -eq 0 ]]; then
+	oraclelinux_print_help
+	exit 0
+fi
+
+declare -A image_entry_cache=()
+
+for template in "${templates[@]}"; do
+	echo "Processing ${template}"
+	# 1. extract location by parsing template using arch
+	yq_filter="
+		.images[] | [.location, .kernel.location, .kernel.cmdline] | @tsv
+	"
+	parsed=$(yq eval "${yq_filter}" "${template}")
+
+	# 3. get the image location
+	arr=()
+	while IFS= read -r line; do arr+=("${line}"); done <<<"${parsed}"
+	locations=("${arr[@]}")
+	for ((index = 0; index < ${#locations[@]}; index++)); do
+		[[ ${locations[index]} != "null" ]] || continue
+		set -e
+		IFS=$'\t' read -r location kernel_location kernel_cmdline <<<"${locations[index]}"
+		set +e # Disable 'set -e' to avoid exiting on error for the next assignment.
+		cache_key=$(
+			set -e # Enable 'set -e' for the next command.
+			oraclelinux_cache_key_for_image_kernel "${location}" "${kernel_location}" "${overriding}"
+		) # Check exit status separately to prevent disabling 'set -e' by using the function call in the condition.
+		# shellcheck disable=2181
+		[[ $? -eq 0 ]] || continue
+		image_entry=$(
+			set -e # Enable 'set -e' for the next command.
+			if [[ -v image_entry_cache[${cache_key}] ]]; then
+				echo "${image_entry_cache[${cache_key}]}"
+			else
+				oraclelinux_image_entry_for_image_kernel "${location}" "${kernel_location}" "${overriding}"
+			fi
+		) # Check exit status separately to prevent disabling 'set -e' by using the function call in the condition.
+		# shellcheck disable=2181
+		[[ $? -eq 0 ]] || continue
+		set -e
+		image_entry_cache[${cache_key}]="${image_entry}"
+		if [[ -n ${image_entry} ]]; then
+			[[ ${kernel_cmdline} != "null" ]] &&
+				jq -e 'has("kernel")' <<<"${image_entry}" >/dev/null &&
+				image_entry=$(jq ".kernel.cmdline = \"${kernel_cmdline}\"" <<<"${image_entry}")
+			echo "${image_entry}" | jq
+			limactl edit --log-level error --set "
+				.images[${index}] = ${image_entry}|
+				(.images[${index}] | ..) style = \"double\"
+			" "${template}"
+		fi
+	done
+done

--- a/hack/update-template-rocky.sh
+++ b/hack/update-template-rocky.sh
@@ -145,8 +145,8 @@ function rocky_latest_image_entry_for_url_spec() {
 }
 
 function rocky_cache_key_for_image_kernel() {
-	local location=$1 overriding=${3:-"{}"} url_spec
-	url_spec=$(rocky_url_spec_from_location "${location}" | jq -r ". + ${overriding}")
+	local location=$1 url_spec
+	url_spec=$(rocky_url_spec_from_location "${location}")
 	jq -r '["rocky", .major_minor_version // .major_version, .target_vendor,
 		if .date_and_ci_job_id then "timestamped" else "latest" end,
 		.arch, .file_extension] | join(":")' <<<"${url_spec}"
@@ -269,7 +269,7 @@ for template in "${templates[@]}"; do
 		set +e # Disable 'set -e' to avoid exiting on error for the next assignment.
 		cache_key=$(
 			set -e # Enable 'set -e' for the next command.
-			rocky_cache_key_for_image_kernel "${location}" "${kernel_location}" "${overriding}"
+			rocky_cache_key_for_image_kernel "${location}" "${kernel_location}"
 		) # Check exit status separately to prevent disabling 'set -e' by using the function call in the condition.
 		# shellcheck disable=2181
 		[[ $? -eq 0 ]] || continue

--- a/hack/update-template-ubuntu.sh
+++ b/hack/update-template-ubuntu.sh
@@ -302,8 +302,8 @@ function ubuntu_cache_key_for_image_kernel_flavor_version() {
 	local location=$1 kernel_location=${2:-null} url_spec with_kernel='' flavor version arch path_suffix
 	url_spec=$(ubuntu_location_url_spec "${location}")
 	[[ ${kernel_location} != "null" ]] && with_kernel=_with_kernel
-	flavor=${3:-$(ubuntu_flavor_from_location_basename "${location}")}
-	version=${4:-$(ubuntu_version_from_location_basename "${location}")}
+	flavor=$(ubuntu_flavor_from_location_basename "${location}")
+	version=$(ubuntu_version_from_location_basename "${location}")
 	arch=$(ubuntu_arch_from_location_basename "${location}")
 	path_suffix=$(ubuntu_path_suffix_from_location_basename "${location}")
 	echo "ubuntu_${url_spec}${with_kernel}_${version}-${flavor}-${arch}-${path_suffix}"
@@ -425,7 +425,7 @@ for template in "${templates[@]}"; do
 		[[ $? -eq 0 ]] || continue
 		cache_key=$(
 			set -e # Enable 'set -e' for the next command.
-			ubuntu_cache_key_for_image_kernel_flavor_version "${location}" "${kernel_location}" "${overriding_flavor}" "${overriding_version}"
+			ubuntu_cache_key_for_image_kernel_flavor_version "${location}" "${kernel_location}"
 		) # Check exit status separately to prevent disabling 'set -e' by using the function call in the condition.
 		# shellcheck disable=2181
 		[[ $? -eq 0 ]] || continue

--- a/hack/update-template.sh
+++ b/hack/update-template.sh
@@ -156,6 +156,8 @@ if [[ ${BASH_SOURCE[0]} == "${0}" ]]; then
 	. "${scriptdir}/update-template-almalinux.sh"
 	# shellcheck source=./update-template-rocky.sh
 	. "${scriptdir}/update-template-rocky.sh"
+	# shellcheck source=./update-template-oraclelinux.sh
+	. "${scriptdir}/update-template-oraclelinux.sh"
 else
 	# this script is sourced
 	return 0

--- a/templates/oraclelinux-8.yaml
+++ b/templates/oraclelinux-8.yaml
@@ -1,5 +1,5 @@
 # This template requires Lima v0.9.0 or later.
-# Oracle image licence: https://www.oracle.com/downloads/licenses/oracle-linux-license.html
+# Oracle image license: https://www.oracle.com/downloads/licenses/oracle-linux-license.html
 # Image source: https://yum.oracle.com/oracle-linux-templates.html
 
 # NOTE: EL8-based distros are known not to work on M1 chips: https://github.com/lima-vm/lima/issues/841

--- a/templates/oraclelinux-9.yaml
+++ b/templates/oraclelinux-9.yaml
@@ -1,5 +1,5 @@
 # This template requires Lima v0.11.3 or later.
-# Oracle image licence: https://www.oracle.com/downloads/licenses/oracle-linux-license.html
+# Oracle image license: https://www.oracle.com/downloads/licenses/oracle-linux-license.html
 # Image source: https://yum.oracle.com/oracle-linux-templates.html
 
 images:


### PR DESCRIPTION
```console
$ hack/update-template-oraclelinux.sh
update-template-oraclelinux.sh: Update the Oracle Linux image location in the specified templates

Usage:
  update-template-oraclelinux.sh [--version-major <major version>] <template.yaml>...

Description:
  This script updates the Oracle Linux image location in the specified templates.
  Image location basename format:

        OL<major version>U<minor version>_<arch>-kvm[-cloud]-b<build number>.qcow2

  Published Oracle Linux image information is fetched from the following URLs:

    OL8:
          x86_64: https://yum.oracle.com/templates/OracleLinux/ol8-template.json
          aarch64: https://yum.oracle.com/templates/OracleLinux/ol8_aarch64-cloud-template.json
          
        OL9:
          x86_64: https://yum.oracle.com/templates/OracleLinux/ol9-template.json
          aarch64: https://yum.oracle.com/templates/OracleLinux/ol9_aarch64-cloud-template.json

  The downloaded files will be cached in the Lima cache directory.

Examples:
  Update the Oracle Linux image location in templates/**.yaml:
  $ update-template-oraclelinux.sh templates/**.yaml

  Update the Oracle Linux image location to major version 9 in ~/.lima/oraclelinux/lima.yaml:
  $ update-template-oraclelinux.sh --version-major 9 ~/.lima/oraclelinux/lima.yaml
  $ limactl factory-reset oraclelinux

Flags:
  --version-major <major version>  Use the specified Oracle Linux <major version>.
                                   The major version must be 7+ for x86_64 or 8+ for aarch64.
  -h, --help                       Print this help message
```
This PR aims to add Oracle Linux support as per https://github.com/lima-vm/lima/issues/1347.
This change will likely conflict with #2811. After one is merged, the other will need to be rebased.