### PR TITLE
Disable AVX-512 support for macOS Intel host

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -73,6 +73,10 @@ func defaultCPUType() CPUType {
 		if arch == X8664 && runtime.GOOS == "darwin" {
 			switch cpuType[arch] {
 			case "host", "max":
+				// disable AVX-512, since it requires trapping instruction faults in guest
+				// Enterprise Linux requires either v2 (SSE4) or v3 (AVX2), but not yet v4.
+				cpuType[arch] += ",-avx512vl"
+
 				// Disable pdpe1gb on Intel Mac
 				// https://github.com/lima-vm/lima/issues/1485
 				// https://stackoverflow.com/a/72863744/5167443


### PR DESCRIPTION
Handling AVX-512 instructions requires promoting threads in the operating system, but it is not required by distros.

So make do with the earlier microarchitectures (v2 and v3), without exposing all the host features of the newest (v4).

v2: https://developers.redhat.com/blog/2021/01/05/building-red-hat-enterprise-linux-9-for-the-x86-64-v2-microarchitecture-level

v3: https://developers.redhat.com/articles/2024/01/02/exploring-x86-64-v3-red-hat-enterprise-linux-10

Closes #3022

Please test with centos-stream-10.yaml on macOS Intel, by commenting out the "cpuType" override in the template

When running on Linux hosts, we can expose AVX-512 in the guest since it doesn't require similar thread promotion.