### PR TITLE
refactor: use netip.AddrPort

### DIFF
--- a/pkg/guestagent/guestagent_linux.go
+++ b/pkg/guestagent/guestagent_linux.go
@@ -271,10 +271,11 @@ func (a *agent) LocalPorts(_ context.Context) ([]*api.IPPort, error) {
 	}
 
 	for _, ipt := range ipts {
+		port := int32(ipt.AddrPort.Port())
 		// Make sure the port isn't already listed from procnettcp
 		found := false
 		for _, re := range res {
-			if re.Port == int32(ipt.Port) {
+			if re.Port == port {
 				found = true
 			}
 		}
@@ -282,8 +283,8 @@ func (a *agent) LocalPorts(_ context.Context) ([]*api.IPPort, error) {
 			if ipt.TCP {
 				res = append(res,
 					&api.IPPort{
-						Ip:       ipt.IP.String(),
-						Port:     int32(ipt.Port), // The port value is already ensured to be within int32 bounds in iptables.go
+						Ip:       ipt.AddrPort.Addr().String(),
+						Port:     port,
 						Protocol: "tcp",
 					})
 			}

--- a/pkg/guestagent/iptables/iptables_test.go
+++ b/pkg/guestagent/iptables/iptables_test.go
@@ -4,6 +4,7 @@
 package iptables
 
 import (
+	"net/netip"
 	"strings"
 	"testing"
 
@@ -84,10 +85,6 @@ func TestParsePortsFromRules(t *testing.T) {
 	l := len(res)
 	assert.Equal(t, l, 2, "unexpected number of ports parsed from iptables")
 
-	if res[0].IP.String() != "0.0.0.0" || res[0].Port != 8082 || res[0].TCP != true {
-		t.Errorf("expected port 8082 on IP 0.0.0.0 with TCP true but got port %d on IP %s with TCP %t", res[0].Port, res[0].IP.String(), res[0].TCP)
-	}
-	if res[1].IP.String() != "127.0.0.1" || res[1].Port != 8081 || res[1].TCP != true {
-		t.Errorf("expected port 8081 on IP 127.0.0.1 with TCP true but go port %d on IP %s with TCP %t", res[1].Port, res[1].IP.String(), res[1].TCP)
-	}
+	assert.Equal(t, res[0], Entry{AddrPort: netip.MustParseAddrPort("0.0.0.0:8082"), TCP: true})
+	assert.Equal(t, res[1], Entry{AddrPort: netip.MustParseAddrPort("127.0.0.1:8081"), TCP: true})
 }


### PR DESCRIPTION
This PR changes the fields of `iptables.Entry` from `IP net.IP` and `Port int` to `AddrPort netip.AddrPort`. This results in slightly simpler code, and `iptables.Entry` becomes comparable.

`net.IP` is not comparable because slices in Go are not comparable.