### PR TITLE
chore: Update golangci-lint from v2.1 to v2.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8.0.0
       with:
-        version: v2.1
+        version: v2.2
         args: --verbose
 
   security:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,6 +81,7 @@ linters:
       confidence: 0.6
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
       rules:
+      - name: bare-return
       - name: blank-imports
       - name: context-as-argument
       - name: context-keys-type
@@ -106,6 +107,7 @@ linters:
       - name: superfluous-else
       - name: time-naming
       - name: unexported-return
+      - name: unnecessary-format
       - name: unreachable-code
       - name: unused-parameter
       - name: use-any

--- a/cmd/limactl/tunnel.go
+++ b/cmd/limactl/tunnel.go
@@ -118,14 +118,14 @@ func tunnelAction(cmd *cobra.Command, args []string) error {
 
 	switch runtime.GOOS {
 	case "darwin":
-		fmt.Fprintf(stdout, "Open <System Settings> → <Network> → <Wi-Fi> (or whatever) → <Details> → <Proxies> → <SOCKS proxy>,\n")
-		fmt.Fprintf(stdout, "and specify the following configuration:\n")
-		fmt.Fprintf(stdout, "- Server: 127.0.0.1\n")
+		fmt.Fprint(stdout, "Open <System Settings> → <Network> → <Wi-Fi> (or whatever) → <Details> → <Proxies> → <SOCKS proxy>,\n")
+		fmt.Fprint(stdout, "and specify the following configuration:\n")
+		fmt.Fprint(stdout, "- Server: 127.0.0.1\n")
 		fmt.Fprintf(stdout, "- Port: %d\n", port)
 	case "windows":
-		fmt.Fprintf(stdout, "Open <Settings> → <Network & Internet> → <Proxy>,\n")
-		fmt.Fprintf(stdout, "and specify the following configuration:\n")
-		fmt.Fprintf(stdout, "- Address: socks=127.0.0.1\n")
+		fmt.Fprint(stdout, "Open <Settings> → <Network & Internet> → <Proxy>,\n")
+		fmt.Fprint(stdout, "and specify the following configuration:\n")
+		fmt.Fprint(stdout, "- Address: socks=127.0.0.1\n")
 		fmt.Fprintf(stdout, "- Port: %d\n", port)
 	default:
 		fmt.Fprintf(stdout, "Set `ALL_PROXY=socks5h://127.0.0.1:%d`, etc.\n", port)

--- a/pkg/guestagent/guestagent_linux.go
+++ b/pkg/guestagent/guestagent_linux.go
@@ -169,7 +169,7 @@ func comparePorts(old, neww []*api.IPPort) (added, removed []*api.IPPort) {
 			}
 		}
 	}
