### PR TITLE
fix: Properly support multi-word executables set via `SSH` environment variable

### DIFF
--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -84,7 +84,7 @@ func copyAction(cmd *cobra.Command, args []string) error {
 		scpFlags = append(scpFlags, "-r")
 	}
 	// this assumes that ssh and scp come from the same place, but scp has no -V
-	legacySSH := sshutil.DetectOpenSSHVersion("ssh").LessThan(*semver.New("8.0.0"))
+	legacySSH := sshutil.DetectOpenSSHVersion(sshutil.SSHExe{Executable: "ssh"}).LessThan(*semver.New("8.0.0"))
 	for _, arg := range args {
 		if runtime.GOOS == "windows" {
 			if filepath.IsAbs(arg) {
@@ -135,14 +135,14 @@ func copyAction(cmd *cobra.Command, args []string) error {
 		// arguments such as ControlPath.  This is preferred as we can multiplex
 		// sessions without re-authenticating (MaxSessions permitting).
 		for _, inst := range instances {
-			sshOpts, err = sshutil.SSHOpts("ssh", inst.Dir, *inst.Config.User.Name, false, false, false, false)
+			sshOpts, err = sshutil.SSHOpts(sshutil.SSHExe{Executable: "ssh"}, inst.Dir, *inst.Config.User.Name, false, false, false, false)
 			if err != nil {
 				return err
 			}
 		}
 	} else {
 		// Copying among multiple hosts; we can't pass in host-specific options.
-		sshOpts, err = sshutil.CommonOpts("ssh", false)
+		sshOpts, err = sshutil.CommonOpts(sshutil.SSHExe{Executable: "ssh"}, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -196,13 +196,13 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	arg0, arg0Args, err := sshutil.SSHArguments()
+	sshExe, err := sshutil.SSHArguments()
 	if err != nil {
 		return err
 	}
 
 	sshOpts, err := sshutil.SSHOpts(
-		arg0,
+		sshExe,
 		inst.Dir,
 		*inst.Config.User.Name,
 		*inst.Config.SSH.LoadDotSSHPubKeys,
@@ -224,7 +224,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	logLevel := "ERROR"
 	// For versions older than OpenSSH 8.9p, LogLevel=QUIET was needed to
 	// avoid the "Shared connection to 127.0.0.1 closed." message with -t.
-	olderSSH := sshutil.DetectOpenSSHVersion(arg0).LessThan(*semver.New("8.9.0"))
+	olderSSH := sshutil.DetectOpenSSHVersion(sshExe).LessThan(*semver.New("8.9.0"))
 	if olderSSH {
 		logLevel = "QUIET"
 	}
@@ -235,7 +235,8 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		"--",
 		script,
 	}...)
-	sshCmd := exec.Command(arg0, append(arg0Args, sshArgs...)...)
+	allArgs := append(sshExe.Args, sshArgs...)
+	sshCmd := exec.Command(sshExe.Executable, allArgs...)
 	sshCmd.Stdin = os.Stdin
 	sshCmd.Stdout = os.Stdout
 	sshCmd.Stderr = os.Stderr

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -196,7 +196,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	sshExe, err := sshutil.SSHArguments()
+	sshExe, err := sshutil.NewSSHExe()
 	if err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		script,
 	}...)
 	allArgs := append(sshExe.Args, sshArgs...)
-	sshCmd := exec.Command(sshExe.Executable, allArgs...)
+	sshCmd := exec.Command(sshExe.Exe, allArgs...)
 	sshCmd.Stdin = os.Stdin
 	sshCmd.Stdout = os.Stdout
 	sshCmd.Stderr = os.Stderr

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -212,7 +212,8 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	sshArgs := sshutil.SSHArgsFromOpts(sshOpts)
+	sshArgs := append([]string{}, sshExe.Args...)
+	sshArgs = append(sshArgs, sshutil.SSHArgsFromOpts(sshOpts)...)
 	if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
 		// required for showing the shell prompt: https://stackoverflow.com/a/626574
 		sshArgs = append(sshArgs, "-t")
@@ -235,8 +236,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		"--",
 		script,
 	}...)
-	allArgs := append(sshExe.Args, sshArgs...)
-	sshCmd := exec.Command(sshExe.Exe, allArgs...)
+	sshCmd := exec.Command(sshExe.Exe, sshArgs...)
 	sshCmd.Stdin = os.Stdin
 	sshCmd.Stdout = os.Stdout
 	sshCmd.Stderr = os.Stderr

--- a/cmd/limactl/show-ssh.go
+++ b/cmd/limactl/show-ssh.go
@@ -92,8 +92,12 @@ func showSSHAction(cmd *cobra.Command, args []string) error {
 	}
 	logrus.Warnf("`limactl show-ssh` is deprecated. Instead, use `ssh -F %s %s`.",
 		filepath.Join(inst.Dir, filenames.SSHConfig), inst.Hostname)
