### PR TITLE
limactl shell: avoid silencing errors

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -185,7 +185,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		sshArgs = append(sshArgs, "-o", "SendEnv=COLORTERM")
 	}
 	sshArgs = append(sshArgs, []string{
-		"-q",
+		"-o", "LogLevel=ERROR",
 		"-p", strconv.Itoa(inst.SSHLocalPort),
 		inst.SSHAddress,
 		"--",


### PR DESCRIPTION
Fix #2980

Before:
```console
$ limactl shell alpine
$ echo $?
255
```

After:
```console
$ limactl shell alpine
suda@127.0.0.1: Permission denied (publickey,keyboard-interactive).
$ echo $?
255
```