### PR TITLE
Upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,10 @@ jobs:
     - name: Verify generated files
       run: make install-tools generate check-generated
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84  # v6.5.2
+      uses: golangci/golangci-lint-action@dec74fa03096ff515422f71d18d41307cacde373  # v7.0.0
       with:
-        version: v1.64.2
-        args: --verbose --timeout=10m
+        version: v2.0.1
+        args: --verbose
     - name: Run yamllint
       run: yamllint .
     - name: Install shellcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,189 +1,147 @@
-#   Copyright The containerd Authors.
-
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-
-#       http://www.apache.org/licenses/LICENSE-2.0
-
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
-
-# -----------------------------------------------------------------------------
-# From https://github.com/containerd/nerdctl/blob/v0.12.1/.golangci.yml
-# -----------------------------------------------------------------------------
----
+# golangci-lint configuration file.
+# https://golangci-lint.run/usage/configuration/
+version: "2"
 run:
   concurrency: 6
-  timeout: 2m  # to avoid timeout locally
 linters:
-  disable-all: true
+  default: none
   enable:
+  - bodyclose
+  - copyloopvar
   - depguard
-  - gofmt
-  - goimports
+  - dupword
+  - errcheck
+  - errorlint
+  - forbidigo
+  - gocritic
+  - godot
   - govet
   - ineffassign
   - misspell
   - nakedret
-  # - prealloc
-  - typecheck
-  # - asciicheck
-  - bodyclose
-  - copyloopvar
-  # - dogsled
-  # - dupl
-  - dupword
-  - errcheck
-  - errorlint
-  # - exhaustive
-  # - exportloopref
-  # - funlen
-  - forbidigo
-  # - gci
-  # - gochecknoglobals
-  # - gochecknoinits
-  # - gocognit
-  # - goconst
-  - gocritic
-  # - gocyclo
-  - godot
-  # - godox
-  - gofumpt
-  # - goheader
-  # - gomodguard
-  # - goprintffuncname
-  # - gosec
-  - gosimple
-  # - lll
-  # - nestif
-  # - nlreturn
   - noctx
   - nolintlint
   - perfsprint
-  # - rowserrcheck
-  # - sqlclosecheck
-  - staticcheck
-  # - stylecheck
-  # - testpackage
-  # - tparallel
   - revive
-  # - unconvert
-  # - unparam
+  - staticcheck
   - unused
   - whitespace
-  # - wrapcheck
-  # - wsl
-linters-settings:
-  depguard:
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+          - pkg: golang.org/x/net/context
+            desc: use the 'context' package from the standard library
+          - pkg: math/rand$
+            desc: use the 'math/rand/v2' package
+    errorlint:
+      asserts: false
+    forbidigo:
+      forbid:
+      - pattern: ^print(ln)?$
+        msg: Do not use builtin print functions. It's for bootstrapping only and may be removed in the future.
+      - pattern: ^fmt\.Print.*$
+        msg: Do not use fmt.Print statements.
+      - pattern: ^testing.T.Fatal.*$
+        msg: Use assert functions from the gotest.tools/v3/assert package instead.
+      analyze-types: true
+    gocritic:
+      disabled-checks:
+      - appendCombine
+      - sloppyReassign
+      - unlabelStmt
+      - rangeValCopy
+      - hugeParam
+      - importShadow
+      - sprintfQuotedString
+      - builtinShadow
+      - filepathJoin
+      # See "Tags" section in https://github.com/go-critic/go-critic#usage
+      enabled-tags:
+      - diagnostic
+      - performance
+      - style
+      - opinionated
+      - experimental
+      settings:
+        ifElseChain:
+          # Min number of if-else blocks that makes the warning trigger.
+          minThreshold: 3
+    perfsprint:
+      int-conversion: false
+      err-error: false
+      errorf: true
+      sprintf1: false
+      strconcat: false
+    revive:
+      # Set below 0.8 to enable error-strings
+      confidence: 0.6
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
+      rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: deep-exit
+      - name: dot-imports
+        arguments:
+        - allowedPackages:
+          - github.com/lima-vm/lima/pkg/must
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+        disabled: true
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: package-comments
+        disabled: true
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: use-any
+      - name: var-declaration
+      - name: var-naming
+    staticcheck:
+      # https://staticcheck.dev/docs/configuration/options/#checks
+      checks:
+      - all
+      - -QF*
+      - -SA3000  # false positive for Go 1.15+. See https://github.com/golang/go/issues/34129
+      - -ST1000
+      - -ST1001  # duplicates revive.dot-imports
+      - -ST1022
+  exclusions:
+    presets:
+    - common-false-positives
+    - legacy
+    - std-error-handling
     rules:
