### PR TITLE
fix inconsistent error in limactl create command when instance name and template is specified

### DIFF
--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -164,28 +164,6 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 		if err := identifiers.Validate(tmpl.Name); err != nil {
 			return nil, fmt.Errorf("argument must be either an instance name, a YAML file path, or a URL, got %q: %w", tmpl.Name, err)
 		}
-		inst, err := store.Inspect(tmpl.Name)
-		if err == nil {
-			if createOnly {
-				return nil, fmt.Errorf("instance %q already exists", tmpl.Name)
-			}
-			logrus.Infof("Using the existing instance %q", tmpl.Name)
-			yqExprs, err := editflags.YQExpressions(flags, false)
-			if err != nil {
-				return nil, err
-			}
-			if len(yqExprs) > 0 {
-				yq := yqutil.Join(yqExprs)
-				inst, err = applyYQExpressionToExistingInstance(inst, yq)
-				if err != nil {
-					return nil, fmt.Errorf("failed to apply yq expression %q to instance %q: %w", yq, tmpl.Name, err)
-				}
-			}
-			return inst, nil
-		}
-		if !errors.Is(err, os.ErrNotExist) {
-			return nil, err
-		}
 		if arg != "" && arg != DefaultInstanceName {
 			logrus.Infof("Creating an instance %q from template://default (Not from template://%s)", tmpl.Name, tmpl.Name)
 			logrus.Warnf("This form is deprecated. Use `limactl create --name=%s template://default` instead", tmpl.Name)
@@ -195,6 +173,29 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	inst, err := store.Inspect(tmpl.Name)
+	if err == nil {
+		if createOnly {
+			return nil, fmt.Errorf("instance %q already exists", tmpl.Name)
+		}
+		logrus.Infof("Using the existing instance %q", tmpl.Name)
+		yqExprs, err := editflags.YQExpressions(flags, false)
+		if err != nil {
+			return nil, err
+		}
+		if len(yqExprs) > 0 {
+			yq := yqutil.Join(yqExprs)
+			inst, err = applyYQExpressionToExistingInstance(inst, yq)
+			if err != nil {
+				return nil, fmt.Errorf("failed to apply yq expression %q to instance %q: %w", yq, tmpl.Name, err)
+			}
+		}
+		return inst, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
 	}
 
 	yqExprs, err := editflags.YQExpressions(flags, true)


### PR DESCRIPTION
```
Change fixes inconsistency in the limactl create command when attempting to create an 
instance with an already existing name, when a template is specified and when it isn't.
```
Fixes https://github.com/lima-vm/lima/issues/2575