### PR TITLE
cmd: add support for restarting a running instance

### DIFF
--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -159,6 +159,7 @@ func newApp() *cobra.Command {
 		newUnprotectCommand(),
 		newTunnelCommand(),
 		newTemplateCommand(),
+		newRestartCommand(),
 	)
 	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
 		rootCmd.AddCommand(startAtLoginCommand())

--- a/cmd/limactl/restart.go
+++ b/cmd/limactl/restart.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"github.com/lima-vm/lima/pkg/instance"
+	"github.com/lima-vm/lima/pkg/store"
+	"github.com/spf13/cobra"
+)
+
+func newRestartCommand() *cobra.Command {
+	restartCmd := &cobra.Command{
+		Use:               "restart INSTANCE",
+		Short:             "Restart a running instance",
+		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
+		RunE:              restartAction,
+		ValidArgsFunction: restartBashComplete,
+		GroupID:           basicCommand,
+	}
+
+	restartCmd.Flags().BoolP("force", "f", false, "force stop and restart the instance")
+	return restartCmd
+}
+
+func restartAction(cmd *cobra.Command, args []string) error {
+	instName := DefaultInstanceName
+	if len(args) > 0 {
+		instName = args[0]
+	}
+
+	inst, err := store.Inspect(instName)
+	if err != nil {
+		return err
+	}
+
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	if force {
+		return instance.RestartForcibly(ctx, inst)
+	}
+
+	return instance.Restart(ctx, inst)
+}
+
+func restartBashComplete(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return bashCompleteInstanceNames(cmd)
+}

--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -42,7 +42,7 @@ func stopAction(cmd *cobra.Command, args []string) error {
 	if force {
 		instance.StopForcibly(inst)
 	} else {
-		err = instance.StopGracefully(inst)
+		err = instance.StopGracefully(inst, false)
 	}
 	// TODO: should we also reconcile networks if graceful stop returned an error?
 	if err == nil {

--- a/pkg/instance/restart.go
+++ b/pkg/instance/restart.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package instance
+
+import (
+	"context"
+
+	networks "github.com/lima-vm/lima/pkg/networks/reconcile"
+	"github.com/lima-vm/lima/pkg/store"
+	"github.com/sirupsen/logrus"
+)
+
+const launchHostAgentForeground = false
+
+func Restart(ctx context.Context, inst *store.Instance) error {
+	if err := StopGracefully(inst, true); err != nil {
+		return err
+	}
+
+	if err := networks.Reconcile(ctx, inst.Name); err != nil {
+		return err
+	}
+
+	if err := Start(ctx, inst, "", launchHostAgentForeground); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func RestartForcibly(ctx context.Context, inst *store.Instance) error {
+	logrus.Info("Restarting the instance forcibly")
+	StopForcibly(inst)
+
+	if err := networks.Reconcile(ctx, inst.Name); err != nil {
+		return err
+	}
+
+	if err := Start(ctx, inst, "", launchHostAgentForeground); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds a new command `limactl restart INSTANCE` which gracefully terminates and restarts Lima instances.