### PR TITLE
qemu: tcg: use `max` by default

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -548,7 +548,8 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	// Machine
 	switch *y.Arch {
 	case limayaml.X8664:
-		if strings.HasPrefix(cpu, "qemu64") && runtime.GOOS != "windows" {
+		switch accel {
+		case "tcg":
 			// use q35 machine with vmware io port disabled.
 			args = appendArgsIfNoConflict(args, "-machine", "q35,vmport=off")
 			// use tcg accelerator with multi threading with 512MB translation block size
@@ -559,10 +560,10 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 			// This will disable CPU S3/S4 state.
 			args = append(args, "-global", "ICH9-LPC.disable_s3=1")
 			args = append(args, "-global", "ICH9-LPC.disable_s4=1")
-		} else if runtime.GOOS == "windows" && accel == "whpx" {
+		case "whpx":
 			// whpx: injection failed, MSI (0, 0) delivery: 0, dest_mode: 0, trigger mode: 0, vector: 0
 			args = appendArgsIfNoConflict(args, "-machine", "q35,accel="+accel+",kernel-irqchip=off")
-		} else {
+		default:
 			args = appendArgsIfNoConflict(args, "-machine", "q35,accel="+accel)
 		}
 	case limayaml.AARCH64:

--- a/templates/_images/centos-stream-10.yaml
+++ b/templates/_images/centos-stream-10.yaml
@@ -28,9 +28,3 @@ firmware:
   # CentOS Stream 10 still requires legacyBIOS
   # https://issues.redhat.com/browse/CS-2672
   legacyBIOS: true
-
-cpuType:
-  # When emulating Intel on ARM hosts, Lima uses the "qemu64" CPU by default (https://github.com/lima-vm/lima/pull/494).
-  # However, CentOS Stream 10 kernel reboots indefinitely due to lack of the support for x86_64-v3 instructions.
-  # This issue is tracked in <https://github.com/lima-vm/lima/issues/3063>.
-  x86_64: "Haswell-v4"

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -334,10 +334,10 @@ os: null
 # Setting of instructions is supported like this: "qemu64,+ssse3".
 # 🟢 Builtin default: hard-coded arch map with type (see the output of `limactl info | jq .defaultTemplate.cpuType`)
 cpuType:
-#   aarch64: "cortex-a76" # (or "host" when running on aarch64 host)
-#   armv7l: "cortex-a7" # (or "host" when running on armv7l host)
-#   riscv64: "rv64" # (or "host" when running on riscv64 host)
-#   x86_64: "qemu64" # (or "host,-pdpe1gb" when running on x86_64 host)
+#   aarch64: "max" # (or "host" when running on aarch64 host)
+#   armv7l:  "max" # (or "host" when running on armv7l host)
+#   riscv64: "max" # (or "host" when running on riscv64 host)
+#   x86_64:  "max" # (or "host" when running on x86_64 host; additional options are appended on Intel Mac)
 
 rosetta:
   # Enable Rosetta inside the VM; needs `vmType: vz`


### PR DESCRIPTION
The previous default value `qemu64` for Intel on ARM was unable to boot recent guests as it only supports x86_64 v1 instructions.

CentOS Stream 10 is known to need x86_64 v3 or later.

Fix #3063