### PR TITLE
Remove unnecessary platform specific workaround in iso9660util

### DIFF
--- a/pkg/iso9660util/iso9660util.go
+++ b/pkg/iso9660util/iso9660util.go
@@ -4,8 +4,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
-	"runtime"
 
 	"github.com/diskfs/go-diskfs/filesystem"
 	"github.com/diskfs/go-diskfs/filesystem/iso9660"
@@ -32,10 +30,6 @@ func Write(isoPath, label string, layout []Entry) error {
 	workdir, err := os.MkdirTemp("", "diskfs_iso")
 	if err != nil {
 		return err
-	}
-	if runtime.GOOS == "windows" {
-		// go-embed unfortunately needs unix path
-		workdir = filepath.ToSlash(workdir)
 	}
 	logrus.Debugf("Creating iso file %s", isoFile.Name())
 	logrus.Debugf("Using %s as workspace", workdir)


### PR DESCRIPTION
I've been experimenting using latest Lima with QEMU on Windows and during my initial tests writing `.iso` file would always result in app panicking inside the third party library (I don't have stack trace preserved unfortunately). By removing this transformation of path I did manage to get a running setup. Probably the native Windows path handling was added in upstream, but I didn't try to bisect there no evidence when it was last working.

cc: @afbjorklund tagging you, because you added this part some time ago https://github.com/lima-vm/lima/commit/f264c90bef3ed9203450454b300e49d9b1361262