### PR TITLE
Add basic root toolbox script for rootless nerdctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ LIMA_CMDS = $(sort lima lima$(bat)) # $(sort ...) deduplicates the list
 LIMA_DEPS = $(addprefix _output/bin/,$(LIMA_CMDS))
 lima: $(LIMA_DEPS)
 
-HELPER_CMDS = nerdctl.lima apptainer.lima docker.lima podman.lima kubectl.lima
+HELPER_CMDS = nerdctl.lima apptainer.lima docker.lima podman.lima kubectl.lima toolbox.lima
 HELPERS_DEPS = $(addprefix _output/bin/,$(HELPER_CMDS))
 helpers: $(HELPERS_DEPS)
 
@@ -435,6 +435,7 @@ uninstall:
 		"$(DEST)/bin/docker.lima" \
 		"$(DEST)/bin/podman.lima" \
 		"$(DEST)/bin/kubectl.lima" \
+		"$(DEST)/bin/toolbox.lima" \
 		"$(DEST)/share/man/man1/lima.1" \
 		"$(DEST)/share/man/man1/limactl"*".1" \
 		"$(DEST)/share/lima" "$(DEST)/share/doc/lima"

--- a/cmd/toolbox.lima
+++ b/cmd/toolbox.lima
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+hostname=$(hostname)
+
+case ${hostname} in
+	lima-*)
+		# already in lima
+		;;
+	*)
+		exec lima "$0" "$@"
+		;;
+esac
+
+machine=$(uname -m)
+
+case ${machine} in
+	aarch64)
+		PLATFORM=linux/arm64
+		;;
+	armv7l)
+		PLATFORM=linux/arm/v7
+		;;
+	riscv64)
+		PLATFORM=linux/riscv64
+		;;
+	x86_64)
+		PLATFORM=linux/amd64
+		;;
+	*)
+		echo "Warning: Unknown machine type ${machine}" >&2
+		exit 1
+		;;
+esac
+
+TOOLBOX_DOCKER_IMAGE=fedora
+TOOLBOX_DOCKER_TAG=latest
+TOOLBOX_USER=root
+TOOLBOX_BIND="--volume=/:/media/root --volume=/usr:/media/root/usr --volume=/run:/media/root/run"
+TOOLBOX_FLAGS=""
+# Ex: "--env=KEY=VALUE"
+TOOLBOX_ENV=""
+
+toolboxrc="${HOME}"/.toolboxrc
+
+# System defaults
+if [ -f "/etc/default/toolbox" ]; then
+	# shellcheck disable=SC1091
+	source "/etc/default/toolbox"
+fi
+
+# User overrides
+if [ -f "${toolboxrc}" ]; then
+	# shellcheck disable=SC1090
+	source "${toolboxrc}"
+fi
+
+if [[ -n "${TOOLBOX_DOCKER_IMAGE}" ]] && [[ -n "${TOOLBOX_DOCKER_TAG}" ]]; then
+	TOOLBOX_NAME=${TOOLBOX_DOCKER_IMAGE}-${TOOLBOX_DOCKER_TAG}
+	have_docker_image="y"
+fi
+
+machinename=$(echo "${USER}-${TOOLBOX_NAME}" | sed -r 's/[^a-zA-Z0-9_.-]/_/g')
+machineimage="${TOOLBOX_IMAGE:-${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}}"
+if ! nerdctl image inspect "${machineimage}" >/dev/null; then
+	if [[ -n "${have_docker_image}" ]]; then
+		nerdctl pull "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}"
+	elif [[ -n "${TOOLBOX_DOCKER_ARCHIVE}" ]]; then
+		curl "${TOOLBOX_DOCKER_ARCHIVE}" | zstd -cd | nerdctl load
+	else
+		echo "Error: No toolbox image specified." >&2
+		exit 1
+	fi
+fi
+
+# Special case for when SSH tries to pass a shell command with -c
+if [ "x${1-}" == x-c ]; then
+	set /bin/sh "$@"
+fi
+
+printf "\033[0;90m\u2591 Entering container %s on %s.\033[0m\n" "${machinename}" "${machineimage}"
+
+# If the container already exists, we need to exec rather than run
+if nerdctl container inspect "${machinename}" >/dev/null 2>&1; then
+	nerdctl start "${machinename}" >/dev/null 2>&1 || true
+	exec nerdctl exec -it "${machinename}" "${@-/bin/bash}"
+fi
+
+# shellcheck disable=SC2086
+nerdctl run --platform ${PLATFORM} --interactive --tty \
+	--name="${machinename}" \
+	--hostname="${hostname}" \
+	--ipc host --network host --pid host \
+	--privileged \
+        ${TOOLBOX_FLAGS} \
+        ${TOOLBOX_BIND} \
+        ${TOOLBOX_ENV} \
+	--user="${TOOLBOX_USER}" "${machineimage}" "$@"


### PR DESCRIPTION
Version of coreos toolbox, using nerdctl instead of systemd.

Uses fedora by default for the toolbox, it can be configured.

Added for a comparison with the `systemd-nspawn` version:

https://github.com/afbjorklund/systemd-toolbox (from coreos)

```console
$ lima ./toolbox 
░ Spawning container anders-fedora-latest on /var/lib/toolbox/anders-fedora-latest.
░ Press Ctrl-] three times within 1s to kill container.
[root@lima-default ~]# 
logout
Container anders-fedora-latest exited successfully.
```

```console
$ ./cmd/toolbox.lima 
░ Entering container anders-fedora-latest on fedora:latest.
[root@lima-default /]# 
exit
```

Issue #3107

Note: these are just small shell scripts, and not real programs.

----

The default image is read-write, so it doesn't really _need_ a toolbox.

When running a read-only OS, you need one to install your tools in...

But when running `lima` you could just as well install them on the VM.
This allows you to run `toolbox.lima` and leave the system untouched.

If it would be needed for system maintenance, it needs `sudo nerdctl`.
Currently it is root on the inside, but still user on the outside (instance)

Running as the user with a home directory mount is better off as a program.

Something like toolbx or distrobox, but with support for `nerdctl` as well?