### PR TITLE
Fix incorrect firmware path suggestion for aarch64 in qemu.go

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -1159,7 +1159,8 @@ func getFirmware(qemuExe string, arch limayaml.Arch) (string, error) {
 	}
 
 	if arch == limayaml.X8664 {
-		return "", fmt.Errorf("could not find firmware for %q (hint: try setting `firmware.legacyBIOS` to `true`)", qemuExe)
+		return "", fmt.Errorf("could not find firmware for %q (hint: try setting `firmware.legacyBIOS` to `true`)", arch)
 	}
-	return "", fmt.Errorf("could not find firmware for %q (hint: try copying the \"edk-%s-code.fd\" firmware to $HOME/.local/share/qemu/)", arch, qemuExe)
+	qemuArch := strings.TrimPrefix(filepath.Base(qemuExe), "qemu-system-")
+	return "", fmt.Errorf("could not find firmware for %q (hint: try copying the \"edk-%s-code.fd\" firmware to $HOME/.local/share/qemu/)", arch, qemuArch)
 }


### PR DESCRIPTION
closes (#3154)
Previously, the error message in qemu.go incorrectly suggested copying "edk-/usr/bin/qemu-system-aarch64-code.fd" instead of the correct firmware file, "edk-aarch64-code.fd". This was due to qemuExe containing the full path to the QEMU binary instead of just the architecture name.

This commit ensures that only "aarch64" is used in the error message, resulting in the correct suggestion: "edk-aarch64-code.fd".
