### PR TITLE
Fix internal links on the website

### DIFF
--- a/website/content/en/docs/_index.md
+++ b/website/content/en/docs/_index.md
@@ -15,11 +15,11 @@ Lima launches Linux virtual machines with automatic file sharing and port forwar
 
 ✅ Intel on Intel
 
-✅ [ARM on Intel](./docs/multi-arch.md)
+✅ [ARM on Intel]({{< ref "/docs/config/multi-arch" >}})
 
 ✅ ARM on ARM
 
-✅ [Intel on ARM](./docs/multi-arch.md)
+✅ [Intel on ARM]({{< ref "/docs/config/multi-arch" >}})
 
 ✅ Various guest Linux distributions: [AlmaLinux](./templates/almalinux.yaml), [Alpine](./templates/alpine.yaml), [Arch Linux](./templates/archlinux.yaml), [Debian](./templates/debian.yaml), [Fedora](./templates/fedora.yaml), [openSUSE](./templates/opensuse.yaml), [Oracle Linux](./templates/oraclelinux.yaml), [Rocky](./templates/rocky.yaml), [Ubuntu](./templates/ubuntu.yaml) (default), ...
 

--- a/website/content/en/docs/faq/_index.md
+++ b/website/content/en/docs/faq/_index.md
@@ -165,7 +165,7 @@ Note: **Only** on macOS versions **before** 10.15.7 you might need to add this e
 #### "QEMU is slow"
 {{% fixlinks %}}
 - Make sure that HVF is enabled with `com.apple.security.hypervisor` entitlement. See ["QEMU crashes with `HV_ERROR`"](#qemu-crashes-with-hv_error).
-- Emulating non-native machines (ARM-on-Intel, Intel-on-ARM) is slow by design. See [`docs/multi-arch.md`](./docs/multi-arch.md) for a workaround.
+- Emulating non-native machines (ARM-on-Intel, Intel-on-ARM) is slow by design. See [`docs/multi-arch.md`]({{< ref "/docs/config/multi-arch" >}}) for a workaround.
 {{% /fixlinks %}}
 
 #### error "killed -9"
@@ -190,7 +190,7 @@ The default guest IP 192.168.5.15 is not accessible from the host and other gues
 
 To add another IP address that is accessible from the host and other virtual machines, enable [`socket_vmnet`](https://github.com/lima-vm/socket_vmnet) (since Lima v0.12).
 
-See [`./docs/network.md`](./docs/network.md).
+See [`docs/network.md`]({{< ref "/docs/config/network" >}}).
 {{% /fixlinks %}}
 
 #### "Ping shows duplicate packets and massive response times"
@@ -216,7 +216,7 @@ sudo /usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/boot
 ### Filesystem sharing
 #### "Filesystem is slow"
 {{% fixlinks %}}
-Try virtiofs. See [`docs/mount.md`](./docs/mount.md)
+Try virtiofs. See [`docs/mount.md`]({{< ref "/docs/config/mount" >}})
 {{% /fixlinks %}}
 
 #### "Filesystem is not writable"


### PR DESCRIPTION
Currently using a static file in the git repository, but they can link directly to generated site instead.

----

The links on the start page of documentation has an extra step in them:

https://lima-vm.io/docs/

https://github.com/lima-vm/lima/blob/master/docs/multi-arch.md

https://lima-vm.io/docs/config/multi-arch/

Seems to be a left-over from when it was moved from the repo to the site...

commit c9a53ae3e8cc712b73dbe2c55ca6fce0aaa43e2b