### PR TITLE
feature: add LocalPath to support use local resource to skip download

### DIFF
--- a/pkg/fileutils/download.go
+++ b/pkg/fileutils/download.go
@@ -5,9 +5,13 @@ package fileutils
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 
@@ -18,12 +22,65 @@ import (
 // ErrSkipped is returned when the downloader did not attempt to download the specified file.
 var ErrSkipped = errors.New("skipped to download")
 
+func CopyFile(src, dst string) error {
+	source, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o660); err != nil {
+		return err
+	}
+	destination, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destination.Close()
+	_, err = io.Copy(destination, source)
+	return err
+}
+
+func GetFileSHA256(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("sha256:%x", hash.Sum(nil)), nil
+}
+
 // DownloadFile downloads a file to the cache, optionally copying it to the destination. Returns path in cache.
-func DownloadFile(ctx context.Context, dest string, f limayaml.File, decompress bool, description string, expectedArch limayaml.Arch) (string, error) {
+func DownloadFile(ctx context.Context, dest string, f limayaml.File, decompress bool, description string, expectedArch limayaml.Arch) (_ string, reterr error) {
 	if f.Arch != expectedArch {
 		return "", fmt.Errorf("%w: %q: unsupported arch: %q", ErrSkipped, f.Location, f.Arch)
 	}
-	fields := logrus.Fields{"location": f.Location, "arch": f.Arch, "digest": f.Digest}
+	fields := logrus.Fields{"location": f.Location, "arch": f.Arch, "digest": f.Digest, "LocalPath": f.LocalPath}
+	if f.LocalPath != "" {
+		if _, err := os.Stat(f.LocalPath); err != nil {
+			return "", err
+		}
+		logrus.WithFields(fields).Infof("Attempting to copy local file %s", description)
+		if reterr != nil {
+			defer os.Remove(dest)
+		}
+		if err := CopyFile(f.LocalPath, dest); err != nil {
+			return "", fmt.Errorf("failed to copy file: %w", err)
+		}
+		sha256Sum, err := GetFileSHA256(dest)
+		if err != nil {
+			return "", fmt.Errorf("failed to getsha256: %w", err)
+		}
+
+		if sha256Sum != f.Digest.String() {
+			return "", fmt.Errorf("wrong sha256 for %s", dest)
+		}
+		return f.LocalPath, nil
+	}
+
 	logrus.WithFields(fields).Infof("Attempting to download %s", description)
 	res, err := downloader.Download(ctx, dest, f.Location,
 		downloader.WithCache(),

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -121,9 +121,10 @@ type Rosetta struct {
 }
 
 type File struct {
-	Location string        `yaml:"location" json:"location"` // REQUIRED
-	Arch     Arch          `yaml:"arch,omitempty" json:"arch,omitempty"`
-	Digest   digest.Digest `yaml:"digest,omitempty" json:"digest,omitempty"`
+	Location  string        `yaml:"location" json:"location"` // REQUIRED
+	Arch      Arch          `yaml:"arch,omitempty" json:"arch,omitempty"`
+	Digest    digest.Digest `yaml:"digest,omitempty" json:"digest,omitempty"`
+	LocalPath string        `yaml:"localPath,omitempty" json:"localPath,omitempty"`
 }
 
 type FileWithVMType struct {


### PR DESCRIPTION
some airgap environment doesn't support to download image. we can use local image when localPath is set.
for example if   localPath is set we can skip to download from https://cloud-images.ubuntu.com/releases/oracular/release-20250701/ubuntu-24.10-server-cloudimg-amd64.img
```
images:
# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.

- location: "https://cloud-images.ubuntu.com/releases/oracular/release-20250701/ubuntu-24.10-server-cloudimg-amd64.img"
  arch: "x86_64"
  digest: "sha256:69f31d3208895e5f646e345fbc95190e5e311ecd1359a4d6ee2c0b6483ceca03"
  localPath: "/tmp/ubuntu-24.10-server-cloudimg-amd64.img"
```