### PR TITLE
Add context to StopGracefully

### DIFF
--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -39,14 +39,15 @@ func stopAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	ctx := cmd.Context()
 	if force {
 		instance.StopForcibly(inst)
 	} else {
-		err = instance.StopGracefully(inst, false)
+		err = instance.StopGracefully(ctx, inst, false)
 	}
 	// TODO: should we also reconcile networks if graceful stop returned an error?
 	if err == nil {
-		err = networks.Reconcile(cmd.Context(), "")
+		err = networks.Reconcile(ctx, "")
 	}
 	return err
 }

--- a/pkg/instance/restart.go
+++ b/pkg/instance/restart.go
@@ -14,7 +14,7 @@ import (
 const launchHostAgentForeground = false
 
 func Restart(ctx context.Context, inst *store.Instance) error {
-	if err := StopGracefully(inst, true); err != nil {
+	if err := StopGracefully(ctx, inst, true); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR removes two `context.TODO()`.