### PR TITLE
Split Go imports into sections: std, default, local

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -146,6 +146,12 @@ issues:
   max-same-issues: 0
 formatters:
   enable:
+  - gci
   - gofmt
   - gofumpt
-  - goimports
+  settings:
+    gci:
+      sections:
+      - standard
+      - default
+      - localmodule

--- a/cmd/lima-guestagent/daemon_linux.go
+++ b/cmd/lima-guestagent/daemon_linux.go
@@ -9,13 +9,14 @@ import (
 	"os"
 	"time"
 
+	"github.com/mdlayher/vsock"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/guestagent"
 	"github.com/lima-vm/lima/pkg/guestagent/api/server"
 	"github.com/lima-vm/lima/pkg/guestagent/serialport"
 	"github.com/lima-vm/lima/pkg/portfwdserver"
-	"github.com/mdlayher/vsock"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 func newDaemonCommand() *cobra.Command {

--- a/cmd/lima-guestagent/install_systemd_linux.go
+++ b/cmd/lima-guestagent/install_systemd_linux.go
@@ -12,9 +12,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/lima-vm/lima/pkg/textutil"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/pkg/textutil"
 )
 
 func newInstallSystemdCommand() *cobra.Command {

--- a/cmd/lima-guestagent/main_linux.go
+++ b/cmd/lima-guestagent/main_linux.go
@@ -6,10 +6,11 @@ package main
 import (
 	"strings"
 
-	"github.com/lima-vm/lima/pkg/debugutil"
-	"github.com/lima-vm/lima/pkg/version"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/pkg/debugutil"
+	"github.com/lima-vm/lima/pkg/version"
 )
 
 func main() {

--- a/cmd/limactl/completion.go
+++ b/cmd/limactl/completion.go
@@ -6,9 +6,10 @@ package main
 import (
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/templatestore"
-	"github.com/spf13/cobra"
 )
 
 func bashCompleteInstanceNames(_ *cobra.Command) ([]string, cobra.ShellCompDirective) {

--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -13,11 +13,12 @@ import (
 	"strings"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/ioutilx"
 	"github.com/lima-vm/lima/pkg/sshutil"
 	"github.com/lima-vm/lima/pkg/store"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 const copyHelp = `Copy files between host and guest

--- a/cmd/limactl/debug.go
+++ b/cmd/limactl/debug.go
@@ -7,9 +7,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/lima-vm/lima/pkg/hostagent/dns"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/pkg/hostagent/dns"
 )
 
 func newDebugCommand() *cobra.Command {

--- a/cmd/limactl/delete.go
+++ b/cmd/limactl/delete.go
@@ -9,12 +9,13 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/autostart"
 	"github.com/lima-vm/lima/pkg/instance"
 	networks "github.com/lima-vm/lima/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/pkg/store"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 func newDeleteCommand() *cobra.Command {

--- a/cmd/limactl/disk.go
+++ b/cmd/limactl/disk.go
@@ -15,12 +15,13 @@ import (
 	contfs "github.com/containerd/continuity/fs"
 	"github.com/docker/go-units"
 	"github.com/lima-vm/go-qcow2reader"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/nativeimgutil"
 	"github.com/lima-vm/lima/pkg/qemu/imgutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 func newDiskCommand() *cobra.Command {

--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -10,6 +10,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/cmd/limactl/editflags"
 	"github.com/lima-vm/lima/pkg/editutil"
 	"github.com/lima-vm/lima/pkg/instance"
@@ -19,8 +22,6 @@ import (
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/lima-vm/lima/pkg/uiutil"
 	"github.com/lima-vm/lima/pkg/yqutil"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 func newEditCommand() *cobra.Command {

--- a/cmd/limactl/factory-reset.go
+++ b/cmd/limactl/factory-reset.go
@@ -9,12 +9,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/cidata"
 	"github.com/lima-vm/lima/pkg/instance"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 func newFactoryResetCommand() *cobra.Command {

--- a/cmd/limactl/genschema.go
+++ b/cmd/limactl/genschema.go
@@ -10,12 +10,12 @@ import (
 	"os"
 
 	"github.com/invopop/jsonschema"
-	"github.com/lima-vm/lima/pkg/jsonschemautil"
-	"github.com/lima-vm/lima/pkg/limayaml"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 
-	"github.com/sirupsen/logrus"
+	"github.com/lima-vm/lima/pkg/jsonschemautil"
+	"github.com/lima-vm/lima/pkg/limayaml"
 )
 
 func newGenSchemaCommand() *cobra.Command {

--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -15,10 +15,11 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/lima-vm/lima/pkg/hostagent"
-	"github.com/lima-vm/lima/pkg/hostagent/api/server"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/pkg/hostagent"
+	"github.com/lima-vm/lima/pkg/hostagent/api/server"
 )
 
 func newHostagentCommand() *cobra.Command {

--- a/cmd/limactl/info.go
+++ b/cmd/limactl/info.go
@@ -7,8 +7,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/lima-vm/lima/pkg/limainfo"
 	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/pkg/limainfo"
 )
 
 func newInfoCommand() *cobra.Command {

--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -12,10 +12,11 @@ import (
 	"strings"
 
 	"github.com/cheggaaa/pb/v3/termutil"
-	"github.com/lima-vm/lima/pkg/store"
 	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/pkg/store"
 )
 
 func fieldNames() []string {

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -11,14 +11,15 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/mattn/go-isatty"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/debugutil"
 	"github.com/lima-vm/lima/pkg/fsutil"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/version"
-	"github.com/mattn/go-isatty"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/limactl/protect.go
+++ b/cmd/limactl/protect.go
@@ -7,9 +7,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/lima-vm/lima/pkg/store"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/pkg/store"
 )
 
 func newProtectCommand() *cobra.Command {

--- a/cmd/limactl/prune.go
+++ b/cmd/limactl/prune.go
@@ -7,12 +7,13 @@ import (
 	"maps"
 	"os"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/downloader"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/templatestore"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 func newPruneCommand() *cobra.Command {

--- a/cmd/limactl/restart.go
+++ b/cmd/limactl/restart.go
@@ -4,9 +4,10 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/instance"
 	"github.com/lima-vm/lima/pkg/store"
-	"github.com/spf13/cobra"
 )
 
 func newRestartCommand() *cobra.Command {

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -14,16 +14,17 @@ import (
 
 	"al.essio.dev/pkg/shellescape"
 	"github.com/coreos/go-semver/semver"
+	"github.com/lima-vm/sshocker/pkg/ssh"
+	"github.com/mattn/go-isatty"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/instance"
 	"github.com/lima-vm/lima/pkg/ioutilx"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	networks "github.com/lima-vm/lima/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/pkg/sshutil"
 	"github.com/lima-vm/lima/pkg/store"
-	"github.com/lima-vm/sshocker/pkg/ssh"
-	"github.com/mattn/go-isatty"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 const shellHelp = `Execute shell in Lima

--- a/cmd/limactl/show-ssh.go
+++ b/cmd/limactl/show-ssh.go
@@ -10,12 +10,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/sshutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 const showSSHExample = `

--- a/cmd/limactl/snapshot.go
+++ b/cmd/limactl/snapshot.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/snapshot"
 	"github.com/lima-vm/lima/pkg/store"
-	"github.com/sirupsen/logrus"
-
-	"github.com/spf13/cobra"
 )
 
 func newSnapshotCommand() *cobra.Command {

--- a/cmd/limactl/start-at-login_unix.go
+++ b/cmd/limactl/start-at-login_unix.go
@@ -10,10 +10,11 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/lima-vm/lima/pkg/autostart"
-	"github.com/lima-vm/lima/pkg/store"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/pkg/autostart"
+	"github.com/lima-vm/lima/pkg/store"
 )
 
 func startAtLoginAction(cmd *cobra.Command, args []string) error {

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -11,6 +11,9 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/cmd/limactl/editflags"
 	"github.com/lima-vm/lima/pkg/editutil"
 	"github.com/lima-vm/lima/pkg/instance"
@@ -22,8 +25,6 @@ import (
 	"github.com/lima-vm/lima/pkg/templatestore"
 	"github.com/lima-vm/lima/pkg/uiutil"
 	"github.com/lima-vm/lima/pkg/yqutil"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 func registerCreateFlags(cmd *cobra.Command, commentPrefix string) {

--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -4,10 +4,11 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/instance"
 	networks "github.com/lima-vm/lima/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/pkg/store"
-	"github.com/spf13/cobra"
 )
 
 func newStopCommand() *cobra.Command {

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -6,8 +6,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/pkg/networks"
 )
 
 const socketVMNetURL = "https://lima-vm.io/docs/config/network/vmnet/#socket_vmnet"

--- a/cmd/limactl/sudoers_darwin.go
+++ b/cmd/limactl/sudoers_darwin.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/pkg/networks"
 )
 
 func sudoersAction(cmd *cobra.Command, args []string) error {

--- a/cmd/limactl/template.go
+++ b/cmd/limactl/template.go
@@ -9,12 +9,13 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/limatmpl"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/yqutil"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 func newTemplateCommand() *cobra.Command {

--- a/cmd/limactl/tunnel.go
+++ b/cmd/limactl/tunnel.go
@@ -11,11 +11,12 @@ import (
 	"runtime"
 	"strconv"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/lima-vm/lima/pkg/freeport"
 	"github.com/lima-vm/lima/pkg/sshutil"
 	"github.com/lima-vm/lima/pkg/store"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 const tunnelHelp = `Create a tunnel for Lima

--- a/cmd/limactl/unprotect.go
+++ b/cmd/limactl/unprotect.go
@@ -7,9 +7,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/lima-vm/lima/pkg/store"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/pkg/store"
 )
 
 func newUnprotectCommand() *cobra.Command {

--- a/cmd/limactl/usernet.go
+++ b/cmd/limactl/usernet.go
@@ -9,8 +9,9 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/lima-vm/lima/pkg/networks/usernet"
 	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/pkg/networks/usernet"
 )
 
 func newUsernetCommand() *cobra.Command {

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/debugutil"
 	instance "github.com/lima-vm/lima/pkg/instance/hostname"
 	"github.com/lima-vm/lima/pkg/iso9660util"
@@ -30,7 +32,6 @@ import (
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/sshutil"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/sirupsen/logrus"
 )
 
 var netLookupIP = func(host string) []net.IP {

--- a/pkg/cidata/cidata_test.go
+++ b/pkg/cidata/cidata_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lima-vm/lima/pkg/networks"
-
 	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/pkg/networks"
 )
 
 func fakeLookupIP(_ string) []net.IP {

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -11,9 +11,9 @@ import (
 	"io/fs"
 	"path"
 
-	"github.com/lima-vm/lima/pkg/iso9660util"
-
 	"github.com/containerd/containerd/identifiers"
+
+	"github.com/lima-vm/lima/pkg/iso9660util"
 	"github.com/lima-vm/lima/pkg/textutil"
 )
 

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -21,12 +21,13 @@ import (
 
 	"github.com/cheggaaa/pb/v3"
 	"github.com/containerd/continuity/fs"
+	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/httpclientutil"
 	"github.com/lima-vm/lima/pkg/localpathutil"
 	"github.com/lima-vm/lima/pkg/lockutil"
 	"github.com/lima-vm/lima/pkg/progressbar"
-	"github.com/opencontainers/go-digest"
-	"github.com/sirupsen/logrus"
 )
 
 // HideProgress is used only for testing.

--- a/pkg/editutil/editutil.go
+++ b/pkg/editutil/editutil.go
@@ -11,10 +11,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/editutil/editorcmd"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/sirupsen/logrus"
 )
 
 func fileWarning(filename string) string {

--- a/pkg/fileutils/download.go
+++ b/pkg/fileutils/download.go
@@ -9,9 +9,10 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/downloader"
 	"github.com/lima-vm/lima/pkg/limayaml"
-	"github.com/sirupsen/logrus"
 )
 
 // ErrSkipped is returned when the downloader did not attempt to download the specified file.

--- a/pkg/guestagent/api/client/client.go
+++ b/pkg/guestagent/api/client/client.go
@@ -8,10 +8,11 @@ import (
 	"math"
 	"net"
 
-	"github.com/lima-vm/lima/pkg/guestagent/api"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/lima-vm/lima/pkg/guestagent/api"
 )
 
 type GuestAgentClient struct {

--- a/pkg/guestagent/api/server/server.go
+++ b/pkg/guestagent/api/server/server.go
@@ -7,11 +7,12 @@ import (
 	"context"
 	"net"
 
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/lima-vm/lima/pkg/guestagent"
 	"github.com/lima-vm/lima/pkg/guestagent/api"
 	"github.com/lima-vm/lima/pkg/portfwdserver"
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func StartServer(lis net.Listener, guest *GuestServer) error {

--- a/pkg/guestagent/guestagent_linux.go
+++ b/pkg/guestagent/guestagent_linux.go
@@ -14,13 +14,14 @@ import (
 
 	"github.com/elastic/go-libaudit/v2"
 	"github.com/elastic/go-libaudit/v2/auparse"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/lima-vm/lima/pkg/guestagent/api"
 	"github.com/lima-vm/lima/pkg/guestagent/iptables"
 	"github.com/lima-vm/lima/pkg/guestagent/kubernetesservice"
 	"github.com/lima-vm/lima/pkg/guestagent/procnettcp"
 	"github.com/lima-vm/lima/pkg/guestagent/timesync"
-	"github.com/sirupsen/logrus"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func New(newTicker func() (<-chan time.Time, func()), iptablesIdle time.Duration) (Agent, error) {

--- a/pkg/hostagent/events/watcher.go
+++ b/pkg/hostagent/events/watcher.go
@@ -9,9 +9,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/lima-vm/lima/pkg/logrusutil"
 	"github.com/nxadm/tail"
 	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/pkg/logrusutil"
 )
 
 func Watch(ctx context.Context, haStdoutPath, haStderrPath string, begin time.Time, onEvent func(Event) bool) error {

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -19,6 +19,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/lima-vm/sshocker/pkg/ssh"
+	"github.com/sethvargo/go-password/password"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -39,9 +42,6 @@ import (
 	"github.com/lima-vm/lima/pkg/sshutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/lima-vm/sshocker/pkg/ssh"
-	"github.com/sethvargo/go-password/password"
-	"github.com/sirupsen/logrus"
 )
 
 type HostAgent struct {

--- a/pkg/hostagent/inotify.go
+++ b/pkg/hostagent/inotify.go
@@ -10,10 +10,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	guestagentapi "github.com/lima-vm/lima/pkg/guestagent/api"
 	"github.com/rjeczalik/notify"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	guestagentapi "github.com/lima-vm/lima/pkg/guestagent/api"
 )
 
 const CacheSize = 10000

--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -9,10 +9,11 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/lima-vm/lima/pkg/ioutilx"
-	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/sshocker/pkg/reversesshfs"
 	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/pkg/ioutilx"
+	"github.com/lima-vm/lima/pkg/limayaml"
 )
 
 type mount struct {

--- a/pkg/hostagent/port.go
+++ b/pkg/hostagent/port.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"net"
 
-	"github.com/lima-vm/lima/pkg/guestagent/api"
-	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/sshocker/pkg/ssh"
 	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/pkg/guestagent/api"
+	"github.com/lima-vm/lima/pkg/limayaml"
 )
 
 type portForwarder struct {

--- a/pkg/hostagent/port_darwin.go
+++ b/pkg/hostagent/port_darwin.go
@@ -12,10 +12,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/lima-vm/lima/pkg/bicopy"
-	"github.com/lima-vm/lima/pkg/portfwd"
 	"github.com/lima-vm/sshocker/pkg/ssh"
 	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/pkg/bicopy"
+	"github.com/lima-vm/lima/pkg/portfwd"
 )
 
 // forwardTCP is not thread-safe.

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/sshocker/pkg/ssh"
 	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/pkg/limayaml"
 )
 
 func (a *HostAgent) waitForRequirements(label string, requirements []requirement) error {

--- a/pkg/instance/ansible.go
+++ b/pkg/instance/ansible.go
@@ -11,10 +11,11 @@ import (
 	"path/filepath"
 
 	"github.com/goccy/go-yaml"
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/sirupsen/logrus"
 )
 
 func runAnsibleProvision(ctx context.Context, inst *store.Instance) error {

--- a/pkg/instance/hostname/hostname_test.go
+++ b/pkg/instance/hostname/hostname_test.go
@@ -6,8 +6,9 @@ package instance_test
 import (
 	"testing"
 
-	instance "github.com/lima-vm/lima/pkg/instance/hostname"
 	"gotest.tools/v3/assert"
+
+	instance "github.com/lima-vm/lima/pkg/instance/hostname"
 )
 
 func TestHostnameFromInstName(t *testing.T) {

--- a/pkg/instance/restart.go
+++ b/pkg/instance/restart.go
@@ -6,9 +6,10 @@ package instance
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	networks "github.com/lima-vm/lima/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/pkg/store"
-	"github.com/sirupsen/logrus"
 )
 
 const launchHostAgentForeground = false

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -18,22 +18,22 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/lima-vm/go-qcow2reader"
+	"github.com/mattn/go-isatty"
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/pkg/downloader"
 	"github.com/lima-vm/lima/pkg/driver"
 	"github.com/lima-vm/lima/pkg/driverutil"
 	"github.com/lima-vm/lima/pkg/executil"
-	"github.com/lima-vm/lima/pkg/nativeimgutil"
-	"github.com/lima-vm/lima/pkg/osutil"
-	"github.com/lima-vm/lima/pkg/qemu/imgutil"
-	"github.com/lima-vm/lima/pkg/usrlocalsharelima"
-	"github.com/mattn/go-isatty"
-
-	"github.com/lima-vm/lima/pkg/downloader"
 	"github.com/lima-vm/lima/pkg/fileutils"
 	hostagentevents "github.com/lima-vm/lima/pkg/hostagent/events"
 	"github.com/lima-vm/lima/pkg/limayaml"
+	"github.com/lima-vm/lima/pkg/nativeimgutil"
+	"github.com/lima-vm/lima/pkg/osutil"
+	"github.com/lima-vm/lima/pkg/qemu/imgutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/sirupsen/logrus"
+	"github.com/lima-vm/lima/pkg/usrlocalsharelima"
 )
 
 // DefaultWatchHostAgentEventsTimeout is the duration to wait for the instance

--- a/pkg/instance/stop.go
+++ b/pkg/instance/stop.go
@@ -12,11 +12,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	hostagentevents "github.com/lima-vm/lima/pkg/hostagent/events"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/sirupsen/logrus"
 )
 
 func StopGracefully(ctx context.Context, inst *store.Instance, isRestart bool) error {

--- a/pkg/limainfo/limainfo.go
+++ b/pkg/limainfo/limainfo.go
@@ -7,13 +7,14 @@ import (
 	"errors"
 	"io/fs"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/driverutil"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/templatestore"
 	"github.com/lima-vm/lima/pkg/usrlocalsharelima"
 	"github.com/lima-vm/lima/pkg/version"
-	"github.com/sirupsen/logrus"
 )
 
 type LimaInfo struct {

--- a/pkg/limatmpl/embed.go
+++ b/pkg/limatmpl/embed.go
@@ -16,12 +16,13 @@ import (
 	"unicode"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/lima-vm/lima/pkg/version/versionutil"
 	"github.com/lima-vm/lima/pkg/yqutil"
-	"github.com/sirupsen/logrus"
 )
 
 // Embed will recursively resolve all "base" dependencies and update the

--- a/pkg/limatmpl/embed_test.go
+++ b/pkg/limatmpl/embed_test.go
@@ -11,10 +11,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
+
+	"github.com/lima-vm/lima/pkg/limayaml"
 )
 
 type embedTestCase struct {

--- a/pkg/limatmpl/locator.go
+++ b/pkg/limatmpl/locator.go
@@ -17,10 +17,11 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/identifiers"
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/ioutilx"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/templatestore"
-	"github.com/sirupsen/logrus"
 )
 
 const yBytesLimit = 4 * 1024 * 1024 // 4MiB

--- a/pkg/limatmpl/locator_test.go
+++ b/pkg/limatmpl/locator_test.go
@@ -8,9 +8,10 @@ import (
 	"runtime"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/lima-vm/lima/pkg/limatmpl"
 	"github.com/lima-vm/lima/pkg/limayaml"
-	"gotest.tools/v3/assert"
 )
 
 func TestInstNameFromImageURL(t *testing.T) {

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -24,6 +24,10 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/docker/go-units"
 	"github.com/goccy/go-yaml"
+	"github.com/pbnjay/memory"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/cpu"
+
 	instance "github.com/lima-vm/lima/pkg/instance/hostname"
 	"github.com/lima-vm/lima/pkg/ioutilx"
 	"github.com/lima-vm/lima/pkg/localpathutil"
@@ -35,9 +39,6 @@ import (
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/lima-vm/lima/pkg/version"
 	"github.com/lima-vm/lima/pkg/version/versionutil"
-	"github.com/pbnjay/memory"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/cpu"
 )
 
 const (

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -16,13 +16,14 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/sirupsen/logrus"
+	"gotest.tools/v3/assert"
+
 	"github.com/lima-vm/lima/pkg/ioutilx"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/ptr"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/sirupsen/logrus"
-	"gotest.tools/v3/assert"
 )
 
 func TestFillDefault(t *testing.T) {

--- a/pkg/limayaml/load.go
+++ b/pkg/limayaml/load.go
@@ -9,9 +9,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/sirupsen/logrus"
 )
 
 // Load loads the yaml and fulfills unspecified fields with the default values.

--- a/pkg/limayaml/marshal.go
+++ b/pkg/limayaml/marshal.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 
 	"github.com/goccy/go-yaml"
-	"github.com/lima-vm/lima/pkg/yqutil"
 	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/pkg/yqutil"
 )
 
 const (

--- a/pkg/limayaml/marshal_test.go
+++ b/pkg/limayaml/marshal_test.go
@@ -6,8 +6,9 @@ package limayaml
 import (
 	"testing"
 
-	"github.com/lima-vm/lima/pkg/ptr"
 	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/pkg/ptr"
 )
 
 func TestMarshalEmpty(t *testing.T) {

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -20,12 +20,13 @@ import (
 	"github.com/containerd/containerd/identifiers"
 	"github.com/coreos/go-semver/semver"
 	"github.com/docker/go-units"
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/localpathutil"
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/version"
 	"github.com/lima-vm/lima/pkg/version/versionutil"
-	"github.com/sirupsen/logrus"
 )
 
 func validateFileObject(f File, fieldName string) error {

--- a/pkg/nativeimgutil/nativeimgutil.go
+++ b/pkg/nativeimgutil/nativeimgutil.go
@@ -18,8 +18,9 @@ import (
 	"github.com/lima-vm/go-qcow2reader/convert"
 	"github.com/lima-vm/go-qcow2reader/image/qcow2"
 	"github.com/lima-vm/go-qcow2reader/image/raw"
-	"github.com/lima-vm/lima/pkg/progressbar"
 	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/pkg/progressbar"
 )
 
 // Disk image size must be aigned to sector size. Qemu block layer is rounding

--- a/pkg/networks/commands_test.go
+++ b/pkg/networks/commands_test.go
@@ -8,8 +8,9 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/pkg/store/dirnames"
 )
 
 func TestCheck(t *testing.T) {

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -13,10 +13,11 @@ import (
 	"sync"
 
 	"github.com/goccy/go-yaml"
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/lima-vm/lima/pkg/textutil"
-	"github.com/sirupsen/logrus"
 )
 
 //go:embed networks.TEMPLATE.yaml

--- a/pkg/networks/reconcile/reconcile.go
+++ b/pkg/networks/reconcile/reconcile.go
@@ -14,12 +14,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/networks/usernet"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
-	"github.com/sirupsen/logrus"
 )
 
 func Reconcile(ctx context.Context, newInst string) error {

--- a/pkg/networks/usernet/client.go
+++ b/pkg/networks/usernet/client.go
@@ -16,6 +16,7 @@ import (
 
 	gvproxyclient "github.com/containers/gvisor-tap-vsock/pkg/client"
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
+
 	"github.com/lima-vm/lima/pkg/driver"
 	"github.com/lima-vm/lima/pkg/httpclientutil"
 	"github.com/lima-vm/lima/pkg/limayaml"

--- a/pkg/networks/usernet/config.go
+++ b/pkg/networks/usernet/config.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/apparentlymart/go-cidr/cidr"
+
 	"github.com/lima-vm/lima/pkg/networks"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/store/dirnames"

--- a/pkg/networks/usernet/config_test.go
+++ b/pkg/networks/usernet/config_test.go
@@ -7,8 +7,9 @@ import (
 	"net"
 	"testing"
 
-	"github.com/lima-vm/lima/pkg/networks"
 	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/pkg/networks"
 )
 
 func TestUsernetConfig(t *testing.T) {

--- a/pkg/networks/usernet/recoincile.go
+++ b/pkg/networks/usernet/recoincile.go
@@ -16,11 +16,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/executil"
 	"github.com/lima-vm/lima/pkg/lockutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
-	"github.com/sirupsen/logrus"
 )
 
 // Start starts a instance a usernet network with the given name.

--- a/pkg/osutil/user.go
+++ b/pkg/osutil/user.go
@@ -13,9 +13,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/sirupsen/logrus"
+
 	. "github.com/lima-vm/lima/pkg/must"
 	"github.com/lima-vm/lima/pkg/version/versionutil"
-	"github.com/sirupsen/logrus"
 )
 
 type User struct {

--- a/pkg/portfwd/client.go
+++ b/pkg/portfwd/client.go
@@ -10,10 +10,11 @@ import (
 	"time"
 
 	"github.com/containers/gvisor-tap-vsock/pkg/services/forwarder"
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/bicopy"
 	"github.com/lima-vm/lima/pkg/guestagent/api"
 	guestagentclient "github.com/lima-vm/lima/pkg/guestagent/api/client"
-	"github.com/sirupsen/logrus"
 )
 
 func HandleTCPConnection(ctx context.Context, client *guestagentclient.GuestAgentClient, conn net.Conn, guestAddr string) {

--- a/pkg/portfwd/forward.go
+++ b/pkg/portfwd/forward.go
@@ -8,10 +8,11 @@ import (
 	"net"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/guestagent/api"
 	guestagentclient "github.com/lima-vm/lima/pkg/guestagent/api/client"
 	"github.com/lima-vm/lima/pkg/limayaml"
-	"github.com/sirupsen/logrus"
 )
 
 var IPv4loopback1 = limayaml.IPv4loopback1

--- a/pkg/portfwd/listener.go
+++ b/pkg/portfwd/listener.go
@@ -10,8 +10,9 @@ import (
 	"strings"
 	"sync"
 
-	guestagentclient "github.com/lima-vm/lima/pkg/guestagent/api/client"
 	"github.com/sirupsen/logrus"
+
+	guestagentclient "github.com/lima-vm/lima/pkg/guestagent/api/client"
 )
 
 type ClosableListeners struct {

--- a/pkg/qemu/entitlementutil/entitlementutil.go
+++ b/pkg/qemu/entitlementutil/entitlementutil.go
@@ -10,10 +10,10 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/lima-vm/lima/pkg/uiutil"
-
 	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/pkg/uiutil"
 )
 
 // IsSigned returns an error if the binary is not signed, or the sign is invalid,

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -20,22 +20,22 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lima-vm/lima/pkg/networks/usernet"
-	"github.com/lima-vm/lima/pkg/osutil"
-
 	"github.com/coreos/go-semver/semver"
 	"github.com/digitalocean/go-qemu/qmp"
 	"github.com/digitalocean/go-qemu/qmp/raw"
 	"github.com/docker/go-units"
+	"github.com/mattn/go-shellwords"
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/fileutils"
 	"github.com/lima-vm/lima/pkg/iso9660util"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/networks"
+	"github.com/lima-vm/lima/pkg/networks/usernet"
+	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/qemu/imgutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/mattn/go-shellwords"
-	"github.com/sirupsen/logrus"
 )
 
 type Config struct {

--- a/pkg/qemu/qemu_driver.go
+++ b/pkg/qemu/qemu_driver.go
@@ -24,6 +24,8 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/digitalocean/go-qemu/qmp"
 	"github.com/digitalocean/go-qemu/qmp/raw"
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/driver"
 	"github.com/lima-vm/lima/pkg/executil"
 	"github.com/lima-vm/lima/pkg/limayaml"
@@ -32,7 +34,6 @@ import (
 	"github.com/lima-vm/lima/pkg/qemu/entitlementutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/sirupsen/logrus"
 )
 
 type LimaQemuDriver struct {

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -20,14 +20,15 @@ import (
 	"time"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/mattn/go-shellwords"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/cpu"
+
 	"github.com/lima-vm/lima/pkg/ioutilx"
 	"github.com/lima-vm/lima/pkg/lockutil"
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/mattn/go-shellwords"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/cpu"
 )
 
 // Environment variable that allows configuring the command (alias) to execute

--- a/pkg/store/disk.go
+++ b/pkg/store/disk.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/lima-vm/go-qcow2reader"
+
 	"github.com/lima-vm/lima/pkg/store/filenames"
 )
 

--- a/pkg/store/fuzz_test.go
+++ b/pkg/store/fuzz_test.go
@@ -8,8 +8,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/lima-vm/lima/pkg/store/filenames"
 	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/pkg/store/filenames"
 )
 
 func FuzzLoadYAMLByFilePath(f *testing.F) {

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -19,6 +19,8 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/sirupsen/logrus"
+
 	hostagentclient "github.com/lima-vm/lima/pkg/hostagent/api/client"
 	instancehostname "github.com/lima-vm/lima/pkg/instance/hostname"
 	"github.com/lima-vm/lima/pkg/limayaml"
@@ -26,7 +28,6 @@ import (
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/lima-vm/lima/pkg/textutil"
 	"github.com/lima-vm/lima/pkg/version/versionutil"
-	"github.com/sirupsen/logrus"
 )
 
 type Status = string

--- a/pkg/store/instance_test.go
+++ b/pkg/store/instance_test.go
@@ -11,8 +11,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lima-vm/lima/pkg/limayaml"
 	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/pkg/limayaml"
 )
 
 const separator = string(filepath.Separator)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/identifiers"
+
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/store/dirnames"
 	"github.com/lima-vm/lima/pkg/store/filenames"

--- a/pkg/usrlocalsharelima/usrlocalsharelima.go
+++ b/pkg/usrlocalsharelima/usrlocalsharelima.go
@@ -13,9 +13,10 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/debugutil"
 	"github.com/lima-vm/lima/pkg/limayaml"
-	"github.com/sirupsen/logrus"
 )
 
 // executableViaArgs0 returns the absolute path to the executable used to start this process.

--- a/pkg/vz/disk.go
+++ b/pkg/vz/disk.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/go-units"
+
 	"github.com/lima-vm/lima/pkg/driver"
 	"github.com/lima-vm/lima/pkg/fileutils"
 	"github.com/lima-vm/lima/pkg/iso9660util"

--- a/pkg/vz/network_darwin.go
+++ b/pkg/vz/network_darwin.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/balajiv113/fd"
-
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/vz/rosetta_directory_share_arm64.go
+++ b/pkg/vz/rosetta_directory_share_arm64.go
@@ -10,8 +10,9 @@ import (
 
 	"github.com/Code-Hex/vz/v3"
 	"github.com/coreos/go-semver/semver"
-	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/pkg/osutil"
 )
 
 func createRosettaDirectoryShareConfiguration() (*vz.VirtioFileSystemDeviceConfiguration, error) {

--- a/pkg/vz/vm_darwin.go
+++ b/pkg/vz/vm_darwin.go
@@ -22,6 +22,8 @@ import (
 	"github.com/docker/go-units"
 	"github.com/lima-vm/go-qcow2reader"
 	"github.com/lima-vm/go-qcow2reader/image/raw"
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/driver"
 	"github.com/lima-vm/lima/pkg/iso9660util"
 	"github.com/lima-vm/lima/pkg/limayaml"
@@ -31,7 +33,6 @@ import (
 	"github.com/lima-vm/lima/pkg/osutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/sirupsen/logrus"
 )
 
 // diskImageCachingMode is set to DiskImageCachingModeCached so as to avoid disk corruption on ARM:

--- a/pkg/vz/vz_driver_darwin.go
+++ b/pkg/vz/vz_driver_darwin.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/Code-Hex/vz/v3"
 	"github.com/coreos/go-semver/semver"
-
 	"github.com/sirupsen/logrus"
 
 	"github.com/lima-vm/lima/pkg/driver"

--- a/pkg/wsl2/fs.go
+++ b/pkg/wsl2/fs.go
@@ -9,10 +9,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/driver"
 	"github.com/lima-vm/lima/pkg/fileutils"
 	"github.com/lima-vm/lima/pkg/store/filenames"
-	"github.com/sirupsen/logrus"
 )
 
 // EnsureFs downloads the root fs.

--- a/pkg/wsl2/vm_windows.go
+++ b/pkg/wsl2/vm_windows.go
@@ -13,11 +13,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/executil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/store/filenames"
 	"github.com/lima-vm/lima/pkg/textutil"
-	"github.com/sirupsen/logrus"
 )
 
 // startVM calls WSL to start a VM.

--- a/pkg/wsl2/wsl_driver_windows.go
+++ b/pkg/wsl2/wsl_driver_windows.go
@@ -11,13 +11,14 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/go-winio/pkg/guid"
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/pkg/driver"
 	"github.com/lima-vm/lima/pkg/freeport"
 	"github.com/lima-vm/lima/pkg/limayaml"
 	"github.com/lima-vm/lima/pkg/reflectutil"
 	"github.com/lima-vm/lima/pkg/store"
 	"github.com/lima-vm/lima/pkg/windows"
-	"github.com/sirupsen/logrus"
 )
 
 var knownYamlProperties = []string{


### PR DESCRIPTION
This PR enables the [`gci`](https://golangci-lint.run/usage/formatters/#gci) formatter and run [`golangci-lint fmt`](https://golangci-lint.run/usage/configuration/#fmt) to automatically split imports into three sections: std, default, local.

`goimports` is now not needed because `gci` replaces it.

Fixes #3584