### PR TITLE
Enable Integration tests in Windows CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,12 +129,10 @@ jobs:
     - name: Enable WSL2
       run: |
         wsl --set-default-version 2
-        # Manually install the latest kernel from MSI
-        Invoke-WebRequest -Uri "https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi" -OutFile "wsl_update_x64.msi"
-        $pwd = (pwd).Path
-        Start-Process msiexec.exe -Wait -ArgumentList "/I $pwd\wsl_update_x64.msi /quiet"
+        wsl --shutdown
         wsl --update
         wsl --status
+        wsl --version
         wsl --list --online
     - name: Install WSL2 distro
       timeout-minutes: 1
@@ -160,22 +158,15 @@ jobs:
       run: go test -v ./...
     - name: Make
       run: make
-# FIXME: Windows CI began to fail on Oct 21, 2024.
-# Something seems to have changed between win22/20241006.1 and win22/20241015.1.
-# https://github.com/lima-vm/lima/issues/2775
-#    - name: Smoke test
-#      # Make sure the path is set properly and then run limactl
-#      run: |
-#        $env:Path = 'C:\Program Files\Git\usr\bin;' + $env:Path
-#        Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $env:Path
-#        .\_output\bin\limactl.exe start template://experimental/wsl2
-#      # TODO: run the full integration tests
-#    - name: Debug
-#      if: always()
-#      run: type C:\Users\runneradmin\.lima\wsl2\ha.stdout.log
-#    - name: Debug
-#      if: always()
-#      run: type C:\Users\runneradmin\.lima\wsl2\ha.stderr.log
+    - name: Integration tests (WSL2, Windows host)
+      run: |
+        $env:Path = "$pwd\_output\bin;" + 'C:\Program Files\Git\usr\bin;' + $env:Path
+        Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $env:Path
+        $env:MSYS2_ENV_CONV_EXCL='HOME_HOST;HOME_GUEST'
+        $env:HOME_HOST=$(cygpath.exe "$env:USERPROFILE")
+        $env:HOME_GUEST="/mnt$env:HOME_HOST"
+        $env:LIMACTL_CREATE_ARGS='--vm-type=wsl2 --mount-type=wsl2 --containerd=system'
+        bash.exe -c "./hack/test-templates.sh templates/experimental/wsl2.yaml"
 
   qemu:
     name: "Integration tests (QEMU, macOS host)"

--- a/hack/common.inc.sh
+++ b/hack/common.inc.sh
@@ -23,7 +23,7 @@ if [[ ${BASH_VERSINFO:-0} -lt 4 ]]; then
 	exit 1
 fi
 
-: "${LIMA_HOME:=$HOME/.lima}"
+: "${LIMA_HOME:=${HOME_HOST:-$HOME}/.lima}"
 _IPERF3=iperf3
 # iperf3-darwin does some magic on macOS to avoid "No route on host" on macOS 15
 # https://github.com/lima-vm/socket_vmnet/issues/85

--- a/hack/test-mount-home.sh
+++ b/hack/test-mount-home.sh
@@ -11,14 +11,15 @@ if [ "$#" -ne 1 ]; then
 fi
 
 NAME="$1"
-hometmp="$HOME/lima-test-tmp"
+hometmp="${HOME_HOST:-$HOME}/lima-test-tmp"
+hometmpguest="${HOME_GUEST:-$HOME}/lima-test-tmp"
 INFO "Testing home access (\"$hometmp\")"
 rm -rf "$hometmp"
 mkdir -p "$hometmp"
 defer "rm -rf \"$hometmp\""
 echo "random-content-${RANDOM}" >"$hometmp/random"
 expected="$(cat "$hometmp/random")"
-got="$(limactl shell "$NAME" cat "$hometmp/random")"
+got="$(limactl shell "$NAME" cat "$hometmpguest/random")"
 INFO "$hometmp/random: expected=${expected}, got=${got}"
 if [ "$got" != "$expected" ]; then
 	ERROR "Home directory is not shared?"

--- a/hack/test-port-forwarding.pl
+++ b/hack/test-port-forwarding.pl
@@ -129,7 +129,8 @@ EOF
 sleep 5;
 
 # Record current log size, so we can skip prior output
-$ENV{LIMA_HOME} ||= "$ENV{HOME}/.lima";
+$ENV{HOME_HOST} ||= "$ENV{HOME}";
+$ENV{LIMA_HOME} ||= "$ENV{HOME_HOST}/.lima";
 my $ha_log = "$ENV{LIMA_HOME}/$instance/ha.stderr.log";
 my $ha_log_size = -s $ha_log or die;
 

--- a/pkg/osutil/user.go
+++ b/pkg/osutil/user.go
@@ -144,6 +144,8 @@ func LimaUser(limaVersion string, warn bool) *user.User {
 			home, err := call([]string{"cygpath", limaUser.HomeDir})
 			if err != nil {
 				logrus.Debug(err)
+			} else {
+				home += ".linux"
 			}
 			if home == "" {
 				drive := filepath.VolumeName(limaUser.HomeDir)
@@ -151,6 +153,7 @@ func LimaUser(limaVersion string, warn bool) *user.User {
 				// replace C: with /c
 				prefix := strings.ToLower(fmt.Sprintf("/%c", drive[0]))
 				home = strings.Replace(home, drive, prefix, 1)
+				home += ".linux"
 			}
 			if !regexPath.MatchString(limaUser.HomeDir) {
 				warning := fmt.Sprintf("local home %q is not a valid Linux path (must match %q); using %q home instead",


### PR DESCRIPTION
Fixes #2775 

My try to address Windows CI. This enables integration tests for Windows. My test run could be found here https://github.com/arixmkii/qcw/actions/runs/13531374510/job/37814107225

It is pretty unstable on my local machine, so, I have no idea if this will be flaky or not. With WSL2 tooling tests felt bullet proof, but Git bash and tooling is not as stable on my local machine.

~The idea is that it will download locally the last known good portable Git for Windows and will use that tooling. Approach is not really suitable for production purposes, but pinning deps for tests only is on the edge of the acceptable.~

Let's at least see if this breaks some other stuff.

