### PR TITLE
Use loopback for SSH connection in WSL2

### DIFF
--- a/pkg/store/instance_windows.go
+++ b/pkg/store/instance_windows.go
@@ -5,7 +5,6 @@ package store
 
 import (
 	"fmt"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -26,7 +25,7 @@ func inspectStatus(instDir string, inst *Instance, y *limayaml.LimaYAML) {
 		inst.SSHLocalPort = 22
 
 		if inst.Status == StatusRunning {
-			sshAddr, err := getWslSSHAddress(inst.Name)
+			sshAddr, err := GetSSHAddress(inst.Name)
 			if err == nil {
 				inst.SSHAddress = sshAddr
 			} else {
@@ -118,21 +117,5 @@ func GetWslStatus(instName string) (string, error) {
 }
 
 func GetSSHAddress(instName string) (string, error) {
-	return getWslSSHAddress(instName)
-}
-
-// GetWslSSHAddress runs a hostname command to get the IP from inside of a wsl2 VM.
-//
-// Expected output (whitespace preserved, [] for optional):
-// PS > wsl -d <distroName> bash -c hostname -I | cut -d' ' -f1
-// 168.1.1.1 [10.0.0.1]
-func getWslSSHAddress(instName string) (string, error) {
-	distroName := "lima-" + instName
-	cmd := exec.Command("wsl.exe", "-d", distroName, "bash", "-c", `hostname -I | cut -d ' ' -f1`)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("failed to get hostname for instance %q, err: %w (out=%q)", instName, err, string(out))
-	}
-
-	return strings.TrimSpace(string(out)), nil
+	return "127.0.0.1", nil
 }


### PR DESCRIPTION
Fixes #3242

According to WSL2 documentation - both mainstream networking modes NAT and mirrored support access to WSL2 running apps via loopback https://learn.microsoft.com/en-us/windows/wsl/networking#accessing-linux-networking-apps-from-windows-localhost

Other Hyper-V networking modes as bridged and may be some others are somewhat supported by WSL2, but are discouraged for common scenarios. 

In this case there is no point to resolve external IP in a distro specific way to successfully run Lima provisioning of the said VM.

I tested this with NAT in GH actions and with mirrored networking locally.

There are setting for preventing access via loopback but there are also firewalls, which would prevent to access over external IP, so, the loopback sounds like a reasonable default and different settings should only be used if specific scenario is detected or if specifically requested. As these scenarios are not documented as of now the code in question could be removed and later reintroduced adjusted to the new usecases.