### PR TITLE
bugfix:fix limactl panic because of invalid digest

### DIFF
--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -122,9 +122,6 @@ func WithDecompress(decompress bool) Opt {
 func WithExpectedDigest(expectedDigest digest.Digest) Opt {
 	return func(o *options) error {
 		if expectedDigest != "" {
-			if !expectedDigest.Algorithm().Available() {
-				return fmt.Errorf("expected digest algorithm %q is not available", expectedDigest.Algorithm())
-			}
 			if err := expectedDigest.Validate(); err != nil {
 				return err
 			}

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -59,6 +59,10 @@ func TestDownloadRemote(t *testing.T) {
 			_, err := Download(context.Background(), localPath, dummyRemoteFileURL, WithExpectedDigest(wrongDigest))
 			assert.ErrorContains(t, err, "expected digest")
 
+			wrongDigest2 := digest.Digest("8313944efb4f38570c689813f288058b674ea6c487017a5a4738dc674b65f9d9")
+			_, err = Download(context.Background(), localPath, dummyRemoteFileURL, WithExpectedDigest(wrongDigest2))
+			assert.ErrorContains(t, err, "invalid checksum digest format")
+
 			r, err := Download(context.Background(), localPath, dummyRemoteFileURL, WithExpectedDigest(dummyRemoteFileDigest))
 			assert.NilError(t, err)
 			assert.Equal(t, StatusDownloaded, r.Status)

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -425,9 +425,6 @@ func validateFileObject(f File, fieldName string) error {
 		errs = errors.Join(errs, fmt.Errorf("field `arch` must be one of %v; got %q", ArchTypes, f.Arch))
 	}
 	if f.Digest != "" {
-		if !f.Digest.Algorithm().Available() {
-			errs = errors.Join(errs, fmt.Errorf("field `%s.digest` refers to an unavailable digest algorithm", fieldName))
-		}
 		if err := f.Digest.Validate(); err != nil {
 			errs = errors.Join(errs, fmt.Errorf("field `%s.digest` is invalid: %s: %w", fieldName, f.Digest.String(), err))
 		}

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -73,6 +73,21 @@ func TestValidateMinimumLimaVersion(t *testing.T) {
 	}
 }
 
+func TestValidateDigest(t *testing.T) {
+	images := `images: [{"location": "https://cloud-images.ubuntu.com/releases/oracular/release-20250701/ubuntu-24.10-server-cloudimg-amd64.img",digest: "69f31d3208895e5f646e345fbc95190e5e311ecd1359a4d6ee2c0b6483ceca03"}]`
+	validProbe := `probes: [{"script": "#!foo"}]`
+	y, err := Load([]byte(validProbe+"\n"+images), "lima.yaml")
+	assert.NilError(t, err)
+	err = Validate(y, false)
+	assert.Error(t, err, "field `images[0].digest` is invalid: 69f31d3208895e5f646e345fbc95190e5e311ecd1359a4d6ee2c0b6483ceca03: invalid checksum digest format")
+
+	images2 := `images: [{"location": "https://cloud-images.ubuntu.com/releases/oracular/release-20250701/ubuntu-24.10-server-cloudimg-amd64.img",digest: "sha001:69f31d3208895e5f646e345fbc95190e5e311ecd1359a4d6ee2c0b6483ceca03"}]`
+	y2, err := Load([]byte(validProbe+"\n"+images2), "lima.yaml")
+	assert.NilError(t, err)
+	err = Validate(y2, false)
+	assert.Error(t, err, "field `images[0].digest` is invalid: sha001:69f31d3208895e5f646e345fbc95190e5e311ecd1359a4d6ee2c0b6483ceca03: unsupported digest algorithm")
+}
+
 func TestValidateProbes(t *testing.T) {
 	images := `images: [{"location": "/"}]`
 	validProbe := `probes: [{"script": "#!foo"}]`


### PR DESCRIPTION
use wrong config

```
- location: "/home/nmx001/ubuntu-24.10-server-cloudimg-amd64.img"
  arch: "x86_64"
  digest: "69f31d3208895e5f646e345fbc95190e5e311ecd1359a4d6ee2c0b6483ceca03"
```



```
? Creating an instance "default" Proceed with the current configuration
panic: no ':' separator in digest "69f31d3208895e5f646e345fbc95190e5e311ecd1359a4d6ee2c0b6483ceca03"

goroutine 1 [running]:
github.com/opencontainers/go-digest.Digest.sepIndex({0xc001380a00, 0x40})
        /home/runner/go/pkg/mod/github.com/opencontainers/go-digest@v1.0.0/digest.go:153 +0x94
github.com/opencontainers/go-digest.Digest.Algorithm(...)
        /home/runner/go/pkg/mod/github.com/opencontainers/go-digest@v1.0.0/digest.go:122
github.com/lima-vm/lima/pkg/limayaml.validateFileObject({{0xc00140c780, 0x33}, {0xc0013fae70, 0x6}, {0xc001380a00, 0x40}}, {0xc0014b63e5, 0x9})
        /home/runner/work/lima/lima/pkg/limayaml/validate.go:434 +0x6de
github.com/lima-vm/lima/pkg/limayaml.Validate(0xc000863b08, 0x1)
        /home/runner/work/lima/lima/pkg/limayaml/validate.go:81 +0x1c72
github.com/lima-vm/lima/pkg/instance.Create({0x15fbda0, 0x25fd2e0}, {0x7ffc46b9d3f5, 0x7}, {0xc000482a00, 0xba6, 0x1500}, 0x1)
        /home/runner/work/lima/lima/pkg/instance/create.go:50 +0x205
main.loadOrCreateInstance(0xc0003fe608, {0xc0004ac870?, 0x0?, 0x0?}, 0x0)
        /home/runner/work/lima/lima/cmd/limactl/start.go:238 +0xdd2
main.startAction(0xc0003fe608, {0xc0004ac870, 0x1, 0x9})
        /home/runner/work/lima/lima/cmd/limactl/start.go:446 +0x78
github.com/spf13/cobra.(*Command).execute(0xc0003fe608, {0xc0004ac7e0, 0x9, 0x9})
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0xc0003fe008)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x46f
github.com/spf13/cobra.(*Command).Execute(...)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071

```