### PR TITLE
Enable port forwarding tests for WSL2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,12 +166,13 @@ jobs:
       run: make
     - name: Integration tests (WSL2, Windows host)
       run: |
-        $env:Path = "$pwd\_output\bin;" + 'C:\Program Files\Git\usr\bin;' + $env:Path
-        Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $env:Path
-        $env:MSYS2_ENV_CONV_EXCL='HOME_HOST;HOME_GUEST'
-        $env:HOME_HOST=$(cygpath.exe "$env:USERPROFILE")
-        $env:HOME_GUEST="/mnt$env:HOME_HOST"
-        $env:LIMACTL_CREATE_ARGS='--vm-type=wsl2 --mount-type=wsl2 --containerd=system'
+        $env:PATH = "$pwd\_output\bin;" + 'C:\msys64\usr\bin;' + $env:PATH
+        pacman -Sy --noconfirm openbsd-netcat diffutils
+        $env:MSYS2_ENV_CONV_EXCL = 'HOME_HOST;HOME_GUEST;_LIMA_WINDOWS_EXTRA_PATH'
+        $env:HOME_HOST = $(cygpath.exe "$env:USERPROFILE")
+        $env:HOME_GUEST = "/mnt$env:HOME_HOST"
+        $env:LIMACTL_CREATE_ARGS = '--vm-type=wsl2 --mount-type=wsl2 --containerd=system'
+        $env:_LIMA_WINDOWS_EXTRA_PATH = 'C:\Program Files\Git\usr\bin'
         bash.exe -c "./hack/test-templates.sh templates/experimental/wsl2.yaml"
 
   qemu:

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -93,7 +93,6 @@ case "$NAME" in
 "wsl2")
 	# TODO https://github.com/lima-vm/lima/issues/3268
 	CHECKS["proxy-settings"]=
-	CHECKS["port-forwards"]=
 	;;
 esac
 


### PR DESCRIPTION
Specifics:
* 127.0.0.1 always forwarded for 127.0.0.1 and 0.0.0.0 binds
* slirp IP address is not available.

All related cases are skipped based on instance name. 

It probably should be machine type, but I would need to collect more knowledge as to how add this test to Perl script.

This one is full of pretty crazy stuff. It took me 20 CI runs in my forked repo in addition to local runs to figure this out. So, some explanation would be helpful.

```perl
my $instanceType = qx(limactl ls --json "$instance" | jq -r '.vmType' | sed s/x/x/);
```
`sed s/x/x` is no-op on Unix trick to remove `\r` from output on Windows, because `chomp` fails to do so.

The only reasonable provider of `nc` was msys2 package manager. But it was impossible to use from Git shell - application will blow up, because of conflicting msys2 runtimes. The only way to use it is through some proxy of a native Windows process, which would separate the msys2 runtimes - something like `cmd /C "bash -c 'nc ...` which is awfully complicated. Alternative is to write a bridge app like this one - https://github.com/arixmkii/go-wsllinks I used it in my CI setup to separate msys2 apps from different roots, but there are no prebuilt versions as of now.

So, the solution is to use msys2 shell, where we can add packages and install all the needed dependencies, but this is known to not work for Lima, because of some sort of bug in ssh, which is addressed in Git distro. For this purpose we will provide Git distro as additional dependency path for `limactl` via `$env:_LIMA_WINDOWS_EXTRA_PATH = 'C:\Program Files\Git\usr\bin'` from the recently merged #3347 
