### PR TITLE
Run golangci-lint on macOS and Windows; fix lint issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,11 +39,6 @@ jobs:
         sudo apt-get install -y protobuf-compiler
     - name: Verify generated files
       run: make install-tools generate check-generated
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8.0.0
-      with:
-        version: v2.1.0
-        args: --verbose
     - name: Run yamllint
       run: yamllint .
     - name: Install shellcheck
@@ -73,6 +68,33 @@ jobs:
       run: go install github.com/kunalkushwaha/ltag@v0.2.5
     - name: Check license boilerplates
       run: ltag -t ./hack/ltag --check -v
+
+  lint-go:
+    name: "Lint Go"
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        runs-on: [ubuntu-24.04, macos-15, windows-2022]
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+    - name: Force git to use LF
+      # This step is required on Windows to work around golangci-lint issues with formatters. See https://github.com/golangci/golangci-lint/discussions/5840
+      # TODO: replace with a checkout option when https://github.com/actions/checkout/issues/226 is implemented
+      if: runner.os == 'Windows'
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
+      with:
+        go-version: 1.24.x
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8.0.0
+      with:
+        version: v2.1
+        args: --verbose
 
   security:
     name: "Vulncheck"

--- a/pkg/lockutil/lockutil_windows.go
+++ b/pkg/lockutil/lockutil_windows.go
@@ -29,18 +29,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// LockFile modified from https://github.com/boltdb/bolt/blob/v1.3.1/bolt_windows.go using MIT
+// LockFile modified from https://github.com/boltdb/bolt/blob/v1.3.1/bolt_windows.go using MIT.
 var (
 	modkernel32      = syscall.NewLazyDLL("kernel32.dll")
 	procLockFileEx   = modkernel32.NewProc("LockFileEx")
 	procUnlockFileEx = modkernel32.NewProc("UnlockFileEx")
 )
 
-const (
-	// see https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
-	LOCKFILE_EXCLUSIVE_LOCK   = 0x00000002
-	LOCKFILE_FAIL_IMMEDIATELY = 0x00000001
-)
+// LOCKFILE_EXCLUSIVE_LOCK from https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
+const flagLockfileExclusiveLock = 0x00000002
 
 func WithDirLock(dir string, fn func() error) error {
 	dirFile, err := os.OpenFile(dir+".lock", os.O_CREATE, 0o644)
@@ -50,7 +47,7 @@ func WithDirLock(dir string, fn func() error) error {
 	defer dirFile.Close()
 	if err := lockFileEx(
 		syscall.Handle(dirFile.Fd()), // hFile
-		LOCKFILE_EXCLUSIVE_LOCK,      // dwFlags
+		flagLockfileExclusiveLock,    // dwFlags
 		0,                            // dwReserved
 		1,                            // nNumberOfBytesToLockLow
 		0,                            // nNumberOfBytesToLockHigh

--- a/pkg/osutil/osutil_windows.go
+++ b/pkg/osutil/osutil_windows.go
@@ -16,7 +16,7 @@ import (
 // UnixPathMax is the value of UNIX_PATH_MAX.
 const UnixPathMax = 108
 
-// Stat is a selection of syscall.Stat_t
+// Stat is a selection of syscall.Stat_t.
 type Stat struct {
 	Uid uint32
 	Gid uint32
@@ -38,8 +38,8 @@ func SysKill(pid int, _ Signal) error {
 	return windows.GenerateConsoleCtrlEvent(syscall.CTRL_BREAK_EVENT, uint32(pid))
 }
 
-func Dup2(oldfd int, newfd syscall.Handle) (err error) {
-	return fmt.Errorf("unimplemented")
+func Dup2(_ int, _ syscall.Handle) error {
+	return errors.New("unimplemented")
 }
 
 func SignalName(sig os.Signal) string {
@@ -53,6 +53,6 @@ func SignalName(sig os.Signal) string {
 	}
 }
 
-func Sysctl(name string) (string, error) {
+func Sysctl(_ string) (string, error) {
 	return "", errors.New("sysctl: unimplemented on Windows")
 }

--- a/pkg/store/instance_windows.go
+++ b/pkg/store/instance_windows.go
@@ -75,7 +75,7 @@ func GetWslStatus(instName string) (string, error) {
 		return "", fmt.Errorf("failed to run `wsl --list --verbose`, err: %w (out=%q)", err, string(out))
 	}
 
-	if len(out) == 0 {
+	if out == "" {
 		return StatusBroken, fmt.Errorf("failed to read instance state for instance %q, try running `wsl --list --verbose` to debug, err: %w", instName, err)
 	}
 
@@ -116,6 +116,6 @@ func GetWslStatus(instName string) (string, error) {
 	return instState, nil
 }
 
-func GetSSHAddress(instName string) (string, error) {
+func GetSSHAddress(_ string) (string, error) {
 	return "127.0.0.1", nil
 }

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -202,7 +202,6 @@ func (l *LimaVzDriver) RunGUI() error {
 	if l.CanRunGUI() {
 		return l.machine.StartGraphicApplication(1920, 1200)
 	}
-	//nolint:revive // error-strings
 	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "vz", *l.Instance.Config.Video.Display)
 }
 

--- a/pkg/windows/registry_windows.go
+++ b/pkg/windows/registry_windows.go
@@ -146,7 +146,7 @@ func GetDistroID(name string) (string, error) {
 }
 
 // GetRandomFreeVSockPort gets a list of all registered VSock ports and returns a non-registered port.
-func GetRandomFreeVSockPort(min, max int) (int, error) {
+func GetRandomFreeVSockPort(minPort, maxPort int) (int, error) {
 	rootKey, err := getGuestCommunicationServicesKey(false)
 	if err != nil {
 		return 0, err
@@ -160,18 +160,18 @@ func GetRandomFreeVSockPort(min, max int) (int, error) {
 
 	type pair struct{ v, offset int }
 	tree := make([]pair, 1, len(used)+1)
-	tree[0] = pair{0, min}
+	tree[0] = pair{0, minPort}
 
 	sort.Ints(used)
 	for i, v := range used {
 		if tree[len(tree)-1].v+tree[len(tree)-1].offset == v {
 			tree[len(tree)-1].offset++
 		} else {
-			tree = append(tree, pair{v - min - i, min + i + 1})
+			tree = append(tree, pair{v - minPort - i, minPort + i + 1})
 		}
 	}
 
-	v := rand.IntN(max - min + 1 - len(used))
+	v := rand.IntN(maxPort - minPort + 1 - len(used))
 
 	for len(tree) > 1 {
 		m := len(tree) / 2

--- a/pkg/wsl2/wsl_driver_windows.go
+++ b/pkg/wsl2/wsl_driver_windows.go
@@ -152,10 +152,9 @@ func (l *LimaWslDriver) Start(ctx context.Context) (chan error, error) {
 	return errCh, err
 }
 
-// Requires WSLg, which requires specific version of WSL2 to be installed.
+// CanRunGUI requires WSLg, which requires specific version of WSL2 to be installed.
 // TODO: Add check and add support for WSLg (instead of VNC) to hostagent.
 func (l *LimaWslDriver) CanRunGUI() bool {
-	// return *l.InstConfig.Video.Display == "wsl"
 	return false
 }
 


### PR DESCRIPTION
This PR adds `golangci-lint` step to run on Windows and macOS. And fixes a few lint issues that appeared on Windows and macOS.

Fixes #3585