### PR TITLE
CI: integrate govulncheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,13 @@ jobs:
       # the allow list corresponds to https://github.com/cncf/foundation/blob/e5db022a0009f4db52b89d9875640cf3137153fe/allowed-third-party-license-policy.md
       run: go-licenses check --include_tests  ./... --allowed_licenses=Apache-2.0,BSD-2-Clause,BSD-2-Clause-FreeBSD,BSD-3-Clause,MIT,ISC,Python-2.0,PostgreSQL,X11,Zlib
 
+  security:
+    name: "Vulncheck"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+    - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee  # v1.0.4
+
   spell:
     name: "Spell check"
     runs-on: ubuntu-24.04


### PR DESCRIPTION
From https://go.dev/blog/govulncheck:
> [Govulncheck](https://golang.org/x/vuln/cmd/govulncheck) is a command-line tool that helps Go users find known vulnerabilities in their project dependencies. The tool can analyze both codebases and binaries, and it reduces noise by prioritizing vulnerabilities in functions that your code is actually calling.

