### PR TITLE
Allow to sftp-server binary found in path

### DIFF
--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/localpathutil"
@@ -63,6 +64,10 @@ func (a *HostAgent) setupMount(m limayaml.Mount) (*mount, error) {
 		RemotePath:          mountPoint,
 		Readonly:            !(*m.Writable),
 		SSHFSAdditionalArgs: []string{"-o", sshfsOptions},
+	}
+	serverPath, err := exec.LookPath("sftp-server")
+	if err == nil {
+		rsf.OpensshSftpServerBinary = serverPath
 	}
 	if err := rsf.Prepare(); err != nil {
 		return nil, fmt.Errorf("failed to prepare reverse sshfs for %q on %q: %w", location, mountPoint, err)


### PR DESCRIPTION
Lima allows to override majority of its dependencies (binaries) via $PATH configuration. `sftp-server` is one prominent exception. `sshocker` library will not try to resolve path unsell OpensshSftpServerBinary param is set to non empty string and will always fallback only to well known candidates.

This adds code in Lima to check if the binary could be found in path and in this case will instruct `sshocker` to use it. 

Implementing this will allow to use Lima with an OS flavor agnostic bundle of dependencies if configured via $PATH variable.