### PR TITLE
Remove VMType check from the lima-init boot script

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/lima.env
+++ b/pkg/cidata/cidata.TEMPLATE.d/lima.env
@@ -65,3 +65,8 @@ LIMA_CIDATA_PLAIN=1
 {{- else}}
 LIMA_CIDATA_PLAIN=
 {{- end}}
+{{- if .NoCloudInit}}
+LIMA_CIDATA_NO_CLOUD_INIT=1
+{{- else}}
+LIMA_CIDATA_NO_CLOUD_INIT=
+{{- end}}

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -114,6 +114,7 @@ type TemplateArgs struct {
 	VirtioPort                      string
 	Plain                           bool
 	TimeZone                        string
+	NoCloudInit                     bool
 }
 
 func ValidateTemplateArgs(args *TemplateArgs) error {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -106,4 +106,5 @@ type DriverFeatures struct {
 	CanRunGUI            bool `json:"canRunGui,omitempty"`
 	DynamicSSHAddress    bool `json:"dynamicSSHAddress"`
 	SkipSocketForwarding bool `json:"skipSocketForwarding"`
+	NoCloudInit          bool `json:"noCloudInit"`
 }

--- a/pkg/driver/wsl2/boot/02-no-cloud-init-setup.sh
+++ b/pkg/driver/wsl2/boot/02-no-cloud-init-setup.sh
@@ -22,4 +22,4 @@ chmod 600 "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
 echo "${LIMA_CIDATA_USER} ALL=(ALL) NOPASSWD:ALL" | tee -a /etc/sudoers.d/99_lima_sudoers
 
 # symlink CIDATA to the hardcoded path for requirement checks (TODO: make this not hardcoded)
-ln -sfFn "${LIMA_CIDATA_MNT}" /mnt/lima-cidata
+[ "$LIMA_CIDATA_MNT" = "/mnt/lima-cidata" ] || ln -sfFn "${LIMA_CIDATA_MNT}" /mnt/lima-cidata

--- a/pkg/driver/wsl2/boot/02-wsl2-setup.sh
+++ b/pkg/driver/wsl2/boot/02-wsl2-setup.sh
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This script replaces the cloud-init functionality of creating a user and setting its SSH keys
-# when using a WSL2 VM.
-[ "$LIMA_CIDATA_VMTYPE" = "wsl2" ] || exit 0
+# when cloud-init is not available
+[ "$LIMA_CIDATA_NO_CLOUD_INIT" = "1" ] || exit 0
 
 # create user
 # shellcheck disable=SC2153

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -310,6 +310,7 @@ func (l *LimaWslDriver) Info() driver.Info {
 	info.Features = driver.DriverFeatures{
 		DynamicSSHAddress:    true,
 		SkipSocketForwarding: true,
+		NoCloudInit:          true,
 		CanRunGUI:            l.canRunGUI(),
 	}
 	return info

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -162,11 +162,12 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 
 	vSockPort := limaDriver.Info().VsockPort
 	virtioPort := limaDriver.Info().VirtioPort
+	noCloudInit := limaDriver.Info().Features.NoCloudInit
 
 	if err := cidata.GenerateCloudConfig(ctx, inst.Dir, instName, inst.Config); err != nil {
 		return nil, err
 	}
-	if err := cidata.GenerateISO9660(ctx, limaDriver, inst.Dir, instName, inst.Config, udpDNSLocalPort, tcpDNSLocalPort, o.guestAgentBinary, o.nerdctlArchive, vSockPort, virtioPort); err != nil {
+	if err := cidata.GenerateISO9660(ctx, limaDriver, inst.Dir, instName, inst.Config, udpDNSLocalPort, tcpDNSLocalPort, o.guestAgentBinary, o.nerdctlArchive, vSockPort, virtioPort, noCloudInit); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Do this when setting up the cidata instead, next to the decision on whether to use "cidata/" directory or "cidata.iso".

This means that this particular boot script is not depending on the driver, but can be used from all container drivers.

* https://github.com/lima-vm/lima/pull/3839

* https://github.com/lima-vm/lima/pull/3840

We probably want to add an explicit `bool` config for it to the driver, instead of checking for the driver name?

And there are still some features left to add to the script (from cloud-config), like the hostname and timezone.

* #3769

Currently we dont use `user-data`, but `lima.env` (+ ssh key)

We execute this script through the `boot.sh` directly (lima-init).