### PR TITLE
hostagent: Log ssh forwarding command

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -758,6 +758,7 @@ func forwardSSH(ctx context.Context, sshConfig *ssh.SSHConfig, port int, local, 
 		}
 	}
 	cmd := exec.CommandContext(ctx, sshConfig.Binary(), args...)
+	logrus.Debugf("Running %q", cmd)
 	if out, err := cmd.Output(); err != nil {
 		if verb == verbForward && strings.HasPrefix(local, "/") {
 			if reverse {


### PR DESCRIPTION
We log a message when forwarding to guest unix socket, but it is not clear from the log how this is implemented, and the code is confusing (using ssh forwarding when using GRPC forwarding). Let's make this more clear by logging the ssh forwarding command.

Example logs:

    {"level":"debug","msg":"Forwarding unix sockets","time":"2025-07-06T15:59:43+03:00"}

    {"level":"info","msg":"Forwarding \"/run/user/501/podman/podman.sock\" (guest) to
        \"/Users/nir/.lima/podman/sock/podman.sock\" (host)","time":"2025-07-06T15:59:43+03:00"}

    {"level":"debug","msg":"Running \"/usr/bin/ssh -F /dev/null -o IdentityFile=\\\"/Users/nir/.lima/_config/user\\\"
        -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NoHostAuthenticationForLocalhost=yes
        -o PreferredAuthentications=publickey -o Compression=no -o BatchMode=yes -o IdentitiesOnly=yes
        -o GSSAPIAuthentication=no -o Ciphers=\\\"^aes128-gcm@openssh.com,aes256-gcm@openssh.com\\\" -o User=nir
        -o ControlMaster=auto -o ControlPath=\\\"/Users/nir/.lima/podman/ssh.sock\\\" -o ControlPersist=yes -T
        -O forward -L /Users/nir/.lima/podman/sock/podman.sock:/run/user/501/podman/podman.sock -N -f -p 53505
        127.0.0.1 --\"","time":"2025-07-06T15:59:43+03:00"}