### PR TITLE
Rename infoutil.GetInfo() to info.New()

### DIFF
--- a/cmd/limactl/info.go
+++ b/cmd/limactl/info.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/lima-vm/lima/pkg/infoutil"
+	"github.com/lima-vm/lima/pkg/limainfo"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +23,7 @@ func newInfoCommand() *cobra.Command {
 }
 
 func infoAction(cmd *cobra.Command, _ []string) error {
-	info, err := infoutil.GetInfo()
+	info, err := limainfo.New()
 	if err != nil {
 		return err
 	}

--- a/pkg/limainfo/limainfo.go
+++ b/pkg/limainfo/limainfo.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright The Lima Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package infoutil
+package limainfo
 
 import (
 	"errors"
@@ -16,7 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type Info struct {
+type LimaInfo struct {
 	Version         string                       `json:"version"`
 	Templates       []templatestore.Template     `json:"templates"`
 	DefaultTemplate *limayaml.LimaYAML           `json:"defaultTemplate"`
@@ -29,7 +29,10 @@ type GuestAgent struct {
 	Location string `json:"location"` // since Lima v1.1.0
 }
 
-func GetInfo() (*Info, error) {
+// New returns a LimaInfo object with the Lima version, a list of all Templates and their location,
+// the DefaultTemplate corresponding to template://default with all defaults filled in, the
+// LimaHome location, a list of all supported VMTypes, and a map of GuestAgents for each architecture.
+func New() (*LimaInfo, error) {
 	b, err := templatestore.Read(templatestore.Default)
 	if err != nil {
 		return nil, err
@@ -38,7 +41,7 @@ func GetInfo() (*Info, error) {
 	if err != nil {
 		return nil, err
 	}
-	info := &Info{
+	info := &LimaInfo{
 		Version:         version.Version,
 		DefaultTemplate: y,
 		VMTypes:         driverutil.Drivers(),


### PR DESCRIPTION
As discussed on Slack, rename `infoutil` to `limainfo`[^1] because we are over-using the `util` suffix in our package names.

[^1]: I suggested to use just `info`, but think `limainfo` is a better name, that is still reasonably short.