### PR TITLE
refactor: replace interface{} with any

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -153,6 +153,7 @@ linters-settings:
     - name: unexported-return
     - name: unreachable-code
     - name: unused-parameter
+    - name: use-any
     - name: var-declaration
     - name: var-naming
   staticcheck:

--- a/cmd/limactl/genschema.go
+++ b/cmd/limactl/genschema.go
@@ -88,7 +88,7 @@ func genschemaAction(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		var y interface{}
+		var y any
 		err = yaml.Unmarshal(b, &y)
 		if err != nil {
 			return err

--- a/pkg/guestagent/kubernetesservice/kubernetesservice_test.go
+++ b/pkg/guestagent/kubernetesservice/kubernetesservice_test.go
@@ -28,7 +28,7 @@ func TestGetPorts(t *testing.T) {
 	kubeClient, informerFactory := newFakeKubeClient()
 	serviceInformer := informerFactory.Core().V1().Services().Informer()
 	_, err := serviceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(interface{}) { serviceCreatedCh <- struct{}{} },
+		AddFunc: func(any) { serviceCreatedCh <- struct{}{} },
 	})
 	assert.NilError(t, err)
 	informerFactory.Start(ctx.Done())

--- a/pkg/instance/ansible.go
+++ b/pkg/instance/ansible.go
@@ -39,17 +39,17 @@ func runAnsiblePlaybook(ctx context.Context, inst *store.Instance, playbook stri
 }
 
 func createAnsibleInventory(inst *store.Instance) (string, error) {
-	vars := map[string]interface{}{
+	vars := map[string]any{
 		"ansible_connection":      "ssh",
 		"ansible_host":            inst.Hostname,
 		"ansible_ssh_common_args": "-F " + inst.SSHConfigFile,
 	}
-	hosts := map[string]interface{}{
+	hosts := map[string]any{
 		inst.Name: vars,
 	}
 	group := "lima"
-	data := map[string]interface{}{
-		group: map[string]interface{}{
+	data := map[string]any{
+		group: map[string]any{
 			"hosts": hosts,
 		},
 	}

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -886,7 +886,7 @@ func executeGuestTemplate(format, instDir string, user User, param map[string]st
 	tmpl, err := template.New("").Parse(format)
 	if err == nil {
 		name := filepath.Base(instDir)
-		data := map[string]interface{}{
+		data := map[string]any{
 			"Name":     name,
 			"Hostname": identifierutil.HostnameFromInstName(name), // TODO: support customization
 			"UID":      *user.UID,
@@ -906,7 +906,7 @@ func executeHostTemplate(format, instDir string, param map[string]string) (bytes
 	tmpl, err := template.New("").Parse(format)
 	if err == nil {
 		limaHome, _ := dirnames.LimaDir()
-		data := map[string]interface{}{
+		data := map[string]any{
 			"Dir":  instDir,
 			"Name": filepath.Base(instDir),
 			// TODO: add hostname fields for the host and the guest

--- a/pkg/limayaml/limayaml_test.go
+++ b/pkg/limayaml/limayaml_test.go
@@ -8,7 +8,7 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func dumpJSON(t *testing.T, d interface{}) string {
+func dumpJSON(t *testing.T, d any) string {
 	b, err := json.Marshal(d)
 	assert.NilError(t, err)
 	return string(b)

--- a/pkg/limayaml/marshal.go
+++ b/pkg/limayaml/marshal.go
@@ -35,7 +35,7 @@ func unmarshalDisk(dst *Disk, b []byte) error {
 	return yaml.Unmarshal(b, dst)
 }
 
-func Unmarshal(data []byte, v interface{}, comment string) error {
+func Unmarshal(data []byte, v any, comment string) error {
 	if err := yaml.UnmarshalWithOptions(data, v, yaml.CustomUnmarshaler[Disk](unmarshalDisk)); err != nil {
 		return fmt.Errorf("failed to unmarshal YAML (%s): %w", comment, err)
 	}

--- a/pkg/osutil/dns_darwin.go
+++ b/pkg/osutil/dns_darwin.go
@@ -25,7 +25,7 @@ func DNSAddresses() ([]string, error) {
 	return addresses, nil
 }
 
-func proxyURL(proxy string, port interface{}) string {
+func proxyURL(proxy string, port any) string {
 	if strings.Contains(proxy, "://") {
 		if portNumber, ok := port.(float64); ok && portNumber != 0 {
 			proxy = fmt.Sprintf("%s:%.0f", proxy, portNumber)

--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -411,8 +411,8 @@ func (a *qArgTemplateApplier) applyTemplate(qArg string) (string, error) {
 		return qArg, nil
 	}
 	funcMap := template.FuncMap{
-		"fd_connect": func(v interface{}) string {
-			fn := func(v interface{}) (string, error) {
+		"fd_connect": func(v any) string {
+			fn := func(v any) (string, error) {
 				s, ok := v.(string)
 				if !ok {
 					return "", fmt.Errorf("non-string argument %+v", v)

--- a/pkg/reflectutil/reflectutil.go
+++ b/pkg/reflectutil/reflectutil.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 )
 
-func UnknownNonEmptyFields(structOrStructPtr interface{}, knownNames ...string) []string {
+func UnknownNonEmptyFields(structOrStructPtr any, knownNames ...string) []string {
 	var unknown []string
 	knownNamesMap := make(map[string]struct{}, len(knownNames))
 	for _, name := range knownNames {

--- a/pkg/sysprof/network_darwin.go
+++ b/pkg/sysprof/network_darwin.go
@@ -20,17 +20,17 @@ type IPv4 struct {
 }
 
 type Proxies struct {
-	ExceptionList []string    `json:"ExceptionList"` // default: ["*.local", "169.254/16"]
-	FTPEnable     string      `json:"FTPEnable"`
-	FTPPort       interface{} `json:"FTPPort"`
-	FTPProxy      string      `json:"FTPProxy"`
-	FTPUser       string      `json:"FTPUser"`
-	HTTPEnable    string      `json:"HTTPEnable"`
-	HTTPPort      interface{} `json:"HTTPPort"`
-	HTTPProxy     string      `json:"HTTPProxy"`
-	HTTPUser      string      `json:"HTTPUser"`
-	HTTPSEnable   string      `json:"HTTPSEnable"`
-	HTTPSPort     interface{} `json:"HTTPSPort"`
-	HTTPSProxy    string      `json:"HTTPSProxy"`
-	HTTPSUser     string      `json:"HTTPSUser"`
+	ExceptionList []string `json:"ExceptionList"` // default: ["*.local", "169.254/16"]
+	FTPEnable     string   `json:"FTPEnable"`
+	FTPPort       any      `json:"FTPPort"`
+	FTPProxy      string   `json:"FTPProxy"`
+	FTPUser       string   `json:"FTPUser"`
+	HTTPEnable    string   `json:"HTTPEnable"`
+	HTTPPort      any      `json:"HTTPPort"`
+	HTTPProxy     string   `json:"HTTPProxy"`
+	HTTPUser      string   `json:"HTTPUser"`
+	HTTPSEnable   string   `json:"HTTPSEnable"`
+	HTTPSPort     any      `json:"HTTPSPort"`
+	HTTPSProxy    string   `json:"HTTPSProxy"`
+	HTTPSUser     string   `json:"HTTPSUser"`
 }

--- a/pkg/textutil/textutil.go
+++ b/pkg/textutil/textutil.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ExecuteTemplate executes a text/template template.
-func ExecuteTemplate(tmpl string, args interface{}) ([]byte, error) {
+func ExecuteTemplate(tmpl string, args any) ([]byte, error) {
 	x, err := template.New("").Parse(tmpl)
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func MissingString(message, text string) string {
 
 // TemplateFuncMap is a text/template FuncMap.
 var TemplateFuncMap = template.FuncMap{
-	"json": func(v interface{}) string {
+	"json": func(v any) string {
 		var b bytes.Buffer
 		enc := json.NewEncoder(&b)
 		enc.SetEscapeHTML(false)
@@ -65,7 +65,7 @@ var TemplateFuncMap = template.FuncMap{
 		}
 		return strings.TrimSuffix(b.String(), "\n")
 	},
-	"yaml": func(v interface{}) string {
+	"yaml": func(v any) string {
 		var b bytes.Buffer
 		enc := yaml.NewEncoder(&b)
 		if err := enc.Encode(v); err != nil {
@@ -73,7 +73,7 @@ var TemplateFuncMap = template.FuncMap{
 		}
 		return "---\n" + strings.TrimSuffix(b.String(), "\n")
 	},
-	"indent": func(a ...interface{}) (string, error) {
+	"indent": func(a ...any) (string, error) {
 		if len(a) == 0 {
 			return "", errors.New("function takes at least one string argument")
 		}
@@ -93,7 +93,7 @@ var TemplateFuncMap = template.FuncMap{
 		}
 		return IndentString(size, text), nil
 	},
-	"missing": func(a ...interface{}) (string, error) {
+	"missing": func(a ...any) (string, error) {
 		if len(a) == 0 {
 			return "", errors.New("function takes at least one string argument")
 		}

--- a/pkg/yqutil/yqutil.go
+++ b/pkg/yqutil/yqutil.go
@@ -101,7 +101,7 @@ func Join(yqExprs []string) string {
 
 func yamlfmtBasicFormatter() (*basic.BasicFormatter, error) {
 	factory := basic.BasicFormatterFactory{}
-	config := map[string]interface{}{
+	config := map[string]any{
 		"indentless_arrays":         true,
 		"line_ending":               "lf", // prefer LF even on Windows
 		"pad_line_comments":         2,


### PR DESCRIPTION
This PR replaces `interface{}` with `any`. Additionally, it configures `revive.use-any` to ensure usages of `any` in the future.
