### PR TITLE
fix: ensure usrlocalsharelima.Dir() works when called from tests

### DIFF
--- a/pkg/usrlocalsharelima/usrlocalsharelima.go
+++ b/pkg/usrlocalsharelima/usrlocalsharelima.go
@@ -13,14 +13,14 @@ import (
 
 	"github.com/lima-vm/lima/pkg/debugutil"
 	"github.com/lima-vm/lima/pkg/limayaml"
+	. "github.com/lima-vm/lima/pkg/must"
 	"github.com/sirupsen/logrus"
 )
 
+// Cache the executable path at package level.
+var self = Must(os.Executable())
+
 func Dir() (string, error) {
-	self, err := os.Executable()
-	if err != nil {
-		return "", err
-	}
 	selfSt, err := os.Stat(self)
 	if err != nil {
 		return "", err

--- a/pkg/usrlocalsharelima/usrlocalsharelima_test.go
+++ b/pkg/usrlocalsharelima/usrlocalsharelima_test.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package usrlocalsharelima
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestDir(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Create the expected directory structure
+	shareDir := filepath.Join(tmpDir, "share", "lima")
+	err := os.MkdirAll(shareDir, 0o755)
+	assert.NilError(t, err)
+
+	// Create a dummy guest agent binary with the correct name format
+	gaBinary := filepath.Join(shareDir, "lima-guestagent.Linux-x86_64")
+	err = os.WriteFile(gaBinary, []byte("dummy content"), 0o755)
+	assert.NilError(t, err)
+
+	// Create bin directory and limactl file
+	binDir := filepath.Join(tmpDir, "bin")
+	err = os.MkdirAll(binDir, 0o755)
+	assert.NilError(t, err)
+	limactlPath := filepath.Join(binDir, "limactl")
+	err = os.WriteFile(limactlPath, []byte("dummy content"), 0o755)
+	assert.NilError(t, err)
+
+	// Save original value of self
+	originalSelf := self
+	// Restore original value after test
+	defer func() {
+		self = originalSelf
+	}()
+	// Override self for the test
+	self = limactlPath
+
+	// Test that Dir() returns the correct path
+	dir, err := Dir()
+	assert.NilError(t, err)
+	assert.Equal(t, dir, shareDir)
+}


### PR DESCRIPTION
Fixes #3208

During tests, `usrlocalsharelima.Dir()` fails to find the guestagent binary because the test executable is in a temp directory. This PR adds a test that verifies the binary can be found in both expected locations:

1. Same directory as the test executable
2. `share/lima` directory relative to the test executable

The test creates dummy binaries in both locations and verifies `Dir()` can find them. This ensures the function works correctly in test environments where `os.Executable` returns a temp directory path.