### PR TITLE
CI: cancel previous running actions if new commits are pushed

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   artifacts-darwin:
     name: Artifacts Darwin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,11 @@ on:
     - "docs/**"
     - "website/**"
     - "**.md"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   LIMACTL_CREATE_ARGS: ""
 


### PR DESCRIPTION
The PR adds a mechanism to cancel previous GitHub Actions run if new commits were pushed to the branch for several long actions which do some testing staff.

See https://turso.tech/blog/simple-trick-to-save-environment-and-money-when-using-github-actions

This is how it looks like from the UI:

<img width="854" alt="image" src="https://github.com/user-attachments/assets/642d9c28-b4e7-46d4-ac6c-55168d7b1dd1">
