### PR TITLE
Define "MCP Sandbox Interface" and implement `limactl mcp serve`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,8 @@ help-targets:
 	@echo  '- limactl                   : Build limactl, and lima'
 	@echo  '- lima                      : Copy lima, and lima.bat'
 	@echo  '- helpers                   : Copy nerdctl.lima, apptainer.lima, docker.lima, podman.lima, and kubectl.lima'
+	# TODO: move CLI plugins to _output/libexec/lima/
+	@echo  '- limactl-plugins           : Build limactl-* CLI plugins'
 	@echo
 	@echo  'Targets for files in _output/share/lima/:'
 	@echo  '- guestagents               : Build guestagents'
@@ -150,7 +152,7 @@ CONFIG_GUESTAGENT_COMPRESS=y
 
 ################################################################################
 .PHONY: binaries
-binaries: limactl helpers guestagents \
+binaries: limactl helpers limactl-plugins guestagents \
 	templates template_experimentals \
 	documentation create-links-in-doc-dir
 
@@ -255,6 +257,11 @@ endif
 ifeq ($(GOOS),darwin)
 	codesign -f -v --entitlements vz.entitlements -s - $@
 endif
+
+limactl-plugins: _output/bin/limactl-mcp$(exe)
+
+_output/bin/limactl-mcp$(exe): $(call dependencies_for_cmd,limactl-mcp) $$(call force_build,$$@)
+	$(ENVS_$@) $(GO_BUILD) -o $@ ./cmd/limactl-mcp
 
 DRIVER_INSTALL_DIR := _output/libexec/lima
 

--- a/cmd/limactl-mcp/main.go
+++ b/cmd/limactl-mcp/main.go
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/v2/pkg/mcp/toolset"
+	"github.com/lima-vm/lima/v2/pkg/store"
+	"github.com/lima-vm/lima/v2/pkg/version"
+)
+
+func main() {
+	if err := newApp().Execute(); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func newApp() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "limactl-mcp",
+		Short:         "Model Context Protocol plugin for Lima (EXPERIMENTAL)",
+		Version:       strings.TrimPrefix(version.Version, "v"),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.AddCommand(
+		newMcpInfoCommand(),
+		newMcpServeCommand(),
+		// TODO: `limactl-mcp install-gemini` ?
+	)
+	return cmd
+}
+
+func newServer() *mcp.Server {
+	impl := &mcp.Implementation{
+		Name:    "lima",
+		Title:   "Lima VM, for sandboxing local command executions and file I/O operations",
+		Version: version.Version,
+	}
+	serverOpts := &mcp.ServerOptions{
+		Instructions: `This MCP server provides tools for sandboxing local command executions and file I/O operations,
+by wrapping them in Lima VM (https://lima-vm.io).
+
+Use these tools to avoid accidentally executing malicious codes directly on the host.
+`,
+	}
+	if runtime.GOOS != "linux" {
+		serverOpts.Instructions += fmt.Sprintf(`
+
+NOTE: the guest OS of the VM is Linux, while the host OS is %s.
+`, strings.ToTitle(runtime.GOOS))
+	}
+	return mcp.NewServer(impl, serverOpts)
+}
+
+func newMcpInfoCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "info",
+		Short: "Show information about the MCP server",
+		Args:  cobra.NoArgs,
+		RunE:  mcpInfoAction,
+	}
+	return cmd
+}
+
+func mcpInfoAction(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	ts, err := toolset.New()
+	if err != nil {
+		return err
+	}
+	server := newServer()
+	if err = ts.RegisterServer(server); err != nil {
+		return err
+	}
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		return err
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "client"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		return err
+	}
+	toolsResult, err := clientSession.ListTools(ctx, &mcp.ListToolsParams{})
+	if err != nil {
+		return err
+	}
+	if err = clientSession.Close(); err != nil {
+		return err
+	}
+	if err = serverSession.Wait(); err != nil {
+		return err
+	}
+	info := &Info{
+		Tools: toolsResult.Tools,
+	}
+	j, err := json.MarshalIndent(info, "", "    ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(cmd.OutOrStdout(), string(j))
+	return err
+}
+
+type Info struct {
+	Tools []*mcp.Tool `json:"tools"`
+}
+
+func newMcpServeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "serve INSTANCE",
+		Short: "Serve MCP over stdio",
+		Long: `Serve MCP over stdio.
+
+Expected to be executed via an AI agent, not by a human`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: mcpServeAction,
+	}
+	return cmd
+}
+
+func mcpServeAction(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	instName := "default"
+	if len(args) > 0 {
+		instName = args[0]
+	}
+
+	ts, err := toolset.New()
+	if err != nil {
+		return err
+	}
+	server := newServer()
+	if err = ts.RegisterServer(server); err != nil {
+		return err
+	}
+
+	inst, err := store.Inspect(ctx, instName)
+	if err != nil {
+		return err
+	}
+	if err = ts.RegisterInstance(ctx, inst); err != nil {
+		return err
+	}
+	transport := &mcp.StdioTransport{}
+	return server.Run(ctx, transport)
+}

