### PR TITLE
chore: Do not install already installed jq and curl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,9 +232,7 @@ jobs:
       # QEMU:      required by Lima itself
       # bash:      required by test-templates.sh (OS version of bash is too old)
       # coreutils: required by test-templates.sh for the "timeout" command
-      # curl:      required by test-templates.sh to download nerdctl for alpine
-      # jq:        required by test-templates.sh to determine download URL for nerdctl
-      run: brew install qemu bash coreutils curl jq
+      run: brew install qemu bash coreutils
     - name: "Adjust LIMACTL_CREATE_ARGS"
       run: echo "LIMACTL_CREATE_ARGS=${LIMACTL_CREATE_ARGS} --vm-type=qemu" >>$GITHUB_ENV
     - name: "Inject `no_timer_check` to kernel cmdline"
@@ -497,7 +495,7 @@ jobs:
       with:
         template: templates/${{ matrix.template }}
     - name: Install test dependencies
-      run: brew install bash coreutils jq
+      run: brew install bash coreutils
     - name: Uninstall qemu
       run: brew uninstall --ignore-dependencies --force qemu
     - name: Test


### PR DESCRIPTION
This PR fixes GHA warnings during "Integration tests (vz)" and "Integration tests (QEMU, macOS host)":

> [Integration tests (vz) (default.yaml)](https://github.com/lima-vm/lima/actions/runs/15482949878/job/43592004298#step:7:8)
jq 1.8.0 is already installed and up-to-date. To reinstall 1.8.0, run: brew reinstall jq
> [Integration tests (QEMU, macOS host)](https://github.com/lima-vm/lima/actions/runs/15482949878/job/43592004347#step:9:12)
jq 1.8.0 is already installed and up-to-date. To reinstall 1.8.0, run: brew reinstall jq
> [Integration tests (QEMU, macOS host)](https://github.com/lima-vm/lima/actions/runs/15482949878/job/43592004347#step:9:8)
curl 8.14.0 is already installed and up-to-date. To reinstall 8.14.0, run: brew reinstall curl

`jq` and `curl` is present on `macos-15-large` https://github.com/actions/runner-images/tree/71ed87ce949ec4d05207c3f84a1dca48a29695c3/images/macos