### PR TITLE
ci: Unbreak release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         # Xcode version
         xcodebuild -version
         # macOS SDK version
-        xcrun --show-sdk-version
+        xcrun --show-sdk-version || true
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         fetch-depth: 1


### PR DESCRIPTION
xcrun --show-sdk-version started to fail now. Suppress the error to unbreak the workflow until we find a better way to find the sdk version or xcrun is fixed.