### PR TITLE
Add interface metrics to network settings

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/network-config
+++ b/pkg/cidata/cidata.TEMPLATE.d/network-config
@@ -7,11 +7,7 @@ ethernets:
     dhcp4: true
     set-name: {{$nw.Interface}}
     dhcp4-overrides:
-    {{- if (eq $nw.Interface $.SlirpNICName) }}
-      route-metric: 200
-    {{- else }}
-      route-metric: 100
-    {{- end }}
+      route-metric: {{$nw.Metric}}
     {{- if and (eq $nw.Interface $.SlirpNICName) (gt (len $.DNSAddresses) 0) }}
     nameservers:
       addresses:
@@ -20,4 +16,3 @@ ethernets:
       {{- end }}
     {{- end }}
   {{- end }}
-

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -256,12 +256,12 @@ func templateArgs(bootScripts bool, instDir, name string, instConfig *limayaml.L
 		})
 	}
 
-	args.Networks = append(args.Networks, Network{MACAddress: limayaml.MACAddress(instDir), Interface: networks.SlirpNICName})
+	args.Networks = append(args.Networks, Network{MACAddress: limayaml.MACAddress(instDir), Interface: networks.SlirpNICName, Metric: 200})
 	for i, nw := range instConfig.Networks {
 		if i == firstUsernetIndex {
 			continue
 		}
-		args.Networks = append(args.Networks, Network{MACAddress: nw.MACAddress, Interface: nw.Interface})
+		args.Networks = append(args.Networks, Network{MACAddress: nw.MACAddress, Interface: nw.Interface, Metric: *nw.Metric})
 	}
 
 	args.Env, err = setupEnv(instConfig.Env, *instConfig.PropagateProxyEnv, args.SlirpGateway)

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -35,6 +35,7 @@ type Containerd struct {
 type Network struct {
 	MACAddress string
 	Interface  string
+	Metric     uint32
 }
 type Mount struct {
 	Tag        string

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -609,6 +609,9 @@ func FillDefault(y, d, o *LimaYAML, filePath string, warn bool) {
 			if nw.MACAddress != "" {
 				networks[i].MACAddress = nw.MACAddress
 			}
+			if nw.Metric != nil {
+				networks[i].Metric = nw.Metric
+			}
 		} else {
 			// unnamed network definitions are not combined/overwritten
 			if nw.Interface != "" {
@@ -626,6 +629,9 @@ func FillDefault(y, d, o *LimaYAML, filePath string, warn bool) {
 		}
 		if nw.Interface == "" {
 			nw.Interface = "lima" + strconv.Itoa(i)
+		}
+		if nw.Metric == nil {
+			nw.Metric = ptr.Of(uint32(100))
 		}
 	}
 

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -255,6 +255,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Networks = slices.Clone(y.Networks)
 	expect.Networks[0].MACAddress = MACAddress(fmt.Sprintf("%s#%d", filePath, 0))
 	expect.Networks[0].Interface = "lima0"
+	expect.Networks[0].Metric = ptr.Of(uint32(100))
 
 	expect.DNS = slices.Clone(y.DNS)
 	expect.PortForwards = []PortForward{
@@ -401,6 +402,7 @@ func TestFillDefault(t *testing.T) {
 			{
 				MACAddress: "11:22:33:44:55:66",
 				Interface:  "def0",
+				Metric:     ptr.Of(uint32(50)),
 			},
 		},
 		DNS: []net.IP{
@@ -622,6 +624,7 @@ func TestFillDefault(t *testing.T) {
 				Lima:       "shared",
 				MACAddress: "10:20:30:40:50:60",
 				Interface:  "def1",
+				Metric:     ptr.Of(uint32(25)),
 			},
 			{
 				Lima:      "bridged",

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -274,8 +274,9 @@ type Network struct {
 	// VZNAT uses VZNATNetworkDeviceAttachment. Needs VZ. No root privilege is required.
 	VZNAT *bool `yaml:"vzNAT,omitempty" json:"vzNAT,omitempty"`
 
-	MACAddress string `yaml:"macAddress,omitempty" json:"macAddress,omitempty"`
-	Interface  string `yaml:"interface,omitempty" json:"interface,omitempty"`
+	MACAddress string  `yaml:"macAddress,omitempty" json:"macAddress,omitempty"`
+	Interface  string  `yaml:"interface,omitempty" json:"interface,omitempty"`
+	Metric     *uint32 `yaml:"metric,omitempty" json:"metric,omitempty"`
 }
 
 type HostResolver struct {

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -384,6 +384,9 @@ networks:
 #   macAddress: ""
 #   # Interface name, defaults to "lima0", "lima1", etc.
 #   interface: ""
+#   # Interface metric, lowest metric becomes the preferred route.
+#   # Defaults to 100. Builtin SLIRP network uses 200.
+#   metric: 100
 #
 # Lima can also connect to "unmanaged" networks addressed by "socket". This
 # means that the daemons will not be controlled by Lima, but must be started


### PR DESCRIPTION
By default all additional interfaces use a metric of 100, so take precedence over the builtin SLIRP network. With this commit the metric of each interface can be set separately.

Fixes #2867
(It doesn't restore the pre-1.0.0 behaviour, but lets the user restore it themselves, if it is important to them. The new settings still seem like a sensible default).