### PR TITLE
Add Guest Agent transport setting

### DIFF
--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -45,13 +45,14 @@ type LimaYAML struct {
 	DNS          []net.IP          `yaml:"dns,omitempty" json:"dns,omitempty"`
 	HostResolver HostResolver      `yaml:"hostResolver,omitempty" json:"hostResolver,omitempty"`
 	// `useHostResolver` was deprecated in Lima v0.8.1, removed in Lima v0.14.0. Use `hostResolver.enabled` instead.
-	PropagateProxyEnv    *bool          `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty" jsonschema:"nullable"`
-	CACertificates       CACertificates `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
-	Rosetta              Rosetta        `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
-	Plain                *bool          `yaml:"plain,omitempty" json:"plain,omitempty" jsonschema:"nullable"`
-	TimeZone             *string        `yaml:"timezone,omitempty" json:"timezone,omitempty" jsonschema:"nullable"`
-	NestedVirtualization *bool          `yaml:"nestedVirtualization,omitempty" json:"nestedVirtualization,omitempty" jsonschema:"nullable"`
-	User                 User           `yaml:"user,omitempty" json:"user,omitempty"`
+	PropagateProxyEnv       *bool            `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty" jsonschema:"nullable"`
+	CACertificates          CACertificates   `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
+	Rosetta                 Rosetta          `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
+	GuestAgentTransportType *GATransportType `yaml:"guestAgentTransportType,omitempty" json:"guestAgentTransportType,omitempty" jsonschema:"nullable"`
+	Plain                   *bool            `yaml:"plain,omitempty" json:"plain,omitempty" jsonschema:"nullable"`
+	TimeZone                *string          `yaml:"timezone,omitempty" json:"timezone,omitempty" jsonschema:"nullable"`
+	NestedVirtualization    *bool            `yaml:"nestedVirtualization,omitempty" json:"nestedVirtualization,omitempty" jsonschema:"nullable"`
+	User                    User             `yaml:"user,omitempty" json:"user,omitempty"`
 }
 
 type BaseTemplates []LocatorWithDigest
@@ -62,10 +63,11 @@ type LocatorWithDigest struct {
 }
 
 type (
-	OS        = string
-	Arch      = string
-	MountType = string
-	VMType    = string
+	OS              = string
+	Arch            = string
+	MountType       = string
+	VMType          = string
+	GATransportType = string
 )
 
 type CPUType = map[Arch]string
@@ -87,6 +89,10 @@ const (
 	QEMU VMType = "qemu"
 	VZ   VMType = "vz"
 	WSL2 VMType = "wsl2"
+
+	VIRTIOGA    GATransportType = "virtio-ga"
+	VSOCKGA     GATransportType = "vsock-ga"
+	HOSTAGENTGA GATransportType = "hostagent-ga"
 )
 
 var (

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -45,6 +45,7 @@ type Config struct {
 	LimaYAML     *limayaml.LimaYAML
 	SSHLocalPort int
 	SSHAddress   string
+	VirtioGA     bool
 }
 
 // MinimumQemuVersion is the minimum supported QEMU version.
@@ -987,11 +988,13 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	args = append(args, "-chardev", fmt.Sprintf("socket,id=%s,path=%s,server=on,wait=off", qmpChardev, qmpSock))
 	args = append(args, "-qmp", "chardev:"+qmpChardev)
 
-	// Guest agent via serialport
-	guestSock := filepath.Join(cfg.InstanceDir, filenames.GuestAgentSock)
-	args = append(args, "-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=qga0", guestSock))
-	args = append(args, "-device", "virtio-serial")
-	args = append(args, "-device", "virtserialport,chardev=qga0,name="+filenames.VirtioPort)
+	if cfg.VirtioGA {
+		// Guest agent via serialport
+		guestSock := filepath.Join(cfg.InstanceDir, filenames.GuestAgentSock)
+		args = append(args, "-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=qga0", guestSock))
+		args = append(args, "-device", "virtio-serial")
+		args = append(args, "-device", "virtserialport,chardev=qga0,name="+filenames.VirtioPort)
+	}
 
 	// QEMU process
 	args = append(args, "-name", "lima-"+cfg.Name)

--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -77,6 +77,7 @@ func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
 		LimaYAML:     l.Instance.Config,
 		SSHLocalPort: l.SSHLocalPort,
 		SSHAddress:   l.Instance.SSHAddress,
+		VirtioGA:     l.VirtioPort != "",
 	}
 	qExe, qArgs, err := Cmdline(ctx, qCfg)
 	if err != nil {

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -367,6 +367,13 @@ rosetta:
   # 🟢 Builtin default: false
   binfmt: null
 
+# Specify communication transport to connect to GuestAgent.
+# Supported values are "virtio-ga", "vsock-ga" and "hostagent-ga".
+# If selected option will not be supported for VMType and Host OS a Warning will be shown and the
+# default mode will be selected.
+# 🟢 Builtin default: not set which results in VMType and Host OS specific behavior
+guestAgentTransportType: null
+
 # Specify the timezone name (as used by the zoneinfo database). Specify the empty string
 # to not set a timezone in the instance.
 # 🟢 Builtin default: use name from /etc/timezone or deduce from symlink target of /etc/localtime


### PR DESCRIPTION
Fixes #3177

Closes #3255 

Adds setting, which could influence, which will then decide, which transport will be in use for connection to GA

Fixes:
* QEMU always creating ga.sock even when SSH forwarder will be used
* Fallback mode to SSH forwarder was unavailable for VZ

If the unsupported option is detected then a warning is printed and fallback will be used instead. The default is VMType and Host OS sensitive (due to limited support of options for some platforms).