### PR TITLE
Clean up codes for QEMU < 7.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -523,3 +523,34 @@ jobs:
         go-version: 1.24.x
     - run: GOOS=netbsd go build ./...
     - run: GOOS=dragonfly go build ./...
+
+  qemu-linux-old:
+    name: "Smoke tests (QEMU, old Linux host)"
+    runs-on: ubuntu-22.04  # QEMU 6.2
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      with:
+        # To avoid "failed to load YAML file \"templates/experimental/riscv64.yaml\": can't parse builtin Lima version \"3f3a6f6\": 3f3a6f6 is not in dotted-tri format"
+        fetch-depth: 0
+    - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+      with:
+        go-version: 1.24.x
+    - name: Make
+      run: make
+    - name: Install
+      run: sudo make install
+    - name: Cache image used by templates/default.yaml
+      uses: ./.github/actions/setup_cache_for_template
+      with:
+        template: templates/default.yaml
+    - name: Install test dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends ovmf qemu-system-x86 qemu-utils
+        qemu-system-x86_64 --version
+        sudo modprobe kvm
+        # `sudo usermod -aG kvm $(whoami)` does not take an effect on GHA
+        sudo chown $(whoami) /dev/kvm
+    - name: Smoke test
+      run: limactl start --tty=false

--- a/website/content/en/docs/config/vmtype.md
+++ b/website/content/en/docs/config/vmtype.md
@@ -29,6 +29,10 @@ unless the config is incompatible with VZ. (e.g., legacyBIOS or 9p is enabled)
 ## QEMU
 "qemu" option makes use of QEMU to run guest operating system. 
 
+Recommended QEMU version:
+- v8.2.1 or later (macOS)
+- v6.2.0 or later (Linux)
+
 ## VZ
 
 | ⚡ Requirement | Lima >= 0.14, macOS >= 13.0 |

--- a/website/content/en/docs/installation/_index.md
+++ b/website/content/en/docs/installation/_index.md
@@ -10,7 +10,7 @@ Supported host OS:
 - Windows (untested)
 
 Prerequisite:
-- QEMU 7.1 or later (Required, only if QEMU driver is used)
+- QEMU (Required, only if [QEMU]({{< ref "/docs/config/vmtype#qemu" >}}) driver is used)
 
 {{< tabpane text=true >}}
 


### PR DESCRIPTION
- QEMU 7.0 is documented as the minimum requirement since 9eb13960f1f5b581e0ba814a70741234695c7672 (Dec 2022)
- Also clean up the hint for QEMU 8.2.0, as QEMU 8.2.0 users should have already updated QEMU to 8.2.1+
- QEMU 4.0 is still exceptionally allowed on linux/amd64 for the compatibility reason, but not tested
- QEMU 6.2 is added to the CI
