### PR TITLE
disk: Round up disk size to 512 bytes

### DIFF
--- a/pkg/nativeimgutil/nativeimgutil_test.go
+++ b/pkg/nativeimgutil/nativeimgutil_test.go
@@ -13,6 +13,24 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+func TestRoundUp(t *testing.T) {
+	tests := []struct {
+		Size    int
+		Rounded int
+	}{
+		{0, 0},
+		{1, 512},
+		{511, 512},
+		{512, 512},
+		{123456789, 123457024},
+	}
+	for _, tc := range tests {
+		if RoundUp(tc.Size) != tc.Rounded {
+			t.Errorf("expected %d, got %d", tc.Rounded, tc.Size)
+		}
+	}
+}
+
 func createImg(name, format, size string) error {
 	return exec.Command("qemu-img", "create", name, "-f", format, size).Run()
 }


### PR DESCRIPTION
Apple virtualization framework rejects disks if the disk size is not aligned to 512 bytes. QEMU block layer round the size up when creating or resizing disks. Let's do the same to ensure that we don't create or resize disk to unusable size.

I added only trivial tests for the RoundUp helper since this kind of code is easy to get wrong. We need to add more tests for creating and resizing disk images.

Fixes #3390