### PR TITLE
Recompress the containerd archive with zstd

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh
@@ -12,9 +12,8 @@ fi
 command -v systemctl >/dev/null 2>&1 || exit 0
 
 # Extract bin/nerdctl and compare whether it is newer than the current /usr/local/bin/nerdctl (if already exists).
-# Takes 4-5 seconds. (FIXME: optimize)
 tmp_extract_nerdctl="$(mktemp -d)"
-tar Cxzf "${tmp_extract_nerdctl}" "${LIMA_CIDATA_MNT}"/nerdctl-full.tgz bin/nerdctl
+tar Cxaf "${tmp_extract_nerdctl}" "${LIMA_CIDATA_MNT}"/"${LIMA_CIDATA_CONTAINERD_ARCHIVE}" bin/nerdctl
 
 if [ ! -f "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl ] || [[ "${tmp_extract_nerdctl}"/bin/nerdctl -nt "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl ]]; then
 	if [ -f "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl ]; then
@@ -28,7 +27,7 @@ if [ ! -f "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl ] || [[ "${tmp_extra
 			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" containerd-rootless-setuptool.sh uninstall
 		)
 	fi
-	tar Cxzf "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}" "${LIMA_CIDATA_MNT}"/nerdctl-full.tgz
+	tar Cxaf "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}" "${LIMA_CIDATA_MNT}"/"${LIMA_CIDATA_CONTAINERD_ARCHIVE}"
 
 	mkdir -p /etc/bash_completion.d
 	nerdctl completion bash >/etc/bash_completion.d/nerdctl

--- a/pkg/cidata/cidata.TEMPLATE.d/lima.env
+++ b/pkg/cidata/cidata.TEMPLATE.d/lima.env
@@ -29,6 +29,9 @@ LIMA_CIDATA_CONTAINERD_SYSTEM=1
 {{- else}}
 LIMA_CIDATA_CONTAINERD_SYSTEM=
 {{- end}}
+{{- if or .Containerd.User .Containerd.System}}
+LIMA_CIDATA_CONTAINERD_ARCHIVE={{.Containerd.Archive}}
+{{- end}}
 LIMA_CIDATA_SLIRP_DNS={{.SlirpDNS}}
 LIMA_CIDATA_SLIRP_GATEWAY={{.SlirpGateway}}
 LIMA_CIDATA_SLIRP_IP_ADDRESS={{.SlirpIPAddress}}

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -29,8 +29,10 @@ type Cert struct {
 }
 
 type Containerd struct {
-	System bool
-	User   bool
+	System     bool
+	User       bool
+	Archive    string
+	Recompress bool
 }
 type Network struct {
 	MACAddress string

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -187,6 +187,7 @@ The volume label is "cidata", as defined by [cloud-init NoCloud](https://docs.cl
 - `LIMA_CIDATA_MOUNTTYPE`: the type of the Lima mounts ("reverse-sshfs", "9p", ...)
 - `LIMA_CIDATA_CONTAINERD_USER`: set to "1" if rootless containerd to be set up
 - `LIMA_CIDATA_CONTAINERD_SYSTEM`: set to "1" if system-wide containerd to be set up
+- `LIMA_CIDATA_CONTAINERD_ARCHIVE`: the name of the containerd archive. `nerdctl-full.tgz`
 - `LIMA_CIDATA_SLIRP_GATEWAY`: set to the IP address of the host on the SLIRP network. `192.168.5.2`.
 - `LIMA_CIDATA_SLIRP_DNS`: set to the IP address of the DNS on the SLIRP network. `192.168.5.3`.
 - `LIMA_CIDATA_SLIRP_IP_ADDRESS`: set to the IP address of the guest on the SLIRP network. `192.168.5.15`.


### PR DESCRIPTION
Takes a couple of seconds to recompress (when creating the `cidata.iso`)...

But cuts the runtime down from 4-5 seconds down to less than 1 second

Choosing the default (fast) compression, so the actual file size is the same.

If the nerdctl project supported .tar.zst too, that time could be avoided?