### PR TITLE
Improve Subsystem paths handling on Windows hosts

### DIFF
--- a/pkg/ioutilx/ioutilx.go
+++ b/pkg/ioutilx/ioutilx.go
@@ -53,7 +53,16 @@ func WindowsSubsystemPath(orig string) (string, error) {
 	out, err := exec.Command("cygpath", filepath.ToSlash(orig)).CombinedOutput()
 	if err != nil {
 		logrus.WithError(err).Errorf("failed to convert path to mingw, maybe not using Git ssh?")
-		return orig, err
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func WindowsSubsystemPathForLinux(orig, distro string) (string, error) {
+	out, err := exec.Command("wsl", "-d", distro, "--exec", "wslpath", filepath.ToSlash(orig)).CombinedOutput()
+	if err != nil {
+		logrus.WithError(err).Errorf("failed to convert path to mingw, maybe wsl command is not operational?")
+		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
 }


### PR DESCRIPTION
Fixes #3303 

Implemented changes 
* hardcoded prefixes remove
* shell now tries to switch directory for WSL2 machines (mounts are controlled outside of Lima, so, we will still try)
* using wslpath inside instance for WSL2 machine to determine mounted path, fallback to cygpath for other cases
* adjusted logic for deciding on home directory on Windows hosts - additional code to erase subsystem mount prefix
* ioutilx APIs now return empty string on error, because returning the original input was sometimes confusing (rarely used approach)

I did local testing with WSL2, plan to test this with QEMU, when I rebase my current experimental branch,