### PR TITLE
CI: redundant `go test` on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,8 +224,6 @@ jobs:
     - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
       with:
         go-version: 1.24.x
-    - name: Unit tests
-      run: go test -v ./...
     - name: Make
       run: make
     - name: Install QEMU


### PR DESCRIPTION
I noticed that `go test -v ./...` runs twice on `windows-2025`:

https://github.com/lima-vm/lima/blob/170824e0f79cf9b33d1bdc28285754195f3211ac/.github/workflows/test.yml#L197
https://github.com/lima-vm/lima/blob/170824e0f79cf9b33d1bdc28285754195f3211ac/.github/workflows/test.yml#L228

We can remove one.