### PR TITLE
Update golangci-lint to 1.62.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8  # v6.1.1
       with:
-        version: v1.60.1
+        version: v1.62.0
         args: --verbose --timeout=10m
     - name: Run yamllint
       run: yamllint .

--- a/cmd/limactl/gendoc.go
+++ b/cmd/limactl/gendoc.go
@@ -116,9 +116,9 @@ weight: 3
 	})
 }
 
-// replaceAll replaces all occurrences of new with old, for all files in dir.
-func replaceAll(dir, old, new string) error {
-	logrus.Infof("Replacing %q with %q", old, new)
+// replaceAll replaces all occurrences of text with replacement, for all files in dir.
+func replaceAll(dir, text, replacement string) error {
+	logrus.Infof("Replacing %q with %q", text, replacement)
 	return filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -133,7 +133,7 @@ func replaceAll(dir, old, new string) error {
 		if err != nil {
 			return err
 		}
-		out := bytes.ReplaceAll(in, []byte(old), []byte(new))
+		out := bytes.ReplaceAll(in, []byte(text), []byte(replacement))
 		err = os.WriteFile(path, out, 0o644)
 		if err != nil {
 			return err


### PR DESCRIPTION
This makes it easy to run `make lint` locally, avoiding noise in the CI
and expensive rebuilds.

This change reveal an issue that was not reported by the older version.
Change the code to avoid this issue.