### PR TITLE
Add example with containers on Podman Engine

### DIFF
--- a/website/content/en/docs/examples/_index.md
+++ b/website/content/en/docs/examples/_index.md
@@ -38,6 +38,14 @@ docker run -d --name nginx -p 127.0.0.1:8080:80 nginx:alpine
 ```
 {{% /tab %}}
 
+{{% tab header="Podman" %}}
+```bash
+limactl start template://podman
+export DOCKER_HOST=$(limactl list podman --format 'unix://{{.Dir}}/sock/podman.sock')
+docker run -d --name nginx -p 127.0.0.1:8080:80 nginx:alpine
+```
+{{% /tab %}}
+
 {{% tab header="Kubernetes" %}}
 ```bash
 limactl start template://k8s


### PR DESCRIPTION
There was no example with using Podman, on https://lima-vm.io

Use the docker client with DOCKER_HOST and compatibility socket,
instead of messing around with podman-remote and CONTAINER_HOST.

For instance Podman Desktop also uses a docker client. Compose too.