### PR TITLE
Add validation for additionalDisks

### DIFF
--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/containerd/containerd/identifiers"
 	"github.com/coreos/go-semver/semver"
 	"github.com/docker/go-units"
 	"github.com/lima-vm/lima/pkg/localpathutil"
@@ -134,6 +135,12 @@ func Validate(y *LimaYAML, warn bool) error {
 
 	if _, err := units.RAMInBytes(*y.Disk); err != nil {
 		return fmt.Errorf("field `memory` has an invalid value: %w", err)
+	}
+
+	for i, disk := range y.AdditionalDisks {
+		if err := identifiers.Validate(disk.Name); err != nil {
+			return fmt.Errorf("field `additionalDisks[%d].name is invalid`: %w", i, err)
+		}
 	}
 
 	for i, f := range y.Mounts {

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -48,6 +48,31 @@ func TestValidateProbes(t *testing.T) {
 	assert.Error(t, err, "field `probe[0].script` must start with a '#!' line")
 }
 
+func TestValidateAdditionalDisks(t *testing.T) {
+	images := `images: [{"location": "/"}]`
+
+	validDisks := `
+additionalDisks:
+  - name: "disk1"
+  - name: "disk2"
+`
+	y, err := Load([]byte(validDisks+"\n"+images), "lima.yaml")
+	assert.NilError(t, err)
+
+	err = Validate(y, false)
+	assert.NilError(t, err)
+
+	invalidDisks := `
+additionalDisks:
+  - name: ""
+`
+	y, err = Load([]byte(invalidDisks+"\n"+images), "lima.yaml")
+	assert.NilError(t, err)
+
+	err = Validate(y, false)
+	assert.Error(t, err, "field `additionalDisks[0].name is invalid`: identifier must not be empty: invalid argument")
+}
+
 func TestValidateParamName(t *testing.T) {
 	images := `images: [{"location": "/"}]`
 	validProvision := `provision: [{"script": "echo $PARAM_name $PARAM_NAME $PARAM_Name_123"}]`


### PR DESCRIPTION
```
change validation to ensure that only Disk type values are allowed in the AdditionalDisks field.
```

Fixes [#3071](https://github.com/lima-vm/lima/issues/3071)