### PR TITLE
guestagent refactoring

### DIFF
--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -32,6 +32,7 @@ func newHostagentCommand() *cobra.Command {
 	hostagentCommand.Flags().StringP("pidfile", "p", "", "Write PID to file")
 	hostagentCommand.Flags().String("socket", "", "Path of hostagent socket")
 	hostagentCommand.Flags().Bool("run-gui", false, "Run GUI synchronously within hostagent")
+	hostagentCommand.Flags().String("guestagent", "", "Local file path (not URL) of lima-guestagent.OS-ARCH[.gz]")
 	hostagentCommand.Flags().String("nerdctl-archive", "", "Local file path (not URL) of nerdctl-full-VERSION-GOOS-GOARCH.tar.gz")
 	return hostagentCommand
 }
@@ -78,6 +79,13 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 
 	initLogrus(stderr)
 	var opts []hostagent.Opt
+	guestagentBinary, err := cmd.Flags().GetString("guestagent")
+	if err != nil {
+		return err
+	}
+	if guestagentBinary != "" {
+		opts = append(opts, hostagent.WithGuestAgentBinary(guestagentBinary))
+	}
 	nerdctlArchive, err := cmd.Flags().GetString("nerdctl-archive")
 	if err != nil {
 		return err

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -75,10 +75,18 @@ type HostAgent struct {
 }
 
 type options struct {
-	nerdctlArchive string // local path, not URL
+	guestAgentBinary string
+	nerdctlArchive   string // local path, not URL
 }
 
 type Opt func(*options) error
+
+func WithGuestAgentBinary(s string) Opt {
+	return func(o *options) error {
+		o.guestAgentBinary = s
+		return nil
+	}
+}
 
 func WithNerdctlArchive(s string) Opt {
 	return func(o *options) error {
@@ -134,7 +142,7 @@ func New(instName string, stdout io.Writer, signalCh chan os.Signal, opts ...Opt
 	if err := cidata.GenerateCloudConfig(inst.Dir, instName, inst.Config); err != nil {
 		return nil, err
 	}
-	if err := cidata.GenerateISO9660(inst.Dir, instName, inst.Config, udpDNSLocalPort, tcpDNSLocalPort, o.nerdctlArchive, vSockPort, virtioPort); err != nil {
+	if err := cidata.GenerateISO9660(inst.Dir, instName, inst.Config, udpDNSLocalPort, tcpDNSLocalPort, o.guestAgentBinary, o.nerdctlArchive, vSockPort, virtioPort); err != nil {
 		return nil, err
 	}
 

--- a/pkg/infoutil/infoutil.go
+++ b/pkg/infoutil/infoutil.go
@@ -4,19 +4,29 @@
 package infoutil
 
 import (
+	"errors"
+	"io/fs"
+
 	"github.com/lima-vm/lima/pkg/driverutil"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/templatestore"
+	"github.com/lima-vm/lima/pkg/usrlocalsharelima"
 	"github.com/lima-vm/lima/pkg/version"
+	"github.com/sirupsen/logrus"
 )
 
 type Info struct {
-	Version         string                   `json:"version"`
-	Templates       []templatestore.Template `json:"templates"`
-	DefaultTemplate *limayaml.LimaYAML       `json:"defaultTemplate"`
-	LimaHome        string                   `json:"limaHome"`
-	VMTypes         []string                 `json:"vmTypes"` // since Lima v0.14.2
+	Version         string                       `json:"version"`
+	Templates       []templatestore.Template     `json:"templates"`
+	DefaultTemplate *limayaml.LimaYAML           `json:"defaultTemplate"`
+	LimaHome        string                       `json:"limaHome"`
+	VMTypes         []string                     `json:"vmTypes"`     // since Lima v0.14.2
+	GuestAgents     map[limayaml.Arch]GuestAgent `json:"guestAgents"` // since Lima v1.1.0
+}
+
+type GuestAgent struct {
+	Location string `json:"location"` // since Lima v1.1.0
 }
 
 func GetInfo() (*Info, error) {
@@ -32,6 +42,7 @@ func GetInfo() (*Info, error) {
 		Version:         version.Version,
 		DefaultTemplate: y,
 		VMTypes:         driverutil.Drivers(),
+		GuestAgents:     make(map[limayaml.Arch]GuestAgent),
 	}
 	info.Templates, err = templatestore.Templates()
 	if err != nil {
@@ -40,6 +51,20 @@ func GetInfo() (*Info, error) {
 	info.LimaHome, err = dirnames.LimaDir()
 	if err != nil {
 		return nil, err
+	}
+	for _, arch := range limayaml.ArchTypes {
+		bin, err := usrlocalsharelima.GuestAgentBinary(limayaml.LINUX, arch)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				logrus.WithError(err).Debugf("Failed to resolve the guest agent binary for %q", arch)
+			} else {
+				logrus.WithError(err).Warnf("Failed to resolve the guest agent binary for %q", arch)
+			}
+			continue
+		}
+		info.GuestAgents[arch] = GuestAgent{
+			Location: bin,
+		}
 	}
 	return info, nil
 }


### PR DESCRIPTION
## Commit 1: guestagent:  prioritize BIN.gz over BIN
    
When both `lima-guestagent.Linux-<ARCH>` and `lima-guestagent.Linux-<ARCH>.gz` are present, the compressed one is chosen with a warning.
    
Preparation for:
- #3325

- - -
## Commit 2: limactl info: show the detected guest agent paths

- - -

## Commit 3: hostagent: verify existence of guestagent earlier