### PR TITLE
Refactor the containerd archive compression

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh
@@ -14,7 +14,7 @@ command -v systemctl >/dev/null 2>&1 || exit 0
 # Extract bin/nerdctl and compare whether it is newer than the current /usr/local/bin/nerdctl (if already exists).
 # Takes 4-5 seconds. (FIXME: optimize)
 tmp_extract_nerdctl="$(mktemp -d)"
-tar Cxzf "${tmp_extract_nerdctl}" "${LIMA_CIDATA_MNT}"/nerdctl-full.tgz bin/nerdctl
+tar Cxaf "${tmp_extract_nerdctl}" "${LIMA_CIDATA_MNT}"/"${LIMA_CIDATA_CONTAINERD_ARCHIVE}" bin/nerdctl
 
 if [ ! -f "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl ] || [[ "${tmp_extract_nerdctl}"/bin/nerdctl -nt "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl ]]; then
 	if [ -f "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl ]; then
@@ -28,7 +28,7 @@ if [ ! -f "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl ] || [[ "${tmp_extra
 			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" containerd-rootless-setuptool.sh uninstall
 		)
 	fi
-	tar Cxzf "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}" "${LIMA_CIDATA_MNT}"/nerdctl-full.tgz
+	tar Cxaf "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}" "${LIMA_CIDATA_MNT}"/"${LIMA_CIDATA_CONTAINERD_ARCHIVE}"
 
 	mkdir -p /etc/bash_completion.d
 	nerdctl completion bash >/etc/bash_completion.d/nerdctl

--- a/pkg/cidata/cidata.TEMPLATE.d/lima.env
+++ b/pkg/cidata/cidata.TEMPLATE.d/lima.env
@@ -29,6 +29,9 @@ LIMA_CIDATA_CONTAINERD_SYSTEM=1
 {{- else}}
 LIMA_CIDATA_CONTAINERD_SYSTEM=
 {{- end}}
+{{- if or .Containerd.User .Containerd.System}}
+LIMA_CIDATA_CONTAINERD_ARCHIVE={{.Containerd.Archive}}
+{{- end}}
 LIMA_CIDATA_SLIRP_DNS={{.SlirpDNS}}
 LIMA_CIDATA_SLIRP_GATEWAY={{.SlirpGateway}}
 LIMA_CIDATA_SLIRP_IP_ADDRESS={{.SlirpIPAddress}}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -116,6 +116,7 @@ func templateArgs(bootScripts bool, instDir, name string, instConfig *limayaml.L
 	if err := limayaml.Validate(instConfig, false); err != nil {
 		return nil, err
 	}
+	archive := "nerdctl-full.tgz"
 	args := TemplateArgs{
 		Debug:              debugutil.Debug,
 		BootScripts:        bootScripts,
@@ -127,7 +128,7 @@ func templateArgs(bootScripts bool, instDir, name string, instConfig *limayaml.L
 		UID:                *instConfig.User.UID,
 		GuestInstallPrefix: *instConfig.GuestInstallPrefix,
 		UpgradePackages:    *instConfig.UpgradePackages,
-		Containerd:         Containerd{System: *instConfig.Containerd.System, User: *instConfig.Containerd.User},
+		Containerd:         Containerd{System: *instConfig.Containerd.System, User: *instConfig.Containerd.User, Archive: archive},
 		SlirpNICName:       networks.SlirpNICName,
 
 		RosettaEnabled: *instConfig.Rosetta.Enabled,
@@ -407,6 +408,7 @@ func GenerateISO9660(instDir, name string, instConfig *limayaml.LimaYAML, udpDNS
 	})
 
 	if nerdctlArchive != "" {
+		nftgz := args.Containerd.Archive
 		nftgzR, err := os.Open(nerdctlArchive)
 		if err != nil {
 			return err
@@ -414,7 +416,7 @@ func GenerateISO9660(instDir, name string, instConfig *limayaml.LimaYAML, udpDNS
 		defer nftgzR.Close()
 		layout = append(layout, iso9660util.Entry{
 			// ISO9660 requires len(Path) <= 30
-			Path:   "nerdctl-full.tgz",
+			Path:   nftgz,
 			Reader: nftgzR,
 		})
 	}

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -29,8 +29,9 @@ type Cert struct {
 }
 
 type Containerd struct {
-	System bool
-	User   bool
+	System  bool
+	User    bool
+	Archive string
 }
 type Network struct {
 	MACAddress string

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -187,6 +187,7 @@ The volume label is "cidata", as defined by [cloud-init NoCloud](https://docs.cl
 - `LIMA_CIDATA_MOUNTTYPE`: the type of the Lima mounts ("reverse-sshfs", "9p", ...)
 - `LIMA_CIDATA_CONTAINERD_USER`: set to "1" if rootless containerd to be set up
 - `LIMA_CIDATA_CONTAINERD_SYSTEM`: set to "1" if system-wide containerd to be set up
+- `LIMA_CIDATA_CONTAINERD_ARCHIVE`: the name of the containerd archive. `nerdctl-full.tgz`
 - `LIMA_CIDATA_SLIRP_GATEWAY`: set to the IP address of the host on the SLIRP network. `192.168.5.2`.
 - `LIMA_CIDATA_SLIRP_DNS`: set to the IP address of the DNS on the SLIRP network. `192.168.5.3`.
 - `LIMA_CIDATA_SLIRP_IP_ADDRESS`: set to the IP address of the guest on the SLIRP network. `192.168.5.15`.


### PR DESCRIPTION
Have tar auto-detect the compression, and pass the filename.

Instead of hardcoding gzip and .tgz in the archive handling.