### PR TITLE
website gha.md: job env variable sets LIMA_VERSION

### DIFF
--- a/website/content/en/docs/examples/gha.md
+++ b/website/content/en/docs/examples/gha.md
@@ -50,6 +50,8 @@ jobs:
         gh attestation verify --owner=lima-vm "${FILE}"
         sudo tar Cxzvf /usr/local "${FILE}"
         rm -f "${FILE}"
+        # Export LIMA_VERSION For the GHA cache key
+        echo "LIMA_VERSION=${LIMA_VERSION}" >>$GITHUB_ENV
 
     - name: "Cache ~/.cache/lima"
       uses: actions/cache@v4


### PR DESCRIPTION
1. Fixes the `cache` action which was resolving `${{ env.LIMA_VERSION }}` to an empty string.

2. Makes the build more functional/reproducible by not getting LIMA_VERSION from an external source.