### PR TITLE
chore: update wsl2 rootfs

### DIFF
--- a/templates/experimental/wsl2.yaml
+++ b/templates/experimental/wsl2.yaml
@@ -4,9 +4,9 @@ vmType: wsl2
 
 images:
 # Source: https://github.com/runfinch/finch-core/blob/main/Dockerfile
-- location: "https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1694791577.tar.gz"
+- location: "https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1738856482.tar.gz"
   arch: "x86_64"
-  digest: "sha256:2d4d2e7386450899c6d0587fd0db21afadb31d974fa744aa9365c883935c5341"
+  digest: "sha256:efbe5fc2b2ec94bbf9e4a6c184bf2b36040faf939c15a016f8d7931de9a481c3"
 
 mountType: wsl2
 


### PR DESCRIPTION
Closes #2781 

The rootfs in template hasn't been updated for some time. Now with integration tests in CI it could be done with increased confidence.