### PR TITLE
Fix gcc line in Makefile for Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,7 +485,7 @@ ifeq ($(GOOS),darwin)
 to_uname_m = $(foreach arch,$(1),$(shell echo $(arch) | sed 's/amd64/x86_64/'))
 else ifeq ($(GOOS),linux)
 # CC is required for cross-compiling on Linux.
-CC = $(call to_uname_m,$(GOARCH))-linux-gnu-gcc
+CC = gcc
 else ifeq ($(GOOS),windows)
 # artifact in zip format also provided for Windows.
 ARTIFACT_FILE_EXTENSIONS += .zip


### PR DESCRIPTION
I needed this change for `make` to succeed on Fedora 41. Not sure if this is the right way to do this, so I'm open to suggestions. I haven't tested this on other Linux distros.

As it is currently on `master`, I've been getting this error when trying to run `make`:

```go
cgo: C compiler "x86_64-linux-gnu-gcc" not found: exec: "x86_64-linux-gnu-gcc": executable file not found in $PATH
```