### PR TITLE
Add timezone validation

### DIFF
--- a/pkg/limayaml/defaults_unix.go
+++ b/pkg/limayaml/defaults_unix.go
@@ -1,0 +1,58 @@
+//go:build !windows
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package limayaml
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func hostTimeZone() string {
+	if tzBytes, err := os.ReadFile("/etc/timezone"); err == nil {
+		if tz := strings.TrimSpace(string(tzBytes)); tz != "" {
+			if _, err := time.LoadLocation(tz); err != nil {
+				logrus.Warnf("invalid timezone found in /etc/timezone: %v", err)
+			} else {
+				return tz
+			}
+		}
+	}
+
+	if zoneinfoFile, err := filepath.EvalSymlinks("/etc/localtime"); err == nil {
+		if tz, err := extractTZFromPath(zoneinfoFile); err != nil {
+			logrus.Warnf("failed to extract timezone from %s: %v", zoneinfoFile, err)
+		} else {
+			return tz
+		}
+	}
+
+	logrus.Warn("unable to determine host timezone, falling back to default value")
+	return ""
+}
+
+func extractTZFromPath(zoneinfoFile string) (string, error) {
+	if zoneinfoFile == "" {
+		return "", errors.New("invalid zoneinfo file path")
+	}
+
+	if _, err := os.Stat(zoneinfoFile); os.IsNotExist(err) {
+		return "", fmt.Errorf("zoneinfo file does not exist: %s", zoneinfoFile)
+	}
+
+	for dir := filepath.Dir(zoneinfoFile); dir != filepath.Dir(dir); dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "Etc", "UTC")); err == nil {
+			return filepath.Rel(dir, zoneinfoFile)
+		}
+	}
+
+	return "", errors.New("timezone base directory not found")
+}

--- a/pkg/limayaml/defaults_unix_test.go
+++ b/pkg/limayaml/defaults_unix_test.go
@@ -1,0 +1,75 @@
+//go:build !windows
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package limayaml
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestExtractTimezoneFromPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create test timezone directory structure
+	assert.NilError(t, os.MkdirAll(filepath.Join(tmpDir, "Etc"), 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(tmpDir, "Etc", "UTC"), []byte{}, 0o644))
+	assert.NilError(t, os.WriteFile(filepath.Join(tmpDir, "UTC"), []byte{}, 0o644))
+	assert.NilError(t, os.MkdirAll(filepath.Join(tmpDir, "Antarctica"), 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(tmpDir, "Antarctica", "Troll"), []byte{}, 0o644))
+
+	tests := []struct {
+		name    string
+		path    string
+		want    string
+		wantErr bool
+	}{
+		{
+			"valid_timezone",
+			filepath.Join(tmpDir, "Antarctica", "Troll"),
+			"Antarctica/Troll",
+			false,
+		},
+		{
+			"root_level_zone",
+			filepath.Join(tmpDir, "UTC"),
+			"UTC",
+			false,
+		},
+		{
+			"outside_zoneinfo",
+			"/tmp/somefile",
+			"",
+			true,
+		},
+		{
+			"empty_path",
+			"",
+			"",
+			true,
+		},
+		{
+			"nonexistent_file",
+			filepath.Join(tmpDir, "Invalid", "Zone"),
+			"",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractTZFromPath(tt.path)
+			if tt.wantErr {
+				assert.Assert(t, err != nil, "expected error but got none")
+			} else {
+				assert.NilError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/limayaml/defaults_windows.go
+++ b/pkg/limayaml/defaults_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package limayaml
+
+func hostTimeZone() string {
+	// WSL2 will automatically set the timezone
+	return ""
+}


### PR DESCRIPTION
My machine accidentally has a symlink in /etc/timezone instead of a proper timezone file, and I spent some time investigating why cloud-init doesn't install anything in the guest, with this error:

```
[    5.994555] cloud-init[685]: 2025-07-03 09:19:09,880 - util.py[WARNING]: Failed loading yaml blob. unacceptable character #x0000: special characters are not allowed
[    5.996367] cloud-init[685]:   in "<unicode string>", position 88
[    5.997206] cloud-init[685]: 2025-07-03 09:19:09,880 - cloud_config.py[WARNING]: Failed at merging in cloud config part from part-001: empty cloud config
```

This PR adds timezone validation using the native Go way. In my case, it prints this warning and falls back to an empty value:

```
WARN[0000] invalid timezone "TZif2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\b\x00\x00..." 
```