### PR TITLE
Add dirnames.TemplatesDir() function

### DIFF
--- a/pkg/store/dirnames/dirnames.go
+++ b/pkg/store/dirnames/dirnames.go
@@ -65,3 +65,12 @@ func LimaDisksDir() (string, error) {
 	}
 	return filepath.Join(limaDir, filenames.DisksDir), nil
 }
+
+// LimaTemplatesDir returns the path of the templates directory, $LIMA_HOME/_templates.
+func LimaTemplatesDir() (string, error) {
+	limaDir, err := LimaDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(limaDir, filenames.TemplatesDir), nil
+}

--- a/pkg/store/filenames/filenames.go
+++ b/pkg/store/filenames/filenames.go
@@ -10,10 +10,11 @@ package filenames
 // Instance names starting with an underscore are reserved for lima internal usage
 
 const (
-	ConfigDir   = "_config"
-	CacheDir    = "_cache"    // not yet implemented
-	NetworksDir = "_networks" // network log files are stored here
-	DisksDir    = "_disks"    // disks are stored here
+	CacheDir     = "_cache" // not yet implemented
+	ConfigDir    = "_config"
+	DisksDir     = "_disks"     // disks are stored here
+	NetworksDir  = "_networks"  // network log files are stored here
+	TemplatesDir = "_templates" // user templates are stored here
 )
 
 // Filenames used inside the ConfigDir

--- a/pkg/templatestore/templatestore.go
+++ b/pkg/templatestore/templatestore.go
@@ -24,11 +24,11 @@ type Template struct {
 	Location string `json:"location"`
 }
 
-func TemplatesPaths() ([]string, error) {
+func templatesPaths() ([]string, error) {
 	if tmplPath := os.Getenv("LIMA_TEMPLATES_PATH"); tmplPath != "" {
 		return strings.Split(tmplPath, string(filepath.ListSeparator)), nil
 	}
-	limaDir, err := dirnames.LimaDir()
+	limaTemplatesDir, err := dirnames.LimaTemplatesDir()
 	if err != nil {
 		return nil, err
 	}
@@ -37,13 +37,13 @@ func TemplatesPaths() ([]string, error) {
 		return nil, err
 	}
 	return []string{
-		filepath.Join(limaDir, "_templates"),
+		limaTemplatesDir,
 		filepath.Join(shareDir, "templates"),
 	}, nil
 }
 
 func Read(name string) ([]byte, error) {
-	paths, err := TemplatesPaths()
+	paths, err := templatesPaths()
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func Read(name string) ([]byte, error) {
 const Default = "default"
 
 func Templates() ([]Template, error) {
-	paths, err := TemplatesPaths()
+	paths, err := templatesPaths()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
All other special directories have a symbolic filename and dirname function.