### PR TITLE
qemu: revert "Restrict pessimization of M4 arch to macOS 15.2"; upgrade Cortex-A72 to Cortex-A76

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -1203,16 +1203,19 @@ func HasHostCPU() bool {
 	switch runtime.GOOS {
 	case "darwin":
 		if hasSMEDarwin() {
-			macOSProductVersion, err := osutil.ProductVersion()
-			if err != nil || (macOSProductVersion.Major == 15 && macOSProductVersion.Minor == 2) {
-				// SME is available since Apple M4 running macOS 15.2, but it was broken on macOS 15.2.
-				// It has been fixed in 15.3.
-				//
-				// https://github.com/lima-vm/lima/issues/3032
-				// https://gitlab.com/qemu-project/qemu/-/issues/2665
-				// https://gitlab.com/qemu-project/qemu/-/issues/2721
-				return false
-			}
+			// [2025-02-05]
+			// SME is available since Apple M4 running macOS 15.2, but it was broken on macOS 15.2.
+			// It has been fixed in 15.3.
+			//
+			// https://github.com/lima-vm/lima/issues/3032
+			// https://gitlab.com/qemu-project/qemu/-/issues/2665
+			// https://gitlab.com/qemu-project/qemu/-/issues/2721
+
+			// [2025-02-12]
+			// SME got broken again after upgrading QEMU from 9.2.0 to 9.2.1 (Homebrew bottle).
+			// Possibly this regression happened in some build process rather than in QEMU itself?
+			// https://github.com/lima-vm/lima/issues/3226
+			return false
 		}
 		return true
 	case "linux":

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -56,7 +56,7 @@ var (
 
 func defaultCPUType() CPUType {
 	cpuType := map[Arch]string{
-		AARCH64: "cortex-a72",
+		AARCH64: "cortex-a76", // available since QEMU 7.1 (Aug 2022)
 		ARMV7L:  "cortex-a7",
 		// Since https://github.com/lima-vm/lima/pull/494, we use qemu64 cpu for better emulation of x86_64.
 		X8664:   "qemu64",

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -314,7 +314,7 @@ os: null
 # Setting of instructions is supported like this: "qemu64,+ssse3".
 # 🟢 Builtin default: hard-coded arch map with type (see the output of `limactl info | jq .defaultTemplate.cpuType`)
 cpuType:
-#   aarch64: "cortex-a72" # (or "host" when running on aarch64 host)
+#   aarch64: "cortex-a76" # (or "host" when running on aarch64 host)
 #   armv7l: "cortex-a7" # (or "host" when running on armv7l host)
 #   riscv64: "rv64" # (or "host" when running on riscv64 host)
 #   x86_64: "qemu64" # (or "host,-pdpe1gb" when running on x86_64 host)

--- a/website/content/en/docs/installation/_index.md
+++ b/website/content/en/docs/installation/_index.md
@@ -9,7 +9,7 @@ Supported host OS:
 - Windows (untested)
 
 Prerequisite:
-- QEMU 7.0 or later (Required, only if QEMU driver is used)
+- QEMU 7.1 or later (Required, only if QEMU driver is used)
 
 {{< tabpane text=true >}}
 


### PR DESCRIPTION
Fix #3226

- - -
## qemu: revert "Restrict pessimization of M4 arch to macOS 15.2"

This commit reverts the substantial part of:
- #3197

SME got broken again after upgrading QEMU from 9.2.0 to 9.2.1 (Homebrew bottle).
```console
$ qemu-system-aarch64 -M virt -accel hvf -cpu host
Unexpected error in object_property_find_err() at ../qom/object.c:1350:
qemu-system-aarch64: Property 'host-arm-cpu.sme' not found
Abort trap: 6
```
Possibly this regression happened in some build process rather than in QEMU itself?

See:
- #3226

- - -
## qemu: upgrade Cortex-A72 to Cortex-A76

Cortex-A76 supports ARMv8.2-A, while Cortex-A72 only supports ARMv8-A.

ARMv8-A is not enough to run AmazonLinux 2023:
```console
$ docker run -it --rm  public.ecr.aws/amazonlinux/amazonlinux:2023
Fatal glibc error: This version of Amazon Linux requires a newer ARM64 processor
                   compliant with at least ARM architecture 8.2-a with Cryptographic
                   extensions. On EC2 this is Graviton 2 or later.
```

Cortex-A76 is available since QEMU 7.1 (Aug 2022).