### PR TITLE
templates: default: use Ubuntu 25.04, Fedora 42

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -305,7 +305,6 @@ jobs:
       matrix:
         # Most templates use 9p as the mount type
         template:
-        - ubuntu-25.04.yaml  # The default version of Ubuntu is still 24.10 due to https://github.com/lima-vm/lima/issues/3334
         - alpine.yaml
         - debian.yaml  # reverse-sshfs
         - fedora.yaml  # The default version of Fedora is still 41 due to https://github.com/lima-vm/lima/issues/3334

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -307,8 +307,7 @@ jobs:
         template:
         - alpine.yaml
         - debian.yaml  # reverse-sshfs
-        - fedora.yaml  # The default version of Fedora is still 41 due to https://github.com/lima-vm/lima/issues/3334
-        - fedora-42.yaml
+        - fedora.yaml
         - archlinux.yaml
         - opensuse.yaml
         - docker.yaml

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -252,6 +252,13 @@ limactl shell "$NAME" bash -c "echo 'foo \"bar\"'"
 
 if [[ -n ${CHECKS["systemd"]} ]]; then
 	set -x
+	# agetty segfaults on Ubuntu 25.04 (x86_64)
+	# > __strncmp_evex () at ../sysdeps/x86_64/multiarch/strcmp-evex.S:316
+	# Should be fixed in Ubuntu 25.10 with util-linux >= 2.41
+	# https://github.com/lima-vm/lima/pull/3643#issuecomment-3006788732
+	if limactl shell "$NAME" systemctl -q is-failed serial-getty@ttyS0.service; then
+		limactl shell "$NAME" sudo systemctl reset-failed serial-getty@ttyS0.service
+	fi
 	if ! limactl shell "$NAME" systemctl is-system-running --wait; then
 		ERROR '"systemctl is-system-running" failed'
 		diagnose "$NAME"

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -699,6 +699,12 @@ func FillDefault(y, d, o *LimaYAML, filePath string, warn bool) {
 	for _, f := range y.MountTypesUnsupported {
 		mountTypesUnsupported[f] = struct{}{}
 	}
+
+	if runtime.GOOS == "windows" {
+		// QEMU for Windows does not support 9p
+		mountTypesUnsupported[NINEP] = struct{}{}
+	}
+
 	// MountType has to be resolved before resolving Mounts
 	if y.MountType == nil {
 		y.MountType = d.MountType

--- a/templates/README.md
+++ b/templates/README.md
@@ -22,8 +22,8 @@ Distro:
 - [`centos-stream-10`](./centos-stream-10.yaml): CentOS Stream 10
 - [`debian-11`](./debian-11.yaml): Debian GNU/Linux 11(bullseye)
 - [`debian-12`](./debian-12.yaml), `debian.yaml`: ⭐Debian GNU/Linux 12(bookworm)
-- [`fedora-41`](./fedora-41.yaml), `fedora.yaml`: ⭐Fedora 41
-- [`fedora-42`](./fedora-42.yaml): Fedora 42
+- [`fedora-41`](./fedora-41.yaml): Fedora 41
+- [`fedora-42`](./fedora-42.yaml), `fedora.yaml`: ⭐Fedora 42
 - [`opensuse-leap`](./opensuse-leap.yaml), `opensuse.yaml`: ⭐openSUSE Leap
 - [`oraclelinux-8`](./oraclelinux-8.yaml): Oracle Linux 8
 - [`oraclelinux-9`](./oraclelinux-9.yaml), `oraclelinux.yaml`: Oracle Linux 9

--- a/templates/_images/fedora.yaml
+++ b/templates/_images/fedora.yaml
@@ -1,1 +1,1 @@
-fedora-41.yaml
+fedora-42.yaml

--- a/templates/_images/ubuntu.yaml
+++ b/templates/_images/ubuntu.yaml
@@ -1,1 +1,1 @@
-ubuntu-24.10.yaml
+ubuntu-25.04.yaml

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -97,7 +97,7 @@ mountTypesUnsupported:
 
 # Mount type for above mounts, such as "reverse-sshfs" (from sshocker), "9p" (QEMU’s virtio-9p-pci, aka virtfs),
 # or "virtiofs" (experimental on Linux; needs `vmType: vz` on macOS).
-# 🟢 Builtin default: "default" (resolved to be "9p" for QEMU since Lima v1.0, "virtiofs" for vz)
+# 🟢 Builtin default: "default" (resolved to be "9p" for QEMU since Lima v1.0 on non-Windows, "virtiofs" for vz)
 mountType: null
 
 # Enable inotify support for mounted directories (EXPERIMENTAL)

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -91,9 +91,7 @@ mounts: []
 # The issue was fixed in Linux v6.12-rc5 (https://github.com/torvalds/linux/commit/be2ca38).
 #
 # 🟢 Builtin default: []
-# 🔵 This file: ["9p"] (as Ubuntu 24.10 uses kernel 6.11)
-mountTypesUnsupported:
-- "9p"
+mountTypesUnsupported: null
 
 # Mount type for above mounts, such as "reverse-sshfs" (from sshocker), "9p" (QEMU’s virtio-9p-pci, aka virtfs),
 # or "virtiofs" (experimental on Linux; needs `vmType: vz` on macOS).

--- a/templates/fedora.yaml
+++ b/templates/fedora.yaml
@@ -1,1 +1,1 @@
-fedora-41.yaml
+fedora-42.yaml

--- a/templates/podman-rootful.yaml
+++ b/templates/podman-rootful.yaml
@@ -13,7 +13,7 @@
 minimumLimaVersion: 1.1.0
 
 base:
-- template://_images/fedora-41
+- template://_images/fedora
 - template://_default/mounts
 
 containerd:

--- a/templates/podman.yaml
+++ b/templates/podman.yaml
@@ -13,7 +13,7 @@
 minimumLimaVersion: 1.1.0
 
 base:
-- template://_images/fedora-41
+- template://_images/fedora
 - template://_default/mounts
 
 containerd:

--- a/templates/ubuntu.yaml
+++ b/templates/ubuntu.yaml
@@ -1,1 +1,1 @@
-ubuntu-24.10.yaml
+ubuntu-25.04.yaml

--- a/website/content/en/docs/config/mount.md
+++ b/website/content/en/docs/config/mount.md
@@ -12,7 +12,7 @@ The default mount type is shown in the following table:
 | < 0.10       | reverse-sshfs + Builtin SFTP server                           |
 | >= 0.10      | reverse-sshfs + OpenSSH SFTP server                           |
 | >= 0.17      | reverse-sshfs + OpenSSH SFTP server for QEMU, virtiofs for VZ |
-| >= 1.0       | 9p for QEMU, virtiofs for VZ                                  |
+| >= 1.0       | 9p for QEMU (on non-Windows), virtiofs for VZ                 |
 
 ## Mount types
 


### PR DESCRIPTION
Ubuntu 24.10 will reach EOL soon (2025-07-10).
https://endoflife.date/ubuntu
    
It should be still noted that Intel Mac with macOS prior to 15.5 requires setting `vmType` to `qemu`:
- #3334