### PR TITLE
Fix mount support in QEMU on Windows hosts

### DIFF
--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 
+	"github.com/lima-vm/lima/pkg/ioutilx"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/sshocker/pkg/reversesshfs"
 	"github.com/sirupsen/logrus"
@@ -47,10 +49,19 @@ func (a *HostAgent) setupMount(m limayaml.Mount) (*mount, error) {
 	}
 	logrus.Infof("Mounting %q on %q", m.Location, *m.MountPoint)
 
+	resolvedLocation := m.Location
+	if runtime.GOOS == "windows" {
+		var err error
+		resolvedLocation, err = ioutilx.WindowsSubsystemPath(m.Location)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	rsf := &reversesshfs.ReverseSSHFS{
 		Driver:              *m.SSHFS.SFTPDriver,
 		SSHConfig:           a.sshConfig,
-		LocalPath:           m.Location,
+		LocalPath:           resolvedLocation,
 		Host:                "127.0.0.1",
 		Port:                a.sshLocalPort,
 		RemotePath:          *m.MountPoint,
@@ -58,22 +69,22 @@ func (a *HostAgent) setupMount(m limayaml.Mount) (*mount, error) {
 		SSHFSAdditionalArgs: []string{"-o", sshfsOptions},
 	}
 	if err := rsf.Prepare(); err != nil {
-		return nil, fmt.Errorf("failed to prepare reverse sshfs for %q on %q: %w", m.Location, *m.MountPoint, err)
+		return nil, fmt.Errorf("failed to prepare reverse sshfs for %q on %q: %w", resolvedLocation, *m.MountPoint, err)
 	}
 	if err := rsf.Start(); err != nil {
-		logrus.WithError(err).Warnf("failed to mount reverse sshfs for %q on %q, retrying with `-o nonempty`", m.Location, *m.MountPoint)
+		logrus.WithError(err).Warnf("failed to mount reverse sshfs for %q on %q, retrying with `-o nonempty`", resolvedLocation, *m.MountPoint)
 		// NOTE: nonempty is not supported for libfuse3: https://github.com/canonical/multipass/issues/1381
 		rsf.SSHFSAdditionalArgs = []string{"-o", "nonempty"}
 		if err := rsf.Start(); err != nil {
-			return nil, fmt.Errorf("failed to mount reverse sshfs for %q on %q: %w", m.Location, *m.MountPoint, err)
+			return nil, fmt.Errorf("failed to mount reverse sshfs for %q on %q: %w", resolvedLocation, *m.MountPoint, err)
 		}
 	}
 
 	res := &mount{
 		close: func() error {
-			logrus.Infof("Unmounting %q", m.Location)
+			logrus.Infof("Unmounting %q", resolvedLocation)
 			if err := rsf.Close(); err != nil {
-				return fmt.Errorf("failed to unmount reverse sshfs for %q on %q: %w", m.Location, *m.MountPoint, err)
+				return fmt.Errorf("failed to unmount reverse sshfs for %q on %q: %w", resolvedLocation, *m.MountPoint, err)
 			}
 			return nil
 		},

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/docker/go-units"
 	"github.com/goccy/go-yaml"
+	"github.com/lima-vm/lima/pkg/ioutilx"
 	"github.com/lima-vm/lima/pkg/version"
 	"github.com/pbnjay/memory"
 	"github.com/sirupsen/logrus"
@@ -830,7 +831,15 @@ func FillDefault(y, d, o *LimaYAML, filePath string, warn bool) {
 			logrus.WithError(err).Warnf("Couldn't expand location %q", mount.Location)
 		}
 		if mount.MountPoint == nil {
-			mounts[i].MountPoint = ptr.Of(mounts[i].Location)
+			mountLocation := mounts[i].Location
+			if runtime.GOOS == "windows" {
+				var err error
+				mountLocation, err = ioutilx.WindowsSubsystemPath(mountLocation)
+				if err != nil {
+					logrus.WithError(err).Warnf("Couldn't convert location %q into mount target", mounts[i].Location)
+				}
+			}
+			mounts[i].MountPoint = ptr.Of(mountLocation)
 		}
 	}
 

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/lima-vm/lima/pkg/ioutilx"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/ptr"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
@@ -225,6 +226,12 @@ func TestFillDefault(t *testing.T) {
 
 	expect.Mounts = slices.Clone(y.Mounts)
 	expect.Mounts[0].MountPoint = ptr.Of(expect.Mounts[0].Location)
+	if runtime.GOOS == "windows" {
+		mountLocation, err := ioutilx.WindowsSubsystemPath(expect.Mounts[0].Location)
+		if err == nil {
+			expect.Mounts[0].MountPoint = ptr.Of(mountLocation)
+		}
+	}
 	expect.Mounts[0].Writable = ptr.Of(false)
 	expect.Mounts[0].SSHFS.Cache = ptr.Of(true)
 	expect.Mounts[0].SSHFS.FollowSymlinks = ptr.Of(false)
@@ -464,6 +471,12 @@ func TestFillDefault(t *testing.T) {
 	expect.Containerd.Archives[0].Arch = *d.Arch
 	expect.Mounts = slices.Clone(d.Mounts)
 	expect.Mounts[0].MountPoint = ptr.Of(expect.Mounts[0].Location)
+	if runtime.GOOS == "windows" {
+		mountLocation, err := ioutilx.WindowsSubsystemPath(expect.Mounts[0].Location)
+		if err == nil {
+			expect.Mounts[0].MountPoint = ptr.Of(mountLocation)
+		}
+	}
 	expect.Mounts[0].SSHFS.Cache = ptr.Of(true)
 	expect.Mounts[0].SSHFS.FollowSymlinks = ptr.Of(false)
 	expect.Mounts[0].SSHFS.SFTPDriver = ptr.Of("")


### PR DESCRIPTION
On Windows there is native path translation needed from location to Unix path mountPoint. And another one is needed for location before passing it to Unix like tooling (sshfs).

I'm not confident if it is better to show original or translated path in Errors. Having native will reduced the amount of lines changed, but would not represent what was actually passed to the command line. It is impossible to translate it earlier, because it is sshfs specific conversion and, for example, QEMU 9P would expect native Windows path on Windows.