### PR TITLE
Kata/Docker Container external driver for Linux

### DIFF
--- a/cmd/lima-driver-ac/main_darwin.go
+++ b/cmd/lima-driver-ac/main_darwin.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+
+	"github.com/lima-vm/lima/v2/pkg/driver/ac"
+	"github.com/lima-vm/lima/v2/pkg/driver/external/server"
+)
+
+// To be used as an external driver for Lima.
+func main() {
+	server.Serve(context.Background(), ac.New())
+}

--- a/cmd/lima-driver-dc/main_linux.go
+++ b/cmd/lima-driver-dc/main_linux.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+
+	"github.com/lima-vm/lima/v2/pkg/driver/dc"
+	"github.com/lima-vm/lima/v2/pkg/driver/external/server"
+)
+
+// To be used as an external driver for Lima.
+func main() {
+	server.Serve(context.Background(), dc.New())
+}

--- a/pkg/driver/ac/ac_driver_darwin.go
+++ b/pkg/driver/ac/ac_driver_darwin.go
@@ -1,0 +1,336 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ac
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+	"net"
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/driver"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/ptr"
+	"github.com/lima-vm/lima/v2/pkg/reflectutil"
+)
+
+var knownYamlProperties = []string{
+	"Arch",
+	"Containerd",
+	"CopyToHost",
+	"CPUType",
+	"Disk",
+	"DNS",
+	"Env",
+	"HostResolver",
+	"Images",
+	"Message",
+	"Mounts",
+	"MountType",
+	"Param",
+	"Plain",
+	"PortForwards",
+	"Probes",
+	"PropagateProxyEnv",
+	"Provision",
+	"SSH",
+	"VMType",
+}
+
+const Enabled = true
+
+type LimaAcDriver struct {
+	Instance *limatype.Instance
+
+	SSHLocalPort int
+	vSockPort    int
+	virtioPort   string
+}
+
+var _ driver.Driver = (*LimaAcDriver)(nil)
+
+func New() *LimaAcDriver {
+	return &LimaAcDriver{
+		vSockPort:  0,
+		virtioPort: "",
+	}
+}
+
+func (l *LimaAcDriver) Configure(_ context.Context, inst *limatype.Instance) *driver.ConfiguredDriver {
+	l.Instance = inst
+	l.SSHLocalPort = inst.SSHLocalPort
+
+	return &driver.ConfiguredDriver{
+		Driver: l,
+	}
+}
+
+func (l *LimaAcDriver) FillConfig(ctx context.Context, cfg *limatype.LimaYAML, _ string) error {
+	if cfg.VMType == nil {
+		cfg.VMType = ptr.Of(limatype.AC)
+	}
+	if cfg.MountType == nil {
+		cfg.MountType = ptr.Of(limatype.WSLMount)
+	}
+	return validateConfig(ctx, cfg)
+}
+
+func (l *LimaAcDriver) Validate(ctx context.Context) error {
+	return validateConfig(ctx, l.Instance.Config)
+}
+
+func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
+	if cfg == nil {
+		return errors.New("configuration is nil")
+	}
+	if *cfg.MountType != limatype.VIRTIOFS && *cfg.MountType != limatype.REVSSHFS {
+		return fmt.Errorf("field `mountType` must be %q or %q for AC driver, got %q", limatype.VIRTIOFS, limatype.REVSSHFS, *cfg.MountType)
+	}
+	// TODO: revise this list for AC
+	if cfg.VMType != nil {
+		if unknown := reflectutil.UnknownNonEmptyFields(cfg, knownYamlProperties...); len(unknown) > 0 {
+			logrus.Warnf("Ignoring: vmType %s: %+v", *cfg.VMType, unknown)
+		}
+	}
+
+	if !limatype.IsNativeArch(*cfg.Arch) {
+		return fmt.Errorf("unsupported arch: %q", *cfg.Arch)
+	}
+
+	if cfg.VMType != nil {
+		if cfg.Images != nil && cfg.Arch != nil {
+			// TODO: real filetype checks
+			tarFileRegex := regexp.MustCompile(`.*tar\.*`)
+			for i, image := range cfg.Images {
+				if unknown := reflectutil.UnknownNonEmptyFields(image, "File"); len(unknown) > 0 {
+					logrus.Warnf("Ignoring: vmType %s: images[%d]: %+v", *cfg.VMType, i, unknown)
+				}
+				match := tarFileRegex.MatchString(image.Location)
+				if image.Arch == *cfg.Arch && !match {
+					return fmt.Errorf("unsupported image type for vmType: %s, tarball root file system required: %q", *cfg.VMType, image.Location)
+				}
+			}
+		}
+
+		if cfg.Mounts != nil {
+			for i, mount := range cfg.Mounts {
+				if unknown := reflectutil.UnknownNonEmptyFields(mount); len(unknown) > 0 {
+					logrus.Warnf("Ignoring: vmType %s: mounts[%d]: %+v", *cfg.VMType, i, unknown)
+				}
+			}
+		}
+
+		if cfg.Networks != nil {
+			for i, network := range cfg.Networks {
+				if unknown := reflectutil.UnknownNonEmptyFields(network); len(unknown) > 0 {
+					logrus.Warnf("Ignoring: vmType %s: networks[%d]: %+v", *cfg.VMType, i, unknown)
+				}
+			}
+		}
+
+		if cfg.Audio.Device != nil {
+			audioDevice := *cfg.Audio.Device
+			if audioDevice != "" {
+				logrus.Warnf("Ignoring: vmType %s: `audio.device`: %+v", *cfg.VMType, audioDevice)
+			}
+		}
+	}
+
+	return nil
+}
+
+//go:embed boot.Linux/*.sh
+var bootLinuxFS embed.FS
+
+func (l *LimaAcDriver) BootScripts(_ context.Context) (map[string][]byte, error) {
+	scripts := make(map[string][]byte)
+
+	entries, err := bootLinuxFS.ReadDir("boot.Linux")
+	if err != nil {
+		return scripts, err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		entryPath := "boot.Linux/" + entry.Name()
+
+		content, err := bootLinuxFS.ReadFile(entryPath)
+		if err != nil {
+			return nil, err
+		}
+
+		scripts[entryPath] = content
+	}
+
+	return scripts, nil
+}
+
+func (l *LimaAcDriver) InspectStatus(ctx context.Context, inst *limatype.Instance) string {
+	status, err := getAcStatus(ctx, inst.Name)
+	if err != nil {
+		inst.Status = limatype.StatusBroken
+		inst.Errors = append(inst.Errors, err)
+	} else {
+		inst.Status = status
+	}
+
+	inst.SSHLocalPort = 22
+
+	if inst.Status == limatype.StatusRunning {
+		sshAddr, err := getSSHAddress(ctx, inst.Name)
+		if err == nil {
+			inst.SSHAddress = sshAddr
+		} else {
+			inst.Errors = append(inst.Errors, err)
+		}
+	}
+
+	return inst.Status
+}
+
+func (l *LimaAcDriver) Delete(ctx context.Context) error {
+	distroName := "lima-" + l.Instance.Name
+	status, err := getAcStatus(ctx, l.Instance.Name)
+	if err != nil {
+		return err
+	}
+	switch status {
+	case limatype.StatusRunning, limatype.StatusStopped, limatype.StatusBroken, limatype.StatusInstalling:
+		return deleteVM(ctx, distroName)
+	}
+
+	logrus.Info("AC VM is not running or does not exist, skipping deletion")
+	return nil
+}
+
+func (l *LimaAcDriver) Start(ctx context.Context) (chan error, error) {
+	logrus.Infof("Starting AC VM")
+	status, err := getAcStatus(ctx, l.Instance.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	distroName := "lima-" + l.Instance.Name
+
+	if status == limatype.StatusUninitialized {
+		if err := EnsureFs(ctx, l.Instance); err != nil {
+			return nil, err
+		}
+		if err := initVM(ctx, l.Instance.Dir, distroName); err != nil {
+			return nil, err
+		}
+		cpus := l.Instance.CPUs
+		memory := int(l.Instance.Memory >> 20) // MiB
+		if err := createVM(ctx, distroName, cpus, memory); err != nil {
+			return nil, err
+		}
+	}
+
+	errCh := make(chan error)
+
+	if err := startVM(ctx, distroName); err != nil {
+		return nil, err
+	}
+
+	if err := provisionVM(
+		ctx,
+		l.Instance.Dir,
+		l.Instance.Name,
+		distroName,
+		errCh,
+	); err != nil {
+		return nil, err
+	}
+
+	return errCh, err
+}
+
+func (l *LimaAcDriver) canRunGUI() bool {
+	return false
+}
+
+func (l *LimaAcDriver) RunGUI(_ context.Context) error {
+	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "ac", *l.Instance.Config.Video.Display)
+}
+
+func (l *LimaAcDriver) Stop(ctx context.Context) error {
+	logrus.Info("Shutting down AC VM")
+	distroName := "lima-" + l.Instance.Name
+	return stopVM(ctx, distroName)
+}
+
+// GuestAgentConn returns the guest agent connection, or nil (if forwarded by ssh).
+func (l *LimaAcDriver) GuestAgentConn(_ context.Context) (net.Conn, string, error) {
+	return nil, "", nil
+}
+
+func (l *LimaAcDriver) Info(_ context.Context) driver.Info {
+	var info driver.Info
+	info.Name = "ac"
+	if l.Instance != nil {
+		info.InstanceDir = l.Instance.Dir
+	}
+	info.VirtioPort = l.virtioPort
+	info.VsockPort = l.vSockPort
+
+	info.Features = driver.DriverFeatures{
+		DynamicSSHAddress:    true,
+		StaticSSHPort:        true,
+		SkipSocketForwarding: true,
+		NoCloudInit:          true,
+		CanRunGUI:            l.canRunGUI(),
+	}
+	return info
+}
+
+func (l *LimaAcDriver) SSHAddress(_ context.Context) (string, error) {
+	return "127.0.0.1", nil
+}
+
+func (l *LimaAcDriver) Create(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaAcDriver) CreateDisk(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaAcDriver) ChangeDisplayPassword(_ context.Context, _ string) error {
+	return nil
+}
+
+func (l *LimaAcDriver) DisplayConnection(_ context.Context) (string, error) {
+	return "", nil
+}
+
+func (l *LimaAcDriver) CreateSnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaAcDriver) ApplySnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaAcDriver) DeleteSnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaAcDriver) ListSnapshots(_ context.Context) (string, error) {
+	return "", errUnimplemented
+}
+
+func (l *LimaAcDriver) ForwardGuestAgent(_ context.Context) bool {
+	// If driver is not providing, use host agent
+	return l.vSockPort == 0 && l.virtioPort == ""
+}
+
+func (l *LimaAcDriver) AdditionalSetupForSSH(_ context.Context) error {
+	return nil
+}

