### PR TITLE
refactor: remove useless copy loop var

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
   - typecheck
   # - asciicheck
   - bodyclose
+  - copyloopvar
   # - dogsled
   # - dupl
   - dupword

--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -131,9 +131,6 @@ func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
 	}
 
 	for i, vhostCmd := range vhostCmds {
-		i := i
-		vhostCmd := vhostCmd
-
 		logrus.Debugf("vhostCmd[%d].Args: %v", i, vhostCmd.Args)
 		if err := vhostCmd.Start(); err != nil {
 			return nil, err


### PR DESCRIPTION
`i := i` in a loop is not needed starting from Go 1.22, see https://go.dev/blog/go1.22#language-changes