### PR TITLE
Remove custom YAML marshaller

### DIFF
--- a/pkg/limayaml/marshal.go
+++ b/pkg/limayaml/marshal.go
@@ -8,14 +8,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func marshalString(s string) ([]byte, error) {
-	if s == "null" || s == "~" {
-		// work around go-yaml bugs
-		return []byte("\"" + s + "\""), nil
-	}
-	return yaml.Marshal(s)
-}
-
 const (
 	documentStart = "---\n"
 	documentEnd   = "...\n"
@@ -23,8 +15,7 @@ const (
 
 // Marshal the struct as a YAML document, optionally as a stream.
 func Marshal(y *LimaYAML, stream bool) ([]byte, error) {
-	options := []yaml.EncodeOption{yaml.CustomMarshaler[string](marshalString)}
-	b, err := yaml.MarshalWithOptions(y, options...)
+	b, err := yaml.Marshal(y)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We used a custom marshaller to properly marshal "~" and "null". This has been fixed in https://github.com/goccy/go-yaml/pull/474, which has been merged in https://github.com/lima-vm/lima/pull/2828.

Dropping the custom marshaller fixes https://github.com/lima-vm/lima/issues/2665.