### PR TITLE
Restrict pessimization of M4 arch to macOS 15.2

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -1194,14 +1194,16 @@ func HasHostCPU() bool {
 	switch runtime.GOOS {
 	case "darwin":
 		if hasSMEDarwin() {
-			// SME is available since Apple M4 running macOS 15.2.
-			//
-			// However, QEMU is not ready to handle SME yet.
-			//
-			// https://github.com/lima-vm/lima/issues/3032
-			// https://gitlab.com/qemu-project/qemu/-/issues/2665
-			// https://gitlab.com/qemu-project/qemu/-/issues/2721
-			return false
+			macOSProductVersion, err := osutil.ProductVersion()
+			if err != nil || macOSProductVersion.Equal(*semver.New("15.2")) {
+				// SME is available since Apple M4 running macOS 15.2, but it was broken on macOS 15.2.
+				// It has been fixed in 15.3.
+				//
+				// https://github.com/lima-vm/lima/issues/3032
+				// https://gitlab.com/qemu-project/qemu/-/issues/2665
+				// https://gitlab.com/qemu-project/qemu/-/issues/2721
+				return false
+			}
 		}
 		return true
 	case "linux":

--- a/pkg/osutil/osversion_darwin.go
+++ b/pkg/osutil/osversion_darwin.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/coreos/go-semver/semver"
 )
 
 // ProductVersion returns the macOS product version like "12.3.1".
-func ProductVersion() (*semver.Version, error) {
+var ProductVersion = sync.OnceValues(func() (*semver.Version, error) {
 	cmd := exec.Command("sw_vers", "-productVersion")
 	// output is like "12.3.1\n"
 	b, err := cmd.Output()
@@ -26,4 +27,4 @@ func ProductVersion() (*semver.Version, error) {
 		return nil, fmt.Errorf("failed to parse macOS version %q: %w", verTrimmed, err)
 	}
 	return verSem, nil
-}
+})


### PR DESCRIPTION
It has reportedly been fixed in 15.3:
* https://gitlab.com/qemu-project/qemu/-/issues/2721#note_2318005270
* another report from a colima user on Slack

This commit also caches the results of `osutil.ProductVersion` (on macOS) because additional calls should always return the same results.

The `cortex-a7` CPU fails to run some workloads that earlier M* CPUs already support:

```
$ docker run -it --rm  public.ecr.aws/amazonlinux/amazonlinux:2023
Fatal glibc error: This version of Amazon Linux requires a newer ARM64 processor
                   compliant with at least ARM architecture 8.2-a with Cryptographic
                   extensions. On EC2 this is Graviton 2 or later.
```