### PR TITLE
Setup sshfs in fuse.conf before setup dns iptables

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/35-setup-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/35-setup-packages.sh
@@ -14,6 +14,12 @@ update_fuse_conf() {
 	fi
 }
 
+# update_fuse_conf has to be called after installing all the packages,
+# otherwise apt-get fails with conflict
+if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
+	update_fuse_conf
+fi
+
 SETUP_DNS=0
 if [ -n "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" ] && [ "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" -ne 0 ]; then
 	SETUP_DNS=1
@@ -24,10 +30,4 @@ fi
 if [ "${SETUP_DNS}" = 1 ]; then
 	# Try to setup iptables rule again, in case we just installed iptables
 	"${LIMA_CIDATA_MNT}/boot/09-host-dns-setup.sh"
-fi
-
-# update_fuse_conf has to be called after installing all the packages,
-# otherwise apt-get fails with conflict
-if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
-	update_fuse_conf
 fi


### PR DESCRIPTION
So that sshfs still works (unblocking the probe), even if there is some issue with iptables and nftables configuration.

* https://github.com/lima-vm/lima/issues/3022#issuecomment-2558429304