### PR TITLE
sshutil: suppress warnings when SSH lacks GSSAPI

### DIFF
--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -29,6 +29,16 @@ func TestParseOpenSSHVersion(t *testing.T) {
 
 	// OpenBSD 5.8
 	assert.Check(t, ParseOpenSSHVersion([]byte("OpenSSH_7.0, LibreSSL")).Equal(*semver.New("7.0.0")))
+
+	// NixOS 25.05
+	assert.Check(t, ParseOpenSSHVersion([]byte(`command-line line 0: Unsupported option "gssapiauthentication"
+OpenSSH_10.0p2, OpenSSL 3.4.1 11 Feb 2025`)).Equal(*semver.New("10.0.2")))
+}
+
+func TestParseOpenSSHGSSAPISupported(t *testing.T) {
+	assert.Check(t, parseOpenSSHGSSAPISupported("OpenSSH_8.4p1 Ubuntu"))
+	assert.Check(t, !parseOpenSSHGSSAPISupported(`command-line line 0: Unsupported option "gssapiauthentication"
+OpenSSH_10.0p2, OpenSSL 3.4.1 11 Feb 2025`))
 }
 
 func Test_detectValidPublicKey(t *testing.T) {


### PR DESCRIPTION
Background
---

Starting with NixOS 24.11, NixOS and nixpkgs no longer enable GSSAPI support in the openssh package by default.
See:
- https://github.com/NixOS/nixpkgs/pull/302688
- https://github.com/NixOS/nixpkgs/blob/df7eb4294b7081e4b828d31f4d77971b4ca85a64/nixos/doc/manual/release-notes/rl-2411.section.md?plain=1#L316-L317
Because of this change, I am experiencing the same issue described in the Alpine Linux issue mentioned https://github.com/lima-vm/lima/issues/3151.

Fixes #3198

How
---

The `ssh -G nothing` approach requires generating a random string and making an additional call to an external ssh command.
Instead, I combined this change into the current `ssh -V` implementation. Is this approach acceptable?