### PR TITLE
refactor: replace fmt.Errorf with errors.New

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,6 +68,7 @@ linters:
   # - nlreturn
   - noctx
   - nolintlint
+  - perfsprint
   # - rowserrcheck
   # - scopelint
   # - sqlclosecheck
@@ -122,6 +123,12 @@ linters-settings:
         minThreshold: 3
   errorlint:
     asserts: false
+  perfsprint:
+    int-conversion: false
+    err-error: false
+    errorf: true
+    sprintf1: false
+    strconcat: false
   revive:
     # Set below 0.8 to enable error-strings
     confidence: 0.6
@@ -179,3 +186,7 @@ issues:
   - text: "exported: comment on exported const"
     linters:
     - revive
+  # Disable perfsprint for fmt.Sprint until https://github.com/catenacyber/perfsprint/issues/39 gets fixed.
+  - text: "fmt.Sprint.* can be replaced with faster"
+    linters:
+    - perfsprint

--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -90,7 +90,7 @@ func copyAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if legacySSH && len(instances) > 1 {
-		return fmt.Errorf("more than one (instance) host is involved in this command, this is only supported for openSSH v8.0 or higher")
+		return errors.New("more than one (instance) host is involved in this command, this is only supported for openSSH v8.0 or higher")
 	}
 	scpFlags = append(scpFlags, "-3", "--")
 	scpArgs = append(scpFlags, scpArgs...)

