### PR TITLE
cidata: Use mac address as dhcpd identifier

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/network-config
+++ b/pkg/cidata/cidata.TEMPLATE.d/network-config
@@ -8,6 +8,7 @@ ethernets:
     set-name: {{$nw.Interface}}
     dhcp4-overrides:
       route-metric: {{$nw.Metric}}
+    dhcp-identifier: mac
     {{- if and (eq $nw.Interface $.SlirpNICName) (gt (len $.DNSAddresses) 0) }}
     nameservers:
       addresses:


### PR DESCRIPTION
On macOS the DHCP server use the DUID+IAID for both hw_address and identifier, which makes it harder to discover the machine mac address by looking up leases in /var/db/dhcpd_leases. It seems that this issue started in macOS 15.

    % cat /var/db/dhcpd_leases
    {
            name=lima-test
            ip_address=192.168.105.4
            hw_address=ff,5c:bb:eb:5e:0:2:0:0:ab:11:72:3e:92:23:14:1d:a7:ba
            identifier=ff,5c:bb:eb:5e:0:2:0:0:ab:11:72:3e:92:23:14:1d:a7:ba
            lease=0x678b8aee
    }

With this change the record is created using the mac address:

    % cat /var/db/dhcpd_leases
    {
            name=lima-test
            ip_address=192.168.105.4
            hw_address=1,52:55:55:ba:82:85
            identifier=1,52:55:55:ba:82:85
            lease=0x678b90c6
    }

The fix is based on:
https://github.com/cirruslabs/linux-image-templates/pull/39.

Minikube have the similar (networkd specific) fix: https://github.com/kubernetes/minikube/pull/3572