### PR TITLE
Make sure that root is in the sudoers file on Alpine

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/00-alpine-user-group.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/00-alpine-user-group.sh
@@ -1,12 +1,21 @@
 #!/bin/sh
+test -f /etc/alpine-release || exit 0
+
+# Make sure that root is in the sudoers file.
+# This is needed to run the user provisioning scripts.
+SUDOERS=/etc/sudoers.d/00-root-user
+if [ ! -f $SUDOERS ]; then
+	echo "root ALL=(ALL) NOPASSWD:ALL" >$SUDOERS
+	chmod 660 $SUDOERS
+fi
+
 # Remove the user embedded in the image,
 # and use cloud-init for users and groups.
-test -f /etc/alpine-release || exit 0
-test "$LIMA_CIDATA_USER" != "alpine" || exit 0
-
-if [ "$(id -u alpine 2>&1)" = "1000" ]; then
-	userdel alpine
-	rmdir /home/alpine
-	cloud-init clean --logs
-	reboot
+if [ "$LIMA_CIDATA_USER" != "alpine" ]; then
+	if [ "$(id -u alpine 2>&1)" = "1000" ]; then
+		userdel alpine
+		rmdir /home/alpine
+		cloud-init clean --logs
+		reboot
+	fi
 fi


### PR DESCRIPTION
Because the Alpine cloud image doesn't include `/etc/sudoers`, and cloud-init just writes a single line to it:

```
#includedir /etc/sudoers.d
```

Without an entry for `root` we cannot run user provisioning scripts because we use `sudo -u $USER …` to do it.