### PR TITLE
Skip loading modules if modprobe is missing

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/00-modprobe.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/00-modprobe.sh
@@ -7,6 +7,9 @@
 # Because Arch Linux removes kernel module files when the kernel package was updated during running cloud-init :(
 
 set -eu
+
+command -v modprobe >/dev/null 2>&1 || exit 0
+
 for f in \
 	fuse \
 	tun tap \


### PR DESCRIPTION
Some distributions or kernels don't use modules, only built-in,
and don't even have "modprobe" installed. So avoid long logs.

Found when running Apple Container, with the kata kernel.