### PR TITLE
test: Update ubuntu runner as 20.04 is going away

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         path: _artifacts/
   release:
     # An old release of Ubuntu is chosen for glibc compatibility
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: artifacts-darwin
     timeout-minutes: 20
     # The maximum access is "read" for PRs from public forked repos


### PR DESCRIPTION
Ubuntu 20.04 is going to be turned off shortly as a host runner.

Use 22.04 instead. The note though may imply problems:

`# An old release of Ubuntu is chosen for glibc compatibility`

IMO it might be better to just use ubuntu-latest and remove the comment?