### PR TITLE
De-deprecate LIMA_SSH_PORT_FORWARDER

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -53,7 +53,7 @@ type HostAgent struct {
 	instName          string
 	instSSHAddress    string
 	sshConfig         *ssh.SSHConfig
-	portForwarder     *portForwarder // legacy SSH port forwarder (deprecated)
+	portForwarder     *portForwarder // legacy SSH port forwarder
 	grpcPortForwarder *portfwd.Forwarder
 
 	onClose []func() error // LIFO
@@ -660,7 +660,6 @@ func (a *HostAgent) processGuestAgentEvents(ctx context.Context, client *guestag
 			}
 		}
 		if useSSHFwd {
-			logrus.Warn("LIMA_SSH_PORT_FORWARDER is deprecated")
 			a.portForwarder.OnEvent(ctx, ev)
 		} else {
 			a.grpcPortForwarder.OnEvent(ctx, client, ev)

--- a/website/content/en/docs/config/environment-variables.md
+++ b/website/content/en/docs/config/environment-variables.md
@@ -75,7 +75,6 @@ This page documents the environment variables used in Lima.
   ```sh
   export LIMA_SSH_PORT_FORWARDER=false
   ```
-- **Note**: Deprecated since v1.1. It is expected that this variable will be removed in future.
 - **The history of the default value**:
   | Version       | Default value       |
   |---------------|---------------------|

--- a/website/content/en/docs/releases/deprecated.md
+++ b/website/content/en/docs/releases/deprecated.md
@@ -8,7 +8,6 @@ The following features are deprecated:
 - CentOS 7 support
 - Loading non-strict YAMLs (i.e., YAMLs with unknown properties)
 - `limactl show-ssh` command (Use `ssh -F ~/.lima/default/ssh.config lima-default` instead)
-- `LIMA_SSH_PORT_FORWARDER=true` (since Lima v1.1)
 - Ansible provisioning mode (Use `ansible-playbook playbook.yaml` after the start instead)
 
 ## Removed features


### PR DESCRIPTION
It should be still legit to prefer the legacy stable implementation