--- a/go.mod
+++ b/go.mod
@@ -31,9 +31,11 @@ require (
 	github.com/mdlayher/vsock v1.2.1 // gomodjail:unconfined
 	github.com/miekg/dns v1.1.68 // gomodjail:unconfined
 	github.com/mikefarah/yq/v4 v4.47.2
+	github.com/modelcontextprotocol/go-sdk v0.4.0
 	github.com/nxadm/tail v1.4.11 // gomodjail:unconfined
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
+	github.com/pkg/sftp v1.13.9
 	github.com/rjeczalik/notify v0.9.3
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sethvargo/go-password v0.3.1
@@ -105,13 +107,13 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pkg/sftp v1.13.9 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	// gomodjail:unconfined
 	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
 	golang.org/x/mod v0.27.0 // indirect
@@ -135,6 +137,7 @@ require (
 
 require (
 	github.com/go-ini/ini v1.67.0 // indirect
+	github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
 github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
+github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76 h1:mBlBwtDebdDYr+zdop8N62a44g+Nbv7o2KjWyS1deR4=
+github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
@@ -191,6 +193,8 @@ github.com/mikefarah/yq/v4 v4.47.2 h1:Jb5fHlvgK5eeaPbreG9UJs1E5w6l5hUzXjeaY6LTTW
 github.com/mikefarah/yq/v4 v4.47.2/go.mod h1:ulYbZUzGJsBDDwO5ohvk/KOW4vW5Iddd/DBeAY1Q09g=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/modelcontextprotocol/go-sdk v0.4.0 h1:RJ6kFlneHqzTKPzlQqiunrz9nbudSZcYLmLHLsokfoU=
+github.com/modelcontextprotocol/go-sdk v0.4.0/go.mod h1:whv0wHnsTphwq7CTiKYHkLtwLC06WMoY2KpO+RB9yXQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -266,6 +270,8 @@ github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/pkg/mcp/msi/filesystem.go
+++ b/pkg/mcp/msi/filesystem.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Portion of AI prompt texts from:
+// - https://github.com/google-gemini/gemini-cli/blob/v0.1.12/docs/tools/file-system.md
+//
+// SPDX-FileCopyrightText: Copyright 2025 Google LLC
+
+package msi
+
+import (
+	"io/fs"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+var ListDirectory = &mcp.Tool{
+	Name:        "list_directory",
+	Description: `Lists the names of files and subdirectories directly within a specified directory path.`,
+}
+
+type ListDirectoryParams struct {
+	Path string `json:"path" jsonschema:"The absolute path to the directory to list."`
+}
+
+// ListDirectoryResultEntry is similar to [io/fs.FileInfo].
+type ListDirectoryResultEntry struct {
+	Name    string       `json:"name" jsonschema:"base name of the file"`
+	Size    *int64       `json:"size,omitempty" jsonschema:"length in bytes for regular files; system-dependent for others"`
+	Mode    *fs.FileMode `json:"mode,omitempty" jsonschema:"file mode bits"`
+	ModTime *time.Time   `json:"time,omitempty" jsonschema:"modification time"`
+	IsDir   *bool        `json:"is_dir,omitempty" jsonschema:"true for a directory"`
+}
+
+type ListDirectoryResult struct {
+	Entries []ListDirectoryResultEntry `json:"entries" jsonschema:"The directory content entries."`
+}
+
+var ReadFile = &mcp.Tool{
+	Name:        "read_file",
+	Description: `Reads and returns the content of a specified file.`,
+}
+
+type ReadFileParams struct {
+	Path string `json:"path" jsonschema:"The absolute path to the file to read."`
+	// Offset *int   `json:"offset,omitempty" jsonschema:"For text files, the 0-based line number to start reading from. Requires limit to be set."`
+	// Limit  *int   `json:"limit,omitempty" jsonschema:"For text files, the maximum number of lines to read. If omitted, reads a default maximum (e.g., 2000 lines) or the entire file if feasible."`
+}
+
+var WriteFile = &mcp.Tool{
+	Name:        "write_file",
+	Description: `Writes content to a specified file. If the file exists, it will be overwritten. If the file doesn't exist, it (and any necessary parent directories) will be created.`,
+}
+
+type WriteFileParams struct {
+	Path    string `json:"path" jsonschema:"The absolute path to the file to write to."`
+	Content string `json:"content" jsonschema:"The content to write into the file."`
+}
+
+var Glob = &mcp.Tool{
+	Name:        "glob",
+	Description: `Finds files matching specific glob patterns (e.g., src/**/*.ts, *.md)`, // Not sorted yet, unlike Gemini
+}
+
+type GlobParams struct {
+	Pattern string  `json:"pattern" jsonschema:"The glob pattern to match against (e.g., '*.py', 'src/**/*.js')."`
+	Path    *string `json:"path,omitempty" jsonschema:"The absolute path to the directory to search within. If omitted, searches the tool's root directory."`
+	// CaseSensitive bool    `json:"case_sensitive,omitempty" jsonschema:": Whether the search should be case-sensitive. Defaults to false."`
+}
+
+var SearchFileContent = &mcp.Tool{
+	Name:        "search_file_content",
+	Description: `searches for a regular expression pattern within the content of files in a specified directory. Internally calls 'git grep -n --no-index'.`,
+}
+
+type SearchFileContentParams struct {
+	Pattern string  `json:"pattern" jsonschema:"The regular expression (regex) to search for (e.g., 'function\\s+myFunction')."`
+	Path    *string `json:"path,omitempty" jsonschema:"The absolute path to the directory to search within. Defaults to the current working directory."`
+	Include *string `json:"include,omitempty" jsonschema:"A glob pattern to filter which files are searched (e.g., '*.js', 'src/**/*.{ts,tsx}'). If omitted, searches most files (respecting common ignores)."`
+}
+
+// TODO: implement Replace

--- a/pkg/mcp/msi/msi.go
+++ b/pkg/mcp/msi/msi.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package msi provides the "MCP Sandbox Interface" (tentative)
+// that should be reusable for other projects too.
+//
+// MCP Sandbox Interface defines MCP (Model Context Protocol) tools
+// that can be used for reading, writing, and executing local files
+// with an appropriate sandboxing technology. The sandboxing technology
+// can be more secure and/or efficient than the default tools provided
+// by an AI agent.
+//
+// MCP Sandbox Interface was inspired by Gemini CLI's built-in tools.
+// https://github.com/google-gemini/gemini-cli/tree/v0.1.12/docs/tools
+//
+// Notable differences from Gemini CLI's built-in tools:
+//   - the output format is JSON, not a plain text
+//   - the output of [SearchFileContent] always corresponds to `git grep -n --no-index`
+//   - [RunShellCommandParams].Command is a string slice, not a string
+//   - [RunShellCommandParams].Directory is a absolute path, not a relative path
+//   - [RunShellCommandParams].Directory must not be empty
+//
+// Eventually, this package may be split to a separate repository.
+package msi

--- a/pkg/mcp/msi/shell.go
+++ b/pkg/mcp/msi/shell.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Portion of AI prompt texts from:
+// - https://github.com/google-gemini/gemini-cli/blob/v0.1.12/docs/tools/shell.md
+//
+// SPDX-FileCopyrightText: Copyright 2025 Google LLC
+
+package msi
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+var RunShellCommand = &mcp.Tool{
+	Name:        "run_shell_command",
+	Description: `Executes a given shell command.`,
+}
+
+type RunShellCommandParams struct {
+	Command     []string `json:"command" jsonschema:"The exact shell command to execute. Defined as a string slice, unlike Gemini's run_shell_command that defines it as a single string."`
+	Description string   `json:"description,omitempty" jsonschema:"A brief description of the command's purpose, which will be potentially shown to the user."`
+	Directory   string   `json:"directory" jsonschema:"The absolute directory in which to execute the command. Unlike Gemini's run_shell_command, this must not be a relative path, and must not be empty."`
+}
+
+type RunShellCommandResult struct {
+	Stdout   string `json:"stdout" jsonschema:"Output from the standard output stream."`
+	Stderr   string `json:"stderr" jsonschema:"Output from the standard error stream."`
+	Error    string `json:"error,omitempty" jsonschema:"Any error message reported by the subprocess."`
+	ExitCode *int   `json:"exit_code,omitempty" jsonschema:"Exit code of the command."`
+}

--- a/pkg/mcp/toolset/filesystem.go
+++ b/pkg/mcp/toolset/filesystem.go
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package toolset
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/lima-vm/lima/v2/pkg/mcp/msi"
+	"github.com/lima-vm/lima/v2/pkg/ptr"
+)
+
+func (ts *ToolSet) ListDirectory(ctx context.Context,
+	_ *mcp.CallToolRequest, args msi.ListDirectoryParams,
+) (*mcp.CallToolResult, any, error) {
+	if ts.inst == nil {
+		return nil, nil, errors.New("instance not registered")
+	}
+	guestPath, err := ts.TranslateHostPath(args.Path)
+	if err != nil {
+		return nil, nil, err
+	}
+	guestEnts, err := ts.sftp.ReadDirContext(ctx, guestPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	res := msi.ListDirectoryResult{
+		Entries: make([]msi.ListDirectoryResultEntry, len(guestEnts)),
+	}
+	for i, f := range guestEnts {
+		res.Entries[i].Name = f.Name()
+		res.Entries[i].Size = ptr.Of(f.Size())
+		res.Entries[i].Mode = ptr.Of(f.Mode())
+		res.Entries[i].ModTime = ptr.Of(f.ModTime())
+		res.Entries[i].IsDir = ptr.Of(f.IsDir())
+	}
+	resJ, err := json.Marshal(res)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(resJ)}},
+	}, nil, nil
+}
+
+func (ts *ToolSet) ReadFile(_ context.Context,
+	_ *mcp.CallToolRequest, args msi.ReadFileParams,
+) (*mcp.CallToolResult, any, error) {
+	if ts.inst == nil {
+		return nil, nil, errors.New("instance not registered")
+	}
+	guestPath, err := ts.TranslateHostPath(args.Path)
+	if err != nil {
+		return nil, nil, err
+	}
+	f, err := ts.sftp.Open(guestPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+	const limitBytes = 32 * 1024 * 1024
+	lr := io.LimitReader(f, limitBytes)
+	b, err := io.ReadAll(lr)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &mcp.CallToolResult{
+		// Gemini:
+		// For text files: The file content, potentially prefixed with a truncation message
+		// (e.g., [File content truncated: showing lines 1-100 of 500 total lines...]\nActual file content...).
+		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+	}, nil, nil
+}
+
+func (ts *ToolSet) WriteFile(_ context.Context,
+	_ *mcp.CallToolRequest, args msi.WriteFileParams,
+) (*mcp.CallToolResult, any, error) {
+	if ts.inst == nil {
+		return nil, nil, errors.New("instance not registered")
+	}
+	guestPath, err := ts.TranslateHostPath(args.Path)
+	if err != nil {
+		return nil, nil, err
+	}
+	f, err := ts.sftp.Create(guestPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+	_, err = f.Write([]byte(args.Content))
+	if err != nil {
+		return nil, nil, err
+	}
+	return &mcp.CallToolResult{
+		// Gemini:
+		// A success message, e.g., `Successfully overwrote file: /path/to/your/file.txt`
+		// or `Successfully created and wrote to new file: /path/to/new/file.txt.`
+		Content: []mcp.Content{&mcp.TextContent{Text: "OK"}},
+	}, nil, nil
+}
+
+func (ts *ToolSet) Glob(_ context.Context,
+	_ *mcp.CallToolRequest, args msi.GlobParams,
+) (*mcp.CallToolResult, any, error) {
+	if ts.inst == nil {
+		return nil, nil, errors.New("instance not registered")
+	}
+	pathStr, err := os.Getwd()
+	if err != nil {
+		return nil, nil, err
+	}
+	if args.Path != nil && *args.Path != "" {
+		pathStr = *args.Path
+	}
+	guestPath, err := ts.TranslateHostPath(pathStr)
+	if err != nil {
+		return nil, nil, err
+	}
+	pattern := path.Join(guestPath, args.Pattern)
+	matches, err := ts.sftp.Glob(pattern)
+	if err != nil {
+		return nil, nil, err
+	}
+	resJ, err := json.Marshal(matches)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &mcp.CallToolResult{
+		// Gemini:
+		// A message like: Found 5 file(s) matching "*.ts" within src, sorted by modification time (newest first):\nsrc/file1.ts\nsrc/subdir/file2.ts...
+		Content: []mcp.Content{&mcp.TextContent{Text: string(resJ)}},
+	}, nil, nil
+}
+
+func (ts *ToolSet) SearchFileContent(ctx context.Context,
+	req *mcp.CallToolRequest, args msi.SearchFileContentParams,
+) (*mcp.CallToolResult, any, error) {
+	if ts.inst == nil {
+		return nil, nil, errors.New("instance not registered")
+	}
+	pathStr, err := os.Getwd()
+	if err != nil {
+		return nil, nil, err
+	}
+	if args.Path != nil && *args.Path != "" {
+		pathStr = *args.Path
+	}
+	guestPath, err := ts.TranslateHostPath(pathStr)
+	if err != nil {
+		return nil, nil, err
+	}
+	if args.Include != nil && *args.Include != "" {
+		guestPath = path.Join(guestPath, *args.Include)
+	}
+	return ts.RunShellCommand(ctx, req, msi.RunShellCommandParams{
+		Command: []string{"git", "grep", "-n", "--no-index", args.Pattern, guestPath},
+	})
+}

--- a/pkg/mcp/toolset/shell.go
+++ b/pkg/mcp/toolset/shell.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package toolset
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os/exec"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/lima-vm/lima/v2/pkg/mcp/msi"
+	"github.com/lima-vm/lima/v2/pkg/ptr"
+)
+
+func (ts *ToolSet) RunShellCommand(ctx context.Context,
+	_ *mcp.CallToolRequest, args msi.RunShellCommandParams,
+) (*mcp.CallToolResult, any, error) {
+	if ts.inst == nil {
+		return nil, nil, errors.New("instance not registered")
+	}
+	guestPath, err := ts.TranslateHostPath(args.Directory)
+	if err != nil {
+		return nil, nil, err
+	}
+	cmd := exec.CommandContext(ctx, ts.limactl,
+		append([]string{"shell", "--workdir=" + guestPath, ts.inst.Name},
+			args.Command...)...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmdErr := cmd.Run()
+	res := msi.RunShellCommandResult{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+	if cmdErr == nil {
+		res.ExitCode = ptr.Of(0)
+	} else {
+		res.Error = cmdErr.Error()
+		if st := cmd.ProcessState; st != nil {
+			res.ExitCode = ptr.Of(st.ExitCode())
+		}
+	}
+	resJ, err := json.Marshal(res)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(resJ)}},
+	}, nil, nil
+}

--- a/pkg/mcp/toolset/toolset.go
+++ b/pkg/mcp/toolset/toolset.go
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package toolset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/pkg/sftp"
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/instance/hostname"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/mcp/msi"
+	"github.com/lima-vm/lima/v2/pkg/sshutil"
+)
+
+func New() (*ToolSet, error) {
+	limactl, err := exec.LookPath("limactl")
+	if err != nil {
+		return nil, err
+	}
+	ts := &ToolSet{
+		limactl: limactl,
+	}
+	return ts, nil
+}
+
+type ToolSet struct {
+	limactl string // needed for `limactl shell --workdir`
+
+	// Set on RegisterInstance()
+	inst    *limatype.Instance
+	sftp    *sftp.Client
+	sftpCmd *exec.Cmd
+}
+
+func newSFTPClient(ctx context.Context, inst *limatype.Instance) (*sftp.Client, *exec.Cmd, error) {
+	sshExe, err := sshutil.NewSSHExe()
+	if err != nil {
+		return nil, nil, err
+	}
+	ssh := append([]string{sshExe.Exe}, sshExe.Args...)
+	ssh = append(ssh, "-F",
+		filepath.Join(inst.Dir, filenames.SSHConfig),
+		hostname.FromInstName(inst.Name))
+
+	cmd := exec.CommandContext(ctx, ssh[0], append(ssh[1:], "-s", "sftp")...)
+	cmd.Stderr = os.Stderr
+	w, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	r, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	if err = cmd.Start(); err != nil {
+		return nil, nil, err
+	}
+	client, err := sftp.NewClientPipe(r, w)
+	if err != nil {
+		if cmd != nil && cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	}
+	return client, cmd, err
+}
+
+func (ts *ToolSet) RegisterInstance(ctx context.Context, inst *limatype.Instance) error {
+	if inst.Status != limatype.StatusRunning {
+		return fmt.Errorf("expected status of instance %q to be %q, got %q",
+			inst.Name, limatype.StatusRunning, inst.Status)
+	}
+	if len(inst.Config.Mounts) == 0 {
+		logrus.Warnf("instance %q has no mount", inst.Name)
+	}
+	ts.inst = inst
+	var err error
+	ts.sftp, ts.sftpCmd, err = newSFTPClient(ctx, inst)
+	return err
+}
+
+func (ts *ToolSet) RegisterServer(server *mcp.Server) error {
+	mcp.AddTool(server, msi.ListDirectory, ts.ListDirectory)
+	mcp.AddTool(server, msi.ReadFile, ts.ReadFile)
+	mcp.AddTool(server, msi.WriteFile, ts.WriteFile)
+	mcp.AddTool(server, msi.Glob, ts.Glob)
+	mcp.AddTool(server, msi.SearchFileContent, ts.SearchFileContent)
+	mcp.AddTool(server, msi.RunShellCommand, ts.RunShellCommand)
+	return nil
+}
+
+func (ts *ToolSet) Close() error {
+	var err error
+	if ts.sftp != nil {
+		err = errors.Join(err, ts.sftp.Close())
+	}
+	if ts.sftpCmd != nil && ts.sftpCmd.Process != nil {
+		err = errors.Join(err, ts.sftpCmd.Process.Kill())
+	}
+	return err
+}
+
+func (ts *ToolSet) TranslateHostPath(hostPath string) (string, error) {
+	if hostPath == "" {
+		return "", errors.New("path is empty")
+	}
+	if !filepath.IsAbs(hostPath) {
+		return "", fmt.Errorf("expected an absolute path, got a relative path: %q", hostPath)
+	}
+	// TODO: make sure that hostPath is mounted
+	return hostPath, nil
+}

