### PR TITLE
website: add simple makefile for testing locally

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -1,0 +1,12 @@
+# See also: package.json
+NPM ?= npm
+
+build serve: _output/docsy
+	$(NPM) run $@
+
+_output/docsy:
+	$(MAKE) -C .. docsy
+
+clean:
+	$(NPM) run $@
+	rm -Rf _output


### PR DESCRIPTION
Something like: `cd website && make serve`

Then you can open <http://localhost:1313/>

Closes #3079

I used hugo-extended 0.113.0 (from package.json)

---

Would recommend using something like: [nvm](https://github.com/nvm-sh/nvm) for the `npm` (and `node`) installation and versioning

The "hugo" program can be found on https://gohugo.io/ and "docsy" is found on https://docsy.dev/