### PR TITLE
refactor: replace fmt.Print with an explicit out to Stdout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,7 @@ linters:
   # - exhaustivestruct
   # - exportloopref
   # - funlen
+  - forbidigo
   # - gci
   # - gochecknoglobals
   # - gochecknoinits

--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -123,7 +123,7 @@ func listAction(cmd *cobra.Command, args []string) error {
 	if listFields {
 		names := fieldNames()
 		sort.Strings(names)
-		fmt.Println(strings.Join(names, "\n"))
+		fmt.Fprintln(cmd.OutOrStdout(), strings.Join(names, "\n"))
 		return nil
 	}
 

--- a/cmd/limactl/snapshot.go
+++ b/cmd/limactl/snapshot.go
@@ -177,11 +177,11 @@ func snapshotListAction(cmd *cobra.Command, args []string) error {
 				continue
 			}
 			tag := fields[1]
-			fmt.Printf("%s\n", tag)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", tag)
 		}
 		return nil
 	}
-	fmt.Print(out)
+	fmt.Fprint(cmd.OutOrStdout(), out)
 	return nil
 }
 

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"runtime"
 
 	"github.com/lima-vm/lima/pkg/networks"
@@ -55,7 +56,7 @@ func sudoersAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if check {
-		return verifySudoAccess(nwCfg, args)
+		return verifySudoAccess(nwCfg, args, cmd.OutOrStdout())
 	}
 	switch len(args) {
 	case 0:
@@ -69,11 +70,11 @@ func sudoersAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Print(sudoers)
+	fmt.Fprint(cmd.OutOrStdout(), sudoers)
 	return nil
 }
 
-func verifySudoAccess(nwCfg networks.Config, args []string) error {
+func verifySudoAccess(nwCfg networks.Config, args []string, stdout io.Writer) error {
 	var file string
 	switch len(args) {
 	case 0:
@@ -90,6 +91,6 @@ func verifySudoAccess(nwCfg networks.Config, args []string) error {
 	if err := nwCfg.VerifySudoAccess(file); err != nil {
 		return err
 	}
-	fmt.Printf("%q is up-to-date (or sudo doesn't require a password)\n", file)
+	fmt.Fprintf(stdout, "%q is up-to-date (or sudo doesn't require a password)\n", file)
 	return nil
 }

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -380,7 +380,7 @@ func ShowMessage(inst *store.Instance) error {
 	logrus.Infof("Message from the instance %q:", inst.Name)
 	for scanner.Scan() {
 		// Avoid prepending logrus "INFO" header, for ease of copy pasting
-		fmt.Println(scanner.Text())
+		fmt.Fprintln(logrus.StandardLogger().Out, scanner.Text())
 	}
 	return scanner.Err()
 }


### PR DESCRIPTION
The PR replaces all `fmt.Print.*` statements with `fmt.Fprint.*` with an explicit stdout. This is for consistency and for easy of testing. Additionally, this PR enables `forbidigo` linter, which forbids using `fmt.Print.*` lines in a codebase.