### PR TITLE
Fix various bugs in the lima-init setup script for WSL2 driver

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/02-wsl2-setup.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/02-wsl2-setup.sh
@@ -8,7 +8,7 @@
 [ "$LIMA_CIDATA_VMTYPE" = "wsl2" ] || exit 0
 
 # create user
-sudo useradd -u "${LIMA_CIDATA_UID}" "${LIMA_CIDATA_USER}" -c "${LIMA_CIDATA_COMMENT}" -d "${LIMA_CIDATA_HOME}" -s "${LIMA_CIDATA_SHELL}"
+sudo useradd -u "${LIMA_CIDATA_UID}" "${LIMA_CIDATA_USER}" -c "${LIMA_CIDATA_COMMENT}" -d "${LIMA_CIDATA_HOME}" -m -s "${LIMA_CIDATA_SHELL}"
 sudo mkdir "${LIMA_CIDATA_HOME}"/.ssh/
 sudo cp "${LIMA_CIDATA_MNT}"/ssh_authorized_keys "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
 sudo chown "${LIMA_CIDATA_USER}" "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/02-wsl2-setup.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/02-wsl2-setup.sh
@@ -8,13 +8,14 @@
 [ "$LIMA_CIDATA_VMTYPE" = "wsl2" ] || exit 0
 
 # create user
-sudo useradd -u "${LIMA_CIDATA_UID}" "${LIMA_CIDATA_USER}" -c "${LIMA_CIDATA_COMMENT}" -d "${LIMA_CIDATA_HOME}" -m -s "${LIMA_CIDATA_SHELL}"
-sudo mkdir "${LIMA_CIDATA_HOME}"/.ssh/
-sudo cp "${LIMA_CIDATA_MNT}"/ssh_authorized_keys "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
-sudo chown "${LIMA_CIDATA_USER}" "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
+useradd -u "${LIMA_CIDATA_UID}" "${LIMA_CIDATA_USER}" -c "${LIMA_CIDATA_COMMENT}" -d "${LIMA_CIDATA_HOME}" -m -s "${LIMA_CIDATA_SHELL}"
+mkdir "${LIMA_CIDATA_HOME}"/.ssh/
+chown "${LIMA_CIDATA_USER}" "${LIMA_CIDATA_HOME}"/.ssh/
+cp "${LIMA_CIDATA_MNT}"/ssh_authorized_keys "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
+chown "${LIMA_CIDATA_USER}" "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
 
 # add $LIMA_CIDATA_USER to sudoers
-echo "${LIMA_CIDATA_USER} ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/99_lima_sudoers
+echo "${LIMA_CIDATA_USER} ALL=(ALL) NOPASSWD:ALL" | tee -a /etc/sudoers.d/99_lima_sudoers
 
 # symlink CIDATA to the hardcoded path for requirement checks (TODO: make this not hardcoded)
-sudo ln -sfFn "${LIMA_CIDATA_MNT}" /mnt/lima-cidata
+ln -sfFn "${LIMA_CIDATA_MNT}" /mnt/lima-cidata

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/02-wsl2-setup.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/02-wsl2-setup.sh
@@ -9,10 +9,13 @@
 
 # create user
 useradd -u "${LIMA_CIDATA_UID}" "${LIMA_CIDATA_USER}" -c "${LIMA_CIDATA_COMMENT}" -d "${LIMA_CIDATA_HOME}" -m -s "${LIMA_CIDATA_SHELL}"
+LIMA_CIDATA_GID=$(id -g "${LIMA_CIDATA_USER}")
 mkdir "${LIMA_CIDATA_HOME}"/.ssh/
-chown "${LIMA_CIDATA_USER}" "${LIMA_CIDATA_HOME}"/.ssh/
+chown "${LIMA_CIDATA_UID}:${LIMA_CIDATA_GID}" "${LIMA_CIDATA_HOME}"/.ssh/
+chmod 700 "${LIMA_CIDATA_HOME}"/.ssh/
 cp "${LIMA_CIDATA_MNT}"/ssh_authorized_keys "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
-chown "${LIMA_CIDATA_USER}" "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
+chown "${LIMA_CIDATA_UID}:${LIMA_CIDATA_GID}" "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
+chmod 600 "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
 
 # add $LIMA_CIDATA_USER to sudoers
 echo "${LIMA_CIDATA_USER} ALL=(ALL) NOPASSWD:ALL" | tee -a /etc/sudoers.d/99_lima_sudoers

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/02-wsl2-setup.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/02-wsl2-setup.sh
@@ -8,7 +8,7 @@
 [ "$LIMA_CIDATA_VMTYPE" = "wsl2" ] || exit 0
 
 # create user
-sudo useradd -u "${LIMA_CIDATA_UID}" "${LIMA_CIDATA_USER}" -c "${LIMA_CIDATA_COMMENT}" -d "${LIMA_CIDATA_HOME}"
+sudo useradd -u "${LIMA_CIDATA_UID}" "${LIMA_CIDATA_USER}" -c "${LIMA_CIDATA_COMMENT}" -d "${LIMA_CIDATA_HOME}" -s "${LIMA_CIDATA_SHELL}"
 sudo mkdir "${LIMA_CIDATA_HOME}"/.ssh/
 sudo cp "${LIMA_CIDATA_MNT}"/ssh_authorized_keys "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
 sudo chown "${LIMA_CIDATA_USER}" "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/02-wsl2-setup.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/02-wsl2-setup.sh
@@ -8,6 +8,7 @@
 [ "$LIMA_CIDATA_VMTYPE" = "wsl2" ] || exit 0
 
 # create user
+# shellcheck disable=SC2153
 useradd -u "${LIMA_CIDATA_UID}" "${LIMA_CIDATA_USER}" -c "${LIMA_CIDATA_COMMENT}" -d "${LIMA_CIDATA_HOME}" -m -s "${LIMA_CIDATA_SHELL}"
 LIMA_CIDATA_GID=$(id -g "${LIMA_CIDATA_USER}")
 mkdir "${LIMA_CIDATA_HOME}"/.ssh/


### PR DESCRIPTION
* Set the user shell when using wsl2 setup script
* Create the home directory when using wsl2 setup
* Don't use sudo for root user in the wsl2 setup
* Set permissions for ssh in wsl2 setup script

Closes #3805

Found these when trying to use it also for AC.

Maybe it (lima-init) should be a separate program?

And merged with some of the other features from:

https://github.com/lima-vm/alpine-lima/blob/main/lima-init.sh