### PR TITLE
Bump alpine-lima to v0.2.44

### DIFF
--- a/templates/_images/alpine-iso.yaml
+++ b/templates/_images/alpine-iso.yaml
@@ -1,9 +1,9 @@
-# Using the Alpine 3.20 aarch64 image with vmType=vz requires macOS Ventura 13.3 or later.
+# Using the Alpine 3.21 aarch64 image with vmType=vz requires macOS Ventura 13.3 or later.
 images:
-- location: https://github.com/lima-vm/alpine-lima/releases/download/v0.2.41/alpine-lima-std-3.20.3-x86_64.iso
+- location: https://github.com/lima-vm/alpine-lima/releases/download/v0.2.44/alpine-lima-std-3.21.3-x86_64.iso
   arch: x86_64
-  digest: sha512:949a353c1676bb406561d22c1b7f9db72fb0cc899c6c50166df3b38e392280a7e7b83f58643a309816d51a48317507c46c3e7e24e52fbc9f20fe817039306db1
+  digest: sha512:60d8c857ee2654ab26d3b7a68f3790e044cdef13e297e18167c2dcc885648a7b86100a4348aee03362edaa212c90b01c3c473c9b5a10500ba95ae6e9d0add2a5
 
-- location: https://github.com/lima-vm/alpine-lima/releases/download/v0.2.41/alpine-lima-std-3.20.3-aarch64.iso
+- location: https://github.com/lima-vm/alpine-lima/releases/download/v0.2.44/alpine-lima-std-3.21.3-aarch64.iso
   arch: aarch64
-  digest: sha512:91ea119fea2bb638519792de2047303b26eaebcdace8df57b76373dc7b1cddcad77aaa9fed2d438fb02351b261783af3264d6bb2716519f8ba211a4b25d6f114
+  digest: sha512:ac421aa43b791f41edbebe4d1ceaee34bf68876af1c75c1992bb497c7411b14a95f51294f09e44beb1cb029ef36e5a6262b01786a08737de07dca92599eb20e2


### PR DESCRIPTION
It now bundles the iproute2 package which adds `ip -j a` support.

Alpine itself is bumped from 3.20.3 to 3.21.3.