### PR TITLE
refactor: Improve textutil.PrefixString

### DIFF
--- a/pkg/textutil/textutil.go
+++ b/pkg/textutil/textutil.go
@@ -26,15 +26,13 @@ func ExecuteTemplate(tmpl string, args interface{}) ([]byte, error) {
 
 // PrefixString adds prefix to beginning of each line.
 func PrefixString(prefix, text string) string {
-	result := []string{}
-	for _, line := range strings.Split(text, "\n") {
-		if line == "" {
-			result = append(result, "")
-			continue
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = prefix + line
 		}
-		result = append(result, prefix+line)
 	}
-	return strings.Join(result, "\n")
+	return strings.Join(lines, "\n")
 }
 
 // IndentString add spaces to beginning of each line.

--- a/pkg/textutil/textutil_test.go
+++ b/pkg/textutil/textutil_test.go
@@ -9,8 +9,11 @@ import (
 )
 
 func TestPrefixString(t *testing.T) {
+	assert.Equal(t, "", PrefixString("- ", ""))
+	assert.Equal(t, "\n", PrefixString("- ", "\n"))
 	assert.Equal(t, "- foo", PrefixString("- ", "foo"))
 	assert.Equal(t, "- foo\n- bar\n", PrefixString("- ", "foo\nbar\n"))
+	assert.Equal(t, "- foo\n\n- bar\n", PrefixString("- ", "foo\n\nbar\n"))
 }
 
 func TestIndentString(t *testing.T) {


### PR DESCRIPTION
This PR improves implementation of the `textutil.PrefixString` by removing unneeded `result` slice.