### PR TITLE
Un-deprecate non-strict YAML

### DIFF
--- a/pkg/limayaml/marshal.go
+++ b/pkg/limayaml/marshal.go
@@ -45,9 +45,7 @@ func Unmarshal(data []byte, v interface{}, comment string) error {
 		return fmt.Errorf("failed to unmarshal YAML (%s): %w", comment, err)
 	}
 	if err := yaml.UnmarshalWithOptions(data, v, yaml.Strict(), yaml.CustomUnmarshaler[Disk](unmarshalDisk)); err != nil {
-		logrus.WithField("comment", comment).WithError(err).Warn("Non-strict YAML is deprecated and will be unsupported in a future version of Lima")
-		// Non-strict YAML is known to be used by Rancher Desktop:
-		// https://github.com/rancher-sandbox/rancher-desktop/blob/c7ea7508a0191634adf16f4675f64c73198e8d37/src/backend/lima.ts#L114-L117
+		logrus.WithField("comment", comment).WithError(err).Warn("Non-strict YAML detected; please check for typos")
 	}
 	return nil
 }


### PR DESCRIPTION
We still warn the user because it could be due to typos, but we no longer threaten to make strict mode the default.

Allowing non-strict YAML is very useful for maintainers switching between feature branches. Failing on non-strict YAML would make it hard to e.g. delete instances that have been created by a different branch that introduces a new field.