### PR TITLE
fix: hiding template private snippets from bashCompletion

### DIFF
--- a/cmd/limactl/completion.go
+++ b/cmd/limactl/completion.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/templatestore"
 	"github.com/spf13/cobra"
@@ -17,11 +19,25 @@ func bashCompleteInstanceNames(_ *cobra.Command) ([]string, cobra.ShellCompDirec
 	return instances, cobra.ShellCompDirectiveNoFileComp
 }
 
-func bashCompleteTemplateNames(_ *cobra.Command) ([]string, cobra.ShellCompDirective) {
+func bashCompleteTemplateNames(_ *cobra.Command, toComplete string) ([]string, cobra.ShellCompDirective) {
 	var comp []string
 	if templates, err := templatestore.Templates(); err == nil {
 		for _, f := range templates {
-			comp = append(comp, "template://"+f.Name)
+			name := "template://" + f.Name
+			if !strings.HasPrefix(name, toComplete) {
+				continue
+			}
+			if len(toComplete) == len(name) {
+				comp = append(comp, name)
+				continue
+			}
+
+			// Skip private snippets (beginning with '_') from completion.
+			if (name[len(toComplete)-1] == '/') && (name[len(toComplete)] == '_') {
+				continue
+			}
+
+			comp = append(comp, name)
 		}
 	}
 	return comp, cobra.ShellCompDirectiveDefault

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -454,12 +454,12 @@ func startAction(cmd *cobra.Command, args []string) error {
 	return instance.Start(ctx, inst, "", launchHostAgentForeground)
 }
 
-func createBashComplete(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-	return bashCompleteTemplateNames(cmd)
+func createBashComplete(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return bashCompleteTemplateNames(cmd, toComplete)
 }
 
-func startBashComplete(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+func startBashComplete(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	compInst, _ := bashCompleteInstanceNames(cmd)
-	compTmpl, _ := bashCompleteTemplateNames(cmd)
+	compTmpl, _ := bashCompleteTemplateNames(cmd, toComplete)
 	return append(compInst, compTmpl...), cobra.ShellCompDirectiveDefault
 }


### PR DESCRIPTION
Resolve: #3458 

Is this correct, or do I need to remove them from `Templates[]` in `templatestore`?