### PR TITLE
Silence `WARN[0000] vmType vz: ignoring networks[0]: [Metric]`

### DIFF
--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -130,6 +130,7 @@ func (l *LimaVzDriver) Validate() error {
 			"Lima",
 			"Socket",
 			"MACAddress",
+			"Metric",
 			"Interface",
 		); len(unknown) > 0 {
 			logrus.Warnf("vmType %s: ignoring networks[%d]: %+v", *l.Instance.Config.VMType, i, unknown)


### PR DESCRIPTION
Fix #2986