### PR TITLE
chore: Fix lint warnings in default.yaml

### DIFF
--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -40,7 +40,7 @@ disk: null
 # 🟢 Builtin default: [] (Mount nothing)
 # 🔵 This file: Mount the home as read-only, /tmp/lima as writable  (inherited via the `base` mechanism later in this file)
 mounts: []
-#- location: "~"
+# - location: "~"
 #  # Configure the mountPoint inside the guest.
 #  # 🟢 Builtin default: value of location
 #  mountPoint: null
@@ -79,7 +79,7 @@ mounts: []
 #    # See https://www.kernel.org/doc/Documentation/filesystems/9p.txt
 #    # 🟢 Builtin default: "fscache" for non-writable mounts, "mmap" for writable mounts
 #    cache: null
-#- location: "/tmp/lima"
+# - location: "/tmp/lima"
 #  # 🟢 Builtin default: false
 #  # 🔵 This file: true (only for "/tmp/lima")
 #  writable: true


### PR DESCRIPTION
This PR fixes the following lint warnings:

<img width="1144" alt="image" src="https://github.com/user-attachments/assets/a2370972-0fc9-4ae0-bfae-ee589441b3fa" />

See https://github.com/lima-vm/lima/actions/runs/15482949878?pr=3610