### PR TITLE
Fix typo in Port Forwarding documentation

### DIFF
--- a/website/content/en/docs/config/port.md
+++ b/website/content/en/docs/config/port.md
@@ -27,7 +27,7 @@ LIMA_SSH_PORT_FORWARDER=true limactl start
 #### Caveats
 
 - Doesn't support UDP based port forwarding
-- Spans child process on host for running SSH master.
+- Spawns child process on host for running SSH master.
 
 ### Using GRPC
 


### PR DESCRIPTION
I had to re-read the bullet a few times before I figured out it probably meant "spawns".