### PR TITLE
vz: Intel Mac: warn if macOS < 15.5

### DIFF
--- a/templates/_images/fedora-42.yaml
+++ b/templates/_images/fedora-42.yaml
@@ -11,6 +11,6 @@ images:
   arch: riscv64
   digest: sha256:537c67710f4f1c9112fecaafafc293b649acd1d35b46619b97b5a5a0132241b0
 
-# # NOTE: Intel Mac requires setting vmType to qemu
+# # NOTE: Intel Mac with macOS prior to 15.5 requires setting vmType to qemu
 # # https://github.com/lima-vm/lima/issues/3334
 # vmType: qemu

--- a/templates/_images/ubuntu-25.04.yaml
+++ b/templates/_images/ubuntu-25.04.yaml
@@ -41,6 +41,6 @@ images:
 - location: https://cloud-images.ubuntu.com/releases/plucky/release/ubuntu-25.04-server-cloudimg-ppc64el.img
   arch: ppc64le
 
-# # NOTE: Intel Mac requires setting vmType to qemu
+# # NOTE: Intel Mac with macOS prior to 15.5 requires setting vmType to qemu
 # # https://github.com/lima-vm/lima/issues/3334
 # vmType: qemu


### PR DESCRIPTION
On Intel Mac with vz, macOS 15.5 or later is needed to boot Linux 6.12 and later. (Ubuntu 25.04, Fedora 42, etc.)

Update issue:
- #3334