### PR TITLE
sudoers: show the command only on darwin

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -13,8 +13,8 @@ ls:
     .yaml: snake_case
 
   cmd/limactl:
-    # valid names are `show-ssh.go` or `show-ssh_test.go`
-    .go: kebab-case | regex:[a-z0-9-]+_test
+    # valid names are `show-ssh.go`, `show-ssh_windows.go` or `show-ssh_test.go`
+    .go: lowercase
 
   docs:
     .md: kebab-case

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -169,7 +169,6 @@ func newApp() *cobra.Command {
 		newListCommand(),
 		newDeleteCommand(),
 		newValidateCommand(),
-		newSudoersCommand(),
 		newPruneCommand(),
 		newHostagentCommand(),
 		newInfoCommand(),
@@ -188,8 +187,8 @@ func newApp() *cobra.Command {
 		newTemplateCommand(),
 		newRestartCommand(),
 	)
-	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
-		rootCmd.AddCommand(startAtLoginCommand())
+	for _, cmd := range additionalAdvancedCommands() {
+		rootCmd.AddCommand(cmd)
 	}
 
 	return rootCmd

--- a/cmd/limactl/main_darwin.go
+++ b/cmd/limactl/main_darwin.go
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "github.com/spf13/cobra"
+
+func additionalAdvancedCommands() []*cobra.Command {
+	return []*cobra.Command{
+		newSudoersCommand(),
+		startAtLoginCommand(),
+	}
+}

--- a/cmd/limactl/main_linux.go
+++ b/cmd/limactl/main_linux.go
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "github.com/spf13/cobra"
+
+func additionalAdvancedCommands() []*cobra.Command {
+	return []*cobra.Command{
+		startAtLoginCommand(),
+	}
+}

--- a/cmd/limactl/main_windows.go
+++ b/cmd/limactl/main_windows.go
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "github.com/spf13/cobra"
+
+func additionalAdvancedCommands() []*cobra.Command {
+	return nil
+}

--- a/cmd/limactl/start-at-login_unix.go
+++ b/cmd/limactl/start-at-login_unix.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // SPDX-FileCopyrightText: Copyright The Lima Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/cmd/limactl/sudoers_darwin.go
+++ b/cmd/limactl/sudoers_darwin.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"runtime"
 
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/sirupsen/logrus"
@@ -42,9 +41,6 @@ See %s for the usage.`, networksURL),
 }
 
 func sudoersAction(cmd *cobra.Command, args []string) error {
-	if runtime.GOOS != "darwin" {
-		return errors.New("sudoers command is only supported on macOS right now")
-	}
 	nwCfg, err := networks.LoadConfig()
 	if err != nil {
 		return err


### PR DESCRIPTION
We can remove the error `"sudoers command is only supported on macOS right now"` by adding the `sudoers` command to the command list only on darwin. 