### PR TITLE
set revive.confidence to default value to avoid false positives

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -126,8 +126,6 @@ linters-settings:
     sprintf1: false
     strconcat: false
   revive:
-    # Set below 0.8 to enable error-strings
-    confidence: 0.6
     # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
     rules:
     - name: blank-imports

--- a/pkg/vz/errors_darwin.go
+++ b/pkg/vz/errors_darwin.go
@@ -7,5 +7,4 @@ package vz
 
 import "errors"
 
-//nolint:revive // error-strings
-var errRosettaUnsupported = errors.New("Rosetta is unsupported on non-ARM64 hosts")
+var errRosettaUnsupported = errors.New("rosetta is unsupported on non-ARM64 hosts")

--- a/pkg/vz/errors_darwin.go
+++ b/pkg/vz/errors_darwin.go
@@ -7,4 +7,4 @@ package vz
 
 import "errors"
 
-var errRosettaUnsupported = errors.New("rosetta is unsupported on non-ARM64 hosts")
+var errRosettaUnsupported = errors.New("Rosetta is unsupported on non-ARM64 hosts")

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -191,8 +191,7 @@ func (l *LimaVzDriver) RunGUI() error {
 	if l.CanRunGUI() {
 		return l.machine.StartGraphicApplication(1920, 1200)
 	}
-	//nolint:revive // error-strings
-	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "vz", *l.Instance.Config.Video.Display)
+	return fmt.Errorf("runGUI is not supported for the given driver '%s' and display '%s'", "vz", *l.Instance.Config.Video.Display)
 }
 
 func (l *LimaVzDriver) Stop(_ context.Context) error {

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -191,7 +191,7 @@ func (l *LimaVzDriver) RunGUI() error {
 	if l.CanRunGUI() {
 		return l.machine.StartGraphicApplication(1920, 1200)
 	}
-	return fmt.Errorf("runGUI is not supported for the given driver '%s' and display '%s'", "vz", *l.Instance.Config.Video.Display)
+	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "vz", *l.Instance.Config.Video.Display)
 }
 
 func (l *LimaVzDriver) Stop(_ context.Context) error {


### PR DESCRIPTION
This PR removes `revive.confidence` to reduce false positives with the `revive.error-strings` rule.