--- a/cmd/limactl/genschema.go
+++ b/cmd/limactl/genschema.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -71,7 +72,7 @@ func genschemaAction(cmd *cobra.Command, args []string) error {
 	}
 
 	if file == "" {
-		return fmt.Errorf("need --schemafile to validate")
+		return errors.New("need --schemafile to validate")
 	}
 	err = os.WriteFile(file, j, 0o644)
 	if err != nil {

--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -52,7 +52,7 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if socket == "" {
-		return fmt.Errorf("socket must be specified (limactl version mismatch?)")
+		return errors.New("socket must be specified (limactl version mismatch?)")
 	}
 
 	instName := args[0]

--- a/cmd/limactl/snapshot.go
+++ b/cmd/limactl/snapshot.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -56,7 +57,7 @@ func snapshotCreateAction(cmd *cobra.Command, args []string) error {
 	}
 
 	if tag == "" {
-		return fmt.Errorf("expected tag")
+		return errors.New("expected tag")
 	}
 
 	ctx := cmd.Context()
@@ -91,7 +92,7 @@ func snapshotDeleteAction(cmd *cobra.Command, args []string) error {
 	}
 
 	if tag == "" {
-		return fmt.Errorf("expected tag")
+		return errors.New("expected tag")
 	}
 
 	ctx := cmd.Context()
@@ -126,7 +127,7 @@ func snapshotApplyAction(cmd *cobra.Command, args []string) error {
 	}
 
 	if tag == "" {
-		return fmt.Errorf("expected tag")
+		return errors.New("expected tag")
 	}
 
 	ctx := cmd.Context()

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -62,7 +62,7 @@ func sudoersAction(cmd *cobra.Command, args []string) error {
 	case 0:
 		// NOP
 	case 1:
-		return fmt.Errorf("the file argument can be specified only for --check mode")
+		return errors.New("the file argument can be specified only for --check mode")
 	default:
 		return fmt.Errorf("unexpected arguments %v", args)
 	}

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -181,7 +181,7 @@ func Download(ctx context.Context, local, remote string, opts ...Opt) (*Result, 
 	var localPath string
 	if local == "" {
 		if o.cacheDir == "" {
-			return nil, fmt.Errorf("caching-only mode requires the cache directory to be specified")
+			return nil, errors.New("caching-only mode requires the cache directory to be specified")
 		}
 	} else {
 		var err error
@@ -347,10 +347,10 @@ func Cached(remote string, opts ...Opt) (*Result, error) {
 		return nil, err
 	}
 	if o.cacheDir == "" {
-		return nil, fmt.Errorf("caching-only mode requires the cache directory to be specified")
+		return nil, errors.New("caching-only mode requires the cache directory to be specified")
 	}
 	if IsLocal(remote) {
-		return nil, fmt.Errorf("local files are not cached")
+		return nil, errors.New("local files are not cached")
 	}
 
 	shad := cacheDirectoryPath(o.cacheDir, remote)
@@ -431,7 +431,7 @@ func IsLocal(s string) bool {
 //   - Expand a leading `~`, or convert relative to absolute name
 func canonicalLocalPath(s string) (string, error) {
 	if s == "" {
-		return "", fmt.Errorf("got empty path")
+		return "", errors.New("got empty path")
 	}
 	if !IsLocal(s) {
 		return "", fmt.Errorf("got non-local path: %q", s)
@@ -588,7 +588,7 @@ func validateCachedDigest(shadDigest string, expectedDigest digest.Digest) error
 
 func validateLocalFileDigest(localPath string, expectedDigest digest.Digest) error {
 	if localPath == "" {
-		return fmt.Errorf("validateLocalFileDigest: got empty localPath")
+		return errors.New("validateLocalFileDigest: got empty localPath")
 	}
 	if expectedDigest == "" {
 		return nil
@@ -651,7 +651,7 @@ func matchLastModified(ctx context.Context, lastModifiedPath, url string) (match
 
 func downloadHTTP(ctx context.Context, localPath, lastModified, contentType, url, description string, expectedDigest digest.Digest) error {
 	if localPath == "" {
-		return fmt.Errorf("downloadHTTP: got empty localPath")
+		return errors.New("downloadHTTP: got empty localPath")
 	}
 	logrus.Debugf("downloading %q into %q", url, localPath)
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -2,7 +2,7 @@ package driver
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net"
 
 	"github.com/lima-vm/lima/pkg/store"
@@ -125,19 +125,19 @@ func (d *BaseDriver) GetDisplayConnection(_ context.Context) (string, error) {
 }
 
 func (d *BaseDriver) CreateSnapshot(_ context.Context, _ string) error {
-	return fmt.Errorf("unimplemented")
+	return errors.New("unimplemented")
 }
 
 func (d *BaseDriver) ApplySnapshot(_ context.Context, _ string) error {
-	return fmt.Errorf("unimplemented")
+	return errors.New("unimplemented")
 }
 
 func (d *BaseDriver) DeleteSnapshot(_ context.Context, _ string) error {
-	return fmt.Errorf("unimplemented")
+	return errors.New("unimplemented")
 }
 
 func (d *BaseDriver) ListSnapshots(_ context.Context) (string, error) {
-	return "", fmt.Errorf("unimplemented")
+	return "", errors.New("unimplemented")
 }
 
 func (d *BaseDriver) ForwardGuestAgent() bool {

--- a/pkg/guestagent/procnettcp/procnettcp.go
+++ b/pkg/guestagent/procnettcp/procnettcp.go
@@ -3,6 +3,7 @@ package procnettcp
 import (
 	"bufio"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -59,10 +60,10 @@ func Parse(r io.Reader, kind Kind) ([]Entry, error) {
 				fieldNames[fields[j]] = j
 			}
 			if _, ok := fieldNames["local_address"]; !ok {
-				return nil, fmt.Errorf("field \"local_address\" not found")
+				return nil, errors.New("field \"local_address\" not found")
 			}
 			if _, ok := fieldNames["st"]; !ok {
-				return nil, fmt.Errorf("field \"st\" not found")
+				return nil, errors.New("field \"st\" not found")
 			}
 
 		default:

--- a/pkg/instance/delete.go
+++ b/pkg/instance/delete.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -12,7 +13,7 @@ import (
 
 func Delete(ctx context.Context, inst *store.Instance, force bool) error {
 	if inst.Protected {
-		return fmt.Errorf("instance is protected to prohibit accidental removal (Hint: use `limactl unprotect`)")
+		return errors.New("instance is protected to prohibit accidental removal (Hint: use `limactl unprotect`)")
 	}
 	if !force && inst.Status != store.StatusStopped {
 		return fmt.Errorf("expected status %q, got %q", store.StatusStopped, inst.Status)

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -227,7 +227,7 @@ func Validate(y *LimaYAML, warn bool) error {
 	needsContainerdArchives := (y.Containerd.User != nil && *y.Containerd.User) || (y.Containerd.System != nil && *y.Containerd.System)
 	if needsContainerdArchives {
 		if len(y.Containerd.Archives) == 0 {
-			return fmt.Errorf("field `containerd.archives` must be provided")
+			return errors.New("field `containerd.archives` must be provided")
 		}
 		for i, f := range y.Containerd.Archives {
 			if err := validateFileObject(f, fmt.Sprintf("containerd.archives[%d]", i)); err != nil {
@@ -341,7 +341,7 @@ func Validate(y *LimaYAML, warn bool) error {
 	}
 
 	if y.HostResolver.Enabled != nil && *y.HostResolver.Enabled && len(y.DNS) > 0 {
-		return fmt.Errorf("field `dns` must be empty when field `HostResolver.Enabled` is true")
+		return errors.New("field `dns` must be empty when field `HostResolver.Enabled` is true")
 	}
 
 	if err := validateNetwork(y); err != nil {

--- a/pkg/networks/validate.go
+++ b/pkg/networks/validate.go
@@ -91,7 +91,7 @@ func validatePath(path string, allowDaemonGroupWritable bool) error {
 		return fmt.Errorf("could not retrieve stat buffer for %q", path)
 	}
 	if runtime.GOOS != "darwin" {
-		return fmt.Errorf("vmnet code must not be called on non-Darwin") // TODO: move to *_darwin.go
+		return errors.New("vmnet code must not be called on non-Darwin") // TODO: move to *_darwin.go
 	}
 	// TODO: cache looked up UIDs/GIDs
 	root, err := osutil.LookupUser("root")

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -78,7 +78,7 @@ func (l *LimaVzDriver) Validate() error {
 	// Calling NewEFIBootLoader to do required version check for latest APIs
 	_, err := vz.NewEFIBootLoader()
 	if errors.Is(err, vz.ErrUnsupportedOSVersion) {
-		return fmt.Errorf("VZ driver requires macOS 13 or higher to run")
+		return errors.New("VZ driver requires macOS 13 or higher to run")
 	}
 	if *l.Instance.Config.MountType == limayaml.NINEP {
 		return fmt.Errorf("field `mountType` must be %q or %q for VZ driver , got %q", limayaml.REVSSHFS, limayaml.VIRTIOFS, *l.Instance.Config.MountType)
@@ -90,7 +90,7 @@ func (l *LimaVzDriver) Validate() error {
 		switch f.VMType {
 		case "", limayaml.VZ:
 			if f.Arch == *l.Instance.Config.Arch {
-				return fmt.Errorf("`firmware.images` configuration is not supported for VZ driver")
+				return errors.New("`firmware.images` configuration is not supported for VZ driver")
 			}
 		}
 	}
@@ -228,5 +228,5 @@ func (l *LimaVzDriver) GuestAgentConn(_ context.Context) (net.Conn, error) {
 			return connect, nil
 		}
 	}
-	return nil, fmt.Errorf("unable to connect to guest agent via vsock port 2222")
+	return nil, errors.New("unable to connect to guest agent via vsock port 2222")
 }


### PR DESCRIPTION
The PR replaces usages of `fmt.Errorf` with `errors.New` for creating errors because the latter is faster. Enables `perfsprint` linter to prevent future regressions.