### PR TITLE
Disable the epel-cisco-openh264 repository

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -90,7 +90,8 @@ elif command -v dnf >/dev/null 2>&1; then
 		elif grep -q -E "release (9|10)" /etc/system-release; then
 			# shellcheck disable=SC2086
 			dnf install ${dnf_install_flags} epel-release
-			dnf config-manager --disable epel >/dev/null 2>&1
+			# Disable the OpenH264 repository as well, by default
+			dnf config-manager --disable epel\* >/dev/null 2>&1
 			dnf_install_flags="${dnf_install_flags} --enablerepo epel"
 		fi
 		# shellcheck disable=SC2086


### PR DESCRIPTION
We only want the regular system repositories by default, but adding the epel-release package enables them on install.

```
Installed Packages
epel-release.noarch                                           9-5.el9                                            @extras
Available Packages
epel-release.noarch                                           9-9.el9                                            epel   
```

We already disabled "epel", so now we need to disable "epel-cisco-openh264" too. "epel-testing" is off by default, though.

```console
[anders@lima-almalinux-9 lima]$ rpm -q --changelog epel-release
* Thu Nov 28 2024 Carl George <carlwgeorge@fedoraproject.org> - 9-9
- Remove the use of $releasever rhbz#2219796

* Fri Aug 30 2024 Troy Dawson <tdawson@redhat.com> - 9-8
- Tweak crb script. Fix for RHEL rhui repos (#2308671)

* Thu Aug 17 2023 Neal Gompa <ngompa@fedoraproject.org> - 9-7
- Fix typo to actually enable EPEL OpenH264 repo

* Tue Aug 15 2023 Neal Gompa <ngompa@fedoraproject.org> - 9-6
- Add EPEL OpenH264 repository (#2053295)

* Fri Apr 14 2023 Troy Dawson <tdawson@redhat.com> - 9-5
- Tweak crb script, check os-release for RHEL (#2186721)

```

https://github.com/lima-vm/lima/pull/3096#issuecomment-2578098052

https://bugzilla.redhat.com/show_bug.cgi?id=2053295

We only use EPEL because sshfs is not included, and we only use sshfs because 9p is not included either.

* #3096