### PR TITLE
Enable gRPC port forwarder by default again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -445,9 +445,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-        - {template: default.yaml, ssh-port-forwarder: true}  # SSH port forwarder is currently still the default
-        - {template: fedora.yaml, ssh-port-forwarder: false}  # gRPC port forwarder will become default in the future
+        template:
+        - default.yaml
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
@@ -469,8 +468,6 @@ jobs:
       run: brew uninstall --ignore-dependencies --force qemu
     - name: Test
       run: ./hack/test-templates.sh templates/${{ matrix.template }}
-      env:
-        LIMA_SSH_PORT_FORWARDER: ${{ matrix.ssh-port-forwarder }}
     - if: failure()
       uses: ./.github/actions/upload_failure_logs_if_exists
       with:

--- a/website/content/en/docs/config/environment-variables.md
+++ b/website/content/en/docs/config/environment-variables.md
@@ -49,14 +49,20 @@ This page documents the environment variables used in Lima.
 
 ### `LIMA_SSH_PORT_FORWARDER`
 
-- **Description**: Specifies to use the SSH port forwarder (slow, stable) instead of gRPC (fast, unstable)
-- **Default**: `true`
+- **Description**: Specifies to use the SSH port forwarder (slow) instead of gRPC (fast, previously unstable)
+- **Default**: `false` (since v1.1.0-beta.0)
 - **Usage**: 
   ```sh
   export LIMA_SSH_PORT_FORWARDER=false
   ```
-- **Note**: It is expected that this variable will be set to `false` by default in future
-  when the gRPC port forwarder is well matured.
+- **Note**: Deprecated since v1.1. It is expected that this variable will be removed in future.
+- **The history of the default value**:
+  | Version       | Default value       |
+  |---------------|---------------------|
+  | v0.1.0        | `true`, effectively |
+  | v1.0.0        | `false`             |
+  | v1.0.1        | `true`              |
+  | v1.1.0-beta.0 | `false`             |
 
 ### `LIMA_USERNET_RESOLVE_IP_ADDRESS_TIMEOUT`
 

--- a/website/content/en/docs/config/port.md
+++ b/website/content/en/docs/config/port.md
@@ -9,14 +9,21 @@ Lima supports automatic port-forwarding of localhost ports from guest to host.
 
 Lima supports two port forwarders: SSH and GRPC.
 
-The default port forwarder is SSH.
+The default port forwarder is shown in the following table.
+
+| Version       | Default |
+| ------------- | ------- |
+| v0.1.0        | SSH     |
+| v1.0.0        | GRPC    |
+| v1.0.1        | SSH     |
+| v1.1.0-beta.0 | GRPC    |
 
 The default was once changed to GRPC in Lima v1.0, but it was reverted to SSH in v1.0.1 due to stability reasons.
-In future, it is expected that GRPC will take over the default position again.
+The default was further reverted to GRPC in Lima v1.1, as the stability issues were resolved.
 
 ### Using SSH
 
-SSH based port forwarding is the default and current model that is supported in Lima.
+SSH based port forwarding is the legacy mode that was previously default.
 
 To explicitly use SSH forwarding use the below command
 

--- a/website/content/en/docs/releases/deprecated.md
+++ b/website/content/en/docs/releases/deprecated.md
@@ -8,6 +8,7 @@ The following features are deprecated:
 - CentOS 7 support
 - Loading non-strict YAMLs (i.e., YAMLs with unknown properties)
 - `limactl show-ssh` command (Use `ssh -F ~/.lima/default/ssh.config lima-default` instead)
+- `LIMA_SSH_PORT_FORWARDER=true` (since Lima v1.1)
 
 ## Removed features
 - YAML property `network`: deprecated in [Lima v0.7.0](https://github.com/lima-vm/lima/commit/07e68230e70b21108d2db3ca5e0efd0e43842fbd)


### PR DESCRIPTION
Fix #3046

The behavior can be rolled by setting `LIMA_SSH_PORT_FORWARDER=true`