### PR TITLE
Fix: resize GuestOS disk

### DIFF
--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -133,6 +133,7 @@ func editAction(cmd *cobra.Command, args []string) error {
 	if err := os.WriteFile(filePath, yBytes, 0o644); err != nil {
 		return err
 	}
+
 	if inst != nil {
 		logrus.Infof("Instance %q configuration edited", inst.Name)
 	}
@@ -154,6 +155,13 @@ func editAction(cmd *cobra.Command, args []string) error {
 	}
 	ctx := cmd.Context()
 	err = networks.Reconcile(ctx, inst.Name)
+	if err != nil {
+		return err
+	}
+
+	// store.Inspect() syncs values between inst.YAML and the store.
+	// This call applies the validated template to the store.
+	inst, err = store.Inspect(inst.Name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Try to fix: #1448 

**How Lima edit disk**
- The `limactl edit` updates the disk value to the store. It does not resize disk image. Users have to manually resize by `qemu-img`
- Does not support --shrink (fails to start instance)

**What I did**
- create a `limactl disk add` command to add an existing qcow2 disk to Lima.  
- To update GuestOS disk, before start instance, It adds a `diffdisk` of the instance to Lima, resize, and delete. 
