### PR TITLE
The wsl2 image source moved upstream in finch

### DIFF
--- a/templates/experimental/wsl2.yaml
+++ b/templates/experimental/wsl2.yaml
@@ -3,7 +3,7 @@
 vmType: wsl2
 
 images:
-# Source: https://github.com/runfinch/finch-core/blob/main/Dockerfile
+# Source: https://github.com/runfinch/finch-core/blob/main/rootfs/Dockerfile (image based on fedora)
 - location: "https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1741837119.tar.gz"
   arch: "x86_64"
   digest: "sha256:1ebee4c785fc4d31fd514365694a7d4d50a95093526c051f76dc63d8ba9fafe6"


### PR DESCRIPTION
Note that it is based on `docker.io/library/fedora:40` image,
in case the Dockerfile should disappear again in the future.

The current image was probably (based on date) created from:
https://github.com/runfinch/finch-core/blob/ab4113b684f69281a126e62a1c19d6e9bfbc25f8/rootfs/Dockerfile


```
public.ecr.aws/docker/library/fedora     41                1e77ba7428ee   13 days ago     161MB
fedora                                   41                1e77ba7428ee   13 days ago     161MB
```