### PR TITLE
Set riscv64 cpu to max

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -66,7 +66,7 @@ func defaultCPUType() CPUType {
 		ARMV7L:  "cortex-a7",
 		// Since https://github.com/lima-vm/lima/pull/494, we use qemu64 cpu for better emulation of x86_64.
 		X8664:   "qemu64",
-		RISCV64: "rv64", // FIXME: what is the right choice for riscv64?
+		RISCV64: "max",
 		S390X:   "qemu", // FIXME: what is the right choice for s390x?
 	}
 	for arch := range cpuType {


### PR DESCRIPTION
https://lore.kernel.org/qemu-devel/20250404152750.332791-1-dbarboza@ventanamicro.com/

> [As more] distros use the 'virt' machine, and they'll start building
> on top of RVA23, and rv64 does not have RVA23 support. In short,
> distros will start to break in the default 'virt' CPU.
>
> Changing the default CPU to 'max' will not cause (intentional) user
> regressions: if the software runs in rv64 it will run in 'max' too given
> that we're adding more extensions as default instead of removing them.

To ensure lima works once Ubuntu 25.10 comes out, which is expected to require RV23, set the cpu type to max.