### PR TITLE
guestagent: Fix isEmptyEvent check

### DIFF
--- a/pkg/guestagent/guestagent_linux.go
+++ b/pkg/guestagent/guestagent_linux.go
@@ -191,9 +191,8 @@ func (a *agent) collectEvent(ctx context.Context, st eventState) (*api.Event, ev
 
 func isEventEmpty(ev *api.Event) bool {
 	empty := &api.Event{}
-	copied := ev
-	copied.Time = nil
-	return reflect.DeepEqual(empty, copied)
+	empty.Time = ev.Time
+	return reflect.DeepEqual(empty, ev)
 }
 
 func (a *agent) Events(ctx context.Context, ch chan *api.Event) {


### PR DESCRIPTION
The intention seems to be checking if an event is equal to empty event, ignoring the event time, by copying the event and setting its time to nil. However instead of copying the event, we use the same object and set the event time to nil.

I don't know if this caused a user visible problem, but it likely log wrong event time if we log the event.