### PR TITLE
Use goheader linter to check Go copyright headers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,7 +53,7 @@ linters:
   - godot
   # - godox
   - gofumpt
-  # - goheader
+  - goheader
   # - gomodguard
   # - goprintffuncname
   # - gosec
@@ -117,6 +117,11 @@ linters-settings:
       ifElseChain:
         # Min number of if-else blocks that makes the warning trigger.
         minThreshold: 3
+  goheader:
+    # Run `golangci-lint run --fix --enable-only goheader` to fix headers.
+    template: |-
+      SPDX-FileCopyrightText: Copyright The Lima Authors
+      SPDX-License-Identifier: Apache-2.0
   errorlint:
     asserts: false
   perfsprint:

--- a/hack/ltag/go.txt
+++ b/hack/ltag/go.txt
@@ -1,3 +1,0 @@
-// SPDX-FileCopyrightText: Copyright The Lima Authors
-// SPDX-License-Identifier: Apache-2.0
-


### PR DESCRIPTION
golangci-lint has [`goheader`](https://golangci-lint.run/usage/linters/#goheader) linter which is designed specifically for checking and fixing headers in Go files.

To fix locally:

```
golangci-lint run --fix enable-only goheader
```

To check:

```
golangci-lint run
```

`containerd/ltag` seems unmaintained. So, I propose using `goheader` instead of `ltag` for Go files.

Follows #3293