### PR TITLE
Add {{.TempDir}} and {{.GlobalTempDir}} variables to host templates

### DIFF
--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -146,10 +147,9 @@ func TestFillDefault(t *testing.T) {
 			},
 		},
 		Mounts: []Mount{
-			// Location will be passed through localpathutil.Expand() which will normalize the name
-			// (add a drive letter). So we must start with a valid local path to match it again later.
-			{Location: filepath.Clean(t.TempDir())},
-			{Location: "{{.Dir}}/{{.Param.ONE}}", MountPoint: ptr.Of("/mnt/{{.Param.ONE}}")},
+			//nolint:usetesting // We need the OS temp directory name here; it is not used to create temp files for testing
+			{Location: filepath.Clean(os.TempDir())},
+			{Location: filepath.Clean("{{.Dir}}/{{.Param.ONE}}"), MountPoint: ptr.Of("/mnt/{{.Param.ONE}}")},
 		},
 		MountType: ptr.Of(NINEP),
 		Provision: []Provision{
@@ -240,7 +240,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Mounts[0].Virtiofs.QueueSize = nil
 	// Only missing Mounts field is Writable, and the default value is also the null value: false
 	expect.Mounts[1].Location = filepath.Join(instDir, y.Param["ONE"])
-	expect.Mounts[1].MountPoint = ptr.Of(fmt.Sprintf("/mnt/%s", y.Param["ONE"]))
+	expect.Mounts[1].MountPoint = ptr.Of(path.Join("/mnt", y.Param["ONE"]))
 	expect.Mounts[1].Writable = ptr.Of(false)
 	expect.Mounts[1].SSHFS.Cache = ptr.Of(true)
 	expect.Mounts[1].SSHFS.FollowSymlinks = ptr.Of(false)

--- a/templates/_default/mounts.yaml
+++ b/templates/_default/mounts.yaml
@@ -1,4 +1,6 @@
 mounts:
 - location: "~"
-- location: "/tmp/lima"
+
+- location: "{{.GlobalTempDir}}/lima"
+  mountPoint: /tmp/lima
   writable: true

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -34,7 +34,8 @@ memory: null
 disk: null
 
 # Expose host directories to the guest, the mount point might be accessible from all UIDs in the guest
-# "location" can use these template variables: {{.Home}}, {{.Dir}}, {{.Name}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
+# "location" can use these template variables: {{.Home}}, {{.Dir}}, {{.Name}}, {{.UID}}, {{.User}}, {{.Param.Key}},
+# {{.GlobalTempDir}}, and {{.TempDir}}. The global temp dir is always "/tmp" on Unix.
 # "mountPoint" can use these template variables: {{.Home}}, {{.Name}}, {{.Hostname}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
 # 🟢 Builtin default: [] (Mount nothing)
 # 🔵 This file: Mount the home as read-only, /tmp/lima as writable  (inherited via the `base` mechanism later in this file)


### PR DESCRIPTION
Allows writing the `/tmp/lima` mount as

```yaml
mounts:
- location: "{{.Temp}}/lima"
  mountPoint: /tmp/lima
```

Note that on macOS this would use `$TMPDIR` and not `/tmp`, so would be a change in behaviour. It would not affect existing instances though.