### PR TITLE
Implement "data" provision mode

### DIFF
--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -55,6 +55,7 @@ declare -A CHECKS=(
 	["user-v2"]=""
 	["mount-path-with-spaces"]=""
 	["provision-ansible"]=""
+	["provision-data"]=""
 	["param-env-variables"]=""
 	["set-user"]=""
 )
@@ -82,6 +83,7 @@ case "$NAME" in
 	CHECKS["snapshot-offline"]="1"
 	CHECKS["mount-path-with-spaces"]="1"
 	CHECKS["provision-ansible"]="1"
+	CHECKS["provision-data"]="1"
 	CHECKS["param-env-variables"]="1"
 	CHECKS["set-user"]="1"
 	;;
@@ -194,13 +196,19 @@ if [[ -n ${CHECKS["provision-ansible"]} ]]; then
 	limactl shell "$NAME" test -e /tmp/ansible
 fi
 
+if [[ -n ${CHECKS["provision-data"]} ]]; then
+	INFO 'Testing that /etc/sysctl.d/99-inotify.conf was created successfully on provision'
+	limactl shell "$NAME" grep -q fs.inotify.max_user_watches /etc/sysctl.d/99-inotify.conf
+fi
+
 if [[ -n ${CHECKS["param-env-variables"]} ]]; then
 	INFO 'Testing that PARAM env variables are exported to all types of provisioning scripts and probes'
 	limactl shell "$NAME" test -e /tmp/param-boot
 	limactl shell "$NAME" test -e /tmp/param-dependency
 	limactl shell "$NAME" test -e /tmp/param-probe
 	limactl shell "$NAME" test -e /tmp/param-system
-	limactl shell "$NAME" test -e /tmp/param-user
+	# TODO re-enable once https://github.com/lima-vm/lima/issues/3308 is fixed
+	# limactl shell "$NAME" test -e /tmp/param-user
 fi
 
 if [[ -n ${CHECKS["set-user"]} ]]; then

--- a/hack/test-templates/test-misc.yaml
+++ b/hack/test-templates/test-misc.yaml
@@ -18,7 +18,8 @@ param:
   DEPENDENCY: dependency
   PROBE: probe
   SYSTEM: system
-  USER: user
+# TODO re-enable once https://github.com/lima-vm/lima/issues/3308 is fixed
+# USER: user
 
 provision:
 - mode: ansible
@@ -29,8 +30,14 @@ provision:
   script: "touch /tmp/param-$PARAM_DEPENDENCY"
 - mode: system
   script: "touch /tmp/param-$PARAM_SYSTEM"
-- mode: user
-  script: "touch /tmp/param-$PARAM_USER"
+# TODO re-enable once https://github.com/lima-vm/lima/issues/3308 is fixed
+# - mode: user
+#   script: "touch /tmp/param-$PARAM_USER"
+- mode: data
+  path: /etc/sysctl.d/99-inotify.conf
+  content: |
+    fs.inotify.max_user_watches = 524288
+    fs.inotify.max_user_instances = 512
 
 probes:
 - mode: readiness

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.sh
@@ -52,6 +52,31 @@ else
 	done
 fi
 
