### PR TITLE
Avoid crash when tunnel cannot be opened

### DIFF
--- a/pkg/portfwd/client.go
+++ b/pkg/portfwd/client.go
@@ -21,6 +21,7 @@ func HandleTCPConnection(ctx context.Context, client *guestagentclient.GuestAgen
 	stream, err := client.Tunnel(ctx)
 	if err != nil {
 		logrus.Errorf("could not open tcp tunnel for id: %s error:%v", id, err)
+		return
 	}
 
 	g, _ := errgroup.WithContext(ctx)
@@ -54,6 +55,7 @@ func HandleUDPConnection(ctx context.Context, client *guestagentclient.GuestAgen
 	stream, err := client.Tunnel(ctx)
 	if err != nil {
 		logrus.Errorf("could not open udp tunnel for id: %s error:%v", id, err)
+		return
 	}
 
 	g, _ := errgroup.WithContext(ctx)


### PR DESCRIPTION
When client.Tunnel() returns an error, then the returned stream is invalid and must not be used.

Fixes this crash during shutdown:

```
{"level":"error","msg":"could not open tcp tunnel for id: tcp-[::1]:80-[::1]:50544 error:rpc error: code = Canceled desc = context canceled","time":"2024-11-06T20:03:38-08:00"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x10386a022]

goroutine 1056 [running]:
github.com/lima-vm/lima/pkg/portfwd.GrpcClientRW.Read({{0xc001dc31e8, 0x18}, {0xc000988530, 0xa}, {0x0, 0x0}}, {0xc0022da000, 0x8000, 0x0?})
	/Users/jan/suse/lima/pkg/portfwd/client.go:135 +0x42
io.copyBuffer({0x103dc6000, 0xc001b083e0}, {0x103dc7500, 0xc000adef00}, {0x0, 0x0, 0x0})
	/usr/local/Cellar/go/1.23.2/libexec/src/io/io.go:429 +0x191
```