### PR TITLE
Add initial support for DragonFly BSD

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -1222,7 +1222,7 @@ func ResolveArch(s *string) Arch {
 
 func IsAccelOS() bool {
 	switch runtime.GOOS {
-	case "darwin", "linux", "netbsd", "windows":
+	case "darwin", "linux", "netbsd", "windows", "dragonfly":
 		// Accelerator
 		return true
 	}

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -1120,6 +1120,8 @@ func Accel(arch limayaml.Arch) string {
 			return "kvm"
 		case "netbsd":
 			return "nvmm"
+		case "dragonfly":
+			return "nvmm"
 		case "windows":
 			return "whpx"
 		}


### PR DESCRIPTION
 DragonFly BSD also supports nvmm acceleration and lima builds out of
 the box.

Right now it has a problem with acceleration and it only uses TCG by default, see discussion here: https://github.com/lima-vm/lima/issues/892#issuecomment-2729728492