### PR TITLE
Search for the data directory using real executable on non-Linux platform

### DIFF
--- a/pkg/usrlocalsharelima/usrlocalsharelima.go
+++ b/pkg/usrlocalsharelima/usrlocalsharelima.go
@@ -57,8 +57,16 @@ func Dir() (string, error) {
 	selfViaOS, err := os.Executable()
 	if err != nil {
 		logrus.WithError(err).Warn("failed to find os.Executable()")
-	} else if len(selfPaths) == 0 || selfViaOS != selfPaths[0] {
-		selfPaths = append(selfPaths, selfViaOS)
+	} else {
+		selfFinalPathViaOS, err := filepath.EvalSymlinks(selfViaOS)
+		if err != nil {
+			logrus.WithError(err).Warn("failed to resolve symlinks")
+			selfFinalPathViaOS = selfViaOS // fallback to the original path
+		}
+
+		if len(selfPaths) == 0 || selfFinalPathViaOS != selfPaths[0] {
+			selfPaths = append(selfPaths, selfFinalPathViaOS)
+		}
 	}
 
 	ostype := limayaml.NewOS("linux")


### PR DESCRIPTION
The problem NixOS/nixpkgs#419596 is similar to #3621, but `os.Executable()` only resolves the issue for Linux systems by retrieving the real path via /proc/self/exe. However, this solution does not address the issue on other operating systems, particularly macOS, where symbolic links still need to be resolved manually.