### PR TITLE
Start QEMU binary as a background process

### DIFF
--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -414,8 +414,7 @@ if [[ -n ${CHECKS["restart"]} ]]; then
 	fi
 
 	INFO "Stopping \"$NAME\""
-	# TODO https://github.com/lima-vm/lima/issues/3221
-	limactl stop "$NAME" || [ "${OS_HOST}" = "Msys" ]
+	limactl stop "$NAME"
 	sleep 3
 
 	if [[ -n ${CHECKS["disk"]} ]]; then
@@ -529,8 +528,7 @@ if [[ $NAME == "fedora" && "$(limactl ls --json "$NAME" | jq -r .vmType)" == "vz
 fi
 
 INFO "Stopping \"$NAME\""
-# TODO https://github.com/lima-vm/lima/issues/3221
-limactl stop "$NAME" || [ "${OS_HOST}" = "Msys" ]
+limactl stop "$NAME"
 sleep 3
 
 INFO "Deleting \"$NAME\""

--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/digitalocean/go-qemu/qmp"
 	"github.com/digitalocean/go-qemu/qmp/raw"
 	"github.com/lima-vm/lima/pkg/driver"
+	"github.com/lima-vm/lima/pkg/executil"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/networks/usernet"
 	"github.com/lima-vm/lima/pkg/store"
@@ -110,6 +111,7 @@ func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
 	}
 	qCmd := exec.CommandContext(ctx, qExe, qArgsFinal...)
 	qCmd.ExtraFiles = append(qCmd.ExtraFiles, applier.files...)
+	qCmd.SysProcAttr = executil.BackgroundSysProcAttr
 	qStdout, err := qCmd.StdoutPipe()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #3221

~It also includes some tweaks for GH workflow - preserves cleaner PATH variable for Powershell, where tools will be added by the test runner Git bash itself.~

Removed the change above from this PR because it will be reworked in #3357