### PR TITLE
ci: raise timeout for golangci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ _artifacts/
 lima.REJECTED.yaml
 schema-limayaml.json
 .config
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _artifacts/
 lima.REJECTED.yaml
 schema-limayaml.json
 .config
+.idea/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@
 ---
 run:
   concurrency: 6
-  timeout: 2m
+  timeout: 2m # 1m by default
 linters:
   disable-all: true
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@
 ---
 run:
   concurrency: 6
+  timeout: 2m
 linters:
   disable-all: true
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@
 ---
 run:
   concurrency: 6
-  timeout: 2m # 1m by default
+  timeout: 2m  # to avoid timeout locally
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
to avoid it locally:
```
ERRO Running error: context loading failed: failed to load packages: failed to load packages: failed to load with go/packages: context deadline exceeded
ERRO Timeout exceeded: try increasing it by passing --timeout option
```