### PR TITLE
Only try to stop qemu-binfmt service on Alpine if it exists

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-rosetta-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-rosetta-volume.sh
@@ -8,7 +8,7 @@ fi
 
 if [ -f /etc/alpine-release ]; then
 	rc-service procfs start --ifnotstarted
-	rc-service qemu-binfmt stop --ifstarted
+	rc-service qemu-binfmt stop --ifexists --ifstarted
 fi
 
 binfmt_entry=/proc/sys/fs/binfmt_misc/rosetta


### PR DESCRIPTION
It is not installed by default.

Fixes #3278