### PR TITLE
templates: update fedora to 41; templates: disable 9p for Linux 6.9-6.11

### DIFF
--- a/pkg/limayaml/limayaml_test.go
+++ b/pkg/limayaml/limayaml_test.go
@@ -34,8 +34,9 @@ func TestDefaultYAML(t *testing.T) {
 	var y LimaYAML
 	err = Unmarshal(bytes, &y, "")
 	assert.NilError(t, err)
-	y.Images = nil // remove default images
-	y.Mounts = nil // remove default mounts
+	y.Images = nil                // remove default images
+	y.Mounts = nil                // remove default mounts
+	y.MountTypesUnsupported = nil // remove default workaround for kernel 6.9-6.11
 	t.Log(dumpJSON(t, y))
 	b, err := Marshal(&y, false)
 	assert.NilError(t, err)

--- a/templates/archlinux.yaml
+++ b/templates/archlinux.yaml
@@ -17,3 +17,7 @@ mounts:
 - location: "~"
 - location: "/tmp/lima"
   writable: true
+
+# 9p is broken in Linux v6.9, v6.10, and v6.11.
+# The issue was fixed in Linux v6.12-rc5 (https://github.com/torvalds/linux/commit/be2ca38).
+mountTypesUnsupported: ["9p"]

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -106,9 +106,14 @@ mounts:
 
 # List of mount types not supported by the kernel of this distro.
 # Also used to resolve the default mount type when not explicitly specified.
+#
+# NOTE: 9p is broken in Linux v6.9, v6.10, and v6.11.
+# The issue was fixed in Linux v6.12-rc5 (https://github.com/torvalds/linux/commit/be2ca38).
+#
 # 🟢 Builtin default: []
+# 🔵 This file: ["9p"] (as Ubuntu 24.10 uses kernel 6.11)
 mountTypesUnsupported:
-# - "9p"
+- "9p"
 
 # Mount type for above mounts, such as "reverse-sshfs" (from sshocker), "9p" (QEMU’s virtio-9p-pci, aka virtfs),
 # or "virtiofs" (experimental on Linux; needs `vmType: vz` on macOS).

--- a/templates/fedora.yaml
+++ b/templates/fedora.yaml
@@ -1,11 +1,11 @@
 # This template requires Lima v0.7.0 or later.
 images:
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2"
+- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2"
   arch: "x86_64"
-  digest: "sha256:ac58f3c35b73272d5986fa6d3bc44fd246b45df4c334e99a07b3bbd00684adee"
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/aarch64/images/Fedora-Cloud-Base-Generic.aarch64-40-1.14.qcow2"
+  digest: "sha256:6205ae0c524b4d1816dbd3573ce29b5c44ed26c9fbc874fbe48c41c89dd0bac2"
+- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-41-1.4.aarch64.qcow2"
   arch: "aarch64"
-  digest: "sha256:ebdce26d861a9d15072affe1919ed753ec7015bd97b3a7d0d0df6a10834f7459"
+  digest: "sha256:085883b42c7e3b980e366a1fe006cd0ff15877f7e6e984426f3c6c67c7cc2faa"
 mounts:
 - location: "~"
 - location: "/tmp/lima"

--- a/templates/fedora.yaml
+++ b/templates/fedora.yaml
@@ -10,3 +10,7 @@ mounts:
 - location: "~"
 - location: "/tmp/lima"
   writable: true
+
+# 9p is broken in Linux v6.9, v6.10, and v6.11 (used by Fedora 41).
+# The issue was fixed in Linux v6.12-rc5 (https://github.com/torvalds/linux/commit/be2ca38).
+mountTypesUnsupported: ["9p"]

--- a/templates/podman-rootful.yaml
+++ b/templates/podman-rootful.yaml
@@ -12,12 +12,12 @@
 
 # This template requires Lima v0.20.0 or later
 images:
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2"
+- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2"
   arch: "x86_64"
-  digest: "sha256:ac58f3c35b73272d5986fa6d3bc44fd246b45df4c334e99a07b3bbd00684adee"
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/aarch64/images/Fedora-Cloud-Base-Generic.aarch64-40-1.14.qcow2"
+  digest: "sha256:6205ae0c524b4d1816dbd3573ce29b5c44ed26c9fbc874fbe48c41c89dd0bac2"
+- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-41-1.4.aarch64.qcow2"
   arch: "aarch64"
-  digest: "sha256:ebdce26d861a9d15072affe1919ed753ec7015bd97b3a7d0d0df6a10834f7459"
+  digest: "sha256:085883b42c7e3b980e366a1fe006cd0ff15877f7e6e984426f3c6c67c7cc2faa"
 
 mounts:
 - location: "~"

--- a/templates/podman-rootful.yaml
+++ b/templates/podman-rootful.yaml
@@ -68,3 +68,7 @@ message: |
   podman system connection default lima-{{.Name}}
   podman{{if eq .HostOS "linux"}} --remote{{end}} run quay.io/podman/hello
   ------
+
+# 9p is broken in Linux v6.9, v6.10, and v6.11 (used by Fedora 41).
+# The issue was fixed in Linux v6.12-rc5 (https://github.com/torvalds/linux/commit/be2ca38).
+mountTypesUnsupported: ["9p"]

--- a/templates/podman.yaml
+++ b/templates/podman.yaml
@@ -57,3 +57,7 @@ message: |
   podman system connection default lima-{{.Name}}
   podman{{if eq .HostOS "linux"}} --remote{{end}} run quay.io/podman/hello
   ------
+
+# 9p is broken in Linux v6.9, v6.10, and v6.11 (used by Fedora 41).
+# The issue was fixed in Linux v6.12-rc5 (https://github.com/torvalds/linux/commit/be2ca38).
+mountTypesUnsupported: ["9p"]

--- a/templates/podman.yaml
+++ b/templates/podman.yaml
@@ -12,12 +12,12 @@
 
 # This template requires Lima v0.8.0 or later
 images:
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2"
+- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2"
   arch: "x86_64"
-  digest: "sha256:ac58f3c35b73272d5986fa6d3bc44fd246b45df4c334e99a07b3bbd00684adee"
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/aarch64/images/Fedora-Cloud-Base-Generic.aarch64-40-1.14.qcow2"
+  digest: "sha256:6205ae0c524b4d1816dbd3573ce29b5c44ed26c9fbc874fbe48c41c89dd0bac2"
+- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-41-1.4.aarch64.qcow2"
   arch: "aarch64"
-  digest: "sha256:ebdce26d861a9d15072affe1919ed753ec7015bd97b3a7d0d0df6a10834f7459"
+  digest: "sha256:085883b42c7e3b980e366a1fe006cd0ff15877f7e6e984426f3c6c67c7cc2faa"
 
 mounts:
 - location: "~"

--- a/templates/ubuntu-24.10.yaml
+++ b/templates/ubuntu-24.10.yaml
@@ -27,3 +27,7 @@ mounts:
 - location: "~"
 - location: "/tmp/lima"
   writable: true
+
+# 9p is broken in Linux v6.9, v6.10, and v6.11 (used by Ubuntu 24.10).
+# The issue was fixed in Linux v6.12-rc5 (https://github.com/torvalds/linux/commit/be2ca38).
+mountTypesUnsupported: ["9p"]


### PR DESCRIPTION
 9p is broken in Linux v6.9, v6.10, and v6.11 (see #2701 and https://github.com/lima-vm/lima/pull/2821#issuecomment-2444856353).
    
The issue was fixed in Linux v6.12-rc5 (https://github.com/torvalds/linux/commit/be2ca38).