### PR TITLE
Update go-diskfs package to 1.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.6
 	github.com/cyphar/filepath-securejoin v0.4.1
 	github.com/digitalocean/go-qemu v0.0.0-20221209210016-f035778c97f7
-	github.com/diskfs/go-diskfs v1.4.1
+	github.com/diskfs/go-diskfs v1.5.0
 	github.com/docker/go-units v0.5.0
 	github.com/elastic/go-libaudit/v2 v2.6.1
 	github.com/foxcpp/go-mockdns v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/digitalocean/go-qemu v0.0.0-20221209210016-f035778c97f7 h1:3OVJAbR131
 github.com/digitalocean/go-qemu v0.0.0-20221209210016-f035778c97f7/go.mod h1:K4+o74YGNjOb9N6yyG+LPj1NjHtk+Qz0IYQPvirbaLs=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
-github.com/diskfs/go-diskfs v1.4.1 h1:iODgkzHLmvXS+1VDztpW53T+dQm8GQzi20y9yUd5UCA=
-github.com/diskfs/go-diskfs v1.4.1/go.mod h1:+tOkQs8CMMog6Nvljg8DGIxEXrgL48iyT3OM3IlSz74=
+github.com/diskfs/go-diskfs v1.5.0 h1:0SANkrab4ifiZBytk380gIesYh5Gc+3i40l7qsrYP4s=
+github.com/diskfs/go-diskfs v1.5.0/go.mod h1:bRFumZeGFCO8C2KNswrQeuj2m1WCVr4Ms5IjWMczMDk=
 github.com/djherbis/times v1.6.0 h1:w2ctJ92J8fBvWPxugmXIv7Nz7Q3iDMKNx9v5ocVH20c=
 github.com/djherbis/times v1.6.0/go.mod h1:gOHeRAz2h+VJNZ5Gmc/o7iD9k4wW7NMVqieYCY99oc0=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=

--- a/pkg/iso9660util/iso9660util.go
+++ b/pkg/iso9660util/iso9660util.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/diskfs/go-diskfs/backend/file"
 	"github.com/diskfs/go-diskfs/filesystem"
 	"github.com/diskfs/go-diskfs/filesystem/iso9660"
 	"github.com/sirupsen/logrus"
@@ -27,6 +28,7 @@ func Write(isoPath, label string, layout []Entry) error {
 		return err
 	}
 
+	backendFile := file.New(isoFile, false)
 	defer isoFile.Close()
 
 	workdir, err := os.MkdirTemp("", "diskfs_iso")
@@ -39,7 +41,7 @@ func Write(isoPath, label string, layout []Entry) error {
 	}
 	logrus.Debugf("Creating iso file %s", isoFile.Name())
 	logrus.Debugf("Using %s as workspace", workdir)
-	fs, err := iso9660.Create(isoFile, 0, 0, 0, workdir)
+	fs, err := iso9660.Create(backendFile, 0, 0, 0, workdir)
 	if err != nil {
 		return err
 	}
@@ -81,11 +83,12 @@ func IsISO9660(imagePath string) (bool, error) {
 		return false, err
 	}
 	defer imageFile.Close()
+	backendFile := file.New(imageFile, true)
 
 	fileInfo, err := imageFile.Stat()
 	if err != nil {
 		return false, err
 	}
-	_, err = iso9660.Read(imageFile, fileInfo.Size(), 0, 0)
+	_, err = iso9660.Read(backendFile, fileInfo.Size(), 0, 0)
 	return err == nil, nil
 }


### PR DESCRIPTION
Currently lima uses 1.4.1 version of the package, but the most recent is 1.5.0 and it has some changes in function signature. I've updated lima to reflect changes in the recent version. It's just a preparation for a fix https://github.com/lima-vm/lima/issues/3150. Here is PR for the package https://github.com/diskfs/go-diskfs/pull/279

It's just the same as #3187, only difference is my signature.