### PR TITLE
Fix version parsing in case of dirty checkout of a tag

### DIFF
--- a/pkg/version/versionutil/versionutil.go
+++ b/pkg/version/versionutil/versionutil.go
@@ -11,10 +11,12 @@ import (
 
 // Parse parses a Lima version string by removing the leading "v" character and
 // stripping everything from the first "-" forward (which are `git describe` artifacts and
-// not semver pre-release markers). So "v0.19.1-16-gf3dc6ed.m" will be parsed as "0.19.1".
+// not semver pre-release markers) or cutting ".m" suffix from exact version.
+// So "v0.19.1-16-gf3dc6ed.m" will be parsed as "0.19.1".
 func Parse(version string) (*semver.Version, error) {
 	version = strings.TrimPrefix(version, "v")
 	version, _, _ = strings.Cut(version, "-")
+	version = strings.TrimSuffix(version, ".m")
 	return semver.NewVersion(version)
 }
 

--- a/pkg/version/versionutil/versionutil_test.go
+++ b/pkg/version/versionutil/versionutil_test.go
@@ -27,3 +27,17 @@ func TestGreaterEqual(t *testing.T) {
 	assert.Equal(t, GreaterEqual("0.2.0", "0.1.0"), true)
 	assert.Equal(t, GreaterEqual("abacab", "0.1.0"), true)
 }
+
+func TestParse(t *testing.T) {
+	v1, err1 := Parse("v0.19.1-16-gf3dc6ed.m")
+	assert.NilError(t, err1)
+	assert.Equal(t, v1.Major, int64(0))
+	assert.Equal(t, v1.Minor, int64(19))
+	assert.Equal(t, v1.Patch, int64(1))
+
+	v2, err2 := Parse("v0.19.1.m")
+	assert.NilError(t, err2)
+	assert.Equal(t, v2.Major, int64(0))
+	assert.Equal(t, v2.Minor, int64(19))
+	assert.Equal(t, v2.Patch, int64(1))
+}


### PR DESCRIPTION
Fixes #3477

Added basic parsing unit tests.