### PR TITLE
Cache the OpenSSH version if it is needed again

### DIFF
--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -74,7 +74,8 @@ func copyAction(cmd *cobra.Command, args []string) error {
 	if recursive {
 		scpFlags = append(scpFlags, "-r")
 	}
-	legacySSH := sshutil.DetectOpenSSHVersion().LessThan(*semver.New("8.0.0"))
+	// this assumes that ssh and scp come from the same place, but scp has no -V
+	legacySSH := sshutil.DetectOpenSSHVersion("ssh").LessThan(*semver.New("8.0.0"))
 	for _, arg := range args {
 		path := strings.Split(arg, ":")
 		switch len(path) {
@@ -115,14 +116,14 @@ func copyAction(cmd *cobra.Command, args []string) error {
 		// arguments such as ControlPath.  This is preferred as we can multiplex
 		// sessions without re-authenticating (MaxSessions permitting).
 		for _, inst := range instances {
-			sshOpts, err = sshutil.SSHOpts(inst.Dir, *inst.Config.User.Name, false, false, false, false)
+			sshOpts, err = sshutil.SSHOpts("ssh", inst.Dir, *inst.Config.User.Name, false, false, false, false)
 			if err != nil {
 				return err
 			}
 		}
 	} else {
 		// Copying among multiple hosts; we can't pass in host-specific options.
-		sshOpts, err = sshutil.CommonOpts(false)
+		sshOpts, err = sshutil.CommonOpts("ssh", false)
 		if err != nil {
 			return err
 		}

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -167,6 +167,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	}
 
 	sshOpts, err := sshutil.SSHOpts(
+		arg0,
 		inst.Dir,
 		*inst.Config.User.Name,
 		*inst.Config.SSH.LoadDotSSHPubKeys,
@@ -188,7 +189,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	logLevel := "ERROR"
 	// For versions older than OpenSSH 8.9p, LogLevel=QUIET was needed to
 	// avoid the "Shared connection to 127.0.0.1 closed." message with -t.
-	olderSSH := sshutil.DetectOpenSSHVersion().LessThan(*semver.New("8.9.0"))
+	olderSSH := sshutil.DetectOpenSSHVersion(arg0).LessThan(*semver.New("8.9.0"))
 	if olderSSH {
 		logLevel = "QUIET"
 	}

--- a/cmd/limactl/show-ssh.go
+++ b/cmd/limactl/show-ssh.go
@@ -89,6 +89,7 @@ func showSSHAction(cmd *cobra.Command, args []string) error {
 	logrus.Warnf("`limactl show-ssh` is deprecated. Instead, use `ssh -F %s %s`.",
 		filepath.Join(inst.Dir, filenames.SSHConfig), inst.Hostname)
 	opts, err := sshutil.SSHOpts(
+		"ssh",
 		inst.Dir,
 		*inst.Config.User.Name,
 		*inst.Config.SSH.LoadDotSSHPubKeys,
@@ -100,7 +101,7 @@ func showSSHAction(cmd *cobra.Command, args []string) error {
 	}
 	opts = append(opts, "Hostname=127.0.0.1")
 	opts = append(opts, fmt.Sprintf("Port=%d", inst.SSHLocalPort))
-	return sshutil.Format(w, instName, format, opts)
+	return sshutil.Format(w, "ssh", instName, format, opts)
 }
 
 func showSSHBashComplete(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/limactl/tunnel.go
+++ b/cmd/limactl/tunnel.go
@@ -106,6 +106,7 @@ func tunnelAction(cmd *cobra.Command, args []string) error {
 	}
 
 	sshOpts, err := sshutil.SSHOpts(
+		arg0,
 		inst.Dir,
 		*inst.Config.User.Name,
 		*inst.Config.SSH.LoadDotSSHPubKeys,

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -143,6 +143,7 @@ func New(instName string, stdout io.Writer, signalCh chan os.Signal, opts ...Opt
 	}
 
 	sshOpts, err := sshutil.SSHOpts(
+		"ssh",
 		inst.Dir,
 		*inst.Config.User.Name,
 		*inst.Config.SSH.LoadDotSSHPubKeys,
@@ -152,7 +153,7 @@ func New(instName string, stdout io.Writer, signalCh chan os.Signal, opts ...Opt
 	if err != nil {
 		return nil, err
 	}
-	if err = writeSSHConfigFile(inst.Name, inst.Dir, inst.SSHAddress, sshLocalPort, sshOpts); err != nil {
+	if err = writeSSHConfigFile("ssh", inst.Name, inst.Dir, inst.SSHAddress, sshLocalPort, sshOpts); err != nil {
 		return nil, err
 	}
 	sshConfig := &ssh.SSHConfig{
@@ -220,7 +221,7 @@ func New(instName string, stdout io.Writer, signalCh chan os.Signal, opts ...Opt
 	return a, nil
 }
 
-func writeSSHConfigFile(instName, instDir, instSSHAddress string, sshLocalPort int, sshOpts []string) error {
+func writeSSHConfigFile(sshPath, instName, instDir, instSSHAddress string, sshLocalPort int, sshOpts []string) error {
 	if instDir == "" {
 		return fmt.Errorf("directory is unknown for the instance %q", instName)
 	}
@@ -231,7 +232,7 @@ func writeSSHConfigFile(instName, instDir, instSSHAddress string, sshLocalPort i
 `); err != nil {
 		return err
 	}
-	if err := sshutil.Format(&b, instName, sshutil.FormatConfig,
+	if err := sshutil.Format(&b, sshPath, instName, sshutil.FormatConfig,
 		append(sshOpts,
 			fmt.Sprintf("Hostname=%s", instSSHAddress),
 			fmt.Sprintf("Port=%d", sshLocalPort),

--- a/pkg/sshutil/format.go
+++ b/pkg/sshutil/format.go
@@ -58,11 +58,11 @@ func quoteOption(o string) string {
 }
 
 // Format formats the ssh options.
-func Format(w io.Writer, instName string, format FormatT, opts []string) error {
+func Format(w io.Writer, sshPath, instName string, format FormatT, opts []string) error {
 	fakeHostname := identifierutil.HostnameFromInstName(instName) // TODO: support customization
 	switch format {
 	case FormatCmd:
-		args := []string{"ssh"}
+		args := []string{sshPath}
 		for _, o := range opts {
 			args = append(args, "-o", quoteOption(o))
 		}


### PR DESCRIPTION
Just to avoid calling it twice:

```
DEBU[0000] OpenSSH version 8.2.1 detected               
DEBU[0000] AES accelerator seems available, prioritizing aes128-gcm@openssh.com and aes256-gcm@openssh.com 
DEBU[0000] OpenSSH version 8.2.1 detected   
```

Found some hard-coded instances of "ssh", and some duplicated code for $SSH (which should be LIMA_SSH, I guess)

* https://github.com/lima-vm/lima/pull/3129

Added some paranoid caching of "stat" info, instead of using just the path like /usr/bin/ssh to cache the version...