### PR TITLE
vz: fix lint issues in tests on darwin

### DIFF
--- a/pkg/vz/network_darwin_test.go
+++ b/pkg/vz/network_darwin_test.go
@@ -10,8 +10,10 @@ import (
 	"testing"
 )
 
-const vmnetMaxPacketSize = 1514
-const packetsCount = 1000
+const (
+	vmnetMaxPacketSize = 1514
+	packetsCount       = 1000
+)
 
 func TestDialQemu(t *testing.T) {
 	listener, err := listenUnix(t.TempDir())
@@ -66,7 +68,7 @@ func TestDialQemu(t *testing.T) {
 
 		// quit packet format:
 		//     0-4:     "quit"
-		copy(buf[:4], []byte("quit"))
+		copy(buf[:4], "quit")
 		if _, err := vzConn.Write(buf[:4]); err != nil {
 			errc <- err
 			return


### PR DESCRIPTION
The PR corrects lint errors when running `make lint` on Mac:

```sh
❯ make lint
golangci-lint run ./...
pkg/vz/network_darwin_test.go:69:3: stringXbytes: can simplify `[]byte("quit")` to `"quit"` (gocritic)
                copy(buf[:4], []byte("quit"))
                ^
pkg/vz/network_darwin_test.go:13: File is not `gofumpt`-ed (gofumpt)
const vmnetMaxPacketSize = 1514
const packetsCount = 1000
make: *** [Makefile:451: lint] Error 1
```