### PR TITLE
Do tilde-expansion only once in FillDefaults()

### DIFF
--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -200,14 +200,6 @@ func templateArgs(bootScripts bool, instDir, name string, instConfig *limayaml.L
 	}
 	for i, f := range instConfig.Mounts {
 		tag := fmt.Sprintf("mount%d", i)
-		location, err := localpathutil.Expand(f.Location)
-		if err != nil {
-			return nil, err
-		}
-		mountPoint, err := localpathutil.Expand(*f.MountPoint)
-		if err != nil {
-			return nil, err
-		}
 		options := "defaults"
 		switch fstype {
 		case "9p", "virtiofs":
@@ -220,7 +212,7 @@ func templateArgs(bootScripts bool, instDir, name string, instConfig *limayaml.L
 				options += fmt.Sprintf(",version=%s", *f.NineP.ProtocolVersion)
 				msize, err := units.RAMInBytes(*f.NineP.Msize)
 				if err != nil {
-					return nil, fmt.Errorf("failed to parse msize for %q: %w", location, err)
+					return nil, fmt.Errorf("failed to parse msize for %q: %w", f.Location, err)
 				}
 				options += fmt.Sprintf(",msize=%d", msize)
 				options += fmt.Sprintf(",cache=%s", *f.NineP.Cache)
@@ -228,9 +220,9 @@ func templateArgs(bootScripts bool, instDir, name string, instConfig *limayaml.L
 			// don't fail the boot, if virtfs is not available
 			options += ",nofail"
 		}
-		args.Mounts = append(args.Mounts, Mount{Tag: tag, MountPoint: mountPoint, Type: fstype, Options: options})
-		if location == hostHome {
-			args.HostHomeMountPoint = mountPoint
+		args.Mounts = append(args.Mounts, Mount{Tag: tag, MountPoint: *f.MountPoint, Type: fstype, Options: options})
+		if f.Location == hostHome {
+			args.HostHomeMountPoint = *f.MountPoint
 		}
 	}
 

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/sys/cpu"
 
 	"github.com/lima-vm/lima/pkg/identifierutil"
+	"github.com/lima-vm/lima/pkg/localpathutil"
 	. "github.com/lima-vm/lima/pkg/must"
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/osutil"
@@ -785,8 +786,13 @@ func FillDefault(y, d, o *LimaYAML, filePath string, warn bool) {
 				mounts[i].NineP.Cache = ptr.Of(Default9pCacheForRO)
 			}
 		}
+		if location, err := localpathutil.Expand(mount.Location); err == nil {
+			mounts[i].Location = location
+		} else {
+			logrus.WithError(err).Warnf("Couldn't expand location %q", mount.Location)
+		}
 		if mount.MountPoint == nil {
-			mounts[i].MountPoint = ptr.Of(mount.Location)
+			mounts[i].MountPoint = ptr.Of(mounts[i].Location)
 		}
 	}
 

--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -25,7 +25,6 @@ import (
 	"github.com/lima-vm/lima/pkg/driver"
 	"github.com/lima-vm/lima/pkg/iso9660util"
 	"github.com/lima-vm/lima/pkg/limayaml"
-	"github.com/lima-vm/lima/pkg/localpathutil"
 	"github.com/lima-vm/lima/pkg/nativeimgutil"
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/networks/usernet"
@@ -548,18 +547,14 @@ func attachFolderMounts(driver *driver.BaseDriver, vmConfig *vz.VirtualMachineCo
 	var mounts []vz.DirectorySharingDeviceConfiguration
 	if *driver.Instance.Config.MountType == limayaml.VIRTIOFS {
 		for i, mount := range driver.Instance.Config.Mounts {
-			expandedPath, err := localpathutil.Expand(mount.Location)
-			if err != nil {
-				return err
-			}
-			if _, err := os.Stat(expandedPath); errors.Is(err, os.ErrNotExist) {
-				err := os.MkdirAll(expandedPath, 0o750)
+			if _, err := os.Stat(mount.Location); errors.Is(err, os.ErrNotExist) {
+				err := os.MkdirAll(mount.Location, 0o750)
 				if err != nil {
 					return err
 				}
 			}
 
-			directory, err := vz.NewSharedDirectory(expandedPath, !*mount.Writable)
+			directory, err := vz.NewSharedDirectory(mount.Location, !*mount.Writable)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
We need to do the expansion before we copy the Location over as the default MountPoint because we can't do tilde expansion for guest filenames (the existing call in cidata.go was an error).

<hr>

This will need to be changed even further when we move `FillDefaults` to use the template embedding code: the mountpoint defaults will need to be filled in before mount entries are combined based on a shared mountpoint value. But that is not yet a concern.