### PR TITLE
ci: cleanup .golangci.yml by removing deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,7 +39,6 @@ linters:
   - errcheck
   - errorlint
   # - exhaustive
-  # - exhaustivestruct
   # - exportloopref
   # - funlen
   - forbidigo
@@ -52,24 +51,18 @@ linters:
   # - gocyclo
   - godot
   # - godox
-  # - goerr113
   - gofumpt
   # - goheader
-  # - golint
-  # - gomnd
   # - gomodguard
   # - goprintffuncname
-  # - gosec (gas)
+  # - gosec
   - gosimple
-  # - interfacer
   # - lll
-  # - maligned
   # - nestif
   # - nlreturn
   - noctx
   - nolintlint
   # - rowserrcheck
-  # - scopelint
   # - sqlclosecheck
   - staticcheck
   # - stylecheck


### PR DESCRIPTION
This PR removes deprecated linters from the golangci-lint configuration, as they are unlikely to be enabled in the future.

The list of deprecated linters: https://github.com/golangci/golangci-lint/blob/v1.62.2/.golangci.reference.yml#L239-L249