### PR TITLE
Adding ip address to the SAN certificate for  k8s.yaml

### DIFF
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -112,6 +112,7 @@ provision:
     apiServer:
       certSANs: # --apiserver-cert-extra-sans
       - "127.0.0.1"
+      - "192.168.5.15"
     networking:
       podSubnet: "10.244.0.0/16" # --pod-network-cidr
     ---


### PR DESCRIPTION
Adding this ip will make software trust the api server since the ip address of the api server will be in the SAN certificate list