### PR TITLE
Unify Lima user home inside guest for all platforms

### DIFF
--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -62,10 +62,7 @@ func TestFillDefault(t *testing.T) {
 	limaHome, err := dirnames.LimaDir()
 	assert.NilError(t, err)
 	user := osutil.LimaUser("0.0.0", false)
-	if runtime.GOOS != "windows" {
-		// manual template expansion for "/home/{{.User}}.linux" (done by FillDefault)
-		user.HomeDir = fmt.Sprintf("/home/%s.linux", user.Username)
-	}
+	user.HomeDir = fmt.Sprintf("/home/%s.linux", user.Username)
 	uid, err := strconv.ParseUint(user.Uid, 10, 32)
 	assert.NilError(t, err)
 


### PR DESCRIPTION
Fixes #3364

I spent some time trying to understand if this code really makes sense. My conclusion is that it is probably the remains from the times, where the idea of mounting HOST home into GUEST home was explored. Since then there was a decision to have GUEST home separately, because it can be used for Lima GA needs. I could not think of any reason why GUEST home should be different from home directories on other platforms. This change remove all of the Windows specifics for GUEST home directory (keeping all other platform specific parts).

I tested this with integration tests using WSL2 and QEMU https://github.com/arixmkii/qcw/actions/runs/14022917109/job/39274813343