-      main:
-        deny:
-        - pkg: "golang.org/x/net/context"
-          desc: "use the 'context' package from the standard library"
-        - pkg: "math/rand$"
-          desc: "use the 'math/rand/v2' package"
-  forbidigo:
-    analyze-types: true
-    forbid:
-    - p: ^print(ln)?$
-      msg: Do not use builtin print functions. It's for bootstrapping only and may be removed in the future.
-    - p: ^fmt\.Print.*$
-      msg: Do not use fmt.Print statements.
-    - p: ^testing.T.Fatal.*$
-      msg: Use assert functions from the gotest.tools/v3/assert package instead.
-  gocritic:
-    # See "Tags" section in https://github.com/go-critic/go-critic#usage
-    enabled-tags:
-    - diagnostic
-    - performance
-    - style
-    - opinionated
-    - experimental
-    disabled-checks:
-    - appendCombine
-    - sloppyReassign
-    - unlabelStmt
-    - rangeValCopy
-    - hugeParam
-    - importShadow
-    - sprintfQuotedString
-    - builtinShadow
-    - filepathJoin
-    settings:
-      ifElseChain:
-        # Min number of if-else blocks that makes the warning trigger.
-        minThreshold: 3
-  errorlint:
-    asserts: false
-  perfsprint:
-    int-conversion: false
-    err-error: false
-    errorf: true
-    sprintf1: false
-    strconcat: false
-  revive:
-    # Set below 0.8 to enable error-strings
-    confidence: 0.6
-    # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
-    rules:
-    - name: blank-imports
-    - name: context-as-argument
-    - name: context-keys-type
-    - name: deep-exit
-    - name: dot-imports
-      arguments:
-      - allowedPackages:
-        - github.com/lima-vm/lima/pkg/must
-    - name: empty-block
-    - name: error-naming
-    - name: error-return
-    - name: error-strings
-    - name: errorf
-    - name: exported
-    - name: increment-decrement
-    - name: indent-error-flow
-    - name: package-comments
-    - name: range
-    - name: receiver-naming
-    - name: redefines-builtin-id
-    - name: superfluous-else
-    - name: time-naming
-    - name: unexported-return
-    - name: unreachable-code
-    - name: unused-parameter
-    - name: use-any
-    - name: var-declaration
-    - name: var-naming
-  staticcheck:
-    # https://staticcheck.dev/docs/configuration/options/#checks
-    checks:
-    - "all"
-    - "-SA3000"  # false positive for Go 1.15+. See https://github.com/golang/go/issues/34129
+    # Allow using Uid, Gid in pkg/osutil.
+    - path: pkg/osutil/
+      text: '(?i)(uid)|(gid)'
+    # Disable some linters for test files.
+    - linters:
+      - godot
+      path: _test\.go
+    # Disable perfsprint for fmt.Sprint until https://github.com/catenacyber/perfsprint/issues/39 gets fixed.
+    - linters:
+      - perfsprint
+      text: fmt.Sprint.* can be replaced with faster
 issues:
   # Maximum issues count per one linter.
   max-issues-per-linter: 0
   # Maximum count of issues with the same text.
   max-same-issues: 0
-  include:
-  - EXC0013  # revive: package comment should be of the form "(.+)..."
-  - EXC0014  # revive: comment on exported (.+) should be of the form "(.+)..."
-  exclude-rules:
-  # Allow using Uid, Gid in pkg/osutil.
-  - path: "pkg/osutil/"
-    text: "uid"
-  # Disable some linters for test files.
-  - path: _test\.go
-    linters:
-    - godot
-  # Disable revive.exported for constants.
-  - text: "exported: comment on exported const"
-    linters:
-    - revive
-  # Disable perfsprint for fmt.Sprint until https://github.com/catenacyber/perfsprint/issues/39 gets fixed.
-  - text: "fmt.Sprint.* can be replaced with faster"
-    linters:
-    - perfsprint
+formatters:
+  enable:
+  - gofmt
+  - gofumpt
+  - goimports

