### PR TITLE
Plain mode: support port forwarding

### DIFF
--- a/hack/test-nonplain-static-port-forward.sh
+++ b/hack/test-nonplain-static-port-forward.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euxo pipefail
+
+INSTANCE=nonplain-static-port-forward
+TEMPLATE=hack/test-templates/static-port-forward.yaml
+
+limactl delete -f $INSTANCE || true
+
+limactl start --name=$INSTANCE --tty=false $TEMPLATE
+
+limactl shell $INSTANCE -- bash -c 'until [ -e /run/nginx.pid ]; do sleep 1; done'
+limactl shell $INSTANCE -- bash -c 'until systemctl is-active --quiet test-server-9080; do sleep 1; done'
+limactl shell $INSTANCE -- bash -c 'until systemctl is-active --quiet test-server-9070; do sleep 1; done'
+
+curl -sSf http://127.0.0.1:9090 | grep -i 'nginx' && echo 'Static port forwarding (9090) works in normal mode!'
+curl -sSf http://127.0.0.1:9080 | grep -i 'Dynamic port 9080' && echo 'Dynamic port forwarding (9080) works in normal mode!'
+curl -sSf http://127.0.0.1:9070 | grep -i 'Dynamic port 9070' && echo 'Dynamic port forwarding (9070) works in normal mode!'
+
+limactl delete -f $INSTANCE
+echo "All tests passed for normal mode - both static and dynamic ports work!"
+# EOF

--- a/hack/test-plain-static-port-forward.sh
+++ b/hack/test-plain-static-port-forward.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euxo pipefail
+
+INSTANCE=plain-static-port-forward
+TEMPLATE=hack/test-templates/static-port-forward.yaml
+
+limactl delete -f $INSTANCE || true
+
+limactl start --name=$INSTANCE --plain=true --tty=false $TEMPLATE
+
+limactl shell $INSTANCE -- bash -c 'until [ -e /run/nginx.pid ]; do sleep 1; done'
+
+curl -sSf http://127.0.0.1:9090 | grep -i 'nginx' && echo 'Static port forwarding (9090) works in plain mode!'
+
+if curl -sSf http://127.0.0.1:9080 2>/dev/null; then
+	echo 'ERROR: Dynamic port 9080 should not be forwarded in plain mode!'
+	exit 1
+else
+	echo 'Dynamic port 9080 is correctly NOT forwarded in plain mode.'
+fi
+
+if curl -sSf http://127.0.0.1:9070 2>/dev/null; then
+	echo 'ERROR: Dynamic port 9070 should not be forwarded in plain mode!'
+	exit 1
+else
+	echo 'Dynamic port 9070 is correctly NOT forwarded in plain mode.'
+fi
+
+limactl delete -f $INSTANCE
+echo "All tests passed for plain mode - only static ports work!"
+# EOF

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -51,6 +51,7 @@ declare -A CHECKS=(
 	["snapshot-offline"]=""
 	["clone"]=""
 	["port-forwards"]="1"
+	["static-port-forwards"]=""
 	["vmnet"]=""
 	["disk"]=""
 	["user-v2"]=""
@@ -94,6 +95,12 @@ case "$NAME" in
 	CHECKS["provision-yq"]="1"
 	CHECKS["param-env-variables"]="1"
 	CHECKS["set-user"]="1"
+	;;
+"static-port-forward")
+	CHECKS["static-port-forwards"]="1"
+	CHECKS["port-forwards"]=""
+	CHECKS["container-engine"]=""
+	CHECKS["restart"]=""
 	;;
 "docker")
 	CONTAINER_ENGINE="docker"
@@ -403,6 +410,13 @@ if [[ -n ${CHECKS["port-forwards"]} ]]; then
 		fi
 	fi
 	set +x
+fi
+
+if [[ -n ${CHECKS["static-port-forwards"]} ]]; then
+	INFO "Testing static port forwarding functionality"
+	"${scriptdir}/test-plain-static-port-forward.sh" "$NAME"
+	"${scriptdir}/test-nonplain-static-port-forward.sh" "$NAME"
+	INFO "All static port forwarding tests passed!"
 fi
 
 if [[ -n ${CHECKS["vmnet"]} ]]; then

