### PR TITLE
Bump ltag to fix module name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,9 +63,7 @@ jobs:
       # the allow list corresponds to https://github.com/cncf/foundation/blob/e5db022a0009f4db52b89d9875640cf3137153fe/allowed-third-party-license-policy.md
       run: go-licenses check --include_tests  ./... --allowed_licenses=$(cat ./hack/allowed-licenses.txt)
     - name: Install ltag
-      # The GitHub repo has been moved from kunalkushwaha/ltag to containerd/ltag,
-      # but the Go module name is not changed yet: https://github.com/containerd/ltag/issues/17
-      run: go install github.com/kunalkushwaha/ltag@v0.2.5
+      run: go install github.com/containerd/ltag@latest
     - name: Check license boilerplates
       run: ltag -t ./hack/ltag --check -v
 


### PR DESCRIPTION
Ref https://github.com/containerd/ltag/pull/19

I assume bumping to `@latest` is fine, or do we want to pin the version?