### PR TITLE
refactor: Remove redundant check for length

### DIFF
--- a/cmd/limactl/disk.go
+++ b/cmd/limactl/disk.go
@@ -253,11 +253,9 @@ func diskDeleteAction(cmd *cobra.Command, args []string) error {
 			}
 			var refInstances []string
 			for _, inst := range instances {
-				if len(inst.AdditionalDisks) > 0 {
-					for _, d := range inst.AdditionalDisks {
-						if d.Name == diskName {
-							refInstances = append(refInstances, inst.Name)
-						}
+				for _, d := range inst.AdditionalDisks {
+					if d.Name == diskName {
+						refInstances = append(refInstances, inst.Name)
 					}
 				}
 			}

--- a/pkg/osutil/dns_darwin.go
+++ b/pkg/osutil/dns_darwin.go
@@ -14,14 +14,12 @@ func DNSAddresses() ([]string, error) {
 		return nil, err
 	}
 	var addresses []string
-	if len(nwData) > 0 {
-		// Return DNS addresses from the first interface that has an IPv4 address.
-		// The networks are in service order already.
-		for _, nw := range nwData {
-			if len(nw.IPv4.Addresses) > 0 {
-				addresses = nw.DNS.ServerAddresses
-				break
-			}
+	// Return DNS addresses from the first interface that has an IPv4 address.
+	// The networks are in service order already.
+	for _, nw := range nwData {
+		if len(nw.IPv4.Addresses) > 0 {
+			addresses = nw.DNS.ServerAddresses
+			break
 		}
 	}
 	return addresses, nil

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -634,35 +634,33 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	baseDisk := filepath.Join(cfg.InstanceDir, filenames.BaseDisk)
 	diffDisk := filepath.Join(cfg.InstanceDir, filenames.DiffDisk)
 	extraDisks := []string{}
-	if len(y.AdditionalDisks) > 0 {
-		for _, d := range y.AdditionalDisks {
-			diskName := d.Name
-			disk, err := store.InspectDisk(diskName)
-			if err != nil {
-				logrus.Errorf("could not load disk %q: %q", diskName, err)
-				return "", nil, err
-			}
-
-			if disk.Instance != "" {
-				if disk.InstanceDir != cfg.InstanceDir {
-					logrus.Errorf("could not attach disk %q, in use by instance %q", diskName, disk.Instance)
-					return "", nil, err
-				}
-				err = disk.Unlock()
-				if err != nil {
-					logrus.Errorf("could not unlock disk %q to reuse in the same instance %q", diskName, cfg.Name)
-					return "", nil, err
-				}
-			}
-			logrus.Infof("Mounting disk %q on %q", diskName, disk.MountPoint)
-			err = disk.Lock(cfg.InstanceDir)
-			if err != nil {
-				logrus.Errorf("could not lock disk %q: %q", diskName, err)
-				return "", nil, err
-			}
-			dataDisk := filepath.Join(disk.Dir, filenames.DataDisk)
-			extraDisks = append(extraDisks, dataDisk)
+	for _, d := range y.AdditionalDisks {
+		diskName := d.Name
+		disk, err := store.InspectDisk(diskName)
+		if err != nil {
+			logrus.Errorf("could not load disk %q: %q", diskName, err)
+			return "", nil, err
 		}
+
+		if disk.Instance != "" {
+			if disk.InstanceDir != cfg.InstanceDir {
+				logrus.Errorf("could not attach disk %q, in use by instance %q", diskName, disk.Instance)
+				return "", nil, err
+			}
+			err = disk.Unlock()
+			if err != nil {
+				logrus.Errorf("could not unlock disk %q to reuse in the same instance %q", diskName, cfg.Name)
+				return "", nil, err
+			}
+		}
+		logrus.Infof("Mounting disk %q on %q", diskName, disk.MountPoint)
+		err = disk.Lock(cfg.InstanceDir)
+		if err != nil {
+			logrus.Errorf("could not lock disk %q: %q", diskName, err)
+			return "", nil, err
+		}
+		dataDisk := filepath.Join(disk.Dir, filenames.DataDisk)
+		extraDisks = append(extraDisks, dataDisk)
 	}
 
 	isBaseDiskCDROM, err := iso9660util.IsISO9660(baseDisk)


### PR DESCRIPTION
The PR refactors the code by removing redundant `if len(slice)` checks before iterating over the entire `slice`. `for` loops over an empty slice do nothing.