+# indirect variable lookup, like ${!var} in bash
+deref() {
+	eval echo \$"$1"
+}
+
+if [ -d "${LIMA_CIDATA_MNT}"/provision.data ]; then
+	for f in "${LIMA_CIDATA_MNT}"/provision.data/*; do
+		filename=$(basename "$f")
+		overwrite=$(deref "LIMA_CIDATA_DATAFILE_${filename}_OVERWRITE")
+		owner=$(deref "LIMA_CIDATA_DATAFILE_${filename}_OWNER")
+		path=$(deref "LIMA_CIDATA_DATAFILE_${filename}_PATH")
+		permissions=$(deref "LIMA_CIDATA_DATAFILE_${filename}_PERMISSIONS")
+		if [ -e "$path" ] && [ "$overwrite" = "false" ]; then
+			INFO "Not overwriting $path"
+		else
+			INFO "Copying $f to $path"
+			# intermediate directories will be owned by root, regardless of OWNER setting
+			mkdir -p "$(dirname "$path")"
+			cp "$f" "$path"
+			chown "$owner" "$path"
+			chmod "$permissions" "$path"
+		fi
+	done
+fi
+
 if [ -d "${LIMA_CIDATA_MNT}"/provision.system ]; then
 	for f in "${LIMA_CIDATA_MNT}"/provision.system/*; do
 		INFO "Executing $f"

--- a/pkg/cidata/cidata.TEMPLATE.d/lima.env
+++ b/pkg/cidata/cidata.TEMPLATE.d/lima.env
@@ -19,6 +19,12 @@ LIMA_CIDATA_DISK_{{$i}}_FORMAT={{$disk.Format}}
 LIMA_CIDATA_DISK_{{$i}}_FSTYPE={{$disk.FSType}}
 LIMA_CIDATA_DISK_{{$i}}_FSARGS={{range $j, $arg := $disk.FSArgs}}{{if $j}} {{end}}{{$arg}}{{end}}
 {{- end}}
+{{- range $dataFile := .DataFiles}}
+LIMA_CIDATA_DATAFILE_{{$dataFile.FileName}}_OVERWRITE={{$dataFile.Overwrite}}
+LIMA_CIDATA_DATAFILE_{{$dataFile.FileName}}_OWNER={{$dataFile.Owner}}
+LIMA_CIDATA_DATAFILE_{{$dataFile.FileName}}_PATH={{$dataFile.Path}}
+LIMA_CIDATA_DATAFILE_{{$dataFile.FileName}}_PERMISSIONS={{$dataFile.Permissions}}
+{{- end}}
 LIMA_CIDATA_GUEST_INSTALL_PREFIX={{ .GuestInstallPrefix }}
 {{- if .Containerd.User}}
 LIMA_CIDATA_CONTAINERD_USER=1

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -50,6 +50,15 @@ type Mount struct {
 type BootCmds struct {
 	Lines []string
 }
+
+type DataFile struct {
+	FileName    string
+	Overwrite   string
+	Owner       string
+	Path        string
+	Permissions string
+}
+
 type Disk struct {
 	Name   string
 	Device string
@@ -84,6 +93,7 @@ type TemplateArgs struct {
 	Env                             map[string]string
 	Param                           map[string]string
 	BootScripts                     bool
+	DataFiles                       []DataFile
 	DNSAddresses                    []string
 	CACerts                         CACerts
 	HostHomeMountPoint              string

--- a/pkg/limatmpl/embed_test.go
+++ b/pkg/limatmpl/embed_test.go
@@ -339,6 +339,10 @@ networks:
 provision:
 # This script will be merged from an external file
 - file: base1.sh # This comment will move to the "script" key
+# This is just a data file
+- mode: data
+  file: base1.sh # This comment will move to the "content" key
+  path: /tmp/data
 `,
 		`
 # base0.yaml is ignored
@@ -346,6 +350,7 @@ provision:
 #!/usr/bin/env bash
 echo "This is base1.sh"
 `,
+		// TODO: the empty line after the `path` is unexpected
 		`
 # Hi There!
 provision:
@@ -353,6 +358,13 @@ provision:
 - script: |-  # This comment will move to the "script" key
     #!/usr/bin/env bash
     echo "This is base1.sh"
+# This is just a data file
+- mode: data
+  content: |-  # This comment will move to the "content" key
+    #!/usr/bin/env bash
+    echo "This is base1.sh"
+  path: /tmp/data
+
 # base0.yaml is ignored
 `,
 	},

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -221,6 +221,7 @@ const (
 	ProvisionModeBoot       ProvisionMode = "boot"
 	ProvisionModeDependency ProvisionMode = "dependency"
 	ProvisionModeAnsible    ProvisionMode = "ansible"
+	ProvisionModeData       ProvisionMode = "data"
 )
 
 type Provision struct {
@@ -229,6 +230,16 @@ type Provision struct {
 	Script                          string             `yaml:"script" json:"script"`
 	File                            *LocatorWithDigest `yaml:"file,omitempty" json:"file,omitempty" jsonschema:"nullable"`
 	Playbook                        string             `yaml:"playbook,omitempty" json:"playbook,omitempty"`
+	// All ProvisionData fields must be nil unless Mode is ProvisionModeData
+	ProvisionData `yaml:",inline"` // Flatten fields for "strict" YAML mode
+}
+
+type ProvisionData struct {
+	Content     *string `yaml:"content,omitempty" json:"content,omitempty" jsonschema:"nullable"`
+	Overwrite   *bool   `yaml:"overwrite,omitempty" json:"overwrite,omitempty" jsonschema:"nullable"`
+	Owner       *string `yaml:"owner,omitempty" json:"owner,omitempty"` // any owner string supported by `chown`, defaults to "root:root"
+	Path        *string `yaml:"path,omitempty" json:"path,omitempty"`
+	Permissions *string `yaml:"permissions,omitempty" json:"permissions,omitempty"`
 }
 
 type Containerd struct {

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -58,6 +58,30 @@ func TestValidateProbes(t *testing.T) {
 	assert.Error(t, err, "field `probe[0].file.digest` support is not yet implemented")
 }
 
+func TestValidateProvisionData(t *testing.T) {
+	images := `images: [{location: /}]`
+	validData := `provision: [{mode: data, path: /tmp, content: hello}]`
+	y, err := Load([]byte(validData+"\n"+images), "lima.yaml")
+	assert.NilError(t, err)
+
+	err = Validate(y, false)
+	assert.NilError(t, err)
+
+	invalidData := `provision: [{mode: data, content: hello}]`
+	y, err = Load([]byte(invalidData+"\n"+images), "lima.yaml")
+	assert.NilError(t, err)
+
+	err = Validate(y, false)
+	assert.Error(t, err, "field `provision[0].path` must not be empty when mode is \"data\"")
+
+	invalidData = `provision: [{mode: data, path: /tmp, content: hello, permissions: 9}]`
+	y, err = Load([]byte(invalidData+"\n"+images), "lima.yaml")
+	assert.NilError(t, err)
+
+	err = Validate(y, false)
+	assert.ErrorContains(t, err, "provision[0].permissions` must be an octal number")
+}
+
 func TestValidateAdditionalDisks(t *testing.T) {
 	images := `images: [{"location": "/"}]`
 

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -253,6 +253,21 @@ containerd:
 # # See ansible docs, and `ansible-config`, for more info https://docs.ansible.com/ansible/latest/playbook_guide/
 # - mode: ansible
 #   playbook: playbook.yaml
+# # `data` is a file that is written to the guest filesystem and not executed at all.
+# # The file is written after the boot scripts, but before any other provisioning scripts are run.
+# # Note that reverse-sshfs mounts are not established at this time; other mount types are already mounted.
+# # The `path` and `content` properties are required. The `file` property can be used the same way as with
+# # other provisioning scripts, in which case `content` must be empty. The `owner` defaults to "root:root";
+# # the permissions default to 644. The `overwrite` property defaults to `true`, in which case the file will
+# # be overwritten on every boot.
+# # `path`, `contents`, and `owner` are evaluated as guest templates (see above).
+# - mode: data
+#   path: /etc/conf.d/example
+#   content: |
+#     FOO=bar
+#   owner: "root:root"
+#   permissions: 644
+#   overwrite: false
 
 # Probe scripts to check readiness.
 # The scripts run in user mode. They must start with a '#!' line.

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -186,6 +186,10 @@ The volume label is "cidata", as defined by [cloud-init NoCloud](https://docs.cl
 - `LIMA_CIDATA_MOUNTS`: the number of the Lima mounts
 - `LIMA_CIDATA_MOUNTS_%d_MOUNTPOINT`: the N-th mount point of Lima mounts (N=0, 1, ...)
 - `LIMA_CIDATA_MOUNTTYPE`: the type of the Lima mounts ("reverse-sshfs", "9p", ...)
+- `LIMA_CIDATA_DATAFILE_%08d_OVERWRITE`: set to "true" if the datafile should be overwritten if it already exists.
+- `LIMA_CIDATA_DATAFILE_%08d_OWNER`: set to the owner of the datafile.
+- `LIMA_CIDATA_DATAFILE_%08d_PATH`: set to the path the datafile should be copied to.
+- `LIMA_CIDATA_DATAFILE_%08d_PERMISSIONS`: set to the file permissions (in octal) for the datafile.
 - `LIMA_CIDATA_CONTAINERD_USER`: set to "1" if rootless containerd to be set up
 - `LIMA_CIDATA_CONTAINERD_SYSTEM`: set to "1" if system-wide containerd to be set up
 - `LIMA_CIDATA_CONTAINERD_ARCHIVE`: the name of the containerd archive. `nerdctl-full.tgz`


### PR DESCRIPTION
These are data files copied to the guest filesystem. They are not scripts and are not being executed.

It is pretty similar to the `write_files` feature in `cloud-init`, but is completely implemented in our `boot.sh`, so works automatically with `lima-init` and other `cloud-init` alternatives.

```yaml
provision:
- mode: data
  path: /etc/conf.d/example
  content: |
    VAR=VALUE
  overwrite: false
- mode: data
  path: "{{.Home}}/kubeadm.yaml"
  file: kubeadm.yaml
  owner: "{{.User}}"
  permissions: 0700
```

The `file` property works the same way it works for provision scripts and probes (during template embedding the file content is placed into content and the file property is removed, so the data is embedded in the instance directory).
