### PR TITLE
Fix `nativeimgutil_test.go` on Windows with QEMU installed

### DIFF
--- a/pkg/nativeimgutil/nativeimgutil_test.go
+++ b/pkg/nativeimgutil/nativeimgutil_test.go
@@ -61,8 +61,7 @@ func TestConvertToRaw(t *testing.T) {
 	assert.NilError(t, err)
 
 	t.Run("qcow without backing file", func(t *testing.T) {
-		resultImage := filepath.Join(tmpDir, strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_"))
-		assert.NilError(t, err)
+		resultImage := filepath.Join(tmpDir, strings.ReplaceAll(strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_"), "/", "_"))
 
 		err = ConvertToRaw(qcowImage.Name(), resultImage, nil, false)
 		assert.NilError(t, err)
@@ -70,8 +69,7 @@ func TestConvertToRaw(t *testing.T) {
 	})
 
 	t.Run("qcow with backing file", func(t *testing.T) {
-		resultImage := filepath.Join(tmpDir, strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_"))
-		assert.NilError(t, err)
+		resultImage := filepath.Join(tmpDir, strings.ReplaceAll(strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_"), "/", "_"))
 
 		err = ConvertToRaw(qcowImage.Name(), resultImage, nil, true)
 		assert.NilError(t, err)
@@ -79,8 +77,8 @@ func TestConvertToRaw(t *testing.T) {
 	})
 
 	t.Run("qcow with extra size", func(t *testing.T) {
-		resultImage := filepath.Join(tmpDir, strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_"))
-		assert.NilError(t, err)
+		resultImage := filepath.Join(tmpDir, strings.ReplaceAll(strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_"), "/", "_"))
+
 		size := int64(2_097_152) // 2mb
 		err = ConvertToRaw(qcowImage.Name(), resultImage, &size, false)
 		assert.NilError(t, err)
@@ -88,8 +86,7 @@ func TestConvertToRaw(t *testing.T) {
 	})
 
 	t.Run("raw", func(t *testing.T) {
-		resultImage := filepath.Join(tmpDir, strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_"))
-		assert.NilError(t, err)
+		resultImage := filepath.Join(tmpDir, strings.ReplaceAll(strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_"), "/", "_"))
 
 		err = ConvertToRaw(rawImage.Name(), resultImage, nil, false)
 		assert.NilError(t, err)


### PR DESCRIPTION
On Windows both '\\' and '/'` would be treated as path separators - need to replace both.

Additional changes - removed assertion, where error is not actually updated - no point in asserting previous error multiple times.

Before this change running Unit tests would result in
```
=== RUN   TestConvertToRaw
=== RUN   TestConvertToRaw/qcow_without_backing_file
time="2025-04-23T21:27:30+03:00" level=info msg="Converting \"C:\\\\msys64\\\\tmp\\\\TestConvertToRaw1483052598\\\\001\\\\qcow.img\" (qcow2) to a raw disk \"C:\\\\msys64\\\\tmp\\\\TestConvertToRaw1483052598\\\\001\\\\TestConvertToRaw\\\\qcow_without_backing_file\""
    nativeimgutil_test.go:68: assertion failed: error is not nil: open C:\msys64\tmp\TestConvertToRaw1483052598\001\TestConvertToRaw\qcow_without_backing_file.lima-1923521838.tmp: The system cannot find the path specified.
=== RUN   TestConvertToRaw/qcow_with_backing_file
time="2025-04-23T21:27:30+03:00" level=info msg="Converting \"C:\\\\msys64\\\\tmp\\\\TestConvertToRaw1483052598\\\\001\\\\qcow.img\" (qcow2) to a raw disk \"C:\\\\msys64\\\\tmp\\\\TestConvertToRaw1483052598\\\\001\\\\TestConvertToRaw\\\\qcow_with_backing_file\""
    nativeimgutil_test.go:77: assertion failed: error is not nil: open C:\msys64\tmp\TestConvertToRaw1483052598\001\TestConvertToRaw\qcow_with_backing_file.lima-831870062.tmp: The system cannot find the path specified.
=== RUN   TestConvertToRaw/qcow_with_extra_size
time="2025-04-23T21:27:30+03:00" level=info msg="Converting \"C:\\\\msys64\\\\tmp\\\\TestConvertToRaw1483052598\\\\001\\\\qcow.img\" (qcow2) to a raw disk \"C:\\\\msys64\\\\tmp\\\\TestConvertToRaw1483052598\\\\001\\\\TestConvertToRaw\\\\qcow_with_extra_size\""
    nativeimgutil_test.go:86: assertion failed: error is not nil: open C:\msys64\tmp\TestConvertToRaw1483052598\001\TestConvertToRaw\qcow_with_extra_size.lima-3723446434.tmp: The system cannot find the path specified.
=== RUN   TestConvertToRaw/raw
time="2025-04-23T21:27:30+03:00" level=info msg="Converting \"C:\\\\msys64\\\\tmp\\\\TestConvertToRaw1483052598\\\\001\\\\raw.img\" (raw) to a raw disk \"C:\\\\msys64\\\\tmp\\\\TestConvertToRaw1483052598\\\\001\\\\TestConvertToRaw\\\\raw\""
    nativeimgutil_test.go:95: assertion failed: error is not nil: failed to copy "C:\\msys64\\tmp\\TestConvertToRaw1483052598\\001\\raw.img" into "C:\\msys64\\tmp\\TestConvertToRaw1483052598\\001\\TestConvertToRaw\\raw": failed to open target C:\msys64\tmp\TestConvertToRaw1483052598\001\TestConvertToRaw\raw: open C:\msys64\tmp\TestConvertToRaw1483052598\001\TestConvertToRaw\raw: The system cannot find the path specified.
--- FAIL: TestConvertToRaw (0.11s)
    --- FAIL: TestConvertToRaw/qcow_without_backing_file (0.00s)
    --- FAIL: TestConvertToRaw/qcow_with_backing_file (0.00s)
    --- FAIL: TestConvertToRaw/qcow_with_extra_size (0.00s)
    --- FAIL: TestConvertToRaw/raw (0.00s)
=== RUN   FuzzConvertToRaw
--- PASS: FuzzConvertToRaw (0.00s)
FAIL
FAIL    github.com/lima-vm/lima/pkg/nativeimgutil       0.902s
```