+	sshExe, err := sshutil.NewSSHExe()
+	if err != nil {
+		return err
+	}
 	opts, err := sshutil.SSHOpts(
-		sshutil.SSHExe{Executable: "ssh"},
+		sshExe,
 		inst.Dir,
 		*inst.Config.User.Name,
 		*inst.Config.SSH.LoadDotSSHPubKeys,

--- a/cmd/limactl/show-ssh.go
+++ b/cmd/limactl/show-ssh.go
@@ -93,7 +93,7 @@ func showSSHAction(cmd *cobra.Command, args []string) error {
 	logrus.Warnf("`limactl show-ssh` is deprecated. Instead, use `ssh -F %s %s`.",
 		filepath.Join(inst.Dir, filenames.SSHConfig), inst.Hostname)
 	opts, err := sshutil.SSHOpts(
-		"ssh",
+		sshutil.SSHExe{Executable: "ssh"},
 		inst.Dir,
 		*inst.Config.User.Name,
 		*inst.Config.SSH.LoadDotSSHPubKeys,

--- a/cmd/limactl/tunnel.go
+++ b/cmd/limactl/tunnel.go
@@ -98,7 +98,8 @@ func tunnelAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	sshArgs := sshutil.SSHArgsFromOpts(sshOpts)
+	sshArgs := append([]string{}, sshExe.Args...)
+	sshArgs = append(sshArgs, sshutil.SSHArgsFromOpts(sshOpts)...)
 	sshArgs = append(sshArgs, []string{
 		"-q", // quiet
 		"-f", // background
@@ -107,8 +108,7 @@ func tunnelAction(cmd *cobra.Command, args []string) error {
 		"-p", strconv.Itoa(inst.SSHLocalPort),
 		inst.SSHAddress,
 	}...)
-	allArgs := append(sshExe.Args, sshArgs...)
-	sshCmd := exec.Command(sshExe.Exe, allArgs...)
+	sshCmd := exec.Command(sshExe.Exe, sshArgs...)
 	sshCmd.Stdout = stderr
 	sshCmd.Stderr = stderr
 	logrus.Debugf("executing ssh (may take a long)): %+v", sshCmd.Args)

--- a/cmd/limactl/tunnel.go
+++ b/cmd/limactl/tunnel.go
@@ -82,7 +82,7 @@ func tunnelAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	sshExe, err := sshutil.SSHArguments()
+	sshExe, err := sshutil.NewSSHExe()
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func tunnelAction(cmd *cobra.Command, args []string) error {
 		inst.SSHAddress,
 	}...)
 	allArgs := append(sshExe.Args, sshArgs...)
-	sshCmd := exec.Command(sshExe.Executable, allArgs...)
+	sshCmd := exec.Command(sshExe.Exe, allArgs...)
 	sshCmd.Stdout = stderr
 	sshCmd.Stderr = stderr
 	logrus.Debugf("executing ssh (may take a long)): %+v", sshCmd.Args)

--- a/cmd/limactl/tunnel.go
+++ b/cmd/limactl/tunnel.go
@@ -82,13 +82,13 @@ func tunnelAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	arg0, arg0Args, err := sshutil.SSHArguments()
+	sshExe, err := sshutil.SSHArguments()
 	if err != nil {
 		return err
 	}
 
 	sshOpts, err := sshutil.SSHOpts(
-		arg0,
+		sshExe,
 		inst.Dir,
 		*inst.Config.User.Name,
 		*inst.Config.SSH.LoadDotSSHPubKeys,
@@ -107,7 +107,8 @@ func tunnelAction(cmd *cobra.Command, args []string) error {
 		"-p", strconv.Itoa(inst.SSHLocalPort),
 		inst.SSHAddress,
 	}...)
-	sshCmd := exec.Command(arg0, append(arg0Args, sshArgs...)...)
+	allArgs := append(sshExe.Args, sshArgs...)
+	sshCmd := exec.Command(sshExe.Executable, allArgs...)
 	sshCmd.Stdout = stderr
 	sshCmd.Stderr = stderr
 	logrus.Debugf("executing ssh (may take a long)): %+v", sshCmd.Args)

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -147,7 +147,7 @@ func New(instName string, stdout io.Writer, signalCh chan os.Signal, opts ...Opt
 	}
 
 	sshOpts, err := sshutil.SSHOpts(
-		"ssh",
+		sshutil.SSHExe{Executable: "ssh"},
 		inst.Dir,
 		*inst.Config.User.Name,
 		*inst.Config.SSH.LoadDotSSHPubKeys,

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -146,8 +146,12 @@ func New(instName string, stdout io.Writer, signalCh chan os.Signal, opts ...Opt
 		return nil, err
 	}
 
+	sshExe, err := sshutil.NewSSHExe()
+	if err != nil {
+		return nil, err
+	}
 	sshOpts, err := sshutil.SSHOpts(
-		sshutil.SSHExe{Executable: "ssh"},
+		sshExe,
 		inst.Dir,
 		*inst.Config.User.Name,
 		*inst.Config.SSH.LoadDotSSHPubKeys,

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -387,9 +387,10 @@ func detectOpenSSHInfo(sshExe SSHExe) openSSHInfo {
 			return *info
 		}
 	}
+	sshArgs := append([]string{}, sshExe.Args...)
 	// -V should be last
-	allArgs := append(sshExe.Args, "-o", "GSSAPIAuthentication=no", "-V")
-	cmd := exec.Command(sshExe.Exe, allArgs...)
+	sshArgs = append(sshArgs, "-o", "GSSAPIAuthentication=no", "-V")
+	cmd := exec.Command(sshExe.Exe, sshArgs...)
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		logrus.Warnf("failed to run %v: stderr=%q", cmd.Args, stderr.String())

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -36,11 +36,11 @@ import (
 const EnvShellSSH = "SSH"
 
 type SSHExe struct {
-	Executable string
-	Args       []string
+	Exe  string
+	Args []string
 }
 
-func SSHArguments() (SSHExe, error) {
+func NewSSHExe() (SSHExe, error) {
 	var sshExe SSHExe
 
 	if sshShell := os.Getenv(EnvShellSSH); sshShell != "" {
@@ -50,7 +50,7 @@ func SSHArguments() (SSHExe, error) {
 			logrus.WithError(err).Warnf("Failed to split %s variable into shell tokens. "+
 				"Falling back to 'ssh' command", EnvShellSSH)
 		case len(sshShellFields) > 0:
-			sshExe.Executable = sshShellFields[0]
+			sshExe.Exe = sshShellFields[0]
 			if len(sshShellFields) > 1 {
 				sshExe.Args = sshShellFields[1:]
 			}
@@ -62,7 +62,7 @@ func SSHArguments() (SSHExe, error) {
 	if err != nil {
 		return SSHExe{}, err
 	}
-	sshExe.Executable = executable
+	sshExe.Exe = executable
 
 	return sshExe, nil
 }
@@ -376,7 +376,7 @@ func detectOpenSSHInfo(sshExe SSHExe) openSSHInfo {
 	)
 	// TODO: Fix this function to properly handle complex SSH commands like "kitten ssh"
 	// The current LookPath, os.Stat, and caching logic doesn't work well for multi-word commands
-	path, err := exec.LookPath(sshExe.Executable)
+	path, err := exec.LookPath(sshExe.Exe)
 	if err != nil {
 		logrus.Warnf("failed to find ssh executable: %v", err)
 	} else {
@@ -391,7 +391,7 @@ func detectOpenSSHInfo(sshExe SSHExe) openSSHInfo {
 	}
 	// -V should be last
 	allArgs := append(sshExe.Args, "-o", "GSSAPIAuthentication=no", "-V")
-	cmd := exec.Command(sshExe.Executable, allArgs...)
+	cmd := exec.Command(sshExe.Exe, allArgs...)
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		logrus.Warnf("failed to run %v: stderr=%q", cmd.Args, stderr.String())

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -35,7 +35,14 @@ import (
 // in place of the 'ssh' executable.
 const EnvShellSSH = "SSH"
 
-func SSHArguments() (arg0 string, arg0Args []string, err error) {
+type SSHExe struct {
+	Executable string
+	Args       []string
+}
+
+func SSHArguments() (SSHExe, error) {
+	var sshExe SSHExe
+
 	if sshShell := os.Getenv(EnvShellSSH); sshShell != "" {
 		sshShellFields, err := shellwords.Parse(sshShell)
 		switch {
@@ -43,21 +50,21 @@ func SSHArguments() (arg0 string, arg0Args []string, err error) {
 			logrus.WithError(err).Warnf("Failed to split %s variable into shell tokens. "+
 				"Falling back to 'ssh' command", EnvShellSSH)
 		case len(sshShellFields) > 0:
-			arg0 = sshShellFields[0]
+			sshExe.Executable = sshShellFields[0]
 			if len(sshShellFields) > 1 {
-				arg0Args = sshShellFields[1:]
+				sshExe.Args = sshShellFields[1:]
 			}
+			return sshExe, nil
 		}
 	}
 
-	if arg0 == "" {
-		arg0, err = exec.LookPath("ssh")
-		if err != nil {
-			return "", []string{""}, err
-		}
+	executable, err := exec.LookPath("ssh")
+	if err != nil {
+		return SSHExe{}, err
 	}
+	sshExe.Executable = executable
 
-	return arg0, arg0Args, nil
+	return sshExe, nil
 }
 
 type PubKey struct {
@@ -177,7 +184,7 @@ var sshInfo struct {
 //
 // The result always contains the IdentityFile option.
 // The result never contains the Port option.
-func CommonOpts(sshPath string, useDotSSH bool) ([]string, error) {
+func CommonOpts(sshExe SSHExe, useDotSSH bool) ([]string, error) {
 	configDir, err := dirnames.LimaConfigDir()
 	if err != nil {
 		return nil, err
@@ -243,7 +250,7 @@ func CommonOpts(sshPath string, useDotSSH bool) ([]string, error) {
 
 	sshInfo.Do(func() {
 		sshInfo.aesAccelerated = detectAESAcceleration()
-		sshInfo.openSSH = detectOpenSSHInfo(sshPath)
+		sshInfo.openSSH = detectOpenSSHInfo(sshExe)
 	})
 
 	if sshInfo.openSSH.GSSAPISupported {
@@ -287,12 +294,12 @@ func identityFileEntry(privateKeyPath string) (string, error) {
 }
 
 // SSHOpts adds the following options to CommonOptions: User, ControlMaster, ControlPath, ControlPersist.
-func SSHOpts(sshPath, instDir, username string, useDotSSH, forwardAgent, forwardX11, forwardX11Trusted bool) ([]string, error) {
+func SSHOpts(sshExe SSHExe, instDir, username string, useDotSSH, forwardAgent, forwardX11, forwardX11Trusted bool) ([]string, error) {
 	controlSock := filepath.Join(instDir, filenames.SSHSock)
 	if len(controlSock) >= osutil.UnixPathMax {
 		return nil, fmt.Errorf("socket path %q is too long: >= UNIX_PATH_MAX=%d", controlSock, osutil.UnixPathMax)
 	}
-	opts, err := CommonOpts(sshPath, useDotSSH)
+	opts, err := CommonOpts(sshExe, useDotSSH)
 	if err != nil {
 		return nil, err
 	}
@@ -361,13 +368,15 @@ var (
 	openSSHInfosRW sync.RWMutex
 )
 
-func detectOpenSSHInfo(ssh string) openSSHInfo {
+func detectOpenSSHInfo(sshExe SSHExe) openSSHInfo {
 	var (
 		info   openSSHInfo
 		exe    sshExecutable
 		stderr bytes.Buffer
 	)
-	path, err := exec.LookPath(ssh)
+	// TODO: Fix this function to properly handle complex SSH commands like "kitten ssh"
+	// The current LookPath, os.Stat, and caching logic doesn't work well for multi-word commands
+	path, err := exec.LookPath(sshExe.Executable)
 	if err != nil {
 		logrus.Warnf("failed to find ssh executable: %v", err)
 	} else {
@@ -381,7 +390,8 @@ func detectOpenSSHInfo(ssh string) openSSHInfo {
 		}
 	}
 	// -V should be last
-	cmd := exec.Command(path, "-o", "GSSAPIAuthentication=no", "-V")
+	allArgs := append(sshExe.Args, "-o", "GSSAPIAuthentication=no", "-V")
+	cmd := exec.Command(sshExe.Executable, allArgs...)
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		logrus.Warnf("failed to run %v: stderr=%q", cmd.Args, stderr.String())
@@ -398,8 +408,8 @@ func detectOpenSSHInfo(ssh string) openSSHInfo {
 	return info
 }
 
-func DetectOpenSSHVersion(ssh string) semver.Version {
-	return detectOpenSSHInfo(ssh).Version
+func DetectOpenSSHVersion(sshExe SSHExe) semver.Version {
+	return detectOpenSSHInfo(sshExe).Version
 }
 
 // detectValidPublicKey returns whether content represent a public key.


### PR DESCRIPTION
Fixes an issue with multi-word, custom ssh command specified via environment variable `SSH`.
As an example, when `export SSH="kitty ssh"` is used, some pre-flight checks use only `kitty` which causes warnings to be logged.
The fix introduces `SSHExe` type to encapsulate whole multi-word executable.

I've also noticed that `detectOpenSSHInfo` would never work properly for `kitty ssh`, nor aliases or scripts, so decided to add a comment while I was in the area.

#### Before
```
~/D/v/lima properly-support-multi-word-SSH-env• 
❱ env | rg SSH=
SSH=kitten ssh
~/D/v/lima properly-support-multi-word-SSH-env• 
❱ limactl shell podman
WARN[0000] failed to run [/opt/homebrew/bin/kitten -o GSSAPIAuthentication=no -V]: stderr="Error: Unknown option: -o. Did you mean:\n\t-h\n" 
[user@lima-podman lima]$ 
```


#### After
```
~/D/v/lima properly-support-multi-word-SSH-env• 
❱ ./_output/bin/limactl shell podman
[user@lima-podman lima]$ 
```