### PR TITLE
Implement feature toggle for GA forwarding mode in QEMU

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -131,8 +131,9 @@ func New(instName string, stdout io.Writer, signalCh chan os.Signal, opts ...Opt
 		}
 		vSockPort = port
 	} else if *inst.Config.VMType == limayaml.QEMU {
-		// virtserialport doesn't seem to work reliably: https://github.com/lima-vm/lima/issues/2064
-		virtioPort = "" // filenames.VirtioPort
+		if *inst.Config.VMOpts.QEMU.VirtioGA {
+			virtioPort = filenames.VirtioPort
+		}
 	}
 
 	if err := cidata.GenerateCloudConfig(inst.Dir, instName, inst.Config); err != nil {

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -835,6 +835,17 @@ func FillDefault(y, d, o *LimaYAML, filePath string, warn bool) {
 	caCerts := unique(append(append(d.CACertificates.Certs, y.CACertificates.Certs...), o.CACertificates.Certs...))
 	y.CACertificates.Certs = caCerts
 
+	if y.VMOpts.QEMU.VirtioGA == nil {
+		y.VMOpts.QEMU.VirtioGA = d.VMOpts.QEMU.VirtioGA
+	}
+	if o.VMOpts.QEMU.VirtioGA != nil {
+		y.VMOpts.QEMU.VirtioGA = o.VMOpts.QEMU.VirtioGA
+	}
+	if y.VMOpts.QEMU.VirtioGA == nil {
+		// virtserialport doesn't seem to work reliably, so, default to false: https://github.com/lima-vm/lima/issues/2064
+		y.VMOpts.QEMU.VirtioGA = ptr.Of(false)
+	}
+
 	if runtime.GOOS == "darwin" && IsNativeArch(AARCH64) {
 		if y.Rosetta.Enabled == nil {
 			y.Rosetta.Enabled = d.Rosetta.Enabled

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -98,6 +98,7 @@ type VMOpts struct {
 
 type QEMUOpts struct {
 	MinimumVersion *string `yaml:"minimumVersion,omitempty" json:"minimumVersion,omitempty" jsonschema:"nullable"`
+	VirtioGA       *bool   `yaml:"virtioGA,omitempty" json:"virtioGA,omitempty" jsonschema:"nullable"`
 }
 
 type Rosetta struct {

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -41,6 +41,7 @@ type Config struct {
 	InstanceDir  string
 	LimaYAML     *limayaml.LimaYAML
 	SSHLocalPort int
+	VirtioGA     bool
 }
 
 // MinimumQemuVersion is the minimum supported QEMU version.
@@ -920,11 +921,13 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	args = append(args, "-chardev", fmt.Sprintf("socket,id=%s,path=%s,server=on,wait=off", qmpChardev, qmpSock))
 	args = append(args, "-qmp", "chardev:"+qmpChardev)
 
-	// Guest agent via serialport
-	guestSock := filepath.Join(cfg.InstanceDir, filenames.GuestAgentSock)
-	args = append(args, "-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=qga0", guestSock))
-	args = append(args, "-device", "virtio-serial")
-	args = append(args, "-device", "virtserialport,chardev=qga0,name="+filenames.VirtioPort)
+	if cfg.VirtioGA {
+		// Guest agent via serialport
+		guestSock := filepath.Join(cfg.InstanceDir, filenames.GuestAgentSock)
+		args = append(args, "-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=qga0", guestSock))
+		args = append(args, "-device", "virtio-serial")
+		args = append(args, "-device", "virtserialport,chardev=qga0,name="+filenames.VirtioPort)
+	}
 
 	// QEMU process
 	args = append(args, "-name", "lima-"+cfg.Name)

--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -72,6 +72,7 @@ func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
 		InstanceDir:  l.Instance.Dir,
 		LimaYAML:     l.Instance.Config,
 		SSHLocalPort: l.SSHLocalPort,
+		VirtioGA:     *l.Instance.Config.VMOpts.QEMU.VirtioGA,
 	}
 	qExe, qArgs, err := Cmdline(ctx, qCfg)
 	if err != nil {

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -304,6 +304,10 @@ vmOpts:
     # Will be ignored if the vmType is not "qemu"
     # 🟢 Builtin default: not set
     minimumVersion: null
+    # Enable virtio port for GA. If disabled then will forward GA via SSH.
+    # Will be ignored if the vmType is not "qemu"
+    # 🟢 Builtin default: false
+    virtioGA : null
 
 # OS: "Linux".
 # 🟢 Builtin default: "Linux"


### PR DESCRIPTION
Fixes #3177

Current code supports 2 modes:
- forwarding via SSH forwarding
- forwarding by QEMU via serialport

In GA they are exclusive modes - it either talks to device or exposes Unix socket inside VM.

At some point the GA part was switched to Unix socket only, but QEMU start command line was not updated. SSH forwarder takes care of it by removing Unix socket before starting its own, but there is no point in having it, when it can't be used.

This code introduces feature toggle allowing to use either mode. Keeping the "unstable" option could be beneficial for environments, where Unix socket forwarding is tricky (Windows hosts).