### PR TITLE
Disable ControlPersist for sshfs connections on Windows

### DIFF
--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -68,6 +68,9 @@ func (a *HostAgent) setupMount(m limayaml.Mount) (*mount, error) {
 		Readonly:            !(*m.Writable),
 		SSHFSAdditionalArgs: []string{"-o", sshfsOptions},
 	}
+	if runtime.GOOS == "windows" {
+		rsf.SSHConfig.Persist = false
+	}
 	if err := rsf.Prepare(); err != nil {
 		return nil, fmt.Errorf("failed to prepare reverse sshfs for %q on %q: %w", resolvedLocation, *m.MountPoint, err)
 	}


### PR DESCRIPTION
This dramatically improves stability for sshfs on Windows. It allowed all integration tests to pass in GH actions CI.

I can't state that it doesn't work at all with it enabled - I had some rare successful runs on local machine (never reproduced in GH actions). It also impossible to fully disable mux in other SSH calls of Lima as it will break SSH port forwarder (so, this part definitely works with comms via Unix socket).

Test run is provided in https://github.com/arixmkii/qcw/actions/runs/14022522017/job/39256363831