### PR TITLE
Add feature to keep mounts with plain mode

### DIFF
--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -92,6 +92,7 @@ func RegisterCreate(cmd *cobra.Command, commentPrefix string) {
 	})
 
 	flags.Bool("plain", false, commentPrefix+"Plain mode. Disables mounts, port forwarding, containerd, etc.")
+	flags.Bool("plain-mounts", false, commentPrefix+"Keep any mounts, of the default type, in plain mode.")
 }
 
 func defaultExprFunc(expr string) func(v *flag.Flag) (string, error) {
@@ -257,6 +258,7 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool) ([]string, error) {
 		{"disk", d(".disk= \"%sGiB\""), false, false},
 		{"vm-type", d(".vmType = %q"), true, false},
 		{"plain", d(".plain = %s"), true, false},
+		{"plain-mounts", d(".plainMounts = %s"), true, false},
 	}
 	var exprs []string
 	for _, def := range defs {

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -420,7 +420,11 @@ func (a *HostAgent) Info(_ context.Context) (*hostagentapi.Info, error) {
 
 func (a *HostAgent) startHostAgentRoutines(ctx context.Context) error {
 	if *a.instConfig.Plain {
-		logrus.Info("Running in plain mode. Mounts, port forwarding, containerd, etc. will be ignored. Guest agent will not be running.")
+		if *a.instConfig.PlainMounts {
+			logrus.Info("Running in plain mode, with mounts. Port forwarding, containerd, etc. will be ignored. Guest agent will not be running.")
+		} else {
+			logrus.Info("Running in plain mode. Mounts, port forwarding, containerd, etc. will be ignored. Guest agent will not be running.")
+		}
 	}
 	a.onClose = append(a.onClose, func() error {
 		logrus.Debugf("shutting down the SSH master")

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -908,6 +908,16 @@ func FillDefault(y, d, o *LimaYAML, filePath string, warn bool) {
 		y.Plain = ptr.Of(false)
 	}
 
+	if y.PlainMounts == nil {
+		y.PlainMounts = d.PlainMounts
+	}
+	if o.PlainMounts != nil {
+		y.PlainMounts = o.PlainMounts
+	}
+	if y.PlainMounts == nil {
+		y.PlainMounts = ptr.Of(false)
+	}
+
 	fixUpForPlainMode(y)
 }
 
@@ -915,7 +925,9 @@ func fixUpForPlainMode(y *LimaYAML) {
 	if !*y.Plain {
 		return
 	}
-	y.Mounts = nil
+	if !*y.PlainMounts {
+		y.Mounts = nil
+	}
 	y.PortForwards = nil
 	y.Containerd.System = ptr.Of(false)
 	y.Containerd.User = ptr.Of(false)

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -120,6 +120,7 @@ func TestFillDefault(t *testing.T) {
 		},
 		NestedVirtualization: ptr.Of(false),
 		Plain:                ptr.Of(false),
+		PlainMounts:          ptr.Of(false),
 		User: User{
 			Name:    ptr.Of(user.Username),
 			Comment: ptr.Of(user.Name),
@@ -508,6 +509,7 @@ func TestFillDefault(t *testing.T) {
 		}
 	}
 	expect.Plain = ptr.Of(false)
+	expect.PlainMounts = ptr.Of(false)
 
 	y = LimaYAML{}
 	FillDefault(&y, &d, &LimaYAML{}, filePath, false)
@@ -751,6 +753,7 @@ func TestFillDefault(t *testing.T) {
 		BinFmt:  ptr.Of(false),
 	}
 	expect.Plain = ptr.Of(false)
+	expect.PlainMounts = ptr.Of(false)
 
 	expect.NestedVirtualization = ptr.Of(false)
 

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -49,6 +49,7 @@ type LimaYAML struct {
 	CACertificates       CACertificates `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
 	Rosetta              Rosetta        `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
 	Plain                *bool          `yaml:"plain,omitempty" json:"plain,omitempty" jsonschema:"nullable"`
+	PlainMounts          *bool          `yaml:"plainMounts,omitempty" json:"plainMounts,omitempty" jsonschema:"nullable"`
 	TimeZone             *string        `yaml:"timezone,omitempty" json:"timezone,omitempty" jsonschema:"nullable"`
 	NestedVirtualization *bool          `yaml:"nestedVirtualization,omitempty" json:"nestedVirtualization,omitempty" jsonschema:"nullable"`
 	User                 User           `yaml:"user,omitempty" json:"user,omitempty"`

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -181,6 +181,10 @@ func Validate(y *LimaYAML, warn bool) error {
 		errs = errors.Join(errs, fmt.Errorf("field `mountType` must not be one of %v (`mountTypesUnsupported`), got %q", y.MountTypesUnsupported, *y.MountType))
 	}
 
+	if *y.Plain && *y.PlainMounts && *y.MountType == REVSSHFS {
+		errs = errors.Join(errs, fmt.Errorf("field `mountType` must not be %v in plain mode", *y.MountType))
+	}
+
 	if warn && runtime.GOOS != "linux" {
 		for i, mount := range y.Mounts {
 			if mount.Virtiofs.QueueSize != nil {

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -555,6 +555,10 @@ guestInstallPrefix: null
 # 🟢 Builtin default: false
 plain: null
 
+# Keep the mounts, in "plain" mode.
+# 🟢 Builtin default: false
+plainMounts: null
+
 # When the "nestedVirtualization" feature is enabled:
 # - Allows running a VM inside the guest VM.
 # - The guest VM must configure QEMU with the `-cpu host` parameters to run a nested VM:


### PR DESCRIPTION
Allows using e.g. virtiofs in plain mode, without needing the guestagent etc.

But only for default mount type, since "reverse-sshfs" still needs non-plain.

Closes #3747

Discussion #3734