### PR TITLE
guestagent/procnettcp: remove unused, unexport funcs

### DIFF
--- a/pkg/guestagent/procnettcp/fuzz_test.go
+++ b/pkg/guestagent/procnettcp/fuzz_test.go
@@ -14,6 +14,6 @@ func FuzzParse(f *testing.F) {
 		if tcp6 {
 			kind = TCP6
 		}
-		_, _ = Parse(bytes.NewReader(data), kind)
+		_, _ = parse(bytes.NewReader(data), kind)
 	})
 }

--- a/pkg/guestagent/procnettcp/procnettcp.go
+++ b/pkg/guestagent/procnettcp/procnettcp.go
@@ -41,11 +41,11 @@ type Entry struct {
 	State State  `json:"state"`
 }
 
-func Parse(r io.Reader, kind Kind) ([]Entry, error) {
-	return ParseWithEndian(r, kind, cpu.IsBigEndian)
+func parse(r io.Reader, kind Kind) ([]Entry, error) {
+	return parseWithEndian(r, kind, cpu.IsBigEndian)
 }
 
-func ParseWithEndian(r io.Reader, kind Kind, isBE bool) ([]Entry, error) {
+func parseWithEndian(r io.Reader, kind Kind, isBE bool) ([]Entry, error) {
 	switch kind {
 	case TCP, TCP6, UDP, UDP6:
 	default:
@@ -78,7 +78,7 @@ func ParseWithEndian(r io.Reader, kind Kind, isBE bool) ([]Entry, error) {
 		default:
 			// localAddress is like "0100007F:053A"
 			localAddress := fields[fieldNames["local_address"]]
-			ip, port, err := ParseAddressWithEndian(localAddress, isBE)
+			ip, port, err := parseAddressWithEndian(localAddress, isBE)
 			if err != nil {
 				return entries, err
 			}
@@ -105,7 +105,7 @@ func ParseWithEndian(r io.Reader, kind Kind, isBE bool) ([]Entry, error) {
 	return entries, nil
 }
 
-// ParseAddress parses a string.
+// parseAddressWithEndian parses a string.
 //
 // Little endian hosts:
 // "0100007F:0050"                         (127.0.0.1:80)
@@ -118,11 +118,7 @@ func ParseWithEndian(r io.Reader, kind Kind, isBE bool) ([]Entry, error) {
 // "00000000000000000000000000000000:0050" (0.0.0.0:80)
 //
 // See https://serverfault.com/questions/592574/why-does-proc-net-tcp6-represents-1-as-1000
-func ParseAddress(s string) (net.IP, uint16, error) {
-	return ParseAddressWithEndian(s, cpu.IsBigEndian)
-}
-
-func ParseAddressWithEndian(s string, isBE bool) (net.IP, uint16, error) {
+func parseAddressWithEndian(s string, isBE bool) (net.IP, uint16, error) {
 	split := strings.SplitN(s, ":", 2)
 	if len(split) != 2 {
 		return nil, 0, fmt.Errorf("unparsable address %q", s)

--- a/pkg/guestagent/procnettcp/procnettcp_linux.go
+++ b/pkg/guestagent/procnettcp/procnettcp_linux.go
@@ -25,7 +25,7 @@ func ParseFiles() ([]Entry, error) {
 			}
 			return res, err
 		}
-		parsed, err := Parse(r, kind)
+		parsed, err := parse(r, kind)
 		if err != nil {
 			_ = r.Close()
 			return res, err

--- a/pkg/guestagent/procnettcp/procnettcp_test.go
+++ b/pkg/guestagent/procnettcp/procnettcp_test.go
@@ -21,7 +21,7 @@ func TestParseTCP(t *testing.T) {
    4: 0100007F:053A 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 31430 1 0000000000000000 100 0 0 10 0                     
    5: 0B3CA8C0:0016 690AA8C0:F705 01 00000000:00000000 02:00028D8B 00000000     0        0 32989 4 0000000000000000 20 4 31 10 19
 `
-	entries, err := ParseWithEndian(strings.NewReader(procNetTCP), TCP, isBE)
+	entries, err := parseWithEndian(strings.NewReader(procNetTCP), TCP, isBE)
 	assert.NilError(t, err)
 	t.Log(entries)
 
@@ -38,7 +38,7 @@ func TestParseTCP6(t *testing.T) {
 	const isBE = false
 	procNetTCP := `  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
 	   0: 000080FE00000000FF57A6705DC771FE:0050 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 850222 1 0000000000000000 100 0 0 10 0`
-	entries, err := ParseWithEndian(strings.NewReader(procNetTCP), TCP6, isBE)
+	entries, err := parseWithEndian(strings.NewReader(procNetTCP), TCP6, isBE)
 	assert.NilError(t, err)
 	t.Log(entries)
 
@@ -54,7 +54,7 @@ func TestParseTCP6Zero(t *testing.T) {
    1: 00000000000000000000000000000000:006F 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 26772 1 0000000000000000 100 0 0 10 0
    2: 00000000000000000000000000000000:0050 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 1210901 1 0000000000000000 100 0 0 10 0
 `
-	entries, err := ParseWithEndian(strings.NewReader(procNetTCP), TCP6, isBE)
+	entries, err := parseWithEndian(strings.NewReader(procNetTCP), TCP6, isBE)
 	assert.NilError(t, err)
 	t.Log(entries)
 
@@ -71,7 +71,7 @@ func TestParseUDP(t *testing.T) {
   731: 0369A8C0:0044 00000000:0000 07 00000000:00000000 00:00000000 00000000   998        0 29132 2 0000000000000000 0         
   731: 0F05A8C0:0044 00000000:0000 07 00000000:00000000 00:00000000 00000000   998        0 4049 2 0000000000000000 0          
  1768: 00000000:1451 00000000:0000 07 00000000:00000000 00:00000000 00000000   502        0 28364 2 0000000000000000 0  `
-	entries, err := ParseWithEndian(strings.NewReader(procNetTCP), UDP, isBE)
+	entries, err := parseWithEndian(strings.NewReader(procNetTCP), UDP, isBE)
 	assert.NilError(t, err)
 	t.Log(entries)
 
@@ -149,7 +149,7 @@ func TestParseAddress(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
-			ip, port, err := ParseAddressWithEndian(test.input, test.bigEndian)
+			ip, port, err := parseAddressWithEndian(test.input, test.bigEndian)
 			if test.expectedErrSubstr != "" {
 				assert.ErrorContains(t, err, test.expectedErrSubstr)
 			} else {


### PR DESCRIPTION
This PR refactors `pkg/guestagent/procnettcp` functions: removes unused `ParseAddress` and unexport functions `Parse`, `ParseWithEndian`, and `ParseAddressWithEndian`.