--- a/pkg/driver/ac/boot.Linux/02-no-cloud-init-setup.sh
+++ b/pkg/driver/ac/boot.Linux/02-no-cloud-init-setup.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# This script replaces the cloud-init functionality of creating a user and setting its SSH keys
+# when cloud-init is not available
+[ "$LIMA_CIDATA_NO_CLOUD_INIT" = "1" ] || exit 0
+
+# create user
+# shellcheck disable=SC2153
+useradd -u "${LIMA_CIDATA_UID}" "${LIMA_CIDATA_USER}" -c "${LIMA_CIDATA_COMMENT}" -d "${LIMA_CIDATA_HOME}" -m -s "${LIMA_CIDATA_SHELL}"
+LIMA_CIDATA_GID=$(id -g "${LIMA_CIDATA_USER}")
+mkdir "${LIMA_CIDATA_HOME}"/.ssh/
+chown "${LIMA_CIDATA_UID}:${LIMA_CIDATA_GID}" "${LIMA_CIDATA_HOME}"/.ssh/
+chmod 700 "${LIMA_CIDATA_HOME}"/.ssh/
+cp "${LIMA_CIDATA_MNT}"/ssh_authorized_keys "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
+chown "${LIMA_CIDATA_UID}:${LIMA_CIDATA_GID}" "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
+chmod 600 "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
+
+# add $LIMA_CIDATA_USER to sudoers
+echo "${LIMA_CIDATA_USER} ALL=(ALL) NOPASSWD:ALL" | tee -a /etc/sudoers.d/99_lima_sudoers
+
+# symlink CIDATA to the hardcoded path for requirement checks (TODO: make this not hardcoded)
+[ "$LIMA_CIDATA_MNT" = "/mnt/lima-cidata" ] || ln -sfFn "${LIMA_CIDATA_MNT}" /mnt/lima-cidata

