### PR TITLE
Update WSL2 tempate and enable systemd tests on Windows

### DIFF
--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -91,8 +91,6 @@ case "$NAME" in
 	CONTAINER_ENGINE="docker"
 	;;
 "wsl2")
-	# TODO https://github.com/lima-vm/lima/issues/3267
-	CHECKS["systemd"]=
 	# TODO https://github.com/lima-vm/lima/issues/3268
 	CHECKS["proxy-settings"]=
 	CHECKS["port-forwards"]=

--- a/templates/experimental/wsl2.yaml
+++ b/templates/experimental/wsl2.yaml
@@ -4,9 +4,9 @@ vmType: wsl2
 
 images:
 # Source: https://github.com/runfinch/finch-core/blob/main/Dockerfile
-- location: "https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1738856482.tar.gz"
+- location: "https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1741837119.tar.gz"
   arch: "x86_64"
-  digest: "sha256:efbe5fc2b2ec94bbf9e4a6c184bf2b36040faf939c15a016f8d7931de9a481c3"
+  digest: "sha256:1ebee4c785fc4d31fd514365694a7d4d50a95093526c051f76dc63d8ba9fafe6"
 
 mountType: wsl2
 


### PR DESCRIPTION
Fixes #3267

This is a try to fix systemd of the WSL2 template.

Changes applied upstream https://github.com/runfinch/finch-core/pull/554

I'm not too confident about this, because it is still flaky on my local machine (though it is a laptop, running Hyper-V with nested virtualization and running Lima inside that VM, so, not too representative) - getty/agetty degraded state sometimes, which in some issues is attributed to race condition, which was fixed, but probably didn't get into Fedora 40. If this fails in CI, I will convert it to draft and revisit after Fedora version bump (F40 will EOL in May).