### PR TITLE
fix(edk2): update candidates path on Arch Linux

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -1146,6 +1146,9 @@ func getFirmware(qemuExe string, arch limayaml.Arch) (string, error) {
 
 	switch arch {
 	case limayaml.X8664:
+		// Archlinux package "edk2-ovmf"
+		// @see: https://archlinux.org/packages/extra/any/edk2-ovmf/files
+		candidates = append(candidates, "/usr/share/edk2/x64/OVMF_CODE.4m.fd")
 		// Debian package "ovmf"
 		candidates = append(candidates, "/usr/share/OVMF/OVMF_CODE.fd")
 		candidates = append(candidates, "/usr/share/OVMF/OVMF_CODE_4M.fd")
@@ -1153,15 +1156,19 @@ func getFirmware(qemuExe string, arch limayaml.Arch) (string, error) {
 		candidates = append(candidates, "/usr/share/edk2/ovmf/OVMF_CODE.fd")
 		// openSUSE package "qemu-ovmf-x86_64"
 		candidates = append(candidates, "/usr/share/qemu/ovmf-x86_64.bin")
-		// Archlinux package "edk2-ovmf"
-		candidates = append(candidates, "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd")
 	case limayaml.AARCH64:
+		// Archlinux package "edk2-aarch64"
+		// @see: https://archlinux.org/packages/extra/any/edk2-aarch64/files
+		candidates = append(candidates, "/usr/share/edk2/aarch64/QEMU_CODE.fd")
 		// Debian package "qemu-efi-aarch64"
 		// Fedora package "edk2-aarch64"
 		candidates = append(candidates, "/usr/share/AAVMF/AAVMF_CODE.fd")
 		// Debian package "qemu-efi-aarch64" (unpadded, backwards compatibility)
 		candidates = append(candidates, "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd")
 	case limayaml.ARMV7L:
+		// Archlinux package "edk2-arm"
+		// @see: https://archlinux.org/packages/extra/any/edk2-arm/files
+		candidates = append(candidates, "/usr/share/edk2/arm/QEMU_CODE.fd")
 		// Debian package "qemu-efi-arm"
 		// Fedora package "edk2-arm"
 		candidates = append(candidates, "/usr/share/AAVMF/AAVMF32_CODE.fd")


### PR DESCRIPTION
`edk2-ovmf` package from the Arch Linux repository no longer provides 2M images.

https://gitlab.archlinux.org/archlinux/packaging/packages/edk2/-/commit/75700baee1f5073d558029efc0e03612bedfc048

### before

```shell
$ limactl start fedora
FATA[0002] exiting, status={Running:false Degraded:false Exiting:true Errors:[] SSHLocalPort:0} (hint: see "/home/fruzitent/.lima/fedora/ha.stderr.log")
```

```json
{"level":"debug","msg":"firmware candidates = [/home/fruzitent/.local/share/qemu/edk2-x86_64-code.fd /usr/share/qemu/edk2-x86_64-code.fd /usr/share/OVMF/OVMF_CODE.fd /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/edk2/ovmf/OVMF_CODE.fd /usr/share/qemu/ovmf-x86_64.bin /usr/share/edk2-ovmf/x64/OVMF_CODE.fd]","time":"2025-06-17T00:06:09+03:00"}
{"level":"fatal","msg":"could not find firmware for \"/usr/bin/qemu-system-x86_64\" (hint: try setting `firmware.legacyBIOS` to `true`)","time":"2025-06-17T00:06:09+03:00"}
```

### after

```shell
$ limactl start fedora
INFO[0001] [hostagent] Using system firmware ("/usr/share/edk2/x64/OVMF_CODE.4m.fd")
```