### PR TITLE
chore: Remove redundant build tags

### DIFF
--- a/pkg/fsutil/fsutil_linux.go
+++ b/pkg/fsutil/fsutil_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package fsutil
 
 import (

--- a/pkg/hostagent/hostagent_windows.go
+++ b/pkg/hostagent/hostagent_windows.go
@@ -1,5 +1,3 @@
-//go:build windows
-
 package hostagent
 
 func adjustNofileRlimit() {}

--- a/pkg/portfwd/control_windows.go
+++ b/pkg/portfwd/control_windows.go
@@ -1,10 +1,9 @@
-//go:build windows
-
 package portfwd
 
 import (
-	"golang.org/x/sys/windows"
 	"syscall"
+
+	"golang.org/x/sys/windows"
 )
 
 func Control(_, _ string, c syscall.RawConn) (err error) {


### PR DESCRIPTION
As the file name ends with `_linux.go` or `_windows.go`, we don't need `//go:build linux` or `//go:build windows` according to https://pkg.go.dev/cmd/go@go1.23.0#hdr-Build_constraints.

See also https://github.com/lima-vm/lima/pull/1967#discussion_r1376052367