--- a/hack/test-templates/static-port-forward.yaml
+++ b/hack/test-templates/static-port-forward.yaml
@@ -1,0 +1,64 @@
+images:
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+  arch: "x86_64"
+
+provision:
+- mode: system
+  script: |
+    apt-get update
+    apt-get install -y nginx python3
+    systemctl enable nginx
+    systemctl start nginx
+
+    cat > /etc/systemd/system/test-server-9080.service << 'EOF'
+    [Unit]
+    Description=Test Server on Port 9080
+    After=network.target
+
+    [Service]
+    Type=simple
+    User=root
+    ExecStart=/usr/bin/python3 -m http.server 9080 --bind 127.0.0.1
+    Restart=always
+
+    [Install]
+    WantedBy=multi-user.target
+    EOF
+
+    cat > /etc/systemd/system/test-server-9070.service << 'EOF'
+    [Unit]
+    Description=Test Server on Port 9070
+    After=network.target
+
+    [Service]
+    Type=simple
+    User=root
+    ExecStart=/usr/bin/python3 -m http.server 9070 --bind 127.0.0.1
+    Restart=always
+
+    [Install]
+    WantedBy=multi-user.target
+    EOF
+
+    mkdir -p /var/www/html-9080
+    mkdir -p /var/www/html-9070
+
+    echo '<html><body><h1>Dynamic port 9080</h1></body></html>' > /var/www/html-9080/index.html
+    echo '<html><body><h1>Dynamic port 9070</h1></body></html>' > /var/www/html-9070/index.html
+
+    systemctl daemon-reload
+    systemctl enable test-server-9080
+    systemctl enable test-server-9070
+    systemctl start test-server-9080
+    systemctl start test-server-9070
+
+portForwards:
+- guestPort: 80
+  hostPort: 9090
+  static: true
+- guestPort: 9080
+  hostPort: 9080
+  static: false
+- guestPort: 9070
+  hostPort: 9070
+  static: false

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -300,6 +300,7 @@ type PortForward struct {
 	Proto             Proto  `yaml:"proto,omitempty" json:"proto,omitempty"`
 	Reverse           bool   `yaml:"reverse,omitempty" json:"reverse,omitempty"`
 	Ignore            bool   `yaml:"ignore,omitempty" json:"ignore,omitempty"`
+	Static            bool   `yaml:"static,omitempty" json:"static,omitempty"`
 }
 
 type CopyToHost struct {

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -823,13 +823,24 @@ func fixUpForPlainMode(y *limatype.LimaYAML) {
 	if !*y.Plain {
 		return
 	}
+	deleteNonStaticPortForwards(&y.PortForwards)
 	y.Mounts = nil
-	y.PortForwards = nil
 	y.Containerd.System = ptr.Of(false)
 	y.Containerd.User = ptr.Of(false)
 	y.VMOpts.VZ.Rosetta.BinFmt = ptr.Of(false)
 	y.VMOpts.VZ.Rosetta.Enabled = ptr.Of(false)
 	y.TimeZone = ptr.Of("")
+}
+
+// deleteNonStaticPortForwards removes all non-static port forwarding rules in case of Plain mode.
+func deleteNonStaticPortForwards(portForwards *[]limatype.PortForward) {
+	staticPortForwards := make([]limatype.PortForward, 0, len(*portForwards))
+	for _, rule := range *portForwards {
+		if rule.Static {
+			staticPortForwards = append(staticPortForwards, rule)
+		}
+	}
+	*portForwards = staticPortForwards
 }
 
 func executeGuestTemplate(format, instDir string, user limatype.User, param map[string]string) (bytes.Buffer, error) {

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -402,6 +402,16 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 			}
 		}
 	}
+	if y.Plain != nil && *y.Plain {
+		const portRangeWarnThreshold = 10
+		for i, rule := range y.PortForwards {
+			guestRange := rule.GuestPortRange[1] - rule.GuestPortRange[0] + 1
+			hostRange := rule.HostPortRange[1] - rule.HostPortRange[0] + 1
+			if guestRange > portRangeWarnThreshold || hostRange > portRangeWarnThreshold {
+				logrus.Warnf("[plain mode] portForwards[%d] covers a range of more than %d ports (guest: %d, host: %d). All ports will be forwarded unconditionally, which may be inefficient.", i, portRangeWarnThreshold, guestRange, hostRange)
+			}
+		}
+	}
 
 	return errs
 }


### PR DESCRIPTION
Fixes [#2962](https://github.com/lima-vm/lima/issues/2962)


# Changes

- Added `--port-forward` CLI flag to `limactl create`, allowing users to specify static port forwards even in plain mode.
- Modified host agent to set up static SSH-based TCP port forwarding in plain mode.
- Updated YAML expressions to handle `portForwards` from CLI.
- Added validation warnings for large port ranges in plain mode.