### PR TITLE
Bind QEMU GA socket only in virtio mode

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -45,6 +45,7 @@ type Config struct {
 	LimaYAML     *limayaml.LimaYAML
 	SSHLocalPort int
 	SSHAddress   string
+	VirtioGA     bool
 }
 
 // MinimumQemuVersion is the minimum supported QEMU version.
@@ -987,11 +988,13 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	args = append(args, "-chardev", fmt.Sprintf("socket,id=%s,path=%s,server=on,wait=off", qmpChardev, qmpSock))
 	args = append(args, "-qmp", "chardev:"+qmpChardev)
 
-	// Guest agent via serialport
-	guestSock := filepath.Join(cfg.InstanceDir, filenames.GuestAgentSock)
-	args = append(args, "-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=qga0", guestSock))
-	args = append(args, "-device", "virtio-serial")
-	args = append(args, "-device", "virtserialport,chardev=qga0,name="+filenames.VirtioPort)
+	if cfg.VirtioGA {
+		// Guest agent via serialport
+		guestSock := filepath.Join(cfg.InstanceDir, filenames.GuestAgentSock)
+		args = append(args, "-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=qga0", guestSock))
+		args = append(args, "-device", "virtio-serial")
+		args = append(args, "-device", "virtserialport,chardev=qga0,name="+filenames.VirtioPort)
+	}
 
 	// QEMU process
 	args = append(args, "-name", "lima-"+cfg.Name)

--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -77,6 +77,7 @@ func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
 		LimaYAML:     l.Instance.Config,
 		SSHLocalPort: l.SSHLocalPort,
 		SSHAddress:   l.Instance.SSHAddress,
+		VirtioGA:     l.VirtioPort != "",
 	}
 	qExe, qArgs, err := Cmdline(ctx, qCfg)
 	if err != nil {


### PR DESCRIPTION
Bugfix part from #3387 

On macOS:

Opened files before the change:

```sh
sudo lsof | grep ga.sock
qemu-syst 42489            arturss   19u     unix 0x490e394c874bdc89         0t0                     /Users/arturss/.lima/default/ga.sock
ssh       42501            arturss   13u     unix  0x5de2ca7d01f8893         0t0                     /Users/arturss/.lima/default/ga.sock
ssh       42501            arturss   14u     unix 0xe8fb28582c31df39         0t0                     /Users/arturss/.lima/default/ga.sock
```

Opened files after the change:
```sh
sudo lsof | grep ga.sock
ssh       43396            arturss   14u     unix 0xac705c05f6f9eaee         0t0                     /Users/arturss/.lima/default/ga.sock
ssh       43396            arturss   17u     unix 0x5c371e023aafcc57         0t0                     /Users/arturss/.lima/default/ga.sock
```