--- a/pkg/driver/ac/errors_darwin.go
+++ b/pkg/driver/ac/errors_darwin.go
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ac
+
+import "errors"
+
+var errUnimplemented = errors.New("unimplemented")

--- a/pkg/driver/ac/fs.go
+++ b/pkg/driver/ac/fs.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ac
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/fileutils"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+)
+
+// EnsureFs downloads the root fs.
+func EnsureFs(ctx context.Context, inst *limatype.Instance) error {
+	baseDisk := filepath.Join(inst.Dir, filenames.BaseDiskLegacy)
+	if _, err := os.Stat(baseDisk); errors.Is(err, os.ErrNotExist) {
+		var ensuredBaseDisk bool
+		errs := make([]error, len(inst.Config.Images))
+		for i, f := range inst.Config.Images {
+			if _, err := fileutils.DownloadFile(ctx, baseDisk, f.File, true, "the image", *inst.Config.Arch); err != nil {
+				errs[i] = err
+				continue
+			}
+			ensuredBaseDisk = true
+			break
+		}
+		if !ensuredBaseDisk {
+			return fileutils.Errors(errs)
+		}
+	}
+	logrus.Info("Download succeeded")
+
+	return nil
+}

--- a/pkg/driver/ac/lima-init.TEMPLATE
+++ b/pkg/driver/ac/lima-init.TEMPLATE
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eu
+export LOG_FILE=/var/log/lima-init.log
+exec > >(tee $LOG_FILE) 2>&1
+ln -sf rtc0 /dev/rtc
+chmod 666 /dev/fuse
+export LIMA_CIDATA_MNT="{{.CIDataPath}}"
+exec "$LIMA_CIDATA_MNT/boot.sh"