-	return
+	return added, removed
 }
 
 func (a *agent) collectEvent(ctx context.Context, st eventState) (*api.Event, eventState) {

--- a/pkg/guestagent/timesync/timesync_linux.go
+++ b/pkg/guestagent/timesync/timesync_linux.go
@@ -18,18 +18,17 @@ func HasRTC() (bool, error) {
 	return !errors.Is(err, os.ErrNotExist), err
 }
 
-func GetRTCTime() (t time.Time, err error) {
+func GetRTCTime() (time.Time, error) {
 	f, err := os.Open(rtc)
 	if err != nil {
-		return
+		return time.Time{}, err
 	}
 	defer f.Close()
 	obj, err := unix.IoctlGetRTCTime(int(f.Fd()))
 	if err != nil {
-		return
+		return time.Time{}, err
 	}
-	t = time.Date(int(obj.Year+1900), time.Month(obj.Mon+1), int(obj.Mday), int(obj.Hour), int(obj.Min), int(obj.Sec), 0, time.UTC)
-	return t, nil
+	return time.Date(int(obj.Year+1900), time.Month(obj.Mon+1), int(obj.Mday), int(obj.Hour), int(obj.Min), int(obj.Sec), 0, time.UTC), nil
 }
 
 func SetSystemTime(t time.Time) error {

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -222,14 +222,11 @@ func writeSSHConfigFile(sshPath, instName, instDir, instSSHAddress string, sshLo
 	if instDir == "" {
 		return fmt.Errorf("directory is unknown for the instance %q", instName)
 	}
-	var b bytes.Buffer
-	if _, err := fmt.Fprintf(&b, `# This SSH config file can be passed to 'ssh -F'.
+	b := bytes.NewBufferString(`# This SSH config file can be passed to 'ssh -F'.
 # This file is created by Lima, but not used by Lima itself currently.
 # Modifications to this file will be lost on restarting the Lima instance.
-`); err != nil {
-		return err
-	}
-	if err := sshutil.Format(&b, sshPath, instName, sshutil.FormatConfig,
+`)
+	if err := sshutil.Format(b, sshPath, instName, sshutil.FormatConfig,
 		append(sshOpts,
 			fmt.Sprintf("Hostname=%s", instSSHAddress),
 			fmt.Sprintf("Port=%d", sshLocalPort),

--- a/pkg/networks/commands_test.go
+++ b/pkg/networks/commands_test.go
@@ -49,7 +49,7 @@ func TestUser(t *testing.T) {
 
 	t.Run("socket_vmnet", func(t *testing.T) {
 		if ok, _ := config.IsDaemonInstalled(SocketVMNet); !ok {
-			t.Skipf("socket_vmnet is not installed")
+			t.Skip("socket_vmnet is not installed")
 		}
 		user, err := config.User(SocketVMNet)
 		assert.NilError(t, err)
@@ -80,7 +80,7 @@ func TestStartCmd(t *testing.T) {
 
 	t.Run("socket_vmnet", func(t *testing.T) {
 		if ok, _ := config.IsDaemonInstalled(SocketVMNet); !ok {
-			t.Skipf("socket_vmnet is not installed")
+			t.Skip("socket_vmnet is not installed")
 		}
 
 		cmd := config.StartCmd("shared", SocketVMNet)

--- a/pkg/portfwd/control_others.go
+++ b/pkg/portfwd/control_others.go
@@ -26,5 +26,5 @@ func Control(_, _ string, c syscall.RawConn) (err error) {
 	if controlErr != nil {
 		err = controlErr
 	}
-	return
+	return err
 }

--- a/pkg/portfwd/control_windows.go
+++ b/pkg/portfwd/control_windows.go
@@ -19,5 +19,5 @@ func Control(_, _ string, c syscall.RawConn) (err error) {
 	if controlErr != nil {
 		err = controlErr
 	}
-	return
+	return err
 }

--- a/pkg/vz/network_darwin_test.go
+++ b/pkg/vz/network_darwin_test.go
@@ -81,7 +81,7 @@ func TestDialQemu(t *testing.T) {
 
 	buf := make([]byte, vmnetMaxPacketSize)
 
-	t.Logf("Receiving and verifying data packets...")
+	t.Log("Receiving and verifying data packets...")
 	for i := range packetsCount {
 		n, err := vzConn.Read(buf)
 		assert.NilError(t, err)


### PR DESCRIPTION
This PR updates golangci-lint to [v2.2.1](https://golangci-lint.run/product/changelog/#v220) and enables new revive checks.

macOS:
```console
$ golangci-lint version
golangci-lint has version 2.2.1 built with go1.24.4 from 66496a9 on 2025-06-29T15:57:59Z
$ golangci-lint run
cmd/limactl/tunnel.go:121:3: unnecessary-format: unnecessary use of formatting function "fmt.Fprintf", you can replace it with "fmt.Fprint" (revive)
                fmt.Fprintf(stdout, "Open <System Settings> → <Network> → <Wi-Fi> (or whatever) → <Details> → <Proxies> → <SOCKS proxy>,\n")
                ^
cmd/limactl/tunnel.go:122:3: unnecessary-format: unnecessary use of formatting function "fmt.Fprintf", you can replace it with "fmt.Fprint" (revive)
                fmt.Fprintf(stdout, "and specify the following configuration:\n")
                ^
cmd/limactl/tunnel.go:123:3: unnecessary-format: unnecessary use of formatting function "fmt.Fprintf", you can replace it with "fmt.Fprint" (revive)
                fmt.Fprintf(stdout, "- Server: 127.0.0.1\n")
                ^
cmd/limactl/tunnel.go:126:3: unnecessary-format: unnecessary use of formatting function "fmt.Fprintf", you can replace it with "fmt.Fprint" (revive)
                fmt.Fprintf(stdout, "Open <Settings> → <Network & Internet> → <Proxy>,\n")
                ^
cmd/limactl/tunnel.go:127:3: unnecessary-format: unnecessary use of formatting function "fmt.Fprintf", you can replace it with "fmt.Fprint" (revive)
                fmt.Fprintf(stdout, "and specify the following configuration:\n")
                ^
cmd/limactl/tunnel.go:128:3: unnecessary-format: unnecessary use of formatting function "fmt.Fprintf", you can replace it with "fmt.Fprint" (revive)
                fmt.Fprintf(stdout, "- Address: socks=127.0.0.1\n")
                ^
pkg/hostagent/hostagent.go:226:15: unnecessary-format: unnecessary use of formatting function "fmt.Fprintf", you can replace it with "fmt.Fprint" (revive)
        if _, err := fmt.Fprintf(&b, `# This SSH config file can be passed to 'ssh -F'.
                     ^
pkg/networks/commands_test.go:52:4: unnecessary-format: unnecessary use of formatting function "t.Skipf", you can replace it with "t.Skip" (revive)
                        t.Skipf("socket_vmnet is not installed")
                        ^
pkg/networks/commands_test.go:83:4: unnecessary-format: unnecessary use of formatting function "t.Skipf", you can replace it with "t.Skip" (revive)
                        t.Skipf("socket_vmnet is not installed")
                        ^
pkg/portfwd/control_others.go:29:2: bare-return: avoid using bare returns, please add return expressions (revive)
        return
        ^
pkg/vz/network_darwin_test.go:84:2: unnecessary-format: unnecessary use of formatting function "t.Logf", you can replace it with "t.Log" (revive)
        t.Logf("Receiving and verifying data packets...")
        ^
11 issues:
* revive: 11
```

Linux:
```console
$ golangci-lint run
pkg/guestagent/guestagent_linux.go:172:2: bare-return: avoid using bare returns, please add return expressions (revive)
  	return
  	^
pkg/guestagent/timesync/timesync_linux.go:24:3: bare-return: avoid using bare returns, please add return expressions (revive)
  		return
  		^
pkg/guestagent/timesync/timesync_linux.go:29:3: bare-return: avoid using bare returns, please add return expressions (revive)
  		return
  		^
  3 issues:
  * revive: 3

```

Windows:
```console
$ golangci-lint run
pkg\portfwd\control_windows.go:22:2: bare-return: avoid using bare returns, please add return expressions (revive)
  	return
  	^
  1 issues:
  * revive: 1

```