### PR TITLE
fix: start-at-login generating systemd target

### DIFF
--- a/pkg/autostart/autostart_test.go
+++ b/pkg/autostart/autostart_test.go
@@ -70,7 +70,7 @@ TimeoutSec=10
 Restart=on-failure
 
 [Install]
-WantedBy=multi-user.target`,
+WantedBy=default.target`,
 			GetExecutable: func() (string, error) {
 				return "/limactl", nil
 			},

--- a/pkg/autostart/lima-vm@INSTANCE.service
+++ b/pkg/autostart/lima-vm@INSTANCE.service
@@ -10,4 +10,4 @@ TimeoutSec=10
 Restart=on-failure
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
This PR apply a patch for Linux part of https://github.com/lima-vm/lima/pull/2151 and fixes #2942

Now registering with `--user`, however it has multi-user targets.

https://github.com/lima-vm/lima/blob/9248baf14a3208249ed38179cdd018ec288d1ef5/pkg/autostart/autostart.go#L91-L92

https://github.com/systemd/systemd/issues/2690#issuecomment-186973730
