### PR TITLE
docs: link `community/contributing` from `dev`

### DIFF
--- a/website/content/en/docs/dev/_index.md
+++ b/website/content/en/docs/dev/_index.md
@@ -2,3 +2,8 @@
 title: Developers' guide
 weight: 500
 ---
+
+This section provides technological resources for developers of Lima.
+
+See also [`Community`](../community) » [`Contributing`](../community/contributing)
+for how to contribute to the project.


### PR DESCRIPTION
Link <https://lima-vm.io/docs/community/contributing/> from <https://lima-vm.io/docs/dev/>.

Close #3792