### PR TITLE
rename UDPEstablished to UDPUnconnected

### DIFF
--- a/pkg/guestagent/guestagent_linux.go
+++ b/pkg/guestagent/guestagent_linux.go
@@ -237,7 +237,7 @@ func (a *agent) LocalPorts(_ context.Context) ([]*api.IPPort, error) {
 					})
 			}
 		case procnettcp.UDP, procnettcp.UDP6:
-			if f.State == procnettcp.UDPEstablished {
+			if f.State == procnettcp.UDPUnconnected {
 				res = append(res,
 					&api.IPPort{
 						Ip:       f.IP.String(),

--- a/pkg/guestagent/procnettcp/procnettcp.go
+++ b/pkg/guestagent/procnettcp/procnettcp.go
@@ -31,7 +31,7 @@ type State = int
 const (
 	TCPEstablished State = 0x1
 	TCPListen      State = 0xA
-	UDPEstablished State = 0x7
+	UDPUnconnected State = 0x7
 )
 
 type Entry struct {

--- a/pkg/guestagent/procnettcp/procnettcp_test.go
+++ b/pkg/guestagent/procnettcp/procnettcp_test.go
@@ -77,7 +77,7 @@ func TestParseUDP(t *testing.T) {
 
 	assert.Check(t, net.ParseIP("127.0.0.54").Equal(entries[0].IP))
 	assert.Equal(t, uint16(53), entries[0].Port)
-	assert.Equal(t, UDPEstablished, entries[0].State)
+	assert.Equal(t, UDPUnconnected, entries[0].State)
 }
 
 func TestParseAddress(t *testing.T) {


### PR DESCRIPTION
I've spent some time debugging issues with UDP forwarding and got sidetracked because of this constant, so I decieded to submit this PR suggesting to change it

there's no "established" for the UDP, and 0x7 is usually called UNCONN in tools like net-tools or ss

strictly speaking there's no "unconnected" constant in the kernel either, but it's a well known way to call it.

this might be a matter of taste, so please feel free to close this PR if you disagree