### PR TITLE
Use common Windows Subsystem path helper for calling tools on Windows

### DIFF
--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -8,9 +8,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/lima-vm/lima/pkg/ioutilx"
 	"github.com/lima-vm/lima/pkg/sshutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/sirupsen/logrus"
@@ -80,6 +83,16 @@ func copyAction(cmd *cobra.Command, args []string) error {
 	// this assumes that ssh and scp come from the same place, but scp has no -V
 	legacySSH := sshutil.DetectOpenSSHVersion("ssh").LessThan(*semver.New("8.0.0"))
 	for _, arg := range args {
+		if runtime.GOOS == "windows" {
+			if filepath.IsAbs(arg) {
+				arg, err = ioutilx.WindowsSubsystemPath(arg)
+				if err != nil {
+					return err
+				}
+			} else {
+				arg = filepath.ToSlash(arg)
+			}
+		}
 		path := strings.Split(arg, ":")
 		switch len(path) {
 		case 1:

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -229,8 +229,11 @@ tmpdir="$(mktemp -d "${TMPDIR:-/tmp}"/lima-test-templates.XXXXXX)"
 defer "rm -rf \"$tmpdir\""
 tmpfile="$tmpdir/lima-hostname"
 rm -f "$tmpfile"
-# TODO support Windows path https://github.com/lima-vm/lima/issues/3215
-limactl cp "$NAME":/etc/hostname "$tmpfile"
+tmpfile_host=$tmpfile
+if [ "${OS_HOST}" = "Msys" ]; then
+	tmpfile_host="$(cygpath -w "$tmpfile")"
+fi
+limactl cp "$NAME":/etc/hostname "$tmpfile_host"
 expected="$(limactl shell "$NAME" cat /etc/hostname)"
 got="$(cat "$tmpfile")"
 INFO "/etc/hostname: expected=${expected}, got=${got}"

--- a/pkg/ioutilx/ioutilx.go
+++ b/pkg/ioutilx/ioutilx.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -48,13 +49,11 @@ func FromUTF16leToString(r io.Reader) (string, error) {
 	return string(out), nil
 }
 
-func CanonicalWindowsPath(orig string) string {
-	newPath := orig
-	out, err := exec.Command("cygpath", "-m", orig).CombinedOutput()
+func WindowsSubsystemPath(orig string) (string, error) {
+	out, err := exec.Command("cygpath", filepath.ToSlash(orig)).CombinedOutput()
 	if err != nil {
 		logrus.WithError(err).Errorf("failed to convert path to mingw, maybe not using Git ssh?")
-	} else {
-		newPath = strings.TrimSpace(string(out))
+		return orig, err
 	}
-	return newPath
+	return strings.TrimSpace(string(out)), nil
 }


### PR DESCRIPTION
Fixes #3164
Fixes #3167
Fixes #3215

This unifies use of `cygpath` tool through the codebase. As currently there will be no support for Windows fork of OpenSSH (missing a lot of features, not only mux, but also basic AF_UNIX) and in future if such support is considered it will have conditional handling in he codebase. 

I switched the tool to generate Unix like paths instead of hybrid ones. They are fully understand by msys2 tooling, so are safe to use to all tools in use. Additionally this opened opportunity to use `wslpath` as drop-in replacement of `cygpath` and provides capabilities to use tooling hosted inside WSL container, where full set of feature is available, which in turns makes QEMU support easier to achieve (mux for port forwarding with SSH forwarder, etc).

There is some special handling added for `/mnt/` prefixes, because it is the difference between `cygpath` and `wslpath` outputs. So, it is a compatibility supporting part.

