### PR TITLE
refactor: replace net.ParseIP("0.0.0.0") with net.IPv4zero

### DIFF
--- a/pkg/guestagent/kubernetesservice/kubernetesservice.go
+++ b/pkg/guestagent/kubernetesservice/kubernetesservice.go
@@ -149,7 +149,7 @@ func (s *ServiceWatcher) GetPorts() []Entry {
 
 			entries = append(entries, Entry{
 				Protocol: Protocol(strings.ToLower(string(portEntry.Protocol))),
-				IP:       net.ParseIP("0.0.0.0"),
+				IP:       net.IPv4zero,
 				Port:     uint16(port),
 			})
 		}

--- a/pkg/guestagent/kubernetesservice/kubernetesservice_test.go
+++ b/pkg/guestagent/kubernetesservice/kubernetesservice_test.go
@@ -63,7 +63,7 @@ func TestGetPorts(t *testing.T) {
 			},
 			want: []Entry{{
 				Protocol: TCP,
-				IP:       net.ParseIP("0.0.0.0"),
+				IP:       net.IPv4zero,
 				Port:     8080,
 			}},
 		},
@@ -85,7 +85,7 @@ func TestGetPorts(t *testing.T) {
 			},
 			want: []Entry{{
 				Protocol: TCP,
-				IP:       net.ParseIP("0.0.0.0"),
+				IP:       net.IPv4zero,
 				Port:     8081,
 			}},
 		},


### PR DESCRIPTION
https://pkg.go.dev/net#pkg-variables:

```go
var (
	// ...
	IPv4zero      = IPv4(0, 0, 0, 0)         // all zeros
)
```