### PR TITLE
Allow an image URL instead of a template reference

### DIFF
--- a/pkg/limatmpl/embed_test.go
+++ b/pkg/limatmpl/embed_test.go
@@ -374,6 +374,12 @@ provision:
 		"base: [{url: base.yaml, digest: deafbad}]",
 		"not yet implemented",
 	},
+	{
+		"Image URLs will be converted into a template",
+		"",
+		"base: https://example.com/lima-linux-riscv64.img",
+		"{arch: riscv64, images: [{location: https://example.com/lima-linux-riscv64.img, arch: riscv64}]}",
+	},
 }
 
 func TestEmbed(t *testing.T) {

--- a/pkg/limatmpl/locator_test.go
+++ b/pkg/limatmpl/locator_test.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package limatmpl_test
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/lima-vm/lima/pkg/limatmpl"
+	"github.com/lima-vm/lima/pkg/limayaml"
+	"gotest.tools/v3/assert"
+)
+
+func TestInstNameFromImageURL(t *testing.T) {
+	t.Run("strips image format and compression method", func(t *testing.T) {
+		name := limatmpl.InstNameFromImageURL("linux.iso.bz2", "unknown")
+		assert.Equal(t, name, "linux")
+	})
+	t.Run("removes generic tags", func(t *testing.T) {
+		name := limatmpl.InstNameFromImageURL("linux-linux_cloudimg.base-x86_64.raw", "unknown")
+		assert.Equal(t, name, "linux-x86_64")
+	})
+	t.Run("removes Alpine `nocloud_` prefix", func(t *testing.T) {
+		name := limatmpl.InstNameFromImageURL("nocloud_linux-x86_64.raw", "unknown")
+		assert.Equal(t, name, "linux-x86_64")
+	})
+	t.Run("removes date tag", func(t *testing.T) {
+		name := limatmpl.InstNameFromImageURL("linux-20250101.raw", "unknown")
+		assert.Equal(t, name, "linux")
+	})
+	t.Run("removes date tag including time", func(t *testing.T) {
+		name := limatmpl.InstNameFromImageURL("linux-20250101-2000.raw", "unknown")
+		assert.Equal(t, name, "linux")
+	})
+	t.Run("removes date tag including zero time", func(t *testing.T) {
+		name := limatmpl.InstNameFromImageURL("linux-20250101.0.raw", "unknown")
+		assert.Equal(t, name, "linux")
+	})
+	t.Run("replace arch with archlinux", func(t *testing.T) {
+		name := limatmpl.InstNameFromImageURL("arch-aarch64.raw", "unknown")
+		assert.Equal(t, name, "archlinux-aarch64")
+	})
+	t.Run("don't replace arch in the middle of the name", func(t *testing.T) {
+		name := limatmpl.InstNameFromImageURL("my-arch-aarch64.raw", "unknown")
+		assert.Equal(t, name, "my-arch-aarch64")
+	})
+	t.Run("removes native arch", func(t *testing.T) {
+		arch := limayaml.NewArch(runtime.GOARCH)
+		image := fmt.Sprintf("linux_cloudimg.base-%s.qcow2.gz", arch)
+		name := limatmpl.InstNameFromImageURL(image, arch)
+		assert.Equal(t, name, "linux")
+	})
+}


### PR DESCRIPTION
The template.Read() method will guess the architecture based on the image filename and construct a template dynamically.

It also strips generic tags from the image name to generate an instance name candidate.

```console
❯ limactl start --containerd none https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/cloud/nocloud_alpine-3.21.2-aarch64-uefi-cloudinit-r0.qcow2
...

❯ limactl shell alpine-3.21.2-r0 uname -a
Linux lima-alpine-3-21-2-r0 6.12.8-0-virt #1-Alpine SMP PREEMPT_DYNAMIC 2025-01-02 12:14:41 aarch64 Linux
```

Closes #3322

This code needs to be updated with `s390x` heuristics once #3319 is merged (or the other way around, depending on which one is merged first).