### PR TITLE
fix: correct validation error message when invalid provision

### DIFF
--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -219,7 +219,7 @@ func Validate(y *LimaYAML, warn bool) error {
 		case ProvisionModeSystem, ProvisionModeUser, ProvisionModeBoot, ProvisionModeData, ProvisionModeDependency, ProvisionModeAnsible:
 		default:
 			return fmt.Errorf("field `provision[%d].mode` must one of %q, %q, %q, %q, %q, or %q",
-				i, ProvisionModeSystem, ProvisionModeUser, ProvisionModeBoot, ProvisionModeDependency, ProvisionModeAnsible, ProvisionModeAnsible)
+				i, ProvisionModeSystem, ProvisionModeUser, ProvisionModeBoot, ProvisionModeData, ProvisionModeDependency, ProvisionModeAnsible)
 		}
 		if p.Mode != ProvisionModeDependency && p.SkipDefaultDependencyResolution != nil {
 			return fmt.Errorf("field `provision[%d].mode` cannot set skipDefaultDependencyResolution, only valid on scripts of type %q",

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -40,6 +40,37 @@ func TestValidateProbes(t *testing.T) {
 	assert.Error(t, err, "field `probe[0].file.digest` support is not yet implemented")
 }
 
+func TestValidateProvisionMode(t *testing.T) {
+	images := `images: [{location: /}]`
+	provisionBoot := `provision: [{mode: boot, script: "touch /tmp/param-$PARAM_BOOT"}]`
+	y, err := Load([]byte(provisionBoot+"\n"+images), "lima.yaml")
+	assert.NilError(t, err)
+
+	err = Validate(y, false)
+	assert.NilError(t, err)
+
+	provisionUser := `provision: [{mode: user, script: "touch /tmp/param-$PARAM_USER"}]`
+	y, err = Load([]byte(provisionUser+"\n"+images), "lima.yaml")
+	assert.NilError(t, err)
+
+	err = Validate(y, false)
+	assert.NilError(t, err)
+
+	provisionDependency := `provision: [{mode: ansible, script: "touch /tmp/param-$PARAM_DEPENDENCY"}]`
+	y, err = Load([]byte(provisionDependency+"\n"+images), "lima.yaml")
+	assert.NilError(t, err)
+
+	err = Validate(y, false)
+	assert.NilError(t, err)
+
+	provisionInvalid := `provision: [{mode: invalid}]`
+	y, err = Load([]byte(provisionInvalid+"\n"+images), "lima.yaml")
+	assert.NilError(t, err)
+
+	err = Validate(y, false)
+	assert.Error(t, err, "field `provision[0].mode` must one of \"system\", \"user\", \"boot\", \"data\", \"dependency\", or \"ansible\"")
+}
+
 func TestValidateProvisionData(t *testing.T) {
 	images := `images: [{location: /}]`
 	validData := `provision: [{mode: data, path: /tmp, content: hello}]`


### PR DESCRIPTION
This PR fixes the validation error message that appears when an invalid provision mode is specified in lima.yaml, e.g. `provision: [{mode: invalid}]`.

Before (duplicated `"ansible"`):

```
field `provision[0].mode` must one of \"system\", \"user\", \"boot\", \"dependency\", \"ansible\", or \"ansible\
```

After:

```
field `provision[0].mode` must one of \"system\", \"user\", \"boot\", \"data\", \"dependency\", or \"ansible\"
```