### PR TITLE
Update `inject-cmdline-to-template.sh`

### DIFF
--- a/hack/inject-cmdline-to-template.sh
+++ b/hack/inject-cmdline-to-template.sh
@@ -57,6 +57,8 @@ done
 if [[ -z ${location} ]]; then
 	echo "Failed to get the image location for ${template}" >&2
 	exit 1
+elif [[ ${location} == https://cloud-images.ubuntu.com/minimal/* ]]; then
+	readonly default_cmdline="root=/dev/vda1 ro console=tty1 console=ttyAMA0"
 elif [[ ${location} == https://cloud-images.ubuntu.com/* ]]; then
 	readonly default_cmdline="root=LABEL=cloudimg-rootfs ro console=tty1 console=ttyAMA0"
 else

--- a/hack/inject-cmdline-to-template.sh
+++ b/hack/inject-cmdline-to-template.sh
@@ -91,7 +91,7 @@ function inject_to() {
 	for field_name in location digest cmdline; do
 		[[ -z ${!field_name} ]] || fields+=("\"${field_name}\": \"${!field_name}\"")
 	done
-	yq -i -I 2 eval "setpath([(.images[] | select(.arch == \"${arch}\") | path)].[${index}] + \"${key}\"; { ${fields[*]}})" "${template}"
+	limactl edit --log-level error --set "setpath([(.images[] | select(.arch == \"${arch}\") | path)].[${index}] + \"${key}\"; { ${fields[*]}})" "${template}"
 }
 inject_to "${template}" "${arch}" "${index}" "kernel" "${kernel_location}" "${kernel_digest}" "${cmdline}"
 inject_to "${template}" "${arch}" "${index}" "initrd" "${initrd_location}" "${initrd_digest}"

--- a/hack/inject-cmdline-to-template.sh
+++ b/hack/inject-cmdline-to-template.sh
@@ -21,6 +21,8 @@ arch="${arch:-$(uname -m)}"
 case "${arch}" in
 amd64 | x86_64) arch=x86_64 ;;
 aarch64 | arm64) arch=aarch64 ;;
+armv7l | armhf) arch=armv7l ;;
+riscv64) arch=riscv64 ;;
 *)
 	echo "Unsupported arch: ${arch}" >&2
 	exit 1

--- a/hack/inject-cmdline-to-template.sh
+++ b/hack/inject-cmdline-to-template.sh
@@ -29,9 +29,7 @@ esac
 
 # 2. extract location by parsing template using arch
 readonly yq_filter="
-[
-    .images | map(select(.arch == \"${arch}\")) | [.[].location]
-]|flatten|.[]
+    .images[]|select(.arch == \"${arch}\")|.location
 "
 parsed=$(yq eval "${yq_filter}" "${template}")
 


### PR DESCRIPTION
- use `limactl edit` instead of `yq -i`
- simplify `yq` filter
- add `armv7l` and `riscv64` to arch
- change `default_cmdline` for minimal flavor  
  use `root=/dev/vda1` instead of `root=LABEL=cloudimg-rootfs` to avoid failing boot
  ```console
  [    0.127771] /dev/root: Can't open blockdev
  [    0.127797] VFS: Cannot open root device "LABEL=cloudimg-rootfs" or unknown-block(0,0): error -6
  [    0.127908] Please append a correct "root=" boot option; here are the available partitions:
  ```
- ~~inject provision[0].script `systemctl enable systemd-time-wait-sync.service`  
  Booting with a kernel image lacks an RTC, so time synchronization is needed to prevent network errors.~~
