### PR TITLE
Fix: Server Shutdown Bug

### DIFF
--- a/pkg/driver/external/client/methods.go
+++ b/pkg/driver/external/client/methods.go
@@ -93,9 +93,7 @@ func (d *DriverClient) Start(ctx context.Context) (chan error, error) {
 func (d *DriverClient) Stop(ctx context.Context) error {
 	d.logger.Debug("Stopping driver instance")
 
-	connCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	_, err := d.DriverSvc.Stop(connCtx, &emptypb.Empty{})
+	_, err := d.DriverSvc.Stop(ctx, &emptypb.Empty{})
 	if err != nil {
 		d.logger.Errorf("Failed to stop driver instance: %v", err)
 		return err


### PR DESCRIPTION
The recently merged PR #3836 introduced a 60-second timeout to shut down the gRPC server if no client connects. However, it has a bug: the timer is not cancelled once a client successfully connects. This causes the server to forcefully shut down after 60 seconds, regardless of whether a client has connected.