### PR TITLE
qemu: avoid `Property 'host-arm-cpu.sme' not found`

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -6,7 +6,7 @@
 skip = .git,go.mod,go.sum,*.pb.desc,*/node_modules/*,*/public/js/*,*/public/scss/*
 
 # Comma separated list of words to be ignored. Words must be lowercased.
-ignore-words-list = ans,distroname,testof,hda,ststr,archtypes
+ignore-words-list = ans,distroname,testof,hda,ststr,archtypes,sme
 
 # Check file names as well.
 check-filenames = true

--- a/pkg/osutil/osutil_unix.go
+++ b/pkg/osutil/osutil_unix.go
@@ -3,7 +3,11 @@
 package osutil
 
 import (
+	"bytes"
+	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -15,4 +19,16 @@ func Dup2(oldfd, newfd int) (err error) {
 
 func SignalName(sig os.Signal) string {
 	return unix.SignalName(sig.(syscall.Signal))
+}
+
+func Sysctl(name string) (string, error) {
+	var stderrBuf bytes.Buffer
+	cmd := exec.Command("sysctl", "-n", name)
+	cmd.Stderr = &stderrBuf
+	stdout, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to run %v: %w (stdout=%q, stderr=%q)", cmd.Args, err,
+			string(stdout), stderrBuf.String())
+	}
+	return strings.TrimSuffix(string(stdout), "\n"), nil
 }

--- a/pkg/osutil/osutil_windows.go
+++ b/pkg/osutil/osutil_windows.go
@@ -1,6 +1,7 @@
 package osutil
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -47,4 +48,8 @@ func SignalName(sig os.Signal) string {
 	default:
 		return fmt.Sprintf("Signal(%d)", sig)
 	}
+}
+
+func Sysctl(name string) (string, error) {
+	return "", errors.New("sysctl: unimplemented on Windows")
 }


### PR DESCRIPTION
Close #3032

SME is available since Apple M4 running macOS 15.2. However, QEMU is not ready to handle SME yet.
- https://gitlab.com/qemu-project/qemu/-/issues/2665
- https://gitlab.com/qemu-project/qemu/-/issues/2721