### PR TITLE
Move jsonschema validation into a utility dir

### DIFF
--- a/cmd/limactl/genschema.go
+++ b/cmd/limactl/genschema.go
@@ -9,10 +9,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/goccy/go-yaml"
 	"github.com/invopop/jsonschema"
+	"github.com/lima-vm/lima/pkg/jsonschemautil"
 	"github.com/lima-vm/lima/pkg/limayaml"
-	jsonschema2 "github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/spf13/cobra"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 
@@ -81,22 +80,8 @@ func genschemaAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	compiler := jsonschema2.NewCompiler()
-	schema2, err := compiler.Compile(file)
-	if err != nil {
-		return err
-	}
 	for _, f := range args {
-		b, err := os.ReadFile(f)
-		if err != nil {
-			return err
-		}
-		var y any
-		err = yaml.Unmarshal(b, &y)
-		if err != nil {
-			return err
-		}
-		err = schema2.Validate(y)
+		err = jsonschemautil.Validate(file, f)
 		if err != nil {
 			return fmt.Errorf("%q: %w", f, err)
 		}

--- a/pkg/jsonschemautil/jsonschemautil.go
+++ b/pkg/jsonschemautil/jsonschemautil.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package jsonschemautil
+
+import (
+	"os"
+
+	"github.com/goccy/go-yaml"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+func Validate(schemafile, instancefile string) error {
+	compiler := jsonschema.NewCompiler()
+	schema, err := compiler.Compile(schemafile)
+	if err != nil {
+		return err
+	}
+	instance, err := os.ReadFile(instancefile)
+	if err != nil {
+		return err
+	}
+	var y any
+	err = yaml.Unmarshal(instance, &y)
+	if err != nil {
+		return err
+	}
+	return schema.Validate(y)
+}

--- a/pkg/jsonschemautil/jsonschemautil_test.go
+++ b/pkg/jsonschemautil/jsonschemautil_test.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package jsonschemautil
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestValidateValidInstance(t *testing.T) {
+	schema := "testdata/schema.json"
+	instance := "testdata/valid.yaml"
+	err := Validate(schema, instance)
+	assert.NilError(t, err)
+}
+
+func TestValidateInvalidInstance(t *testing.T) {
+	schema := "testdata/schema.json"
+	instance := "testdata/invalid.yaml"
+	err := Validate(schema, instance)
+	assert.ErrorContains(t, err, "jsonschema validation failed")
+}

--- a/pkg/jsonschemautil/testdata/invalid.yaml
+++ b/pkg/jsonschemautil/testdata/invalid.yaml
@@ -1,0 +1,2 @@
+name: John Doe
+age: "30"

--- a/pkg/jsonschemautil/testdata/schema.json
+++ b/pkg/jsonschemautil/testdata/schema.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "age": {
+      "type": "integer"
+    }
+  }
+}

--- a/pkg/jsonschemautil/testdata/valid.yaml
+++ b/pkg/jsonschemautil/testdata/valid.yaml
@@ -1,0 +1,2 @@
+name: John Doe
+age: 30


### PR DESCRIPTION
This performs the same task as py "check-jsonschema" or "jv".

But included with Lima, instead of being a separate CLI tool.

Add simple example, for unit test.

See https://tour.json-schema.org/

Closes #3510

It is a little wasteful to compile the schema everytime, but on the other hand it doesn't take long to run.

~~We don't _actually_ validate that the jsonschema library works here, but we could do that if we wanted to...~~