### PR TITLE
Make sure to install podman package from repo

### DIFF
--- a/templates/podman-rootful.yaml
+++ b/templates/podman-rootful.yaml
@@ -31,7 +31,7 @@ provision:
   script: |
     #!/bin/bash
     set -eux -o pipefail
-    command -v podman >/dev/null 2>&1 && exit 0
+    command -v podman >/dev/null 2>&1 && test -e /etc/lima-podman && exit 0
     if [ ! -e /etc/systemd/system/podman.socket.d/override.conf ]; then
       mkdir -p /etc/systemd/system/podman.socket.d
       cat <<-EOF >/etc/systemd/system/podman.socket.d/override.conf
@@ -43,7 +43,7 @@ provision:
       mkdir -p /etc/tmpfiles.d
       echo "d /run/podman 0700 {{.User}} -" > /etc/tmpfiles.d/podman.conf
     fi
-    dnf -y install podman
+    dnf -y install --best podman && touch /etc/lima-podman
 - mode: system
   script: |
     #!/bin/bash

--- a/templates/podman.yaml
+++ b/templates/podman.yaml
@@ -31,8 +31,8 @@ provision:
   script: |
     #!/bin/bash
     set -eux -o pipefail
-    command -v podman >/dev/null 2>&1 && exit 0
-    dnf -y install podman
+    command -v podman >/dev/null 2>&1 && test -e /etc/lima-podman && exit 0
+    dnf -y install --best podman && touch /etc/lima-podman
 - mode: user
   script: |
     #!/bin/bash


### PR DESCRIPTION
Newer versions of Fedora come with an older pre-installed Podman,
make sure to install the package from the repository like before.

Closes #2978

----

Fixes the issue on my machine:

```console
INFO[0019] READY. Run `limactl shell podman` to open the shell. 
INFO[0019] Message from the instance "podman":          
To run `podman` on the host (assumes podman-remote is installed), run the following commands:
------
podman system connection add lima-podman "unix:///home/anders/.lima/podman/sock/podman.sock"
podman system connection default lima-podman
podman --remote run quay.io/podman/hello
------
$ podman.lima version
Client:       Podman Engine
Version:      4.9.3
API Version:  4.9.3
Go Version:   go1.21.7
Git Commit:   8d2b55ddde1bc81f43d018dfc1ac027c06b26a7f
Built:        Fri Feb 16 11:30:23 2024
OS/Arch:      linux/amd64

Server:       Podman Engine
Version:      5.3.1
API Version:  5.3.1
Go Version:   go1.23.3
Built:        Thu Nov 21 01:00:00 2024
OS/Arch:      linux/amd64
```

It needed --best too, or it would exit:

`Package "podman-5:5.2.5-1.fc41.x86_64" is already installed.`