--- a/pkg/logrusutil/logrusutil_test.go
+++ b/pkg/logrusutil/logrusutil_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPropagateJSON(t *testing.T) {
-	loggerWithoutTs := func(output *bytes.Buffer) *logrus.Logger {
+	loggerWithoutTS := func(output *bytes.Buffer) *logrus.Logger {
 		logger := logrus.New()
 		logger.SetOutput(output)
 		logger.SetLevel(logrus.TraceLevel)
@@ -23,7 +23,7 @@ func TestPropagateJSON(t *testing.T) {
 
 	t.Run("trace level", func(t *testing.T) {
 		actual := &bytes.Buffer{}
-		logger := loggerWithoutTs(actual)
+		logger := loggerWithoutTS(actual)
 		jsonLine := []byte(`{"level": "trace"}`)
 
 		PropagateJSON(logger, jsonLine, "header", time.Time{})
@@ -32,7 +32,7 @@ func TestPropagateJSON(t *testing.T) {
 	})
 	t.Run("debug level", func(t *testing.T) {
 		actual := &bytes.Buffer{}
-		logger := loggerWithoutTs(actual)
+		logger := loggerWithoutTS(actual)
 		jsonLine := []byte(`{"level": "debug"}`)
 
 		PropagateJSON(logger, jsonLine, "header", time.Time{})
@@ -41,7 +41,7 @@ func TestPropagateJSON(t *testing.T) {
 	})
 	t.Run("info level", func(t *testing.T) {
 		actual := &bytes.Buffer{}
-		logger := loggerWithoutTs(actual)
+		logger := loggerWithoutTS(actual)
 		jsonLine := []byte(`{"level": "info"}`)
 
 		PropagateJSON(logger, jsonLine, "header", time.Time{})
@@ -50,7 +50,7 @@ func TestPropagateJSON(t *testing.T) {
 	})
 	t.Run("error level", func(t *testing.T) {
 		actual := &bytes.Buffer{}
-		logger := loggerWithoutTs(actual)
+		logger := loggerWithoutTS(actual)
 		jsonLine := []byte(`{"level": "error"}`)
 
 		PropagateJSON(logger, jsonLine, "header", time.Time{})
@@ -59,7 +59,7 @@ func TestPropagateJSON(t *testing.T) {
 	})
 	t.Run("warning level", func(t *testing.T) {
 		actual := &bytes.Buffer{}
-		logger := loggerWithoutTs(actual)
+		logger := loggerWithoutTS(actual)
 		jsonLine := []byte(`{"level": "warning"}`)
 
 		PropagateJSON(logger, jsonLine, "header", time.Time{})
@@ -68,7 +68,7 @@ func TestPropagateJSON(t *testing.T) {
 	})
 	t.Run("panic level", func(t *testing.T) {
 		actual := &bytes.Buffer{}
-		logger := loggerWithoutTs(actual)
+		logger := loggerWithoutTS(actual)
 		jsonLine := []byte(`{"level": "panic"}`)
 
 		PropagateJSON(logger, jsonLine, "header", time.Time{})
@@ -77,7 +77,7 @@ func TestPropagateJSON(t *testing.T) {
 	})
 	t.Run("fatal level", func(t *testing.T) {
 		actual := &bytes.Buffer{}
-		logger := loggerWithoutTs(actual)
+		logger := loggerWithoutTS(actual)
 		jsonLine := []byte(`{"level": "fatal"}`)
 
 		PropagateJSON(logger, jsonLine, "header", time.Time{})
@@ -86,7 +86,7 @@ func TestPropagateJSON(t *testing.T) {
 	})
 	t.Run("SetLevel", func(t *testing.T) {
 		actual := &bytes.Buffer{}
-		logger := loggerWithoutTs(actual)
+		logger := loggerWithoutTS(actual)
 		logger.SetLevel(logrus.ErrorLevel)
 		jsonLine := []byte(`{"level": "warning"}`)
 
@@ -96,7 +96,7 @@ func TestPropagateJSON(t *testing.T) {
 	})
 	t.Run("extra fields", func(t *testing.T) {
 		actual := &bytes.Buffer{}
-		logger := loggerWithoutTs(actual)
+		logger := loggerWithoutTS(actual)
 		jsonLine := []byte(`{"level": "warning", "error": "oops", "extra": "field"}`)
 
 		PropagateJSON(logger, jsonLine, "header", time.Time{})
@@ -105,7 +105,7 @@ func TestPropagateJSON(t *testing.T) {
 	})
 	t.Run("timestamp", func(t *testing.T) {
 		actual := &bytes.Buffer{}
-		logger := loggerWithoutTs(actual)
+		logger := loggerWithoutTS(actual)
 		logger.SetFormatter(&logrus.TextFormatter{DisableTimestamp: false})
 		jsonLine := []byte(`{"level": "warning", "time": "2024-03-06T00:20:53-08:00"}`)
 
@@ -115,7 +115,7 @@ func TestPropagateJSON(t *testing.T) {
 	})
 	t.Run("empty json line", func(t *testing.T) {
 		actual := &bytes.Buffer{}
-		logger := loggerWithoutTs(actual)
+		logger := loggerWithoutTS(actual)
 		jsonLine := []byte{}
 
 		PropagateJSON(logger, jsonLine, "header", time.Time{})
@@ -124,7 +124,7 @@ func TestPropagateJSON(t *testing.T) {
 	})
 	t.Run("unmarshal failed", func(t *testing.T) {
 		actual := &bytes.Buffer{}
-		logger := loggerWithoutTs(actual)
+		logger := loggerWithoutTS(actual)
 		jsonLine := []byte(`"`)
 
 		PropagateJSON(logger, jsonLine, "header", time.Time{})
@@ -134,7 +134,7 @@ func TestPropagateJSON(t *testing.T) {
 	})
 	t.Run("begin time after time in jsonLine", func(t *testing.T) {
 		actual := &bytes.Buffer{}
-		logger := loggerWithoutTs(actual)
+		logger := loggerWithoutTS(actual)
 		jsonLine := []byte(`{"level": "info", "time": "2023-12-01T00:00:00.0000+00:00"}`)
 		begin := time.Date(2023, time.December, 15, 0, 0, 0, 0, time.UTC)
 
@@ -144,7 +144,7 @@ func TestPropagateJSON(t *testing.T) {
 	})
 	t.Run("parse level failed", func(t *testing.T) {
 		actual := &bytes.Buffer{}
-		logger := loggerWithoutTs(actual)
+		logger := loggerWithoutTS(actual)
 		jsonLine := []byte(`{"level": "info", "level": "unknown level"}`)
 
 		PropagateJSON(logger, jsonLine, "header", time.Time{})

--- a/pkg/qemu/entitlementutil/entitlementutil.go
+++ b/pkg/qemu/entitlementutil/entitlementutil.go
@@ -73,7 +73,7 @@ func Sign(qExe string) error {
 // The result can be used *ONLY* for controlling hint messages.
 // DO NOT change the behavior of Lima depending on this result.
 //
-//nolint:revive // underscores in this function name intentionally added
+//nolint:revive,staticcheck // underscores in this function name intentionally added
 func isColimaWrapper__useThisFunctionOnlyForPrintingHints__(qExe string) bool {
 	return strings.Contains(qExe, "/.colima/_wrapper/")
 }

--- a/pkg/vz/errors_darwin.go
+++ b/pkg/vz/errors_darwin.go
@@ -7,5 +7,5 @@ package vz
 
 import "errors"
 
-//nolint:revive // error-strings
+//nolint:revive,staticcheck // false positives with proper nouns
 var errRosettaUnsupported = errors.New("Rosetta is unsupported on non-ARM64 hosts")


### PR DESCRIPTION
`golangci-lint` upgrades to [v2](https://golangci-lint.run/product/changelog/#v200) and the configuration changed a lot.

This PR adapts `.golangci.yml` to v2 schema according to the [Migration Guide](https://golangci-lint.run/product/migration-guide/).