### PR TITLE
Disable GA serial port in QEMU as it is not used by GA

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -920,11 +920,13 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	args = append(args, "-chardev", fmt.Sprintf("socket,id=%s,path=%s,server=on,wait=off", qmpChardev, qmpSock))
 	args = append(args, "-qmp", "chardev:"+qmpChardev)
 
+	// virtserialport doesn't seem to work reliably: https://github.com/lima-vm/lima/issues/2064
+	// should go together with hostagent::New changes
 	// Guest agent via serialport
-	guestSock := filepath.Join(cfg.InstanceDir, filenames.GuestAgentSock)
-	args = append(args, "-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=qga0", guestSock))
-	args = append(args, "-device", "virtio-serial")
-	args = append(args, "-device", "virtserialport,chardev=qga0,name="+filenames.VirtioPort)
+	// guestSock := filepath.Join(cfg.InstanceDir, filenames.GuestAgentSock)
+	// args = append(args, "-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=qga0", guestSock))
+	// args = append(args, "-device", "virtio-serial")
+	// args = append(args, "-device", "virtserialport,chardev=qga0,name="+filenames.VirtioPort)
 
 	// QEMU process
 	args = append(args, "-name", "lima-"+cfg.Name)


### PR DESCRIPTION
GA was switched back to use SSH socket forwarding due to stability issues, but QEMU still exposes the serial as a Unix socket, which is

1) unused
2) removed from FS and replaced with forwarded via SSH

This is unnecessary and confusing. Future code changes might introduce a common feature toggle to disable code paths simultaneously in QEMU, HA and GA setup, but for now it at least will make both code paths consistent.
