### PR TITLE
limactl shell: ask whether to start the instance if not running

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -51,6 +51,7 @@ func newShellCommand() *cobra.Command {
 }
 
 func shellAction(cmd *cobra.Command, args []string) error {
+	_ = os.Setenv("_LIMACTL_SHELL_IN_ACTION", "")
 	// simulate the behavior of double dash
 	newArg := []string{}
 	if len(args) >= 2 && args[1] == "--" {
@@ -68,15 +69,36 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	inst, err := store.Inspect(instName)
+	tty, err := interactive(cmd)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("instance %q does not exist, run `limactl create %s` to create a new instance", instName, instName)
-		}
 		return err
 	}
-	if inst.Status == store.StatusStopped {
-		return fmt.Errorf("instance %q is stopped, run `limactl start %s` to start the instance", instName, instName)
+	inst, err := store.Inspect(instName)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if !tty {
+			return fmt.Errorf("instance %q does not exist, run `limactl create %s` to create a new instance", instName, instName)
+		}
+		if err := askToStart(cmd, instName, true); err != nil {
+			return err
+		}
+		inst, err = store.Inspect(instName)
+	} else if inst.Status == store.StatusStopped {
+		if !tty {
+			return fmt.Errorf("instance %q is stopped, run `limactl start %s` to start the instance", instName, instName)
+		}
+		if err := askToStart(cmd, instName, false); err != nil {
+			return err
+		}
+		inst, err = store.Inspect(instName)
+	}
+	if err != nil {
+		return err
+	}
+	if inst.Status != store.StatusRunning {
+		return fmt.Errorf("instance %q status is not %q but %q", inst.Name, store.StatusRunning, inst.Status)
 	}
 
 	// When workDir is explicitly set, the shell MUST have workDir as the cwd, or exit with an error.

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -307,10 +307,17 @@ func watchHostAgentEvents(ctx context.Context, inst *store.Instance, haStdoutPat
 				err = xerr
 				return true
 			}
-			if *inst.Config.Plain {
-				logrus.Infof("READY. Run `ssh -F %q %s` to open the shell.", inst.SSHConfigFile, inst.Hostname)
+			// _LIMACTL_SHELL_IN_ACTION is set if `limactl shell` invoked `limactl start`.
+			// In this case we shouldn't print "Run `lima` to open the shell",
+			// because the user has already executed the `lima` command.
+			if _, limactlShellInAction := os.LookupEnv("_LIMACTL_SHELL_IN_ACTION"); limactlShellInAction {
+				logrus.Infof("READY.")
 			} else {
-				logrus.Infof("READY. Run `%s` to open the shell.", LimactlShellCmd(inst.Name))
+				if *inst.Config.Plain {
+					logrus.Infof("READY. Run `ssh -F %q %s` to open the shell.", inst.SSHConfigFile, inst.Hostname)
+				} else {
+					logrus.Infof("READY. Run `%s` to open the shell.", LimactlShellCmd(inst.Name))
+				}
 			}
 			_ = ShowMessage(inst)
 			err = nil


### PR DESCRIPTION
This is an edited version of #2763 with a simpler control flow.

It automatically picks the template corresponding to the desired instance name, if it exists. Otherwise it uses default:

```console
$ limactl shell alpine
? Do you want to create and start the instance "alpine" using the "alpine" template now? Yes
? Creating an instance "alpine" Proceed with the current configuration
…
```