### PR TITLE
Add `boot/00-check-rtc-and-wait-ntp.sh` to cidata

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/00-check-rtc-and-wait-ntp.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/00-check-rtc-and-wait-ntp.sh
@@ -9,6 +9,11 @@ test ! -c /dev/rtc0 || exit 0
 # This script is intended for services running with systemd.
 command -v systemctl >/dev/null 2>&1 || exit 0
 
+echo_with_time_usec() {
+	time_usec=$(timedatectl show --property=TimeUSec)
+	echo "${time_usec}, ${1}"
+}
+
 # Enable `systemd-time-wait-sync.service` to wait for NTP synchronization at an earlier stage.
 systemctl enable systemd-time-wait-sync.service
 
@@ -16,19 +21,43 @@ systemctl enable systemd-time-wait-sync.service
 max_retry=60 retry=0
 until ntp_synchronized=$(timedatectl show --property=NTPSynchronized --value) && [ "${ntp_synchronized}" = "yes" ] ||
 	[ "${retry}" -gt "${max_retry}" ]; do
-	time_usec=$(timedatectl show --property=TimeUSec)
-	echo "${time_usec}, Waiting for NTP synchronization..."
+	if [ "${retry}" -eq 0 ]; then
+		# If /dev/rtc is not available, the system time set during the Linux kernel build is used.
+		# The larger the difference between this system time and the NTP server time, the longer the NTP synchronization will take.
+		# By setting the system time to the modification time of this script, which is likely to be closer to the actual time,
+		# the NTP synchronization time can be shortened.
+		echo_with_time_usec "Setting the system time to the modification time of ${0}."
+
+		# To set the time to a specified time, it is necessary to stop systemd-timesyncd.
+		systemctl stop systemd-timesyncd
+
+		# Since `timedatectl set-time` fails if systemd-timesyncd is not stopped,
+		# ensure that it is completely stopped before proceeding.
+		until pid_of_timesyncd=$(systemctl show systemd-timesyncd --property=MainPID --value) && [ "${pid_of_timesyncd}" -eq 0 ]; do
+			echo_with_time_usec "Waiting for systemd-timesyncd to stop..."
+			sleep 1
+		done
+
+		# Set the system time to the modification time of this script.
+		modification_time=$(stat -c %y "${0}")
+		echo_with_time_usec "Setting the system time to ${modification_time}."
+		timedatectl set-time "${modification_time}"
+
+		# Restart systemd-timesyncd
+		systemctl start systemd-timesyncd
+	else
+		echo_with_time_usec "Waiting for NTP synchronization..."
+	fi
 	retry=$((retry + 1))
 	sleep 1
 done
 # Print the result of NTP synchronization
 ntp_message=$(timedatectl show-timesync --property=NTPMessage)
-time_usec=$(timedatectl show --property=TimeUSec)
 if [ "${ntp_synchronized}" = "yes" ]; then
-	echo "${time_usec}, NTP synchronization complete."
+	echo_with_time_usec "NTP synchronization complete."
 	echo "${ntp_message}"
 else
-	echo "${time_usec}, NTP synchronization timed out."
+	echo_with_time_usec "NTP synchronization timed out."
 	echo "${ntp_message}"
 	exit 1
 fi

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/00-check-rtc-and-wait-ntp.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/00-check-rtc-and-wait-ntp.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+# In vz, the VM lacks an RTC when booting with a kernel image (see: https://developer.apple.com/forums/thread/760344).
+# This causes incorrect system time until NTP synchronizes it, leading to TLS errors.
+# To avoid TLS errors, this script waits for NTP synchronization if RTC is unavailable.
+test ! -c /dev/rtc0 || exit 0
+
+# This script is intended for services running with systemd.
+command -v systemctl >/dev/null 2>&1 || exit 0
+
+# Enable `systemd-time-wait-sync.service` to wait for NTP synchronization at an earlier stage.
+systemctl enable systemd-time-wait-sync.service
+
+# For the first boot, where the above setting is not yet active, wait for NTP synchronization here.
+until ntp_synchronized=$(timedatectl show --property=NTPSynchronized --value) && [ "${ntp_synchronized}" = "yes" ]; do
+	time_usec=$(timedatectl show --property=TimeUSec)
+	echo "${time_usec}, Waiting for NTP synchronization..."
+	sleep 1
+done
+# Print the result of NTP synchronization
+ntp_message=$(timedatectl show-timesync --property=NTPMessage)
+time_usec=$(timedatectl show --property=TimeUSec)
+echo "${time_usec}, NTP synchronization complete."
+echo "${ntp_message}"

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/00-check-rtc-and-wait-ntp.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/00-check-rtc-and-wait-ntp.sh
@@ -21,9 +21,12 @@ until ntp_synchronized=$(timedatectl show --property=NTPSynchronized --value) &&
 	if [ "${retry}" -eq 0 ]; then
 		# If /dev/rtc is not available, the system time set during the Linux kernel build is used.
 		# The larger the difference between this system time and the NTP server time, the longer the NTP synchronization will take.
