### PR TITLE
Remove redundant major version number from instance name

### DIFF
--- a/pkg/limatmpl/locator_test.go
+++ b/pkg/limatmpl/locator_test.go
@@ -52,4 +52,12 @@ func TestInstNameFromImageURL(t *testing.T) {
 		name := limatmpl.InstNameFromImageURL(image, arch)
 		assert.Equal(t, name, "linux")
 	})
+	t.Run("removes redundant major version", func(t *testing.T) {
+		name := limatmpl.InstNameFromImageURL("rocky-8-8.10.raw", "unknown")
+		assert.Equal(t, name, "rocky-8.10")
+	})
+	t.Run("don't remove non-redundant major version", func(t *testing.T) {
+		name := limatmpl.InstNameFromImageURL("rocky-8-9.10.raw", "unknown")
+		assert.Equal(t, name, "rocky-8-9.10")
+	})
 }


### PR DESCRIPTION
almalinux and rocky use image names that include the major version number twice. This commit strips it:

```
almalinux-8-8.10 → almalinux-8.10
almalinux-9-9.5  → almalinux-9.5
rocky-8-8.10     → rocky-8.10
rocky-9-9.5      → rocky-9.5
```