### PR TITLE
refactor: use math/rand/v2 instead of math/rand

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,6 +84,8 @@ linters-settings:
         deny:
         - pkg: "golang.org/x/net/context"
           desc: "use the 'context' package from the standard library"
+        - pkg: "math/rand$"
+          desc: "use the 'math/rand/v2' package"
   forbidigo:
     analyze-types: true
     forbid:

--- a/pkg/windows/registry_windows.go
+++ b/pkg/windows/registry_windows.go
@@ -2,7 +2,7 @@ package windows
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"slices"
 	"sort"
 	"strconv"
@@ -168,7 +168,7 @@ func GetRandomFreeVSockPort(min, max int) (int, error) {
 		}
 	}
 
-	v := rand.Intn(max - min + 1 - len(used))
+	v := rand.IntN(max - min + 1 - len(used))
 
 	for len(tree) > 1 {
 		m := len(tree) / 2


### PR DESCRIPTION
This PR refactors tests to use [`math/rand/v2`](https://go.dev/blog/randv2) instead of `math/rand`.