### PR TITLE
CI: fix the commit hash of golangci-lint-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Verify generated files
       run: make install-tools generate check-generated
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@a5307c8f68bcd21ff73283f8629eb09caa60d7a7  # v7.0.0
+      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd  # v7.0.0
       with:
         version: v2.0.1
         args: --verbose


### PR DESCRIPTION
Probably a wrong hash for v7.0.0 was accidentally introduced in https://github.com/lima-vm/lima/pull/3330#discussion_r2023091814 , unless v7.0.0 was retagged.

Anyway, there was no security concern in the previous hashes AFAICS.