### PR TITLE
go.mod: drop dependency on github.com/containerd/containerd

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,26 @@
+Lima
+Copyright The Lima Authors.
+
+This project contains portions of other projects that are licensed under the terms of Apache License 2.0.
+The NOTICE files of those projects are replicated here for compliance of the section 4(d) of the license.
+
+=== https://github.com/containerd/containerd ===
+https://github.com/containerd/containerd/blob/v2.1.1/LICENSE
+https://github.com/containerd/containerd/blob/v2.1.1/NOTICE
+
+> Docker
+> Copyright 2012-2015 Docker, Inc.
+>
+> This product includes software developed at Docker, Inc. (https://www.docker.com).
+>
+> The following is courtesy of our legal counsel:
+>
+>
+> Use and transfer of Docker may be subject to certain restrictions by the
+> United States and other governments.
+> It is your responsibility to ensure that your use and/or transfer does not
+> violate applicable laws.
+>
+> For more information, please see https://www.bis.doc.gov
+>
+> See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/balajiv113/fd v0.0.0-20230330094840-143eec500f3e
 	github.com/cheggaaa/pb/v3 v3.1.7 // gomodjail:unconfined
-	github.com/containerd/containerd v1.7.27
 	github.com/containerd/continuity v0.4.5
 	github.com/containers/gvisor-tap-vsock v0.8.6 // gomodjail:unconfined
 	github.com/coreos/go-semver v0.3.1
@@ -63,7 +62,6 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.7.1 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/digitalocean/go-libvirt v0.0.0-20220804181439-8648fbde413e // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,12 +32,8 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cheggaaa/pb/v3 v3.1.7 h1:2FsIW307kt7A/rz/ZI2lvPO+v3wKazzE4K/0LtTWsOI=
 github.com/cheggaaa/pb/v3 v3.1.7/go.mod h1:/Ji89zfVPeC/u5j8ukD0MBPHt2bzTYp74lQ7KlgFWTQ=
-github.com/containerd/containerd v1.7.27 h1:yFyEyojddO3MIGVER2xJLWoCIn+Up4GaHFquP7hsFII=
-github.com/containerd/containerd v1.7.27/go.mod h1:xZmPnl75Vc+BLGt4MIfu6bp+fy03gdHAn9bz+FreFR0=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
-github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
-github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containers/gvisor-tap-vsock v0.8.6 h1:9SeAXK+K2o36CtrgYk6zRXbU3zrayjvkrI8b7/O6u5A=

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -11,8 +11,7 @@ import (
 	"io/fs"
 	"path"
 
-	"github.com/containerd/containerd/identifiers"
-
+	"github.com/lima-vm/lima/pkg/identifiers"
 	"github.com/lima-vm/lima/pkg/iso9660util"
 	"github.com/lima-vm/lima/pkg/textutil"
 )

--- a/pkg/identifiers/validate.go
+++ b/pkg/identifiers/validate.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// From https://github.com/containerd/containerd/blob/v2.1.1/pkg/identifiers/validate.go
+// SPDX-FileCopyrightText: Copyright The containerd Authors
+// LICENSE: https://github.com/containerd/containerd/blob/v2.1.1/LICENSE
+// NOTICE: https://github.com/containerd/containerd/blob/v2.1.1/NOTICE
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package identifiers provides common validation for identifiers and keys
+// across Lima (originally from containerd).
+//
+// Identifiers in Lima must be a alphanumeric, allowing limited
+// underscores, dashes and dots.
+//
+// While the character set may be expanded in the future, identifiers
+// are guaranteed to be safely used as filesystem path components.
+package identifiers
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+const (
+	maxLength  = 76
+	alphanum   = `[A-Za-z0-9]+`
+	separators = `[._-]`
+)
+
+// identifierRe defines the pattern for valid identifiers.
+var identifierRe = regexp.MustCompile(reAnchor(alphanum + reGroup(separators+reGroup(alphanum)) + "*"))
+
+// Validate returns nil if the string s is a valid identifier.
+//
+// Identifiers are similar to the domain name rules according to RFC 1035, section 2.3.1. However
+// rules in this package are relaxed to allow numerals to follow period (".") and mixed case is
+// allowed.
+//
+// In general identifiers that pass this validation should be safe for use as filesystem path components.
+func Validate(s string) error {
+	if s == "" {
+		return errors.New("identifier must not be empty")
+	}
+
+	if len(s) > maxLength {
+		return fmt.Errorf("identifier %q greater than maximum length (%d characters)", s, maxLength)
+	}
+
+	if !identifierRe.MatchString(s) {
+		return fmt.Errorf("identifier %q must match %v", s, identifierRe)
+	}
+	return nil
+}
+
+func reGroup(s string) string {
+	return `(?:` + s + `)`
+}
+
+func reAnchor(s string) string {
+	return `^` + s + `$`
+}

--- a/pkg/identifiers/validate_test.go
+++ b/pkg/identifiers/validate_test.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// From https://github.com/containerd/containerd/blob/v2.1.1/pkg/identifiers/validate_test.go
+// SPDX-FileCopyrightText: Copyright The containerd Authors
+// LICENSE: https://github.com/containerd/containerd/blob/v2.1.1/LICENSE
+// NOTICE: https://github.com/containerd/containerd/blob/v2.1.1/NOTICE
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package identifiers
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestValidIdentifiers(t *testing.T) {
+	for _, input := range []string{
+		"default",
+		"Default",
+		t.Name(),
+		"default-default",
+		"containerd.io",
+		"foo.boo",
+		"swarmkit.docker.io",
+		"0912341234",
+		"task.0.0123456789",
+		"container.system-75-f19a.00",
+		"underscores_are_allowed",
+		strings.Repeat("a", maxLength),
+	} {
+		t.Run(input, func(t *testing.T) {
+			assert.NilError(t, Validate(input))
+		})
+	}
+}
+
+func TestInvalidIdentifiers(t *testing.T) {
+	for _, input := range []string{
+		"",
+		".foo..foo",
+		"foo/foo",
+		"foo/..",
+		"foo..foo",
+		"foo.-boo",
+		"-foo.boo",
+		"foo.boo-",
+		"but__only_tasteful_underscores",
+		"zn--e9.org", // or something like it!
+		"default--default",
+		strings.Repeat("a", maxLength+1),
+	} {
+		t.Run(input, func(t *testing.T) {
+			assert.ErrorContains(t, Validate(input), "")
+		})
+	}
+}

--- a/pkg/limatmpl/locator.go
+++ b/pkg/limatmpl/locator.go
@@ -16,9 +16,9 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/containerd/containerd/identifiers"
 	"github.com/sirupsen/logrus"
 
+	"github.com/lima-vm/lima/pkg/identifiers"
 	"github.com/lima-vm/lima/pkg/ioutilx"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/templatestore"

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -17,11 +17,11 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/containerd/containerd/identifiers"
 	"github.com/coreos/go-semver/semver"
 	"github.com/docker/go-units"
 	"github.com/sirupsen/logrus"
 
+	"github.com/lima-vm/lima/pkg/identifiers"
 	"github.com/lima-vm/lima/pkg/localpathutil"
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/osutil"

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -86,7 +86,7 @@ additionalDisks:
 	assert.NilError(t, err)
 
 	err = Validate(y, false)
-	assert.Error(t, err, "field `additionalDisks[0].name is invalid`: identifier must not be empty: invalid argument")
+	assert.Error(t, err, "field `additionalDisks[0].name is invalid`: identifier must not be empty")
 }
 
 func TestValidateParamName(t *testing.T) {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -10,8 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containerd/containerd/identifiers"
-
+	"github.com/lima-vm/lima/pkg/identifiers"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"


### PR DESCRIPTION
Silences govulncheck false positives GO-2025-3699 and GO-2025-3701.
- https://github.com/golang/vulndb/issues/3711
- https://github.com/golang/vulndb/issues/3712

The dependency was also problematic because it looked like as if it was the actual daemon version running in the VM.

Copied https://github.com/containerd/containerd/tree/v2.1.1/pkg/identifiers with the modification to drop the dependency on other containerd packages.

The NOTICE file was added for compliance of the section 4(d) of the Apache License Version 2.0.