### PR TITLE
website: unlink hijacked devops toolkit series link

### DIFF
--- a/website/content/en/docs/talks/_index.md
+++ b/website/content/en/docs/talks/_index.md
@@ -21,7 +21,7 @@ Read the [slides](https://www.slideshare.net/AkihiroSuda/cncf-tagruntime-2022100
 ## 2023
 ### DevOps Toolkit 2023-02-09
 
-[Anders Björklund](https://github.com/afbjorklund) presented Lima in [The DevOps Toolkit Series](https://www.devopstoolkitseries.com/).
+[Anders Björklund](https://github.com/afbjorklund) presented Lima in The DevOps Toolkit Series.
 
 Watch the [video](https://www.youtube.com/watch?v=GDInFocQJTU).
 


### PR DESCRIPTION
This link in the talks page redirects to some site that wouldn't surprise me if it was trying to shift malware. (Some strange poker game behind what looked like a captcha). I guess the domain has changed hands.

```
% curl --head https://www.devopstoolkitseries.com/
HTTP/2 301 
date: Wed, 07 May 2025 22:23:17 GMT
location: https://www.theoutletshoppesatburlington.com/
server: cloudflare
...
```