### PR TITLE
templates: add fedora-42

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,7 +244,8 @@ jobs:
         template:
         - alpine.yaml
         - debian.yaml  # reverse-sshfs
-        - fedora.yaml
+        - fedora.yaml  # The default version of Fedora is still 41 due to https://github.com/lima-vm/lima/issues/3334
+        - fedora-42.yaml
         - archlinux.yaml
         - opensuse.yaml
         - docker.yaml

--- a/templates/README.md
+++ b/templates/README.md
@@ -20,7 +20,8 @@ Distro:
 - [`centos-stream-10`](./centos-stream-10.yaml): CentOS Stream 10
 - [`debian-11`](./debian-11.yaml): Debian GNU/Linux 11(bullseye)
 - [`debian-12`](./debian-12.yaml), `debian.yaml`: ⭐Debian GNU/Linux 12(bookworm)
-- [`fedora`](./fedora.yaml): ⭐Fedora
+- [`fedora-41`](./fedora-41.yaml), `fedora.yaml`: ⭐Fedora 41
+- [`fedora-42`](./fedora-42.yaml): Fedora 42
 - [`opensuse-leap`](./opensuse-leap.yaml), `opensuse.yaml`: ⭐openSUSE Leap
 - [`oraclelinux-8`](./oraclelinux-8.yaml): Oracle Linux 8
 - [`oraclelinux-9`](./oraclelinux-9.yaml), `oraclelinux.yaml`: Oracle Linux 9

--- a/templates/fedora-41.yaml
+++ b/templates/fedora-41.yaml
@@ -1,0 +1,16 @@
+# This template requires Lima v0.7.0 or later.
+images:
+- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2"
+  arch: "x86_64"
+  digest: "sha256:6205ae0c524b4d1816dbd3573ce29b5c44ed26c9fbc874fbe48c41c89dd0bac2"
+- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-41-1.4.aarch64.qcow2"
+  arch: "aarch64"
+  digest: "sha256:085883b42c7e3b980e366a1fe006cd0ff15877f7e6e984426f3c6c67c7cc2faa"
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+
+# 9p is broken in Linux v6.9, v6.10, and v6.11 (used by Fedora 41).
+# The issue was fixed in Linux v6.12-rc5 (https://github.com/torvalds/linux/commit/be2ca38).
+mountTypesUnsupported: ["9p"]

--- a/templates/fedora-42.yaml
+++ b/templates/fedora-42.yaml
@@ -1,0 +1,16 @@
+# This template requires Lima v0.7.0 or later.
+images:
+- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2"
+  arch: "x86_64"
+  digest: "sha256:e401a4db2e5e04d1967b6729774faa96da629bcf3ba90b67d8d9cce9906bec0f"
+- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-42-1.1.aarch64.qcow2"
+  arch: "aarch64"
+  digest: "sha256:e10658419a8d50231037dc781c3155aa94180a8c7a74e5cac2a6b09eaa9342b7"
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+
+# # NOTE: Intel Mac requires setting vmType to qemu
+# # https://github.com/lima-vm/lima/issues/3334
+# vmType: qemu

--- a/templates/fedora.yaml
+++ b/templates/fedora.yaml
@@ -1,16 +1,1 @@
-# This template requires Lima v0.7.0 or later.
-images:
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2"
-  arch: "x86_64"
-  digest: "sha256:6205ae0c524b4d1816dbd3573ce29b5c44ed26c9fbc874fbe48c41c89dd0bac2"
-- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-41-1.4.aarch64.qcow2"
-  arch: "aarch64"
-  digest: "sha256:085883b42c7e3b980e366a1fe006cd0ff15877f7e6e984426f3c6c67c7cc2faa"
-mounts:
-- location: "~"
-- location: "/tmp/lima"
-  writable: true
-
-# 9p is broken in Linux v6.9, v6.10, and v6.11 (used by Fedora 41).
-# The issue was fixed in Linux v6.12-rc5 (https://github.com/torvalds/linux/commit/be2ca38).
-mountTypesUnsupported: ["9p"]
+fedora-41.yaml


### PR DESCRIPTION
`template://fedora` still refers to Fedora 41, as Fedora 42 does not work on Intel Mac with vz (issue 3334)