### PR TITLE
fix: avoid duplicate READY message when shell is already running

### DIFF
--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -313,6 +313,13 @@ func watchHostAgentEvents(ctx context.Context, inst *store.Instance, haStdoutPat
 			if *inst.Config.Plain {
 				logrus.Infof("READY. Run `ssh -F %q %s` to open the shell.", inst.SSHConfigFile, inst.Hostname)
 			} else {
+				// Check if a shell session is already running
+				if _, err := os.Stat(filepath.Join(inst.Dir, "ssh.pid")); err == nil {
+					// Shell session exists, skip the READY message
+					_ = ShowMessage(inst)
+					err = nil
+					return true
+				}
 				logrus.Infof("READY. Run `%s` to open the shell.", LimactlShellCmd(inst.Name))
 			}
 			_ = ShowMessage(inst)


### PR DESCRIPTION
This commit modifies the start.go file to check for an existing shell session (via ssh.pid) before showing the READY message. This prevents duplicate READY messages when the shell is already launched.

## Fixes 
#3452 