--- a/website/content/en/docs/config/ai/_index.md
+++ b/website/content/en/docs/config/ai/_index.md
@@ -1,0 +1,11 @@
+---
+title: AI
+weight: 90
+---
+
+There are two kinds of scenario to use Lima with AI:
+
+- [AI in Lima](./ai-in-lima): running an AI agent inside a VM
+- [Lima in AI](./lima-in-ai): calling Lima's MCP tools from an AI agent running outside a VM
+
+<!-- TODO: add a comparison table -->

--- a/website/content/en/docs/config/ai/ai-in-lima/_index.md
+++ b/website/content/en/docs/config/ai/ai-in-lima/_index.md
@@ -1,0 +1,19 @@
+---
+title: AI in Lima
+weight: 10
+---
+
+Lima is useful for running AI agents (e.g., Codex, Claude, Gemini) so as to prevent them
+from directly reading, writing, or executing the host files.
+
+Lima v2.0 is planned to be released with built-in templates for well-known AI agents.
+
+For Lima v1.x, you can install AI agents in Lima manually.
+
+e.g.,
+
+```bash
+lima sudo apt install -y npm
+lima sudo npm install -g @google/gemini-cli
+lima gemini
+```

--- a/website/content/en/docs/config/ai/lima-in-ai/_index.md
+++ b/website/content/en/docs/config/ai/lima-in-ai/_index.md
@@ -1,0 +1,7 @@
+---
+title: Lima in AI (MCP)
+weight: 10
+---
+
+Starting with Lima v2.0, Lima provides Model Context Protocol (MCP) tools
+for reading, writing, and executing local files using a VM sandbox.

