### PR TITLE
website: remove sidebar search box and enhance the one in the top navigation bar

### DIFF
--- a/website/assets/scss/_variables_project.scss
+++ b/website/assets/scss/_variables_project.scss
@@ -33,3 +33,22 @@ $td-sidebar-tree-root-color: #222 !default;
     border-color: $secondary transparent transparent transparent !important;
   }
 }
+
+.td-search__input {
+  color: var(--bs-body-color) !important;
+  border: 1px solid var(--bs-gray-400) !important;
+}
+
+.td-search__input:focus {
+  color: inherit !important;
+  border-color: var(--bs-body-bg) !important;
+  box-shadow: 0 0 0 2px var(--bs-primary) !important;
+}
+
+.td-search__input::placeholder {
+  color: var(--bs-gray) !important;
+}
+
+.td-search__icon {
+  color: $secondary !important;
+}

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -142,7 +142,7 @@ navbar_translucent_over_cover_disable = false
 # Enable to show the side bar menu in its compact state.
 sidebar_menu_compact = false
 # Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
-sidebar_search_disable = false
+sidebar_search_disable = true
 sidebar_menu_foldable = true
 ul_show = 1
 


### PR DESCRIPTION
Hi!

I’d like to make a small contribution to Lima :)

#### Overview
I have updated the `_variables_project.scss` file to unify the styling of the search boxes, following the recent addition of local search powered by **Lunr**.

#### Benefits
These changes enhance visual consistency and accessibility.

#### Visual Comparison
Below is before-and-after comparison to showcase the improvements.

The homepage:
![comparison](https://github.com/user-attachments/assets/d3913921-538e-4112-8c39-3989757118cb)

`/docs` after the changes:
![new](https://github.com/user-attachments/assets/5efa3cc1-5b81-45b3-827e-82d23caf0157)

---

Thank you for considering this contribution. I look forward to your feedback :)