### PR TITLE
info: silence "guest agent binary could not be found"

### DIFF
--- a/pkg/usrlocalsharelima/usrlocalsharelima.go
+++ b/pkg/usrlocalsharelima/usrlocalsharelima.go
@@ -115,7 +115,7 @@ func GuestAgentBinary(ostype limayaml.OS, arch limayaml.Arch) (string, error) {
 	res, err := chooseGABinary([]string{comp, uncomp})
 	if err != nil {
 		logrus.Debug(err)
-		return "", fmt.Errorf("guest agent binary could not be found for %s-%s (Hint: try installing `lima-additional-guestagents` package)", ostype, arch)
+		return "", fmt.Errorf("guest agent binary could not be found for %s-%s: %w (Hint: try installing `lima-additional-guestagents` package)", ostype, arch, err)
 	}
 	return res, nil
 }


### PR DESCRIPTION
Fix #3570

`pkg/limainfo` expects `fs.ErrNoExist` when the guest agent binary could not be found

https://github.com/lima-vm/lima/blob/44f3da4a6a734730a663612661b851be1ece60cd/pkg/limainfo/limainfo.go#L59-L67