### PR TITLE
Make sure the port forwarding protocol is always lowercase

### DIFF
--- a/pkg/guestagent/kubernetesservice/kubernetesservice.go
+++ b/pkg/guestagent/kubernetesservice/kubernetesservice.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -24,7 +25,7 @@ type Protocol string
 const (
 	// UDP/SCTP when lima port forwarding works on those protocols.
 
-	TCP Protocol = "TCP"
+	TCP Protocol = "tcp"
 )
 
 type Entry struct {
@@ -142,7 +143,7 @@ func (s *ServiceWatcher) GetPorts() []Entry {
 			}
 
 			entries = append(entries, Entry{
-				Protocol: Protocol(portEntry.Protocol),
+				Protocol: Protocol(strings.ToLower(string(portEntry.Protocol))),
 				IP:       net.ParseIP("0.0.0.0"),
 				Port:     uint16(port),
 			})


### PR DESCRIPTION
The ServicePort.Protocol is always uppercase, e.g. "TCP", but the api.IPPort.protocol is always lowercase, i.e. "tcp".

Since UDP support was added in #2411 the hostagent filters on the protocol values.

cc @pendo324 @balajiv113 @Nino-K 