### PR TITLE
templates: Add Debian and Fedora riscv64 images

### DIFF
--- a/templates/_images/fedora-41.yaml
+++ b/templates/_images/fedora-41.yaml
@@ -7,6 +7,10 @@ images:
   arch: aarch64
   digest: sha256:085883b42c7e3b980e366a1fe006cd0ff15877f7e6e984426f3c6c67c7cc2faa
 
+- location: https://dl.fedoraproject.org/pub/alt/risc-v/release/41/Cloud/riscv64/images/Fedora-Cloud-Base-Generic-41.20250224-1026a2d0e311.riscv64.qcow2
+  arch: riscv64
+  digest: sha256:6a8272a858d7f1498f49ce362b34f0b9b959885f63285158947e045abfeece40
+
 # 9p is broken in Linux v6.9, v6.10, and v6.11 (used by Fedora 41).
 # The issue was fixed in Linux v6.12-rc5 (https://github.com/torvalds/linux/commit/be2ca38).
 mountTypesUnsupported: [9p]

--- a/templates/_images/fedora-42.yaml
+++ b/templates/_images/fedora-42.yaml
@@ -7,6 +7,9 @@ images:
   arch: aarch64
   digest: sha256:e10658419a8d50231037dc781c3155aa94180a8c7a74e5cac2a6b09eaa9342b7
 
+- location: https://dl.fedoraproject.org/pub/alt/risc-v/release/42/Cloud/riscv64/images/Fedora-Cloud-Base-Generic-42.20250414-8635a3a5bfcd.riscv64.qcow2
+  arch: riscv64
+  digest: sha256:537c67710f4f1c9112fecaafafc293b649acd1d35b46619b97b5a5a0132241b0
 
 # # NOTE: Intel Mac requires setting vmType to qemu
 # # https://github.com/lima-vm/lima/issues/3334

--- a/templates/experimental/debian-sid.yaml
+++ b/templates/experimental/debian-sid.yaml
@@ -9,4 +9,7 @@ images:
 - location: https://cloud.debian.org/images/cloud/sid/daily/latest/debian-sid-genericcloud-arm64-daily.qcow2
   arch: aarch64
 
+- location: https://cloud.debian.org/images/cloud/sid/daily/latest/debian-sid-genericcloud-riscv64-daily.qcow2
+  arch: riscv64
+
 mountTypesUnsupported: [9p]


### PR DESCRIPTION
The Debian image is the latest from unstable as there's no release yet for riscv64.

Fedora is a Fedora 42 cloud image. It's not clear how often this will be updated, so the URL may become stale at some point.