### PR TITLE
community: set up regular Zoom meetings

### DIFF
--- a/website/content/en/docs/community/_index.md
+++ b/website/content/en/docs/community/_index.md
@@ -13,8 +13,9 @@ The GitHub repo of Lima can be found at <https://github.com/lima-vm/lima>.
   - New account: <https://slack.cncf.io/>
   - Login: <https://cloud-native.slack.com/>
 
-- Zoom meetings are currently not regularly held due to timezone diversity,
-  but feel free to reach out to us if you want to host meetings
+- Zoom meetings (tentatively monthly)
+  - Meeting notes & agenda proposals: https://github.com/lima-vm/lima/discussions/categories/meetings
+  - Calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/lima
 
 - See <https://github.com/lima-vm/.github/blob/main/SECURITY.md> for how to report security issues.
 


### PR DESCRIPTION
Regular meetings will probably happen monthly on every third Thursday, at 05:30 UTC. (22:30 PDT, 07:30 CEST, 11:00 IST, 14:30 JST)

The frequency and the time can be adjusted depending on the needs and the availability of the participants.

The first regular meeting will be at 2025-08-21 (Thursday) 05:30 UTC.

See the discussion:
- #3866.

Fix #3798