### PR TITLE
Add support for collecting instance IP address

### DIFF
--- a/pkg/guestagent/api/client/client.go
+++ b/pkg/guestagent/api/client/client.go
@@ -76,3 +76,7 @@ func (c *GuestAgentClient) Tunnel(ctx context.Context) (api.GuestService_TunnelC
 	}
 	return stream, nil
 }
+
+func (c *GuestAgentClient) GetIP(ctx context.Context, req *api.GetIPRequest) (*api.GetIPRespond, error) {
+	return c.cli.GetIP(ctx, req)
+}

--- a/pkg/guestagent/api/guestservice.pb.desc
+++ b/pkg/guestagent/api/guestservice.pb.desc
@@ -1,5 +1,5 @@
 
-…
+û
 guestservice.protogoogle/protobuf/empty.protogoogle/protobuf/timestamp.proto"0
 Info(
 local_ports (2.IPPortR
@@ -23,9 +23,15 @@ mount_path (	R	mountPath.
 data (Rdata
 
 guest_addr (	R	guestAddr&
-udp_target_addr (	RudpTargetAddr2È
+udp_target_addr (	RudpTargetAddr"-
+GetIPRequest
+
+ip_version (	R	ipVersion"
+GetIPRespond
+ip (	Rip2ï
 GuestService(
 GetInfo.google.protobuf.Empty.Info-
 	GetEvents.google.protobuf.Empty.Event01
 PostInotify.Inotify.google.protobuf.Empty(,
-Tunnel.TunnelMessage.TunnelMessage(0B/Z-github.com/lima-vm/lima/v2/pkg/guestagent/apibproto3
+Tunnel.TunnelMessage.TunnelMessage(0%
+GetIP.GetIPRequest.GetIPRespondB/Z-github.com/lima-vm/lima/v2/pkg/guestagent/apibproto3

--- a/pkg/guestagent/api/guestservice.pb.go
+++ b/pkg/guestagent/api/guestservice.pb.go
@@ -323,6 +323,94 @@ func (x *TunnelMessage) GetUdpTargetAddr() string {
 	return ""
 }
 
+type GetIPRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	IpVersion     string                 `protobuf:"bytes,1,opt,name=ip_version,json=ipVersion,proto3" json:"ip_version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetIPRequest) Reset() {
+	*x = GetIPRequest{}
+	mi := &file_guestservice_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetIPRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetIPRequest) ProtoMessage() {}
+
+func (x *GetIPRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_guestservice_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetIPRequest.ProtoReflect.Descriptor instead.
+func (*GetIPRequest) Descriptor() ([]byte, []int) {
+	return file_guestservice_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *GetIPRequest) GetIpVersion() string {
+	if x != nil {
+		return x.IpVersion
+	}
+	return ""
+}
+
+type GetIPRespond struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Ip            string                 `protobuf:"bytes,1,opt,name=ip,proto3" json:"ip,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetIPRespond) Reset() {
+	*x = GetIPRespond{}
+	mi := &file_guestservice_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetIPRespond) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetIPRespond) ProtoMessage() {}
+
+func (x *GetIPRespond) ProtoReflect() protoreflect.Message {
+	mi := &file_guestservice_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetIPRespond.ProtoReflect.Descriptor instead.
+func (*GetIPRespond) Descriptor() ([]byte, []int) {
+	return file_guestservice_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *GetIPRespond) GetIp() string {
+	if x != nil {
+		return x.Ip
+	}
+	return ""
+}
+
 var File_guestservice_proto protoreflect.FileDescriptor
 
 const file_guestservice_proto_rawDesc = "" +
@@ -350,12 +438,18 @@ const file_guestservice_proto_rawDesc = "" +
 	"\x04data\x18\x03 \x01(\fR\x04data\x12\x1d\n" +
 	"\n" +
 	"guest_addr\x18\x04 \x01(\tR\tguestAddr\x12&\n" +
-	"\x0fudp_target_addr\x18\x05 \x01(\tR\rudpTargetAddr2\xc8\x01\n" +
+	"\x0fudp_target_addr\x18\x05 \x01(\tR\rudpTargetAddr\"-\n" +
+	"\fGetIPRequest\x12\x1d\n" +
+	"\n" +
+	"ip_version\x18\x01 \x01(\tR\tipVersion\"\x1e\n" +
+	"\fGetIPRespond\x12\x0e\n" +
+	"\x02ip\x18\x01 \x01(\tR\x02ip2\xef\x01\n" +
 	"\fGuestService\x12(\n" +
 	"\aGetInfo\x12\x16.google.protobuf.Empty\x1a\x05.Info\x12-\n" +
 	"\tGetEvents\x12\x16.google.protobuf.Empty\x1a\x06.Event0\x01\x121\n" +
 	"\vPostInotify\x12\b.Inotify\x1a\x16.google.protobuf.Empty(\x01\x12,\n" +
-	"\x06Tunnel\x12\x0e.TunnelMessage\x1a\x0e.TunnelMessage(\x010\x01B/Z-github.com/lima-vm/lima/v2/pkg/guestagent/apib\x06proto3"
+	"\x06Tunnel\x12\x0e.TunnelMessage\x1a\x0e.TunnelMessage(\x010\x01\x12%\n" +
+	"\x05GetIP\x12\r.GetIPRequest\x1a\r.GetIPRespondB/Z-github.com/lima-vm/lima/v2/pkg/guestagent/apib\x06proto3"
 
 var (
 	file_guestservice_proto_rawDescOnce sync.Once
@@ -369,35 +463,39 @@ func file_guestservice_proto_rawDescGZIP() []byte {
 	return file_guestservice_proto_rawDescData
 }
 
-var file_guestservice_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_guestservice_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_guestservice_proto_goTypes = []any{
 	(*Info)(nil),                  // 0: Info
 	(*Event)(nil),                 // 1: Event
 	(*IPPort)(nil),                // 2: IPPort
 	(*Inotify)(nil),               // 3: Inotify
 	(*TunnelMessage)(nil),         // 4: TunnelMessage
-	(*timestamppb.Timestamp)(nil), // 5: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),         // 6: google.protobuf.Empty
+	(*GetIPRequest)(nil),          // 5: GetIPRequest
+	(*GetIPRespond)(nil),          // 6: GetIPRespond
+	(*timestamppb.Timestamp)(nil), // 7: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),         // 8: google.protobuf.Empty
 }
 var file_guestservice_proto_depIdxs = []int32{
-	2, // 0: Info.local_ports:type_name -> IPPort
-	5, // 1: Event.time:type_name -> google.protobuf.Timestamp
-	2, // 2: Event.added_local_ports:type_name -> IPPort
-	2, // 3: Event.removed_local_ports:type_name -> IPPort
-	5, // 4: Inotify.time:type_name -> google.protobuf.Timestamp
-	6, // 5: GuestService.GetInfo:input_type -> google.protobuf.Empty
-	6, // 6: GuestService.GetEvents:input_type -> google.protobuf.Empty
-	3, // 7: GuestService.PostInotify:input_type -> Inotify
-	4, // 8: GuestService.Tunnel:input_type -> TunnelMessage
-	0, // 9: GuestService.GetInfo:output_type -> Info
-	1, // 10: GuestService.GetEvents:output_type -> Event
-	6, // 11: GuestService.PostInotify:output_type -> google.protobuf.Empty
-	4, // 12: GuestService.Tunnel:output_type -> TunnelMessage
-	9, // [9:13] is the sub-list for method output_type
-	5, // [5:9] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	2,  // 0: Info.local_ports:type_name -> IPPort
+	7,  // 1: Event.time:type_name -> google.protobuf.Timestamp
+	2,  // 2: Event.added_local_ports:type_name -> IPPort
+	2,  // 3: Event.removed_local_ports:type_name -> IPPort
+	7,  // 4: Inotify.time:type_name -> google.protobuf.Timestamp
+	8,  // 5: GuestService.GetInfo:input_type -> google.protobuf.Empty
+	8,  // 6: GuestService.GetEvents:input_type -> google.protobuf.Empty
+	3,  // 7: GuestService.PostInotify:input_type -> Inotify
+	4,  // 8: GuestService.Tunnel:input_type -> TunnelMessage
+	5,  // 9: GuestService.GetIP:input_type -> GetIPRequest
+	0,  // 10: GuestService.GetInfo:output_type -> Info
+	1,  // 11: GuestService.GetEvents:output_type -> Event
+	8,  // 12: GuestService.PostInotify:output_type -> google.protobuf.Empty
+	4,  // 13: GuestService.Tunnel:output_type -> TunnelMessage
+	6,  // 14: GuestService.GetIP:output_type -> GetIPRespond
+	10, // [10:15] is the sub-list for method output_type
+	5,  // [5:10] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_guestservice_proto_init() }
@@ -411,7 +509,7 @@ func file_guestservice_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_guestservice_proto_rawDesc), len(file_guestservice_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/guestagent/api/guestservice.proto
+++ b/pkg/guestagent/api/guestservice.proto
@@ -11,11 +11,11 @@ service GuestService {
   rpc PostInotify(stream Inotify) returns (google.protobuf.Empty);
 
   rpc Tunnel(stream TunnelMessage) returns (stream TunnelMessage);
+
+  rpc GetIP(GetIPRequest) returns (GetIPRespond);
 }
 
-message Info {
-  repeated IPPort local_ports = 1;
-}
+message Info { repeated IPPort local_ports = 1; }
 
 message Event {
   google.protobuf.Timestamp time = 1;
@@ -42,3 +42,6 @@ message TunnelMessage {
   string guest_addr = 4;
   string udp_target_addr = 5;
 }
+
+message GetIPRequest { string ip_version = 1; }
+message GetIPRespond { string ip = 1; }

--- a/pkg/guestagent/api/guestservice_grpc.pb.go
+++ b/pkg/guestagent/api/guestservice_grpc.pb.go
@@ -24,6 +24,7 @@ const (
 	GuestService_GetEvents_FullMethodName   = "/GuestService/GetEvents"
 	GuestService_PostInotify_FullMethodName = "/GuestService/PostInotify"
 	GuestService_Tunnel_FullMethodName      = "/GuestService/Tunnel"
+	GuestService_GetIP_FullMethodName       = "/GuestService/GetIP"
 )
 
 // GuestServiceClient is the client API for GuestService service.
@@ -34,6 +35,7 @@ type GuestServiceClient interface {
 	GetEvents(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[Event], error)
 	PostInotify(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[Inotify, emptypb.Empty], error)
 	Tunnel(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[TunnelMessage, TunnelMessage], error)
+	GetIP(ctx context.Context, in *GetIPRequest, opts ...grpc.CallOption) (*GetIPRespond, error)
 }
 
 type guestServiceClient struct {
@@ -99,6 +101,16 @@ func (c *guestServiceClient) Tunnel(ctx context.Context, opts ...grpc.CallOption
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type GuestService_TunnelClient = grpc.BidiStreamingClient[TunnelMessage, TunnelMessage]
 
+func (c *guestServiceClient) GetIP(ctx context.Context, in *GetIPRequest, opts ...grpc.CallOption) (*GetIPRespond, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetIPRespond)
+	err := c.cc.Invoke(ctx, GuestService_GetIP_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // GuestServiceServer is the server API for GuestService service.
 // All implementations must embed UnimplementedGuestServiceServer
 // for forward compatibility.
@@ -107,6 +119,7 @@ type GuestServiceServer interface {
 	GetEvents(*emptypb.Empty, grpc.ServerStreamingServer[Event]) error
 	PostInotify(grpc.ClientStreamingServer[Inotify, emptypb.Empty]) error
 	Tunnel(grpc.BidiStreamingServer[TunnelMessage, TunnelMessage]) error
+	GetIP(context.Context, *GetIPRequest) (*GetIPRespond, error)
 	mustEmbedUnimplementedGuestServiceServer()
 }
 
@@ -128,6 +141,9 @@ func (UnimplementedGuestServiceServer) PostInotify(grpc.ClientStreamingServer[In
 }
 func (UnimplementedGuestServiceServer) Tunnel(grpc.BidiStreamingServer[TunnelMessage, TunnelMessage]) error {
 	return status.Errorf(codes.Unimplemented, "method Tunnel not implemented")
+}
+func (UnimplementedGuestServiceServer) GetIP(context.Context, *GetIPRequest) (*GetIPRespond, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetIP not implemented")
 }
 func (UnimplementedGuestServiceServer) mustEmbedUnimplementedGuestServiceServer() {}
 func (UnimplementedGuestServiceServer) testEmbeddedByValue()                      {}
@@ -193,6 +209,24 @@ func _GuestService_Tunnel_Handler(srv interface{}, stream grpc.ServerStream) err
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type GuestService_TunnelServer = grpc.BidiStreamingServer[TunnelMessage, TunnelMessage]
 
+func _GuestService_GetIP_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetIPRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GuestServiceServer).GetIP(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GuestService_GetIP_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GuestServiceServer).GetIP(ctx, req.(*GetIPRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // GuestService_ServiceDesc is the grpc.ServiceDesc for GuestService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -203,6 +237,10 @@ var GuestService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetInfo",
 			Handler:    _GuestService_GetInfo_Handler,
+		},
+		{
+			MethodName: "GetIP",
+			Handler:    _GuestService_GetIP_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/pkg/guestagent/api/server/server.go
+++ b/pkg/guestagent/api/server/server.go
@@ -56,3 +56,7 @@ func (s *GuestServer) PostInotify(server api.GuestService_PostInotifyServer) err
 func (s *GuestServer) Tunnel(stream api.GuestService_TunnelServer) error {
 	return s.TunnelS.Start(stream)
 }
+
+func (s *GuestServer) GetIP(ctx context.Context, req *api.GetIPRequest) (*api.GetIPRespond, error) {
+	return s.Agent.IP(ctx, req.IpVersion)
+}

--- a/pkg/guestagent/guestagent.go
+++ b/pkg/guestagent/guestagent.go
@@ -14,4 +14,5 @@ type Agent interface {
 	Events(ctx context.Context, ch chan *api.Event)
 	LocalPorts(ctx context.Context) ([]*api.IPPort, error)
 	HandleInotify(event *api.Inotify)
+	IP(ctx context.Context, ipVersion string) (*api.GetIPRespond, error)
 }

--- a/pkg/guestagent/guestagent_linux.go
+++ b/pkg/guestagent/guestagent_linux.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/guestagent/api"
 	"github.com/lima-vm/lima/v2/pkg/guestagent/iptables"
 	"github.com/lima-vm/lima/v2/pkg/guestagent/kubernetesservice"
+	"github.com/lima-vm/lima/v2/pkg/guestagent/metricutil"
 	"github.com/lima-vm/lima/v2/pkg/guestagent/procnettcp"
 	"github.com/lima-vm/lima/v2/pkg/guestagent/ticker"
 	"github.com/lima-vm/lima/v2/pkg/guestagent/timesync"
@@ -45,8 +46,7 @@ func New(ctx context.Context, ticker ticker.Ticker, iptablesIdle time.Duration) 
 
 	auditStatus, err := auditClient.GetStatus()
 	if err != nil {
-		// syscall.EPERM is returned when using audit from a non-initial namespace
-		// https://github.com/torvalds/linux/blob/633b47cb009d09dc8f4ba9cdb3a0ca138809c7c7/kernel/audit.c#L1054-L1057
+		// syscall.EPERM is returned when using audit from a non-initial namespace https://github.com/torvalds/linux/blob/633b47cb009d09dc8f4ba9cdb3a0ca138809c7c7/kernel/audit.c#L1054-L1057
 		if !errors.Is(err, syscall.EPERM) {
 			return nil, err
 		}
@@ -370,4 +370,9 @@ func (a *agent) HandleInotify(event *api.Inotify) {
 			logrus.Errorf("error in inotify handle. Event: %s, Error: %s", event, err)
 		}
 	}
+}
+
+func (a *agent) IP(ctx context.Context, ipVersion string) (*api.GetIPRespond, error) {
+	out, err := metricutil.GetDefaultIP(ipVersion)
+	return &api.GetIPRespond{Ip: out}, err
 }

--- a/pkg/guestagent/metricutil/ip.go
+++ b/pkg/guestagent/metricutil/ip.go
@@ -1,0 +1,33 @@
+package metricutil
+
+import (
+	"errors"
+	"net"
+)
+
+// getIP return default ip address on the guest instance.
+// There would be several interfaces in a guest, This function return the default route to host.lima.internal.
+func GetDefaultIP(ipVersion string) (string, error) {
+	var dest string
+
+	switch ipVersion {
+	case "4":
+		dest = "host.lima.internal:1"
+	default:
+		return "", errors.New("unsupported ipVersion: " + ipVersion)
+	}
+
+	conn, err := net.Dial("udp", dest)
+	if err != nil {
+		err = errors.New("cannot determine the default IP:")
+		return "", err
+	}
+	defer conn.Close()
+
+	ipAddress, _, err := net.SplitHostPort(conn.LocalAddr().String())
+	if err != nil {
+		return "", err
+	}
+
+	return ipAddress, err
+}

--- a/pkg/hostagent/api/api.go
+++ b/pkg/hostagent/api/api.go
@@ -4,5 +4,6 @@
 package api
 
 type Info struct {
-	SSHLocalPort int `json:"sshLocalPort,omitempty"`
+	SSHLocalPort int    `json:"sshLocalPort,omitempty"`
+	GuestIPv4Address      string `json:"guestIPv4Address,omitempty"`
 }

--- a/pkg/limatype/lima_instance.go
+++ b/pkg/limatype/lima_instance.go
@@ -47,6 +47,7 @@ type Instance struct {
 	Protected       bool              `json:"protected"`
 	LimaVersion     string            `json:"limaVersion"`
 	Param           map[string]string `json:"param,omitempty"`
+	IPv4Address     string            `json:"ipv4,omitempty"`
 }
 
 // Protect protects the instance to prohibit accidental removal.

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -83,6 +83,7 @@ func Inspect(ctx context.Context, instName string) (*limatype.Instance, error) {
 				inst.Errors = append(inst.Errors, fmt.Errorf("failed to get Info from %q: %w", haSock, err))
 			} else {
 				inst.SSHLocalPort = info.SSHLocalPort
+				inst.IPv4Address = info.GuestIPv4Address
 			}
 		}
 	}
@@ -144,6 +145,7 @@ func Inspect(ctx context.Context, instName string) (*limatype.Instance, error) {
 		inst.Errors = append(inst.Errors, err)
 	}
 	inst.Param = y.Param
+
 	return inst, nil
 }
 


### PR DESCRIPTION
## What does this PR do?
- Fix #3616 
- Adds support for generating an instance `instance_info.json` file.
- This file includes basic instance information: _name, IPv4, and IPv6 addresses._


## Implementation details
### With GuestAgent:
- The raw output from `ip -j a` is embedded as `json_bytes` in the gRPC Events message.
- The GuestAgent listens for this event, extracts the IP information, and writes it to the `instance_info.json` file.

### Without GuestAgent (Plain mode):
- This PR updates the `executeSSH()` function signature to return both the command output and error (instead of just error).
- After completing any requirements setup, HostAgent uses `executeSSH()` to run `ip -j a`, processes the output, and writes the instance info locally.

## Testing
- Setup: Lima upstream master, OS(Ubuntu 22.02)
- templates: almalinux alpine debian fedora opensuse oraclelinux ubuntu
- Test command: `limactl start INSTNAME --network lima:user-v2`
-  **Result**
    - With GuestAgent: All tests passed.
    - Plain Mode: Failed on AlmaLinux and Alpine — instances did not start successfully.
