### PR TITLE
CI: unify Windows runners to `windows-2025`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        runs-on: [ubuntu-24.04, macos-15, windows-2022]
+        runs-on: [ubuntu-24.04, macos-15, windows-2025]
     runs-on: ${{ matrix.runs-on }}
     steps:
     - name: Force git to use LF
@@ -150,7 +150,7 @@ jobs:
 
   windows:
     name: "Windows tests (WSL2)"
-    runs-on: windows-2025-8-cores
+    runs-on: windows-2025
     timeout-minutes: 30
     steps:
     - name: Enable WSL2


### PR DESCRIPTION
Different windows runners were used across QEMU, WSL2, and linters