### PR TITLE
Makefile: split lima-additional-guestagents-*.tar.gz from  lima-*.tar.gz

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,8 @@ jobs:
       run: make artifacts-linux
     - name: "Make misc artifacts"
       run: make artifacts-misc
+    - name: "Validate artifactts"
+      run: ./hack/validate-artifact.sh ./_artifacts/*.tar.gz
     - name: "SHA256SUMS"
       run: |
         ( cd _artifacts; sha256sum *.tar.gz ) | tee /tmp/SHA256SUMS

--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ ALL_GUESTAGENTS = $(addsuffix $(gz),$(ALL_GUESTAGENTS_NOT_COMPRESSED))
 guestagent_path = $(foreach arch,$(2),$($(1)_GUESTAGENT_PATH_COMMON)$(arch)$(gz))
 
 ifeq ($(CONFIG_GUESTAGENT_OS_LINUX),y)
-NATIVE_GUESTAGENT_ARCH = $(shell uname -m | sed -e s/arm64/aarch64/)
+NATIVE_GUESTAGENT_ARCH = $(shell echo $(GOARCH) | sed -e s/arm64/aarch64/ -e s/arm/armv7l/ -e s/amd64/x86_64/)
 NATIVE_GUESTAGENT = $(call guestagent_path,LINUX,$(NATIVE_GUESTAGENT_ARCH))
 ADDITIONAL_GUESTAGENT_ARCHS = $(filter-out $(NATIVE_GUESTAGENT_ARCH),$(LINUX_GUESTAGENT_ARCHS))
 ADDITIONAL_GUESTAGENTS = $(call guestagent_path,LINUX,$(ADDITIONAL_GUESTAGENT_ARCHS))

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ exe: _output/bin/limactl$(exe)
 
 .PHONY: minimal native
 minimal: clean limactl native-guestagent default_template
-native: clean limactl helpers native-guestagent templates
+native: clean limactl helpers native-guestagent templates template_experimentals
 
 ################################################################################
 # Kconfig

--- a/Makefile
+++ b/Makefile
@@ -581,7 +581,7 @@ artifact-%-arm64 artifact-%-aarch64 artifact-arm64 artifact-aarch64: GOARCH = ar
 
 # build cross arch binaries.
 artifact-%: $$(call generate_manpages_if_needed)
-	make artifact GOOS=$(GOOS) GOARCH=$(GOARCH)
+	make clean artifact GOOS=$(GOOS) GOARCH=$(GOARCH)
 
 .PHONY: artifacts-misc
 artifacts-misc: | _artifacts

--- a/Makefile
+++ b/Makefile
@@ -509,6 +509,7 @@ generate:
 
 ################################################################################
 # _artifacts/lima-$(VERSION_TRIMMED)-$(ARTIFACT_OS)-$(ARTIFACT_UNAME_M)
+# _artifacts/lima-additional-guestagents-$(VERSION_TRIMMED)-$(ARTIFACT_OS)-$(ARTIFACT_UNAME_M)
 .PHONY: artifact
 
 # returns the capitalized string of $(1).
@@ -534,11 +535,13 @@ endif
 ARTIFACT_OS = $(call capitalize,$(GOOS))
 ARTIFACT_UNAME_M = $(call to_uname_m,$(GOARCH))
 ARTIFACT_PATH_COMMON = _artifacts/lima-$(VERSION_TRIMMED)-$(ARTIFACT_OS)-$(ARTIFACT_UNAME_M)
+ARTIFACT_ADDITIONAL_GUESTAGENTS_PATH_COMMON = _artifacts/lima-additional-guestagents-$(VERSION_TRIMMED)-$(ARTIFACT_OS)-$(ARTIFACT_UNAME_M)
 
-artifact: $(addprefix $(ARTIFACT_PATH_COMMON),$(ARTIFACT_FILE_EXTENSIONS))
+artifact: $(addprefix $(ARTIFACT_PATH_COMMON),$(ARTIFACT_FILE_EXTENSIONS)) \
+	$(addprefix $(ARTIFACT_ADDITIONAL_GUESTAGENTS_PATH_COMMON),$(ARTIFACT_FILE_EXTENSIONS))
 
 ARTIFACT_DES =  _output/bin/limactl$(exe) $(LIMA_DEPS) $(HELPERS_DEPS) \
-	$(ALL_GUESTAGENTS) \
+	$(NATIVE_GUESTAGENT) \
 	$(TEMPLATES) $(TEMPLATE_EXPERIMENTALS) \
 	$(DOCUMENTATION) _output/share/doc/lima/templates \
 	_output/share/man/man1/limactl.1
@@ -547,7 +550,16 @@ ARTIFACT_DES =  _output/bin/limactl$(exe) $(LIMA_DEPS) $(HELPERS_DEPS) \
 $(ARTIFACT_PATH_COMMON).tar.gz: $(ARTIFACT_DES) | _artifacts
 	$(TAR) -C _output/ --no-xattrs -czvf $@ ./
 
+$(ARTIFACT_ADDITIONAL_GUESTAGENTS_PATH_COMMON).tar.gz:
+	# FIXME: do not exec make from make
+	make clean additional-guestagents
+	$(TAR) -C _output/ --no-xattrs -czvf $@ ./
+
 $(ARTIFACT_PATH_COMMON).zip: $(ARTIFACT_DES) | _artifacts
+	cd _output && $(ZIP) -r ../$@ *
+
+$(ARTIFACT_ADDITIONAL_GUESTAGENTS_PATH_COMMON).zip:
+	make clean additional-guestagents
 	cd _output && $(ZIP) -r ../$@ *
 
 # generate manpages using native limactl.

--- a/hack/validate-artifact.sh
+++ b/hack/validate-artifact.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script validates that lima-<VERSION>-Darwin-arm64.tar.gz
+# contains lima-guestagent.Linux-aarch64
+# but does not contain share/lima/lima-guestagent.Linux-x86_64
+
+set -eu -o pipefail
+
+must_contain() {
+	tmp="$(mktemp)"
+	tar tzf "$1" >"$tmp"
+	if ! grep -q "$2" "$tmp"; then
+		echo >&2 "ERROR: $1 must contain $2"
+		cat "$tmp"
+		rm -f "$tmp"
+		exit 1
+	fi
+	rm -f "$tmp"
+}
+
+must_not_contain() {
+	tmp="$(mktemp)"
+	tar tzf "$1" >"$tmp"
+	if grep -q "$2" "$tmp"; then
+		echo >&2 "ERROR: $1 must not contain $2"
+		cat "$tmp"
+		rm -f "$tmp"
+		exit 1
+	fi
+	rm -f "$tmp"
+}
+
+validate_artifact() {
+	FILE="$1"
+	MYARCH="x86_64"
+	OTHERARCH="aarch64"
+	if [[ $FILE == *"aarch64"* || $FILE == *"arm64"* ]]; then
+		MYARCH="aarch64"
+		OTHERARCH="x86_64"
+	fi
+	if [[ $FILE == *"go-mod-vendor.tar.gz" ]]; then
+		: NOP
+	elif [[ $FILE == *"lima-additional-guestagents"*".tar.gz" ]]; then
+		must_not_contain "$FILE" "lima-guestagent.Linux-$MYARCH"
+		must_contain "$FILE" "lima-guestagent.Linux-$OTHERARCH"
+	elif [[ $FILE == *"lima-"*".tar.gz" ]]; then
+		must_not_contain "$FILE" "lima-guestagent.Linux-$OTHERARCH"
+		must_contain "$FILE" "lima-guestagent.Linux-$MYARCH"
+	else
+		echo >&2 "ERROR: Unexpected file: $FILE"
+		exit 1
+	fi
+}
+
+for FILE in "$@"; do
+	validate_artifact "$FILE"
+done

--- a/website/content/en/docs/installation/_index.md
+++ b/website/content/en/docs/installation/_index.md
@@ -45,6 +45,9 @@ and extract it under `/usr/local` (or somewhere else).
 ```bash
 VERSION=$(curl -fsSL https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
 curl -fsSL "https://github.com/lima-vm/lima/releases/download/${VERSION}/lima-${VERSION:1}-$(uname -s)-$(uname -m).tar.gz" | tar Cxzvm /usr/local
+
+# For Lima v1.1 onward
+curl -fsSL "https://github.com/lima-vm/lima/releases/download/${VERSION}/lima-additional-guestagents-${VERSION:1}-$(uname -s)-$(uname -m).tar.gz" | tar Cxzvm /usr/local
 ```
 {{% /tab %}}
 {{< /tabpane >}}

--- a/website/content/en/docs/installation/source.md
+++ b/website/content/en/docs/installation/source.md
@@ -36,13 +36,21 @@ export PATH=$HOME/.local/bin:$PATH
 ## Packaging Lima for Distribution
 After building Lima from source, you may want to package it for installation on other machines:
 
+1. The package for the core component and the native guest agent:
 ```bash
+make clean native
 cd _output
-# Create a compressed archive
 tar czf lima-package.tar.gz *
 ```
 
-This package can then be transferred and installed on the target system.
+2. The package for the additional guest agents:
+```
+make clean additional-guestagents
+cd _output
+tar czf lima-additional-guestagents-package.tar.gz *
+```
+
+These packages can then be transferred and installed on the target system.
 
 ## Advanced Configuration with Kconfig Tools
 (This step is not needed for most users)


### PR DESCRIPTION
`make artifact` now produces two archives that will be uploaded to <https://github.com/lima-vm/lima/releases>:

1. `lima-<VERSION>-Darwin-arm64.tar.gz`: (`make native`)
  - core components (bin/limactl, share/lima/templates, ...)
  - share/lima/lima-guestagent.Linux-aarch64

2. `lima-additional-guestagents-<VERSION>-Darwin-arm64.tar.gz`: (`make additional-guestagents`)
  - share/lima/lima-guestagent.Linux-armv7l
  - share/lima/lima-guestagent.Linux-ppc64le
  - share/lima/lima-guestagent.Linux-riscv64
  - share/lima/lima-guestagent.Linux-s390x
  - share/lima/lima-guestagent.Linux-x86_64

For compatibility reason, `make` still builds the guestagents for all the architectures by default.

Package maintainers are suggested to split `lima` package to `lima` and `lima-additional-guestagents`.

Fix #3321