--- a/website/content/en/docs/config/ai/lima-in-ai/gemini.md
+++ b/website/content/en/docs/config/ai/lima-in-ai/gemini.md
@@ -1,0 +1,60 @@
+---
+title: Gemini
+weight: 20
+
+---
+
+| ⚡ Requirement    | Lima >= 2.0 |
+|-------------------|-------------|
+
+This page describes how to use Lima as an sandbox for [Google Gemini CLI](https://github.com/google-gemini/gemini-cli).
+
+## Prerequisite
+In addition to Gemini and Lima, make sure that `limactl mcp` plugin is installed:
+
+```console
+$ limactl mcp -v
+limactl-mcp version 2.0.0-alpha.1
+```
+
+The `limactl mcp` plugin is bundled in Lima since v2.0, however, it may not be installed
+depending on the method of the [installation](../../../installation/).
+
+## Configuration
+1. Run the default Lima instance, with a mount of your project directory:
+```bash
+limactl start --mount-only "$(pwd):w" default
+```
+
+Drop the `:w` suffix if you do not want to allow writing to the mounted directory.
+
+1. Create `.gemini/extensions/lima/gemini-extension.json` as follows:
+```json
+{
+  "name": "lima",
+  "version": "2.0.0",
+  "mcpServers": {
+    "lima": {
+      "command": "limactl",
+      "args": [
+        "mcp",
+        "serve",
+        "default"
+      ]
+    }
+  }
+}
+```
+
+1. Modify `.gemini/settings.json` so as to disable Gemini CLI's [built-in tools](https://github.com/google-gemini/gemini-cli/tree/main/docs/tools)
+except ones that do not relate to local command execution and file I/O:
+```json
+{
+  "coreTools": ["WebFetchTool", "WebSearchTool", "MemoryTool"]
+}
+```
+
+## Usage
+Just run `gemini` in your project directory.
+
+Gemini automatically recognizes the MCP tools provided by Lima.

--- a/website/content/en/docs/releases/experimental.md
+++ b/website/content/en/docs/releases/experimental.md
@@ -19,6 +19,7 @@ The following commands are experimental and subject to change:
 - `limactl snapshot *`
 - `limactl tunnel`
 - `limactl template *`
+- `limactl mcp *`
 
 ## Graduated
 


### PR DESCRIPTION
This PR allows AI agents such as Gemini CLI to wrap local file operations (read/write/execute) inside Lima VM.

It should work with Claude Code, Codex, etc.  too, but they might need a modification to disable their built-in local file operation tools. (Help wanted for testing)

This feature will be available in Lima v2.0
- https://github.com/lima-vm/lima/issues/3712


Preview of the documentation: https://deploy-preview-3744--lima-vm.netlify.app/docs/config/ai/

- - -
## Interface

`pkg/mcp/msi` defines "MCP Sandbox Interface" (tentative) that should be reusable for other projects too.

MCP Sandbox Interface defines MCP (Model Context Protocol) tools that can be used for reading, writing, and executing local files with an appropriate sandboxing technology. The sandboxing technology can be more secure and/or efficient than the default tools provided by an AI agent.

MCP Sandbox Interface was inspired by Gemini CLI's built-in tools. https://github.com/google-gemini/gemini-cli/tree/v0.1.12/docs/tools

## Implementation

`limactl mcp serve INSTANCE` launches an MCP server that implements the MCP Sandbox Interface.

Use <https://github.com/modelcontextprotocol/inspector> to play around with the server.

```bash
limactl start default
brew install mcp-inspector
mcp-inspector
```
In the web browser,
- Set `Command` to `limactl`
- Set `Arguments` to `mcp serve default`
- Click `▶️Connect`

## Usage with Gemni CLI

1. Create `.gemini/extensions/lima/gemini-extension.json` as follows:
```json
{
  "name": "lima",
  "version": "2.0.0",
  "mcpServers": {
    "lima": {
      "command": "limactl",
      "args": [
        "mcp",
        "serve",
        "default"
      ]
    }
  }
}
```

2. Modify `.gemini/settings.json` so as to disable Gemini CLI's built-in tools except ones that do not relate to local command execution and file I/O:
```json
{
  "coreTools": ["WebFetchTool", "WebSearchTool", "MemoryTool"]
}
```


- - -

TODOs
- [x] Support writing files
- [ ] Test