### PR TITLE
ci: set GitHub Actions user to prevent brew command failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -470,6 +470,8 @@ jobs:
         brew install bash coreutils
         # QEMU 9.1.0 seems to break on GitHub runners, both on Monterey and Ventura
         # We revert back to 8.2.1, which seems to work fine
+        git config --global user.name "GitHub Actions Bot"
+        git config --global user.email "nobody@localhost"
         ./hack/brew-install-version.sh qemu 8.2.1
     - name: Test
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2


### PR DESCRIPTION
close #3886 