### PR TITLE
docs: fix the URL to faasd

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -54,7 +54,7 @@ Container image builders:
 - [`buildkit`](./buildkit.yaml): BuildKit
 
 Container orchestration:
-- [`faasd`](./faasd.yaml): [Faasd](https://docs.openfaas.com/deployment/faasd/)
+- [`faasd`](./faasd.yaml): [Faasd](https://docs.openfaas.com/deployment/edge/)
 - [`k3s`](./k3s.yaml): Kubernetes via k3s
 - [`k8s`](./k8s.yaml): Kubernetes via kubeadm
 - [`experimental/u7s`](./experimental/u7s.yaml): [Usernetes](https://github.com/rootless-containers/usernetes): Rootless Kubernetes


### PR DESCRIPTION
The link `https://docs.openfaas.com/deployment/faasd/` has been moved to `https://docs.openfaas.com/deployment/edge/`. The previous version can be viewed at https://web.archive.org/web/20250121162548/https://docs.openfaas.com/deployment/faasd/.

<details><summary>Wayback Machive Screenshot</summary>
<p>

<img width="1484" alt="image" src="https://github.com/user-attachments/assets/0eb91899-bc50-48b8-83a4-5d767a82760a" />

</p>
</details> 

This broken link was found with the help of [lychee](https://github.com/lycheeverse/lychee):

```console
❯ lychee --no-progress --max-concurrency 1 --scheme https --scheme http .
   [WARN ] Error creating request: InvalidPathToUri("/images/internals/lima-sequence-diagram.png")
   [WARN ] Error creating request: InvalidPathToUri("/images/demo.gif")
   [WARN ] Error creating request: InvalidPathToUri("/images/cncf-color-bg.svg")
   [ERROR] http://127.0.0.1:8080/
     [404] https://docs.openfaas.com/deployment/faasd/
Issues found in 2 inputs. Find details below.

[./templates/README.md]:
     [404] https://docs.openfaas.com/deployment/faasd/ | Rejected status code (this depends on your "accept" configuration): Not Found

[./website/content/en/docs/examples/_index.md]:
   [ERROR] http://127.0.0.1:8080/ | Network error: error sending request for url (http://127.0.0.1:8080/) Maybe a certificate error?

🔍 295 Total (in 1m 9s) ✅ 159 OK 🚫 2 Errors 👻 134 Excluded
```