### PR TITLE
Use SSHAddress for SSH forwarding in QEMU

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -41,6 +41,7 @@ type Config struct {
 	InstanceDir  string
 	LimaYAML     *limayaml.LimaYAML
 	SSHLocalPort int
+	SSHAddress   string
 }
 
 // MinimumQemuVersion is the minimum supported QEMU version.
@@ -716,8 +717,8 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	// Configure default usernetwork with limayaml.MACAddress(driver.Instance.Dir) for eth0 interface
 	firstUsernetIndex := limayaml.FirstUsernetIndex(y)
 	if firstUsernetIndex == -1 {
-		args = append(args, "-netdev", fmt.Sprintf("user,id=net0,net=%s,dhcpstart=%s,hostfwd=tcp:127.0.0.1:%d-:22",
-			networks.SlirpNetwork, networks.SlirpIPAddress, cfg.SSHLocalPort))
+		args = append(args, "-netdev", fmt.Sprintf("user,id=net0,net=%s,dhcpstart=%s,hostfwd=tcp:%s:%d-:22",
+			networks.SlirpNetwork, networks.SlirpIPAddress, cfg.SSHAddress, cfg.SSHLocalPort))
 	} else {
 		qemuSock, err := usernet.Sock(y.Networks[firstUsernetIndex].Lima, usernet.QEMUSock)
 		if err != nil {

--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -72,6 +72,7 @@ func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
 		InstanceDir:  l.Instance.Dir,
 		LimaYAML:     l.Instance.Config,
 		SSHLocalPort: l.SSHLocalPort,
+		SSHAddress:   l.Instance.SSHAddress,
 	}
 	qExe, qArgs, err := Cmdline(ctx, qCfg)
 	if err != nil {


### PR DESCRIPTION
Fixes #3241

Extending config (effectively data object to pass into driver) with a new field. The field is filled in with the value from Instance. The field is filled only in Start method as it is only used during QEMU machine startup and make no sense in other methods.

Right now it will always be 127.0.0.1 as it is hardcoded during Instance inspect, but in my Windows experiment this value is updated based on WSL2 networking mode (this code still distant from upstream). There is no immediate use for this change, but there is no good reason to have this hardcoded inside driver, when there is already configurable source of truth.