### PR TITLE
Allow drivers to negotiate transport independent of hostagent

### DIFF
--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -41,6 +41,13 @@ type LimaQemuDriver struct {
 }
 
 func New(driver *driver.BaseDriver) *LimaQemuDriver {
+	driver.VSockPort = 0
+	driver.VirtioPort = filenames.VirtioPort
+	// virtserialport doesn't seem to work reliably: https://github.com/lima-vm/lima/issues/2064
+	// but on Windows default Unix socket forwarding is not available
+	if runtime.GOOS != "windows" {
+		driver.VirtioPort = ""
+	}
 	return &LimaQemuDriver{
 		BaseDriver: driver,
 	}

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -72,6 +72,8 @@ type LimaVzDriver struct {
 }
 
 func New(driver *driver.BaseDriver) *LimaVzDriver {
+	driver.VSockPort = 2222
+	driver.VirtioPort = ""
 	return &LimaVzDriver{
 		BaseDriver: driver,
 	}

--- a/pkg/wsl2/wsl_driver_windows.go
+++ b/pkg/wsl2/wsl_driver_windows.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/lima-vm/lima/pkg/driver"
+	"github.com/lima-vm/lima/pkg/freeport"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/reflectutil"
 	"github.com/lima-vm/lima/pkg/store"
@@ -49,6 +50,12 @@ type LimaWslDriver struct {
 }
 
 func New(driver *driver.BaseDriver) *LimaWslDriver {
+	port, err := freeport.VSock()
+	if err != nil {
+		logrus.WithError(err).Error("failed to get free VSock port")
+	}
+	driver.VSockPort = port
+	driver.VirtioPort = ""
 	return &LimaWslDriver{
 		BaseDriver: driver,
 	}


### PR DESCRIPTION
Fixes #3177

Closes #3387

Hostagent will agree to whatever driver returns as a transport via BaseDriver interface.

This is re-implemented concept from previous one. Now it follows the maintainer recommendation in https://github.com/lima-vm/lima/pull/3387#issuecomment-2760002905

> I think we should derive best mode of transport and use it as default always. Giving these config will confuse folks using it also this transport is internal to lima guest agent

The change required was to move the configuration code from hostagent into drivers themselves to populate and then make hostagent the settings consumer.