### PR TITLE
test: refactor to use assert pkg instead of t.Fatal

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,6 +88,15 @@ linters-settings:
         deny:
         - pkg: "golang.org/x/net/context"
           desc: "use the 'context' package from the standard library"
+  forbidigo:
+    analyze-types: true
+    forbid:
+    - p: ^print(ln)?$
+      msg: Do not use builtin print functions. It's for bootstrapping only and may be removed in the future.
+    - p: ^fmt\.Print.*$
+      msg: Do not use fmt.Print statements.
+    - p: ^testing.T.Fatal.*$
+      msg: Use assert functions from the gotest.tools/v3/assert package instead.
   gocritic:
     # See "Tags" section in https://github.com/go-critic/go-critic#usage
     enabled-tags:

--- a/pkg/downloader/fuzz_test.go
+++ b/pkg/downloader/fuzz_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+	"gotest.tools/v3/assert"
 )
 
 var algorithm = digest.Algorithm("sha256")
@@ -16,9 +17,7 @@ func FuzzDownload(f *testing.F) {
 		localFile := filepath.Join(t.TempDir(), "localFile")
 		remoteFile := filepath.Join(t.TempDir(), "remoteFile")
 		err := os.WriteFile(remoteFile, fileContents, 0o600)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		testLocalFileURL := "file://" + remoteFile
 		if checkDigest {
 			d := algorithm.FromBytes(fileContents)

--- a/pkg/guestagent/iptables/iptables_test.go
+++ b/pkg/guestagent/iptables/iptables_test.go
@@ -3,6 +3,8 @@ package iptables
 import (
 	"strings"
 	"testing"
+
+	"gotest.tools/v3/assert"
 )
 
 // data is from a run of `iptables -t nat -S` with two containers running (started
@@ -74,14 +76,10 @@ func TestParsePortsFromRules(t *testing.T) {
 	}
 
 	res, err := parsePortsFromRules(rules)
-	if err != nil {
-		t.Errorf("parsing iptables ports failed with error: %s", err)
-	}
+	assert.NilError(t, err, "parsing iptables ports failed")
 
 	l := len(res)
-	if l != 2 {
-		t.Fatalf("expected 2 ports parsed from iptables but parsed %d", l)
-	}
+	assert.Equal(t, l, 2, "unexpected number of ports parsed from iptables")
 
 	if res[0].IP.String() != "0.0.0.0" || res[0].Port != 8082 || res[0].TCP != true {
 		t.Errorf("expected port 8082 on IP 0.0.0.0 with TCP true but got port %d on IP %s with TCP %t", res[0].Port, res[0].IP.String(), res[0].TCP)

--- a/pkg/iso9660util/fuzz_test.go
+++ b/pkg/iso9660util/fuzz_test.go
@@ -4,15 +4,15 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"gotest.tools/v3/assert"
 )
 
 func FuzzIsISO9660(f *testing.F) {
 	f.Fuzz(func(t *testing.T, fileContents []byte) {
 		imageFile := filepath.Join(t.TempDir(), "fuzz.iso")
 		err := os.WriteFile(imageFile, fileContents, 0o600)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		_, _ = IsISO9660(imageFile)
 	})
 }

--- a/pkg/limayaml/limayaml_test.go
+++ b/pkg/limayaml/limayaml_test.go
@@ -10,9 +10,7 @@ import (
 
 func dumpJSON(t *testing.T, d interface{}) string {
 	b, err := json.Marshal(d)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	return string(b)
 }
 

--- a/pkg/lockutil/lockutil_test.go
+++ b/pkg/lockutil/lockutil_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gotest.tools/v3/assert"
 )
 
 const parallel = 20
@@ -46,11 +48,7 @@ func TestWithDirLock(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(log)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	lines := strings.Split(strings.Trim(string(data), "\n"), "\n")
-	if len(lines) != 1 {
-		t.Errorf("Expected one writer, got %v", lines)
-	}
+	assert.Equal(t, len(lines), 1, "unexpected number of writers")
 }

--- a/pkg/nativeimgutil/fuzz_test.go
+++ b/pkg/nativeimgutil/fuzz_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"gotest.tools/v3/assert"
 )
 
 func FuzzConvertToRaw(f *testing.F) {
@@ -11,9 +13,7 @@ func FuzzConvertToRaw(f *testing.F) {
 		srcPath := filepath.Join(t.TempDir(), "src.img")
 		destPath := filepath.Join(t.TempDir(), "dest.img")
 		err := os.WriteFile(srcPath, imgData, 0o600)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		_ = ConvertToRaw(srcPath, destPath, &size, withBacking)
 	})
 }

--- a/pkg/store/fuzz_test.go
+++ b/pkg/store/fuzz_test.go
@@ -6,15 +6,14 @@ import (
 	"testing"
 
 	"github.com/lima-vm/lima/pkg/store/filenames"
+	"gotest.tools/v3/assert"
 )
 
 func FuzzLoadYAMLByFilePath(f *testing.F) {
 	f.Fuzz(func(t *testing.T, fileContents []byte) {
 		localFile := filepath.Join(t.TempDir(), "yaml_file.yml")
 		err := os.WriteFile(localFile, fileContents, 0o600)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		_, _ = LoadYAMLByFilePath(localFile)
 	})
 }
@@ -24,19 +23,13 @@ func FuzzInspect(f *testing.F) {
 		limaDir := t.TempDir()
 		t.Setenv("LIMA_HOME", limaDir)
 		err := os.MkdirAll(filepath.Join(limaDir, "fuzz-instance"), 0o700)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		ymlFile := filepath.Join(limaDir, "fuzz-instance", filenames.LimaYAML)
 		limaVersionFile := filepath.Join(limaDir, filenames.LimaVersion)
 		err = os.WriteFile(ymlFile, yml, 0o600)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		err = os.WriteFile(limaVersionFile, limaVersion, 0o600)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		_, _ = Inspect("fuzz-instance")
 	})
 }


### PR DESCRIPTION
This PR refactors tests:

- Replaces `if err != nil { t.Fatal(err) }` with `assert.NilError(t, err)` for consistency with other tests.
- Extends the `forbidigo` rules to forbid using `t.Fatal` in tests.

Using `t.Error` is acceptable. Sometimes tests need to report failure and continue execution.