### PR TITLE
refactor: Limayaml validation functions

### DIFF
--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -121,7 +121,7 @@ func editAction(cmd *cobra.Command, args []string) error {
 		return saveRejectedYAML(yBytes, err)
 	}
 
-	if err := limayaml.ValidateYAMLAgainstLatestConfig(yBytes, yContent); err != nil {
+	if err := limayaml.ValidateAgainstLatestConfig(yBytes, yContent); err != nil {
 		return saveRejectedYAML(yBytes, err)
 	}
 

--- a/pkg/limayaml/load.go
+++ b/pkg/limayaml/load.go
@@ -63,7 +63,7 @@ func load(b []byte, filePath string, warn bool) (*LimaYAML, error) {
 	}
 
 	// It should be called before the `y` parameter is passed to FillDefault() that execute template.
-	if err := ValidateParamIsUsed(&y); err != nil {
+	if err := validateParamIsUsed(&y); err != nil {
 		return nil, err
 	}
 

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -266,7 +266,7 @@ provision:
 		"field `provision[1].path` must not be empty when mode is \"data\"")
 }
 
-func TestValidateYAMLAgainstLatestConfig(t *testing.T) {
+func TestValidateAgainstLatestConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		yNew    string
@@ -308,7 +308,7 @@ func TestValidateYAMLAgainstLatestConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateYAMLAgainstLatestConfig([]byte(tt.yNew), []byte(tt.yLatest))
+			err := ValidateAgainstLatestConfig([]byte(tt.yNew), []byte(tt.yLatest))
 			if tt.wantErr == nil {
 				assert.NilError(t, err)
 			} else {


### PR DESCRIPTION
This PR refactors and rearranges functions in the `limayaml` package:

- Moves the unexported `validateFileObject` below `Validate` for improved readability.
- Makes `ValidateParamIsUsed` unexported.
- Renames `limayaml.ValidateYAMLAgainstLatestConfig` to `limayaml.ValidateAgainstLatestConfig`.