### PR TITLE
Allow dotted instance names in `limactl start`

### DIFF
--- a/pkg/limatmpl/locator_test.go
+++ b/pkg/limatmpl/locator_test.go
@@ -61,3 +61,64 @@ func TestInstNameFromImageURL(t *testing.T) {
 		assert.Equal(t, name, "rocky-8-9.10")
 	})
 }
+
+func TestSeemsTemplateURL(t *testing.T) {
+	arg := "template://foo/bar"
+	t.Run(arg, func(t *testing.T) {
+		is, name := limatmpl.SeemsTemplateURL(arg)
+		assert.Equal(t, is, true)
+		assert.Equal(t, name, "foo/bar")
+	})
+	notTemplateURLs := []string{
+		"file:///foo",
+		"http://foo",
+		"https://foo",
+		"foo",
+	}
+	for _, arg := range notTemplateURLs {
+		t.Run(arg, func(t *testing.T) {
+			is, _ := limatmpl.SeemsTemplateURL(arg)
+			assert.Equal(t, is, false)
+		})
+	}
+}
+
+func TestSeemsHTTPURL(t *testing.T) {
+	httpURLs := []string{
+		"http://foo/",
+		"https://foo/",
+	}
+	for _, arg := range httpURLs {
+		t.Run(arg, func(t *testing.T) {
+			assert.Equal(t, limatmpl.SeemsHTTPURL(arg), true)
+		})
+	}
+	notHTTPURLs := []string{
+		"file:///foo",
+		"template://foo",
+		"foo",
+	}
+	for _, arg := range notHTTPURLs {
+		t.Run(arg, func(t *testing.T) {
+			assert.Equal(t, limatmpl.SeemsHTTPURL(arg), false)
+		})
+	}
+}
+
+func TestSeemsFileURL(t *testing.T) {
+	arg := "file:///foo"
+	t.Run(arg, func(t *testing.T) {
+		assert.Equal(t, limatmpl.SeemsFileURL(arg), true)
+	})
+	notFileURLs := []string{
+		"http://foo",
+		"https://foo",
+		"template://foo",
+		"foo",
+	}
+	for _, arg := range notFileURLs {
+		t.Run(arg, func(t *testing.T) {
+			assert.Equal(t, limatmpl.SeemsFileURL(arg), false)
+		})
+	}
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -5,6 +5,7 @@ package store
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,6 +42,19 @@ func Validate() error {
 		if _, err := os.Stat(yamlPath); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// ValidateInstName checks if the name is a valid instance name. For this it needs to
+// be a valid identifier, and not end in .yml or .yaml (case insensitively).
+func ValidateInstName(name string) error {
+	if err := identifiers.Validate(name); err != nil {
+		return fmt.Errorf("instance name %q is not a valid identifier: %w", name, err)
+	}
+	lower := strings.ToLower(name)
+	if strings.HasSuffix(lower, ".yml") || strings.HasSuffix(lower, ".yaml") {
+		return fmt.Errorf("instance name %q must not end with .yml or .yaml suffix", name)
 	}
 	return nil
 }
@@ -93,7 +107,7 @@ func Disks() ([]string, error) {
 // InstanceDir returns the instance dir.
 // InstanceDir does not check whether the instance exists.
 func InstanceDir(name string) (string, error) {
-	if err := identifiers.Validate(name); err != nil {
+	if err := ValidateInstName(name); err != nil {
 		return "", err
 	}
 	limaDir, err := dirnames.LimaDir()

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestValidateInstName(t *testing.T) {
+	instNames := []string{
+		"default",
+		"Ubuntu-20.04",
+		"example.com",
+		"under_score",
+		"1-2_3.4",
+		"yml",
+		"yaml",
+		"foo.yaml.com",
+	}
+	for _, arg := range instNames {
+		t.Run(arg, func(t *testing.T) {
+			err := ValidateInstName(arg)
+			assert.NilError(t, err)
+		})
+	}
+	invalidIdentifiers := []string{
+		"",
+		"my/instance",
+		"my\\instance",
+		"c:default",
+		"dot.",
+		".dot",
+		"dot..dot",
+		"underscore_",
+		"_underscore",
+		"underscore__underscore",
+		"dash-",
+		"-dash",
+		"dash--dash",
+	}
+	for _, arg := range invalidIdentifiers {
+		t.Run(arg, func(t *testing.T) {
+			err := ValidateInstName(arg)
+			assert.ErrorContains(t, err, "not a valid identifier")
+		})
+	}
+	yamlNames := []string{
+		"default.yaml",
+		"MY.YAML",
+		"My.YmL",
+	}
+	for _, arg := range yamlNames {
+		t.Run(arg, func(t *testing.T) {
+			err := ValidateInstName(arg)
+			assert.ErrorContains(t, err, "must not end with .y")
+		})
+	}
+}


### PR DESCRIPTION
`limatmpl.Read()` no longer returns an empty template when called with an instance name because it now needs to be able to read any kind of file via the `template://` mechanism.

This commit changes the callers to no longer call `limatmpl.Read()` with an instance name. This also allows simplification of the locator type selection: every locator that is not a URL can now be treated as a local file.

Fixes #3574