--- a/pkg/driver/ac/vm_darwin.go
+++ b/pkg/driver/ac/vm_darwin.go
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ac
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/textutil"
+)
+
+// init system (pid 1) in VM.
+const initSystem = "openrc"
+
+// createVM calls AC to create a VM.
+func createVM(ctx context.Context, distroName string, cpus, memory int) error {
+	imageName := distroName
+	entrypoint := "/sbin/init"
+	// /sbin/init is normally just a symlink to systemd
+	// eventually we might want to look inside the image
+	switch initSystem {
+	case "systemd":
+		entrypoint = "/lib/systemd/systemd"
+	case "openrc":
+		entrypoint = "/sbin/openrc-init"
+	default:
+		logrus.Infof("unknown init system, running only vminitd")
+	}
+	out, err := exec.CommandContext(ctx,
+		"container",
+		"create",
+		"--name",
+		distroName,
+		"--cpus",
+		fmt.Sprintf("%d", cpus),
+		"--memory",
+		fmt.Sprintf("%dM", memory),
+		"--entrypoint",
+		entrypoint,
+		imageName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `container create %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+// startVM calls AC to start a VM.
+func startVM(ctx context.Context, distroName string) error {
+	out, err := exec.CommandContext(ctx,
+		"container",
+		"start",
+		distroName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `container start %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+// initVM calls AC to import a new VM specifically for Lima.
+func initVM(ctx context.Context, instanceDir, distroName string) error {
+	imageName := distroName
+	dockerFile := filepath.Join(instanceDir, "Dockerfile")
+	fileContents := fmt.Sprintf("FROM scratch\nADD %s /\n", filenames.BaseDiskLegacy)
+	err := os.WriteFile(dockerFile, []byte(fileContents), 0o644)
+	if err != nil {
+		return err
+	}
+	baseDisk := filepath.Join(instanceDir, filenames.BaseDiskLegacy)
+	logrus.Infof("Importing distro from %q to %q", baseDisk, instanceDir)
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	err = os.Chdir(instanceDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Chdir(wd) }()
+	out, err := exec.CommandContext(ctx,
+		"container",
+		"build",
+		"-t",
+		imageName,
+		instanceDir).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `container build -t %s %s`: %w (out=%q)",
+			imageName, instanceDir, err, out)
+	}
+	return nil
+}
+
+// stopVM calls AC to stop a running VM.
+func stopVM(ctx context.Context, distroName string) error {
+	out, err := exec.CommandContext(ctx,
+		"container",
+		"stop",
+		distroName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `container stop %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+//go:embed lima-init.TEMPLATE
+var limaBoot string
+
+// copyDir copies a directory.
+func copyDir(ctx context.Context, distroName, src, dst string) error {
+	cmd := exec.CommandContext(ctx, "container", "exec", distroName, "mkdir", "-p", dst)
+	if err := cmd.Run(); err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			logrus.Debugf("run stderr: %s", exiterr.Stderr)
+		}
+		return fmt.Errorf("failed to run %v: %w", cmd.Args, err)
+	}
+	logrus.Infof("Copying directory from %q to \"%s:%s\"", src, distroName, dst)
+	tar1 := exec.CommandContext(ctx, "tar", "Cc", src, ".")
+	tar2 := exec.CommandContext(ctx, "container", "exec", "-i", distroName, "tar", "Cx", dst)
+
+	p, err := tar1.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	tar2.Stdin = p
+	if err := tar2.Start(); err != nil {
+		return err
+	}
+	if err := tar1.Run(); err != nil {
+		return err
+	}
+	if err := tar2.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// provisionVM starts Lima's boot process inside an already imported VM.
+func provisionVM(ctx context.Context, instanceDir, instanceName, distroName string, errCh chan<- error) error {
+	ciDataPath := filepath.Join(instanceDir, filenames.CIDataISODir)
+	// can't mount the cidata, due to problems with virtiofs mounts
+	if err := copyDir(ctx, distroName, ciDataPath, "/mnt/lima-cidata"); err != nil {
+		return fmt.Errorf("failed to copy cidata directory: %w", err)
+	}
+	m := map[string]string{
+		"CIDataPath": "/mnt/lima-cidata",
+	}
+	limaBootB, err := textutil.ExecuteTemplate(limaBoot, m)
+	if err != nil {
+		return fmt.Errorf("failed to construct ac boot.sh script: %w", err)
+	}
+	go func() {
+		cmd := exec.CommandContext(
+			ctx,
+			"container",
+			"exec",
+			"-i",
+			distroName,
+			"/bin/bash",
+		)
+		cmd.Stdin = bytes.NewReader(limaBootB)
+		out, err := cmd.CombinedOutput()
+		logrus.Debugf("%v: %q", cmd.Args, string(out))
+		if err != nil {
+			errCh <- fmt.Errorf(
+				"error running command that executes boot.sh (%v): %w, "+
+					"check /var/log/lima-init.log for more details (out=%q)", cmd.Args, err, string(out))
+		}
+
+		for {
+			<-ctx.Done()
+			logrus.Info("Context closed, stopping vm")
+			if status, err := getAcStatus(ctx, instanceName); err == nil &&
+				status == limatype.StatusRunning {
+				_ = stopVM(ctx, distroName)
+			}
+		}
+	}()
+
+	return err
+}
+
+// deleteVM calls AC to delete a VM.
+func deleteVM(ctx context.Context, distroName string) error {
+	imageName := distroName
+	logrus.Info("Deleting AC VM")
+	out, err := exec.CommandContext(ctx,
+		"container",
+		"rm",
+		"-f",
+		distroName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `container rm -f %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	out, err = exec.CommandContext(ctx,
+		"container",
+		"image",
+		"rm",
+		imageName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `container image rm %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+type Network struct {
+	Address  string `json:"address"`
+	Gateway  string `json:"gateway"`
+	Hostname string `json:"hostname"`
+	Network  string `json:"network"`
+}
+
+type Container struct {
+	Status   string         `json:"status"`
+	Config   map[string]any `json:"configuration"`
+	Networks []Network      `json:"networks,omitempty"`
+}
+
+// listContainers returns all containers in the system.
+//
+// but currently there is _no_ way to filter in the list.
+// so we need to loop through all of them in the client.
+func listContainers(ctx context.Context) ([]Container, error) {
+	out, err := exec.CommandContext(
+		ctx,
+		"container",
+		"list",
+		"--format=json",
+	).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run `container list --format=json`, err: %w (out=%q)", err, out)
+	}
+
+	var list []Container
+	err = json.Unmarshal(out, &list)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json output, err: %w (out=%q)", err, out)
+	}
+	return list, nil
+}
+
+func getAcStatus(ctx context.Context, instName string) (string, error) {
+	distroName := "lima-" + instName
+	list, err := listContainers(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	instState := limatype.StatusUninitialized
+	for _, c := range list {
+		// container don't have real ID
+		// (any --name replaces the UUID)
+		if c.Config["id"] == distroName {
+			switch c.Status {
+			case "stopped":
+				instState = limatype.StatusStopped
+			case "running":
+				instState = limatype.StatusRunning
+			default:
+				instState = limatype.StatusUnknown
+			}
+			break
+		}
+	}
+
+	return instState, nil
+}
+
+func getSSHAddress(ctx context.Context, instName string) (string, error) {
+	distroName := "lima-" + instName
+	list, err := listContainers(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	instAddress := "127.0.0.1"
+	for _, c := range list {
+		// container don't have real ID
+		// (any --name replaces the UUID)
+		if c.Config["id"] == distroName {
+			if len(c.Networks) > 0 {
+				instAddress = c.Networks[0].Address
+			}
+			break
+		}
+	}
+
+	return strings.Replace(instAddress, "/24", "", 1), nil
+}

--- a/pkg/driver/dc/boot.Linux/02-no-cloud-init-setup.sh
+++ b/pkg/driver/dc/boot.Linux/02-no-cloud-init-setup.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# This script replaces the cloud-init functionality of creating a user and setting its SSH keys
+# when cloud-init is not available
+[ "$LIMA_CIDATA_NO_CLOUD_INIT" = "1" ] || exit 0
+
+# create user
+# shellcheck disable=SC2153
+useradd -u "${LIMA_CIDATA_UID}" "${LIMA_CIDATA_USER}" -c "${LIMA_CIDATA_COMMENT}" -d "${LIMA_CIDATA_HOME}" -m -s "${LIMA_CIDATA_SHELL}"
+LIMA_CIDATA_GID=$(id -g "${LIMA_CIDATA_USER}")
+mkdir "${LIMA_CIDATA_HOME}"/.ssh/
+chown "${LIMA_CIDATA_UID}:${LIMA_CIDATA_GID}" "${LIMA_CIDATA_HOME}"/.ssh/
+chmod 700 "${LIMA_CIDATA_HOME}"/.ssh/
+cp "${LIMA_CIDATA_MNT}"/ssh_authorized_keys "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
+chown "${LIMA_CIDATA_UID}:${LIMA_CIDATA_GID}" "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
+chmod 600 "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
+
+# add $LIMA_CIDATA_USER to sudoers
+echo "${LIMA_CIDATA_USER} ALL=(ALL) NOPASSWD:ALL" | tee -a /etc/sudoers.d/99_lima_sudoers
+
+# symlink CIDATA to the hardcoded path for requirement checks (TODO: make this not hardcoded)
+[ "$LIMA_CIDATA_MNT" = "/mnt/lima-cidata" ] || ln -sfFn "${LIMA_CIDATA_MNT}" /mnt/lima-cidata

--- a/pkg/driver/dc/dc_driver_linux.go
+++ b/pkg/driver/dc/dc_driver_linux.go
@@ -1,0 +1,336 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dc
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+	"net"
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/driver"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/ptr"
+	"github.com/lima-vm/lima/v2/pkg/reflectutil"
+)
+
+var knownYamlProperties = []string{
+	"Arch",
+	"Containerd",
+	"CopyToHost",
+	"CPUType",
+	"Disk",
+	"DNS",
+	"Env",
+	"HostResolver",
+	"Images",
+	"Message",
+	"Mounts",
+	"MountType",
+	"Param",
+	"Plain",
+	"PortForwards",
+	"Probes",
+	"PropagateProxyEnv",
+	"Provision",
+	"SSH",
+	"VMType",
+}
+
+const Enabled = true
+
+type LimaDcDriver struct {
+	Instance *limatype.Instance
+
+	SSHLocalPort int
+	vSockPort    int
+	virtioPort   string
+}
+
+var _ driver.Driver = (*LimaDcDriver)(nil)
+
+func New() *LimaDcDriver {
+	return &LimaDcDriver{
+		vSockPort:  0,
+		virtioPort: "",
+	}
+}
+
+func (l *LimaDcDriver) Configure(_ context.Context, inst *limatype.Instance) *driver.ConfiguredDriver {
+	l.Instance = inst
+	l.SSHLocalPort = inst.SSHLocalPort
+
+	return &driver.ConfiguredDriver{
+		Driver: l,
+	}
+}
+
+func (l *LimaDcDriver) FillConfig(ctx context.Context, cfg *limatype.LimaYAML, _ string) error {
+	if cfg.VMType == nil {
+		cfg.VMType = ptr.Of(limatype.DC)
+	}
+	if cfg.MountType == nil {
+		cfg.MountType = ptr.Of(limatype.WSLMount)
+	}
+	return validateConfig(ctx, cfg)
+}
+
+func (l *LimaDcDriver) Validate(ctx context.Context) error {
+	return validateConfig(ctx, l.Instance.Config)
+}
+
+func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
+	if cfg == nil {
+		return errors.New("configuration is nil")
+	}
+	if *cfg.MountType != limatype.REVSSHFS {
+		return fmt.Errorf("field `mountType` must be %q for DC driver, got %q", limatype.REVSSHFS, *cfg.MountType)
+	}
+	// TODO: revise this list for DC
+	if cfg.VMType != nil {
+		if unknown := reflectutil.UnknownNonEmptyFields(cfg, knownYamlProperties...); len(unknown) > 0 {
+			logrus.Warnf("Ignoring: vmType %s: %+v", *cfg.VMType, unknown)
+		}
+	}
+
+	if !limatype.IsNativeArch(*cfg.Arch) {
+		return fmt.Errorf("unsupported arch: %q", *cfg.Arch)
+	}
+
+	if cfg.VMType != nil {
+		if cfg.Images != nil && cfg.Arch != nil {
+			// TODO: real filetype checks
+			tarFileRegex := regexp.MustCompile(`.*tar\.*`)
+			for i, image := range cfg.Images {
+				if unknown := reflectutil.UnknownNonEmptyFields(image, "File"); len(unknown) > 0 {
+					logrus.Warnf("Ignoring: vmType %s: images[%d]: %+v", *cfg.VMType, i, unknown)
+				}
+				match := tarFileRegex.MatchString(image.Location)
+				if image.Arch == *cfg.Arch && !match {
+					return fmt.Errorf("unsupported image type for vmType: %s, tarball root file system required: %q", *cfg.VMType, image.Location)
+				}
+			}
+		}
+
+		if cfg.Mounts != nil {
+			for i, mount := range cfg.Mounts {
+				if unknown := reflectutil.UnknownNonEmptyFields(mount); len(unknown) > 0 {
+					logrus.Warnf("Ignoring: vmType %s: mounts[%d]: %+v", *cfg.VMType, i, unknown)
+				}
+			}
+		}
+
+		if cfg.Networks != nil {
+			for i, network := range cfg.Networks {
+				if unknown := reflectutil.UnknownNonEmptyFields(network); len(unknown) > 0 {
+					logrus.Warnf("Ignoring: vmType %s: networks[%d]: %+v", *cfg.VMType, i, unknown)
+				}
+			}
+		}
+
+		if cfg.Audio.Device != nil {
+			audioDevice := *cfg.Audio.Device
+			if audioDevice != "" {
+				logrus.Warnf("Ignoring: vmType %s: `audio.device`: %+v", *cfg.VMType, audioDevice)
+			}
+		}
+	}
+
+	return nil
+}
+
+//go:embed boot.Linux/*.sh
+var bootLinuxFS embed.FS
+
+func (l *LimaDcDriver) BootScripts(_ context.Context) (map[string][]byte, error) {
+	scripts := make(map[string][]byte)
+
+	entries, err := bootLinuxFS.ReadDir("boot.Linux")
+	if err != nil {
+		return scripts, err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		entryPath := "boot.Linux/" + entry.Name()
+
+		content, err := bootLinuxFS.ReadFile(entryPath)
+		if err != nil {
+			return nil, err
+		}
+
+		scripts[entryPath] = content
+	}
+
+	return scripts, nil
+}
+
+func (l *LimaDcDriver) InspectStatus(ctx context.Context, inst *limatype.Instance) string {
+	status, err := getDcStatus(ctx, inst.Name)
+	if err != nil {
+		inst.Status = limatype.StatusBroken
+		inst.Errors = append(inst.Errors, err)
+	} else {
+		inst.Status = status
+	}
+
+	inst.SSHLocalPort = 22
+
+	if inst.Status == limatype.StatusRunning {
+		sshAddr, err := getSSHAddress(ctx, inst.Name)
+		if err == nil {
+			inst.SSHAddress = sshAddr
+		} else {
+			inst.Errors = append(inst.Errors, err)
+		}
+	}
+
+	return inst.Status
+}
+
+func (l *LimaDcDriver) Delete(ctx context.Context) error {
+	distroName := "lima-" + l.Instance.Name
+	status, err := getDcStatus(ctx, l.Instance.Name)
+	if err != nil {
+		return err
+	}
+	switch status {
+	case limatype.StatusRunning, limatype.StatusStopped, limatype.StatusBroken, limatype.StatusInstalling:
+		return deleteVM(ctx, distroName)
+	}
+
+	logrus.Info("AC VM is not running or does not exist, skipping deletion")
+	return nil
+}
+
+func (l *LimaDcDriver) Start(ctx context.Context) (chan error, error) {
+	logrus.Infof("Starting DC VM")
+	status, err := getDcStatus(ctx, l.Instance.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	distroName := "lima-" + l.Instance.Name
+
+	if status == limatype.StatusUninitialized {
+		if err := EnsureFs(ctx, l.Instance); err != nil {
+			return nil, err
+		}
+		if err := initVM(ctx, l.Instance.Dir, distroName); err != nil {
+			return nil, err
+		}
+		cpus := l.Instance.CPUs
+		memory := int(l.Instance.Memory >> 20) // MiB
+		if err := createVM(ctx, distroName, cpus, memory); err != nil {
+			return nil, err
+		}
+	}
+
+	errCh := make(chan error)
+
+	if err := startVM(ctx, distroName); err != nil {
+		return nil, err
+	}
+
+	if err := provisionVM(
+		ctx,
+		l.Instance.Dir,
+		l.Instance.Name,
+		distroName,
+		errCh,
+	); err != nil {
+		return nil, err
+	}
+
+	return errCh, err
+}
+
+func (l *LimaDcDriver) canRunGUI() bool {
+	return false
+}
+
+func (l *LimaDcDriver) RunGUI(_ context.Context) error {
+	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "dc", *l.Instance.Config.Video.Display)
+}
+
+func (l *LimaDcDriver) Stop(ctx context.Context) error {
+	logrus.Info("Shutting down DC VM")
+	distroName := "lima-" + l.Instance.Name
+	return stopVM(ctx, distroName)
+}
+
+// GuestAgentConn returns the guest agent connection, or nil (if forwarded by ssh).
+func (l *LimaDcDriver) GuestAgentConn(_ context.Context) (net.Conn, string, error) {
+	return nil, "", nil
+}
+
+func (l *LimaDcDriver) Info(_ context.Context) driver.Info {
+	var info driver.Info
+	info.Name = "dc"
+	if l.Instance != nil {
+		info.InstanceDir = l.Instance.Dir
+	}
+	info.VirtioPort = l.virtioPort
+	info.VsockPort = l.vSockPort
+
+	info.Features = driver.DriverFeatures{
+		DynamicSSHAddress:    true,
+		StaticSSHPort:        true,
+		SkipSocketForwarding: true,
+		NoCloudInit:          true,
+		CanRunGUI:            l.canRunGUI(),
+	}
+	return info
+}
+
+func (l *LimaDcDriver) SSHAddress(_ context.Context) (string, error) {
+	return "127.0.0.1", nil
+}
+
+func (l *LimaDcDriver) Create(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaDcDriver) CreateDisk(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaDcDriver) ChangeDisplayPassword(_ context.Context, _ string) error {
+	return nil
+}
+
+func (l *LimaDcDriver) DisplayConnection(_ context.Context) (string, error) {
+	return "", nil
+}
+
+func (l *LimaDcDriver) CreateSnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaDcDriver) ApplySnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaDcDriver) DeleteSnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaDcDriver) ListSnapshots(_ context.Context) (string, error) {
+	return "", errUnimplemented
+}
+
+func (l *LimaDcDriver) ForwardGuestAgent(_ context.Context) bool {
+	// If driver is not providing, use host agent
+	return l.vSockPort == 0 && l.virtioPort == ""
+}
+
+func (l *LimaDcDriver) AdditionalSetupForSSH(_ context.Context) error {
+	return nil
+}

--- a/pkg/driver/dc/errors_linux.go
+++ b/pkg/driver/dc/errors_linux.go
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dc
+
+import "errors"
+
+var errUnimplemented = errors.New("unimplemented")

--- a/pkg/driver/dc/fs.go
+++ b/pkg/driver/dc/fs.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dc
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/fileutils"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+)
+
+// EnsureFs downloads the root fs.
+func EnsureFs(ctx context.Context, inst *limatype.Instance) error {
+	baseDisk := filepath.Join(inst.Dir, filenames.BaseDiskLegacy)
+	if _, err := os.Stat(baseDisk); errors.Is(err, os.ErrNotExist) {
+		var ensuredBaseDisk bool
+		errs := make([]error, len(inst.Config.Images))
+		for i, f := range inst.Config.Images {
+			if _, err := fileutils.DownloadFile(ctx, baseDisk, f.File, true, "the image", *inst.Config.Arch); err != nil {
+				errs[i] = err
+				continue
+			}
+			ensuredBaseDisk = true
+			break
+		}
+		if !ensuredBaseDisk {
+			return fileutils.Errors(errs)
+		}
+	}
+	logrus.Info("Download succeeded")
+
+	return nil
+}

--- a/pkg/driver/dc/lima-init.TEMPLATE
+++ b/pkg/driver/dc/lima-init.TEMPLATE
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+export LOG_FILE=/var/log/lima-init.log
+exec > >(tee $LOG_FILE) 2>&1
+export LIMA_CIDATA_MNT="{{.CIDataPath}}"
+exec "$LIMA_CIDATA_MNT/boot.sh"

--- a/pkg/driver/dc/vm_linux.go
+++ b/pkg/driver/dc/vm_linux.go
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dc
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/textutil"
+)
+
+// init system (pid 1) in VM.
+const initSystem = "openrc"
+
+// OCI runtime for container.
+const ociRuntime = "runc"
+
+// createVM calls DC to create a VM.
+func createVM(ctx context.Context, distroName string, cpus, memory int) error {
+	imageName := distroName
+	entrypoint := "--init"
+	// /sbin/init is normally just a symlink to systemd
+	// eventually we might want to look inside the image
+	// note: docker does not seem to resolve symlinks here
+	// so need to give canonical path, after resolving root
+	switch initSystem {
+	case "systemd":
+		entrypoint = "--entrypoint=/usr/lib/systemd/systemd"
+	case "openrc":
+		entrypoint = "--entrypoint=/usr/sbin/openrc-init"
+	default:
+		logrus.Infof("unknown init system, running only --init")
+	}
+	out, err := exec.CommandContext(ctx,
+		"docker",
+		"create",
+		"--name",
+		distroName,
+		"--cpus",
+		fmt.Sprintf("%d", cpus),
+		"--memory",
+		fmt.Sprintf("%d", int64(memory)<<20),
+		"--runtime",
+		ociRuntime,
+		"--tmpfs",
+		"/run", // for systemd (and openrc)
+		entrypoint,
+		imageName,
+		"sleep",
+		"infinity").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `docker create %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+// startVM calls DC to start a VM.
+func startVM(ctx context.Context, distroName string) error {
+	out, err := exec.CommandContext(ctx,
+		"docker",
+		"start",
+		distroName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `docker start %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+// initVM calls DC to import a new VM specifically for Lima.
+func initVM(ctx context.Context, instanceDir, distroName string) error {
+	imageName := distroName
+	baseDisk := filepath.Join(instanceDir, filenames.BaseDiskLegacy)
+	logrus.Infof("Importing distro from %q to %q", baseDisk, instanceDir)
+	out, err := exec.CommandContext(ctx,
+		"docker",
+		"import",
+		baseDisk,
+		imageName,
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `docker import %s %s`: %w (out=%q)",
+			baseDisk, imageName, err, out)
+	}
+	return nil
+}
+
+// stopVM calls DC to stop a running VM.
+func stopVM(ctx context.Context, distroName string) error {
+	out, err := exec.CommandContext(ctx,
+		"docker",
+		"stop",
+		distroName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `docker stop %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+//go:embed lima-init.TEMPLATE
+var limaBoot string
+
+func dockerExecCmd(ctx context.Context, arg ...string) *exec.Cmd {
+	// "RunQ does not support 'docker exec'. Use 'runq-exec' instead."
+	if ociRuntime == "runq" {
+		runqExec := "/var/lib/runq/runq-exec"
+		args := append([]string{runqExec}, arg...)
+		time.Sleep(100 * time.Millisecond)
+		return exec.CommandContext(ctx, "sudo", args...)
+	}
+	args := append([]string{"exec"}, arg...)
+	return exec.CommandContext(ctx, "docker", args...)
+}
+
+// copyDir copies a directory.
+func copyDir(ctx context.Context, distroName, src, dst string) error {
+	cmd := dockerExecCmd(ctx, distroName, "mkdir", "-p", dst)
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	if err := cmd.Run(); err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			logrus.Debugf("run stderr: %s", exiterr.Stderr)
+		}
+		stderr := stderrBuf.String()
+		return fmt.Errorf("failed to run %v: %w %s", cmd.Args, err, stderr)
+	}
+	logrus.Infof("Copying directory from %q to \"%s:%s\"", src, distroName, dst)
+
+	tar1 := exec.CommandContext(ctx, "tar", "Cc", src, ".")
+	tar2 := dockerExecCmd(ctx, "-i", distroName, "tar", "Cx", dst)
+
+	p, err := tar1.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	tar2.Stdin = p
+	if err := tar2.Start(); err != nil {
+		return err
+	}
+	if err := tar1.Run(); err != nil {
+		return err
+	}
+	if err := tar2.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// provisionVM starts Lima's boot process inside an already imported VM.
+func provisionVM(ctx context.Context, instanceDir, instanceName, distroName string, errCh chan<- error) error {
+	ciDataPath := filepath.Join(instanceDir, filenames.CIDataISODir)
+	// can't mount the cidata, due to problems with virtiofs mounts
+	if err := copyDir(ctx, distroName, ciDataPath, "/mnt/lima-cidata"); err != nil {
+		return fmt.Errorf("failed to copy cidata directory: %w", err)
+	}
+	m := map[string]string{
+		"CIDataPath": "/mnt/lima-cidata",
+	}
+	limaBootB, err := textutil.ExecuteTemplate(limaBoot, m)
+	if err != nil {
+		return fmt.Errorf("failed to construct dc boot.sh script: %w", err)
+	}
+	go func() {
+		cmd := dockerExecCmd(
+			ctx,
+			"-i",
+			distroName,
+			"/bin/bash",
+		)
+		cmd.Stdin = bytes.NewReader(limaBootB)
+		out, err := cmd.CombinedOutput()
+		logrus.Debugf("%v: %q", cmd.Args, string(out))
+		if err != nil {
+			errCh <- fmt.Errorf(
+				"error running command that executes boot.sh (%v): %w, "+
+					"check /var/log/lima-init.log for more details (out=%q)", cmd.Args, err, string(out))
+		}
+
+		for {
+			<-ctx.Done()
+			logrus.Info("Context closed, stopping vm")
+			if status, err := getDcStatus(ctx, instanceName); err == nil &&
+				status == limatype.StatusRunning {
+				_ = stopVM(ctx, distroName)
+			}
+		}
+	}()
+
+	return err
+}
+
+// deleteVM calls DC to delete a VM.
+func deleteVM(ctx context.Context, distroName string) error {
+	imageName := distroName
+	logrus.Info("Deleting DC VM")
+	out, err := exec.CommandContext(ctx,
+		"docker",
+		"rm",
+		"-f",
+		distroName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `docker rm -f %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	out, err = exec.CommandContext(ctx,
+		"docker",
+		"image",
+		"rm",
+		imageName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `docker image rm %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+func inspectContainer(ctx context.Context, distroName, format string) (string, error) {
+	out, err := exec.CommandContext(
+		ctx,
+		"docker",
+		"inspect",
+		"--format="+format,
+		distroName,
+	).CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(out), fmt.Sprintf("No such object: %s", distroName)) ||
+			strings.Contains(string(out), fmt.Sprintf("no such object: %s", distroName)) {
+			return "", nil
+		}
+		if strings.Contains(string(out), "map has no entry for key") {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to run `docker inspect`, err: %w (out=%q)", err, out)
+	}
+	return strings.TrimSuffix(string(out), "\n"), nil
+}
+
+func getDcStatus(ctx context.Context, instName string) (string, error) {
+	distroName := "lima-" + instName
+	out, err := inspectContainer(ctx, distroName, "{{ .State.Status }}")
+	if err != nil {
+		return "", err
+	}
+	if out == "" {
+		return limatype.StatusUninitialized, nil
+	}
+
+	var instState string
+	switch out {
+	case "exited":
+		instState = limatype.StatusStopped
+	case "running":
+		instState = limatype.StatusRunning
+	default:
+		instState = limatype.StatusUnknown
+	}
+
+	return instState, nil
+}
+
+func getSSHAddress(ctx context.Context, instName string) (string, error) {
+	distroName := "lima-" + instName
+	out, err := inspectContainer(ctx, distroName, "{{ .NetworkSettings.IPAddress }}")
+	if err != nil {
+		return "", err
+	}
+	if out == "" {
+		out, err = inspectContainer(ctx, distroName, "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}")
+		if err != nil {
+			return "", err
+		}
+	}
+	if out == "" {
+		return "127.0.0.1", nil
+	}
+
+	instAddress := out
+
+	return instAddress, nil
+}

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -150,7 +150,7 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 	if err != nil {
 		return nil, err
 	}
-	if *inst.Config.VMType == limatype.WSL2 || *inst.Config.VMType == limatype.AC {
+	if *inst.Config.VMType == limatype.WSL2 || *inst.Config.VMType == limatype.AC || *inst.Config.VMType == limatype.DC {
 		sshLocalPort = inst.SSHLocalPort
 	}
 

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -150,6 +150,9 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 	if err != nil {
 		return nil, err
 	}
+	if *inst.Config.VMType == limatype.WSL2 || *inst.Config.VMType == limatype.AC {
+		sshLocalPort = inst.SSHLocalPort
+	}
 
 	var udpDNSLocalPort, tcpDNSLocalPort int
 	if *inst.Config.HostResolver.Enabled {

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -97,13 +97,14 @@ const (
 	VZ   VMType = "vz"
 	WSL2 VMType = "wsl2"
 	AC   VMType = "ac"
+	DC   VMType = "dc"
 )
 
 var (
 	OSTypes    = []OS{LINUX, DARWIN, FREEBSD}
 	ArchTypes  = []Arch{X8664, AARCH64, ARMV7L, PPC64LE, RISCV64, S390X}
 	MountTypes = []MountType{REVSSHFS, NINEP, VIRTIOFS, WSLMount}
-	VMTypes    = []VMType{QEMU, VZ, WSL2, AC}
+	VMTypes    = []VMType{QEMU, VZ, WSL2, AC, DC}
 )
 
 type User struct {

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -96,13 +96,14 @@ const (
 	QEMU VMType = "qemu"
 	VZ   VMType = "vz"
 	WSL2 VMType = "wsl2"
+	AC   VMType = "ac"
 )
 
 var (
 	OSTypes    = []OS{LINUX, DARWIN, FREEBSD}
 	ArchTypes  = []Arch{X8664, AARCH64, ARMV7L, PPC64LE, RISCV64, S390X}
 	MountTypes = []MountType{REVSSHFS, NINEP, VIRTIOFS, WSLMount}
-	VMTypes    = []VMType{QEMU, VZ, WSL2}
+	VMTypes    = []VMType{QEMU, VZ, WSL2, AC}
 )
 
 type User struct {

--- a/templates/experimental/ac.yaml
+++ b/templates/experimental/ac.yaml
@@ -1,0 +1,23 @@
+vmType: ac
+
+arch: aarch64
+cpus: 4
+memory: 1GiB
+disk: 512GiB
+
+images:
+- location: "debian-rootfs-arm64.tar.gz"
+  arch: "aarch64"
+
+# virtiofs is broken
+mountType: reverse-sshfs
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+
+# The built-in containerd installer does not support OpenRC currently.
+containerd:
+  system: false
+  user: false

--- a/templates/experimental/dc.yaml
+++ b/templates/experimental/dc.yaml
@@ -1,0 +1,15 @@
+vmType: dc
+
+images:
+- location: "debian-rootfs-amd64.tar.gz"
+  arch: "x86_64"
+- location: "debian-rootfs-arm64.tar.gz"
+  arch: "aarch64"
+
+# no native mounts yet
+mountType: reverse-sshfs
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true

--- a/website/content/en/docs/config/vmtype/ac.md
+++ b/website/content/en/docs/config/vmtype/ac.md
@@ -1,0 +1,9 @@
+---
+title: AC
+weight: 3
+---
+
+> **Warning**
+> "ac" option is experimental
+
+"ac" option makes use of Apple Container to run the guest OS.

--- a/website/content/en/docs/config/vmtype/dc.md
+++ b/website/content/en/docs/config/vmtype/dc.md
@@ -1,0 +1,9 @@
+---
+title: DC
+weight: 3
+---
+
+> **Warning**
+> "dc" option is experimental
+
+"dc" option makes use of Docker Container to run the guest OS.


### PR DESCRIPTION
A new Linux driver similar to the WSL2 driver for Windows,
creating virtual machines from container images (as rootfs).

Depends-On #3839

`make native && ADDITIONAL_DRIVERS=dc make additional-drivers`

(this is a draft, until the driver framework has been finalized)

----

* https://github.com/lima-vm/lima/discussions/3829

Intended for use with [Kata containers](https://katacontainers.io/) or similar runtime

<img src="https://katacontainers.io/static/6e497f9d3752ca1e354d0d2949abc020/8fef6/katacontainers_traditionalvskata_diagram.jpg" width="800" />

Not related with `template://docker`, inside the instance.