### PR TITLE
Check if there is a newer engine available

### DIFF
--- a/templates/docker-rootful.yaml
+++ b/templates/docker-rootful.yaml
@@ -43,7 +43,10 @@ provision:
   script: |
     #!/bin/bash
     set -eux -o pipefail
-    command -v docker >/dev/null 2>&1 && exit 0
+    if command -v docker >/dev/null 2>&1; then
+        apt-get -y -qq install --only-upgrade 'docker-ce*'
+        exit 0
+    fi
     if [ ! -e /etc/systemd/system/docker.socket.d/override.conf ]; then
       mkdir -p /etc/systemd/system/docker.socket.d
       # Alternatively we could just add the user to the "docker" group, but that requires restarting the user session

--- a/templates/docker.yaml
+++ b/templates/docker.yaml
@@ -43,7 +43,10 @@ provision:
   script: |
     #!/bin/bash
     set -eux -o pipefail
-    command -v docker >/dev/null 2>&1 && exit 0
+    if command -v docker >/dev/null 2>&1; then
+        apt-get -y -qq install --only-upgrade 'docker-ce*'
+        exit 0
+    fi
     export DEBIAN_FRONTEND=noninteractive
     curl -fsSL https://get.docker.com | sh
     # NOTE: you may remove the lines below, if you prefer to use rootful docker, not rootless

--- a/templates/podman-rootful.yaml
+++ b/templates/podman-rootful.yaml
@@ -31,7 +31,10 @@ provision:
   script: |
     #!/bin/bash
     set -eux -o pipefail
-    command -v podman >/dev/null 2>&1 && exit 0
+    if command -v podman >/dev/null 2>&1; then
+        dnf -y upgrade --setopt=metadata_expire=never podman
+        exit 0
+    fi
     if [ ! -e /etc/systemd/system/podman.socket.d/override.conf ]; then
       mkdir -p /etc/systemd/system/podman.socket.d
       cat <<-EOF >/etc/systemd/system/podman.socket.d/override.conf

--- a/templates/podman.yaml
+++ b/templates/podman.yaml
@@ -31,7 +31,10 @@ provision:
   script: |
     #!/bin/bash
     set -eux -o pipefail
-    command -v podman >/dev/null 2>&1 && exit 0
+    if command -v podman >/dev/null 2>&1; then
+        dnf -y upgrade --setopt=metadata_expire=never podman
+        exit 0
+    fi
     dnf -y install podman
 - mode: user
   script: |


### PR DESCRIPTION
Previously only "nerdctl-full" was updated automatically, but docker and podman were never updated after installation.

The dependencies are supposed to be updated when necessary, by using the normal package manager's requirements system...

Note: might want to make this feature optional, by adding cidata variable?

Closes #2978