### PR TITLE
refactor: Simplify yqutil.Join

### DIFF
--- a/pkg/yqutil/yqutil.go
+++ b/pkg/yqutil/yqutil.go
@@ -93,9 +93,6 @@ func EvaluateExpression(expression string, content []byte) ([]byte, error) {
 }
 
 func Join(yqExprs []string) string {
-	if len(yqExprs) == 0 {
-		return ""
-	}
 	return strings.Join(yqExprs, " | ")
 }
 

--- a/pkg/yqutil/yqutil_test.go
+++ b/pkg/yqutil/yqutil_test.go
@@ -120,3 +120,39 @@ foo:
 	assert.NilError(t, err)
 	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(out)))
 }
+
+func TestJoin(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected string
+	}{
+		{
+			name:     "multiple values",
+			input:    []string{"foo", "bar", "baz"},
+			expected: "foo | bar | baz",
+		},
+		{
+			name:     "one value",
+			input:    []string{"foo"},
+			expected: "foo",
+		},
+		{
+			name:     "empty values",
+			input:    []string{},
+			expected: "",
+		},
+		{
+			name:     "nil values",
+			input:    nil,
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := Join(test.input)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
The PR refactors the implementation of the `yqutil.Join` function and adds tests for it.