### PR TITLE
Don't panic when deleting instances that don't validate

### DIFF
--- a/pkg/instance/delete.go
+++ b/pkg/instance/delete.go
@@ -21,10 +21,11 @@ func Delete(ctx context.Context, inst *store.Instance, force bool) error {
 
 	StopForcibly(inst)
 
-	if err := unregister(ctx, inst); err != nil {
-		return fmt.Errorf("failed to unregister %q: %w", inst.Dir, err)
+	if len(inst.Errors) == 0 {
+		if err := unregister(ctx, inst); err != nil {
+			return fmt.Errorf("failed to unregister %q: %w", inst.Dir, err)
+		}
 	}
-
 	if err := os.RemoveAll(inst.Dir); err != nil {
 		return fmt.Errorf("failed to remove %q: %w", inst.Dir, err)
 	}

--- a/pkg/limayaml/marshal.go
+++ b/pkg/limayaml/marshal.go
@@ -35,8 +35,8 @@ func unmarshalDisk(dst *Disk, b []byte) error {
 	return yaml.Unmarshal(b, dst)
 }
 
-func Unmarshal(data []byte, v any, comment string) error {
-	if err := yaml.UnmarshalWithOptions(data, v, yaml.CustomUnmarshaler[Disk](unmarshalDisk)); err != nil {
+func Unmarshal(data []byte, y *LimaYAML, comment string) error {
+	if err := yaml.UnmarshalWithOptions(data, y, yaml.CustomUnmarshaler[Disk](unmarshalDisk)); err != nil {
 		return fmt.Errorf("failed to unmarshal YAML (%s): %w", comment, err)
 	}
 	// the go-yaml library doesn't catch all markup errors, unfortunately
@@ -44,7 +44,8 @@ func Unmarshal(data []byte, v any, comment string) error {
 	if err := yqutil.ValidateContent(data); err != nil {
 		return fmt.Errorf("failed to unmarshal YAML (%s): %w", comment, err)
 	}
-	if err := yaml.UnmarshalWithOptions(data, v, yaml.Strict(), yaml.CustomUnmarshaler[Disk](unmarshalDisk)); err != nil {
+	var ignore LimaYAML
+	if err := yaml.UnmarshalWithOptions(data, &ignore, yaml.Strict(), yaml.CustomUnmarshaler[Disk](unmarshalDisk)); err != nil {
 		logrus.WithField("comment", comment).WithError(err).Warn("Non-strict YAML detected; please check for typos")
 	}
 	return nil


### PR DESCRIPTION
During Lima development you can end up with Lima instances that don't validate with the current version. In that case deleting them may be impossible:

```console
❯ l delete -f alpine
WARN[0000] Non-strict YAML detected; please check for typos  comment="main file \"/Users/jan/.lima/alpine/lima.yaml\"" error="[20:3] unknown field \"content\"\n  18 | provision:\n  19 | - mode: data\n> 20 |   content: this is my data\n         ^\n  21 |   path: /etc/datafile"
INFO[0000] The  driver process seems already stopped
INFO[0000] The host agent process seems already stopped
INFO[0000] Removing *.pid *.sock *.tmp under "/Users/jan/.lima/alpine"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x10122618c]

goroutine 1 [running]:
github.com/lima-vm/lima/pkg/driverutil.CreateTargetDriverInstance(...)
	/Users/jan/suse/lima/pkg/driverutil/instance.go:12
github.com/lima-vm/lima/pkg/instance.unregister({0x101940da0, 0x1028a6b00}, 0x140005b4640)
	/Users/jan/suse/lima/pkg/instance/delete.go:36 +0x5c
```

This PR skips unregistering the instance and just deletes the files when validation returned any errors.

A second commit does some minor refactoring I did while investigating this issue.