-		# By setting the system time to the modification time of this script, which is likely to be closer to the actual time,
+		# By setting the system time to the modification time of the reference file, which is likely to be closer to the actual time,
+		reference_file="${LIMA_CIDATA_MNT:-/mnt/lima-cidata}/user-data"
+		[ -f "${reference_file}" ] || reference_file="${0}"
+
 		# the NTP synchronization time can be shortened.
-		echo_with_time_usec "Setting the system time to the modification time of ${0}."
+		echo_with_time_usec "Setting the system time to the modification time of ${reference_file}."
 
 		# To set the time to a specified time, it is necessary to stop systemd-timesyncd.
 		systemctl stop systemd-timesyncd
@@ -35,8 +38,8 @@ until ntp_synchronized=$(timedatectl show --property=NTPSynchronized --value) &&
 			sleep 1
 		done
 
-		# Set the system time to the modification time of this script.
-		modification_time=$(stat -c %y "${0}")
+		# Set the system time to the modification time of the reference file.
+		modification_time=$(stat -c %y "${reference_file}")
 		echo_with_time_usec "Setting the system time to ${modification_time}."
 		timedatectl set-time "${modification_time}"
 

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/00-check-rtc-and-wait-ntp.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/00-check-rtc-and-wait-ntp.sh
@@ -14,9 +14,6 @@ echo_with_time_usec() {
 	echo "${time_usec}, ${1}"
 }
 
-# Enable `systemd-time-wait-sync.service` to wait for NTP synchronization at an earlier stage.
-systemctl enable systemd-time-wait-sync.service
-
 # For the first boot, where the above setting is not yet active, wait for NTP synchronization here.
 max_retry=60 retry=0
 until ntp_synchronized=$(timedatectl show --property=NTPSynchronized --value) && [ "${ntp_synchronized}" = "yes" ] ||


### PR DESCRIPTION
In vz, the VM lacks an RTC when booting with a kernel image (see: https://developer.apple.com/forums/thread/760344). This causes incorrect system time until NTP synchronizes it, leading to TLS errors. To avoid TLS errors, this script waits for NTP synchronization if RTC is unavailable.

This script does the following:
- Exits with 0 if `/dev/rtc0` exists.
- Exits with 0 if `systemctl` is not available.
- Enables `systemd-time-wait-sync.service` to wait for NTP synchronization at an earlier stage on subsequent boots.
- Waits for NTP synchronization within the script for the first boot.

Log output during execution:
```console
LIMA 2024-08-08T23:51:15+09:00| Executing /mnt/lima-cidata/boot/00-check-rtc-and-wait-ntp.sh
Created symlink /etc/systemd/system/sysinit.target.wants/systemd-time-wait-sync.service → /usr/lib/systemd/system/systemd-time-wait-sync.service.
TimeUSec=Thu 2024-08-08 23:51:15 JST, Waiting for NTP synchronization...
TimeUSec=Thu 2024-08-08 23:51:16 JST, Waiting for NTP synchronization...
...
TimeUSec=Thu 2024-08-08 23:51:41 JST, Waiting for NTP synchronization...
TimeUSec=Thu 2024-08-08 23:51:42 JST, Waiting for NTP synchronization...
TimeUSec=Tue 2024-11-12 11:43:37 JST, NTP synchronization complete.
NTPMessage={ Leap=0, Version=4, Mode=4, Stratum=2, Precision=-25, RootDelay=991us, RootDispersion=259us, Reference=11FD1CFB, OriginateTimestamp=Thu 2024-08-08 23:51:43 JST, ReceiveTimestamp=Tue 2024-11-12 11:43:36 JST, TransmitTimestamp=Tue 2024-11-12 11:43:36 JST, DestinationTimestamp=Thu 2024-08-08 23:51:43 JST, Ignored=no, PacketCount=1, Jitter=0 }
```