### PR TITLE
use temp directory as destination directory for copy command

### DIFF
--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -192,10 +192,11 @@ if [ "$got" != "$expected" ]; then
 fi
 
 INFO "Testing limactl copy command"
-tmpfile="$HOME/lima-hostname"
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}"/lima-test-templates.XXXXXX)"
+defer "rm -rf \"$tmpdir\""
+tmpfile="$tmpdir/lima-hostname"
 rm -f "$tmpfile"
 limactl cp "$NAME":/etc/hostname "$tmpfile"
-defer "rm -f \"$tmpfile\""
 expected="$(limactl shell "$NAME" cat /etc/hostname)"
 got="$(cat "$tmpfile")"
 INFO "/etc/hostname: expected=${expected}, got=${got}"


### PR DESCRIPTION
```
Change switches local tests from using $HOME/lima-hostname to a 
temporary directory to prevent conflicts with user-created files 
and permission errors when writing to it. 
```

Fixes https://github.com/lima-vm/lima/issues/3162