### PR TITLE
Finish $LIMA_TEMPLATES_PATH, add $LIMA_HOME/_templates

### DIFF
--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -371,16 +371,18 @@ func createStartActionCommon(cmd *cobra.Command, _ []string) (exit bool, err err
 	if listTemplates, err := cmd.Flags().GetBool("list-templates"); err != nil {
 		return true, err
 	} else if listTemplates {
-		if templates, err := templatestore.Templates(); err == nil {
-			w := cmd.OutOrStdout()
-			for _, f := range templates {
-				// Don't show internal base templates like `_default/*` and `_images/*`.
-				if !strings.HasPrefix(f.Name, "_") {
-					_, _ = fmt.Fprintln(w, f.Name)
-				}
-			}
-			return true, nil
+		templates, err := templatestore.Templates()
+		if err != nil {
+			return true, err
 		}
+		w := cmd.OutOrStdout()
+		for _, f := range templates {
+			// Don't show internal base templates like `_default/*` and `_images/*`.
+			if !strings.HasPrefix(f.Name, "_") {
+				_, _ = fmt.Fprintln(w, f.Name)
+			}
+		}
+		return true, nil
 	}
 	return false, nil
 }

--- a/website/content/en/docs/config/environment-variables.md
+++ b/website/content/en/docs/config/environment-variables.md
@@ -30,7 +30,7 @@ This page documents the environment variables used in Lima.
 ### `LIMA_TEMPLATES_PATH`
 
 - **Description**: Specifies the directories used to resolve `template://` URLs.
-- **Default**: `/usr/local/share/lima/templates`
+- **Default**: `$LIMA_HOME/_templates:/usr/local/share/lima/templates`
 - **Usage**:
   ```sh
   export LIMA_TEMPLATES_PATH="$HOME/.config/lima/templates:/usr/local/share/lima/templates"

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -107,6 +107,12 @@ When using `vmType: vz` (Virtualization.framework), on boot, any qcow2 (default)
 
 `ls` will also only show the full/virtual size of the disks. To see the allocated space, `du -h disk_path` or `qemu-img info disk_path` can be used instead. See [#1405](https://github.com/lima-vm/lima/pull/1405) for more details.
 
+## Templates directory (`${LIMA_HOME}/_templates`)
+
+The templates directory can store additional template files that can be referenced with the `template://` schema.
+
+If the template directory exists (and `$LIMA_TEMPLATES_PATH` is not set), then this directory will be searched before the `/usr/local/share/lima/templates` default directory that contains all the templates bundled with Lima itself.
+
 ## Lima cache directory (`~/Library/Caches/lima`)
 
 Currently hard-coded to `~/Library/Caches/lima` on macOS.


### PR DESCRIPTION
#3453 added support to locate templates via `LIMA_TEMPLATES_PATH`.

It was however not listing templates from the additional template directories for e.g. `limactl start --list-templates` and didn't include them in shell completions.

This PR adds the missing functionality, and also adds `$LIMA_HOME/_templates` as a default template search location if the directory exists and `LIMA_TEMPLATES_PATH` is not set.

In addition to making user templates addressable via `template://` schema this also allows the user for example to create `$LIMA_HOME/_templates/_default/mounts.yaml` to override the default mounts used by all the builtin templates.

This PR intentionally uses 3 commits that are related, but independent. I don't think they should be squashed.