### PR TITLE
refactor: Fix staticcheck QF* issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -118,7 +118,8 @@ linters:
       # https://staticcheck.dev/docs/configuration/options/#checks
       checks:
       - all
-      - -QF*
+      - -QF1001  # apply De Morgan's law
+      - -QF1008  # remove embedded field from selector
       - -SA3000  # false positive for Go 1.15+. See https://github.com/golang/go/issues/34129
       - -ST1000
       - -ST1001  # duplicates revive.dot-imports

--- a/pkg/guestagent/kubernetesservice/kubernetesservice.go
+++ b/pkg/guestagent/kubernetesservice/kubernetesservice.go
@@ -140,9 +140,10 @@ func (s *ServiceWatcher) GetPorts() []Entry {
 			}
 
 			var port int32
-			if service.Spec.Type == corev1.ServiceTypeNodePort {
+			switch service.Spec.Type {
+			case corev1.ServiceTypeNodePort:
 				port = portEntry.NodePort
-			} else if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
+			case corev1.ServiceTypeLoadBalancer:
 				port = portEntry.Port
 			}
 

--- a/pkg/hostagent/dns/dns.go
+++ b/pkg/hostagent/dns/dns.go
@@ -78,11 +78,7 @@ func newStaticClientConfig(ips []string) (*dns.ClientConfig, error) {
 
 func (h *Handler) lookupCnameToHost(cname string) string {
 	seen := make(map[string]bool)
-	for {
-		// break cyclic definition
-		if seen[cname] {
-			break
-		}
+	for !seen[cname] { // break cyclic definition
 		if _, ok := h.cnameToHost[cname]; ok {
 			seen[cname] = true
 			cname = h.cnameToHost[cname]


### PR DESCRIPTION
The PR fixes issues reported by staticcheck under the `QF*` checks:

```console
$ golangci-lint run
pkg/guestagent/kubernetesservice/kubernetesservice.go:143:4: QF1003: could use tagged switch on service.Spec.Type (staticcheck)
                        if service.Spec.Type == corev1.ServiceTypeNodePort {
                        ^
pkg/hostagent/dns/dns.go:83:3: QF1006: could lift into loop condition (staticcheck)
                if seen[cname] {
                ^
2 issues:
* staticcheck: 2
```

The `if seen[cname] { break }` condition was not covered by tests, so I added test cases for cyclic definitions.