### PR TITLE
hack/test-templates.sh: fix LIMACTL_CREATE_ARGS: unbound variable

### DIFF
--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -163,7 +163,7 @@ fi
 
 set -x
 # shellcheck disable=SC2086
-"${LIMACTL_CREATE[@]}" ${LIMACTL_CREATE_ARGS} "$FILE_HOST"
+"${LIMACTL_CREATE[@]}" ${LIMACTL_CREATE_ARGS:-} "$FILE_HOST"
 set +x
 
 if [[ -n ${CHECKS["mount-path-with-spaces"]} ]]; then


### PR DESCRIPTION
When trying to run test-templates locally, I received the error "./hack/test-templates.sh: line 166: LIMACTL_CREATE_ARGS: unbound variable":

```console
$ ./hack/test-templates.sh templates/default.yaml 
TEST| [INFO] Validating "/workspaces/lima/templates/default.yaml"
WARN[0000] invalid timezone found in /etc/timezone: time: invalid location name 
INFO[0000] "/workspaces/lima/templates/default.yaml": OK 
WARN[0000] No instance found. Run `limactl create` to create an instance. 
WARN[0000] invalid timezone found in /etc/timezone: time: invalid location name 
TEST| [INFO] Setup port forwarding rules for testing in "/home/vscode/lima-config-tmp/default.yaml"
TEST| [INFO] Validating "/home/vscode/lima-config-tmp/default.yaml"
WARN[0000] invalid timezone found in /etc/timezone: time: invalid location name 
INFO[0000] "/home/vscode/lima-config-tmp/default.yaml": OK 
TEST| [INFO] Make sure template embedding copies "/home/vscode/lima-config-tmp/default.yaml" exactly
TEST| [INFO] Creating "default" from "/home/vscode/lima-config-tmp/default.yaml"
./hack/test-templates.sh: line 166: LIMACTL_CREATE_ARGS: unbound variable
++ eval rm -rf '"/home/vscode/lima-config-tmp";' limactl delete -f '"default"'
+++ rm -rf /home/vscode/lima-config-tmp
+++ limactl delete -f default
WARN[0000] Ignoring non-existent instance "default"
```

This PR fixes that by using safe expansion at the call site.

`LIMACTL_CREATE_ARGS` is needed for Windows:
https://github.com/lima-vm/lima/blob/96c717915715200c371343dd5bb49ad61e0abb31/.github/workflows/test.yml#L207