### PR TITLE
Add badge to DeepWiki AI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 # Lima: Linux Machines
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/lima-vm/lima)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/6505/badge)](https://www.bestpractices.dev/projects/6505)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/lima-vm/lima/badge)](https://scorecard.dev/viewer/?uri=github.com/lima-vm/lima)
 


### PR DESCRIPTION
Having the badge in the README will trigger the docs to be automatically rebuild once a week.

I put the DeepWiki badge first purely for aesthetic reasons because I think this looks better

![CleanShot 2025-06-11 at 13 04 46@2x](https://github.com/user-attachments/assets/9b913c84-ca90-46e7-a4ec-c7e5d1e975bd)

than

![CleanShot 2025-06-11 at 13 05 04@2x](https://github.com/user-attachments/assets/e3db7f6d-7605-4d56-91d9-89b7dca78767)

