### PR TITLE
Move k8s image pull to a separate step

### DIFF
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -147,6 +147,14 @@ probes:
     fi
   hint: |
     See "/var/log/cloud-init-output.log" in the guest
+- description: "kubernetes images to be pulled"
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! timeout 30s bash -c "images=\"$(kubeadm config images list)\"; until for image in \$images; do sudo crictl image -q \$image | grep -q sha256; done; do sleep 3; done"; then
+      echo >&2 "k8s images are not pulled yet"
+      exit 1
+    fi
 - description: "kubeadm to be completed"
   script: |
     #!/bin/bash

--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -97,8 +97,10 @@ provision:
     set -eux -o pipefail
     test -e /etc/kubernetes/admin.conf && exit 0
     export KUBECONFIG=/etc/kubernetes/admin.conf
+    systemctl stop kubelet
     kubeadm config images list
     kubeadm config images pull --cri-socket=unix:///run/containerd/containerd.sock
+    systemctl start kubelet
     # Initializing your control-plane node
     cat <<EOF >kubeadm-config.yaml
     kind: InitConfiguration


### PR DESCRIPTION
It can take a while, so do it in a separate provisioning step.

Turn off the kubelet until it is done, to cut down on logging:

```
[   87.432334] cloud-init[1063]: + kubeadm config images pull --cri-socket=unix:///run/containerd/containerd.sock
[^[[0;32m  OK  ^[[0m] Started ^[[0;1;39mkubelet.service^[[0m - kubelet: The Kubernetes Node Agent.^M
[^[[0;32m  OK  ^[[0m] Started ^[[0;1;39mkubelet.service^[[0m - kubelet: The Kubernetes Node Agent.^M
[  109.962640] cloud-init[1063]: [config/images] Pulled registry.k8s.io/kube-apiserver:v1.32.0
[^[[0;32m  OK  ^[[0m] Started ^[[0;1;39mkubelet.service^[[0m - kubelet: The Kubernetes Node Agent.^M
[^[[0;32m  OK  ^[[0m] Started ^[[0;1;39mkubelet.service^[[0m - kubelet: The Kubernetes Node Agent.^M
[  127.815678] cloud-init[1063]: [config/images] Pulled registry.k8s.io/kube-controller-manager:v1.32.0
[^[[0;32m  OK  ^[[0m] Started ^[[0;1;39mkubelet.service^[[0m - kubelet: The Kubernetes Node Agent.^M
[  135.802980] cloud-init[1063]: [config/images] Pulled registry.k8s.io/kube-scheduler:v1.32.0
[^[[0;32m  OK  ^[[0m] Started ^[[0;1;39mkubelet.service^[[0m - kubelet: The Kubernetes Node Agent.^M
[  151.838119] cloud-init[1063]: [config/images] Pulled registry.k8s.io/kube-proxy:v1.32.0
[^[[0;32m  OK  ^[[0m] Started ^[[0;1;39mkubelet.service^[[0m - kubelet: The Kubernetes Node Agent.^M
[  160.425302] cloud-init[1063]: [config/images] Pulled registry.k8s.io/coredns/coredns:v1.11.3
[^[[0;32m  OK  ^[[0m] Started ^[[0;1;39mkubelet.service^[[0m - kubelet: The Kubernetes Node Agent.^M
[  167.723052] cloud-init[1063]: [config/images] Pulled registry.k8s.io/pause:3.10
[^[[0;32m  OK  ^[[0m] Started ^[[0;1;39mkubelet.service^[[0m - kubelet: The Kubernetes Node Agent.^M
[  178.685421] cloud-init[1063]: [config/images] Pulled registry.k8s.io/etcd:3.5.16-0
```

----

Note: the whole `kubeadm config images pull` is optional.

We do it as a separate step, to improve feedback and troubleshooting.

Otherwise it will done during the "preflight" of the `kubeadm init`:
```
[preflight] Pulling images required for setting up a Kubernetes cluster
[preflight] This might take a minute or two, depending on the speed of your internet connection
[preflight] You can also perform this action in beforehand using 'kubeadm config images pull'
```