### PR TITLE
feature: "yq" provision mode

### DIFF
--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -56,6 +56,7 @@ declare -A CHECKS=(
 	["user-v2"]=""
 	["mount-path-with-spaces"]=""
 	["provision-data"]=""
+	["provision-yq"]=""
 	["param-env-variables"]=""
 	["set-user"]=""
 	["preserve-env"]="1"
@@ -90,6 +91,7 @@ case "$NAME" in
 	CHECKS["clone"]="1"
 	CHECKS["mount-path-with-spaces"]="1"
 	CHECKS["provision-data"]="1"
+	CHECKS["provision-yq"]="1"
 	CHECKS["param-env-variables"]="1"
 	CHECKS["set-user"]="1"
 	;;
@@ -197,6 +199,11 @@ fi
 if [[ -n ${CHECKS["provision-data"]} ]]; then
 	INFO 'Testing that /etc/sysctl.d/99-inotify.conf was created successfully on provision'
 	limactl shell "$NAME" grep -q fs.inotify.max_user_watches /etc/sysctl.d/99-inotify.conf
+fi
+
+if [[ -n ${CHECKS["provision-yq"]} ]]; then
+	INFO 'Testing that /tmp/param-yq.json was created successfully on provision'
+	limactl shell "$NAME" grep -q '"YQ": "yq"' /tmp/param-yq.json
 fi
 
 if [[ -n ${CHECKS["param-env-variables"]} ]]; then

--- a/hack/test-templates/test-misc.yaml
+++ b/hack/test-templates/test-misc.yaml
@@ -20,6 +20,7 @@ param:
   PROBE: probe
   SYSTEM: system
   USER: user
+  YQ: yq
 
 provision:
 - mode: ansible
@@ -37,6 +38,10 @@ provision:
   content: |
     fs.inotify.max_user_watches = 524288
     fs.inotify.max_user_instances = 512
+- mode: yq
+  path: "/tmp/param-{{.Param.YQ}}.json"
+  expression: .YQ = "{{.Param.YQ}}"
+  user: "{{.User}}"
 
 probes:
 - mode: readiness

--- a/pkg/cidata/cidata.TEMPLATE.d/lima.env
+++ b/pkg/cidata/cidata.TEMPLATE.d/lima.env
@@ -25,6 +25,12 @@ LIMA_CIDATA_DATAFILE_{{$dataFile.FileName}}_OWNER={{$dataFile.Owner}}
 LIMA_CIDATA_DATAFILE_{{$dataFile.FileName}}_PATH={{$dataFile.Path}}
 LIMA_CIDATA_DATAFILE_{{$dataFile.FileName}}_PERMISSIONS={{$dataFile.Permissions}}
 {{- end}}
+{{- range $yqProvision := .YQProvisions}}
+LIMA_CIDATA_YQ_PROVISION_{{$yqProvision.FileName}}_FORMAT={{$yqProvision.Format}}
+LIMA_CIDATA_YQ_PROVISION_{{$yqProvision.FileName}}_OWNER={{$yqProvision.Owner}}
+LIMA_CIDATA_YQ_PROVISION_{{$yqProvision.FileName}}_PATH={{$yqProvision.Path}}
+LIMA_CIDATA_YQ_PROVISION_{{$yqProvision.FileName}}_PERMISSIONS={{$yqProvision.Permissions}}
+{{- end}}
 LIMA_CIDATA_GUEST_INSTALL_PREFIX={{ .GuestInstallPrefix }}
 {{- if .Containerd.User}}
 LIMA_CIDATA_CONTAINERD_USER=1

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -335,6 +335,15 @@ func templateArgs(ctx context.Context, bootScripts bool, instDir, name string, i
 				Permissions: *f.Permissions,
 			})
 		}
+		if f.Mode == limatype.ProvisionModeYQ {
+			args.YQProvisions = append(args.YQProvisions, YQProvision{
+				FileName:    fmt.Sprintf("%08d", i),
+				Format:      *f.Format,
+				Owner:       *f.Owner,
+				Path:        *f.Path,
+				Permissions: *f.Permissions,
+			})
+		}
 	}
 
 	return &args, nil
@@ -401,6 +410,11 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 			layout = append(layout, iso9660util.Entry{
 				Path:   fmt.Sprintf("provision.%s/%08d", f.Mode, i),
 				Reader: strings.NewReader(*f.Content),
+			})
+		case limatype.ProvisionModeYQ:
+			layout = append(layout, iso9660util.Entry{
+				Path:   fmt.Sprintf("provision.%s/%08d", f.Mode, i),
+				Reader: strings.NewReader(*f.Expression),
 			})
 		case limatype.ProvisionModeBoot:
 			continue

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -58,6 +58,14 @@ type DataFile struct {
 	Permissions string
 }
 
+type YQProvision struct {
+	FileName    string
+	Format      string
+	Owner       string
+	Path        string
+	Permissions string
+}
+
 type Disk struct {
 	Name   string
 	Device string
@@ -93,6 +101,7 @@ type TemplateArgs struct {
 	Param                           map[string]string
 	BootScripts                     bool
 	DataFiles                       []DataFile
+	YQProvisions                    []YQProvision
 	DNSAddresses                    []string
 	CACerts                         CACerts
 	HostHomeMountPoint              string

--- a/pkg/limatmpl/embed.go
+++ b/pkg/limatmpl/embed.go
@@ -648,6 +648,11 @@ func (tmpl *Template) embedAllScripts(ctx context.Context, embedAll bool) error 
 			if p.Content != nil {
 				continue
 			}
+		case limatype.ProvisionModeYQ:
+			newName = "expression"
+			if p.Expression != nil {
+				continue
+			}
 		default:
 			if p.Script != "" {
 				continue

--- a/pkg/limatmpl/embed_test.go
+++ b/pkg/limatmpl/embed_test.go
@@ -343,6 +343,9 @@ provision:
 - mode: data
   file: base1.sh # This comment will move to the "content" key
   path: /tmp/data
+- mode: yq
+  file: base1.sh # This comment will move to the "expression" key
+  path: /tmp/yq
 `,
 		`
 # base0.yaml is ignored
@@ -364,6 +367,11 @@ provision:
     #!/usr/bin/env bash
     echo "This is base1.sh"
   path: /tmp/data
+- mode: yq
+  expression: |-  # This comment will move to the "expression" key
+    #!/usr/bin/env bash
+    echo "This is base1.sh"
+  path: /tmp/yq
 
 # base0.yaml is ignored
 `,

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -235,6 +235,7 @@ const (
 	ProvisionModeDependency ProvisionMode = "dependency"
 	ProvisionModeAnsible    ProvisionMode = "ansible" // DEPRECATED
 	ProvisionModeData       ProvisionMode = "data"
+	ProvisionModeYQ         ProvisionMode = "yq"
 )
 
 type Provision struct {
@@ -245,6 +246,9 @@ type Provision struct {
 	Playbook                        string             `yaml:"playbook,omitempty" json:"playbook,omitempty"` // DEPRECATED
 	// All ProvisionData fields must be nil unless Mode is ProvisionModeData
 	ProvisionData `yaml:",inline"` // Flatten fields for "strict" YAML mode
+	// ProvisionModeYQ borrows Owner, Path, and Permissions from ProvisionData
+	Expression *string `yaml:"expression,omitempty" json:"expression,omitempty" jsonschema:"nullable"`
+	Format     *string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"nullable"`
 }
 
 type ProvisionData struct {

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -405,13 +405,27 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 			if provision.Overwrite == nil {
 				provision.Overwrite = ptr.Of(true)
 			}
+		}
+		if provision.Mode == limatype.ProvisionModeYQ {
+			if provision.Expression != nil {
+				if out, err := executeGuestTemplate(*provision.Expression, instDir, y.User, y.Param); err == nil {
+					provision.Expression = ptr.Of(out.String())
+				} else {
+					logrus.WithError(err).Warnf("Couldn't process expression %q as a template", *provision.Expression)
+				}
+			}
+			if provision.Format == nil {
+				provision.Format = ptr.Of("auto")
+			}
+		}
+		if provision.Mode == limatype.ProvisionModeData || provision.Mode == limatype.ProvisionModeYQ {
 			if provision.Owner == nil {
 				provision.Owner = ptr.Of("root:root")
 			} else {
 				if out, err := executeGuestTemplate(*provision.Owner, instDir, y.User, y.Param); err == nil {
 					provision.Owner = ptr.Of(out.String())
 				} else {
-					logrus.WithError(err).Warnf("Couldn't owner %q as a template", *provision.Owner)
+					logrus.WithError(err).Warnf("Couldn't process owner %q as a template", *provision.Owner)
 				}
 			}
 			// Path is required; validation will throw an error when it is nil

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -246,6 +246,49 @@ containerd:
 #   owner: "root:root"
 #   permissions: 644
 #   overwrite: false
+# # Create or edit a file in the guest filesystem by using `yq`.
+# # The file specified by `path` will be updated by `expression`.
+# # An empty file of the required `format` will be created if it does not yet exist.
+# # `format` defaults to "auto" and will be detected by file extension of `path`.
+# # If the extension is not recognized by `yq` then `format` must be set to a
+# # value from this list:
+# #   "auto", "csv", "ini", "json", "props", "tsv", "toml", "xml", "yaml"
+# # See https://github.com/mikefarah/yq for more info.
+# # Any missing directories will be created as needed.
+# # The file permissions will be set to the specified value.
+# # The file and directory creation will be performed as the specified owner.
+# # If the existing file is not writable by the specified owner, the operation will fail.
+# # `path` and `expression` are required.
+# # `owner` and `permissions` are optional. Defaults to "root:root" and 644.
+# - mode: yq
+#   path: "{{.Home}}/.config/docker/daemon.json"
+#   expression: ".features.containerd-snapshotter = {{.Param.containerdSnapshotter}}"
+#   format: auto
+#   owner: "{{.User}}"
+#   permissions: 644
+#
+# Q. In what order are provision scripts executed?
+# A. All provisions are processed per boot by each module in stages of cloud-init as follows:
+#   1. cloud-init 'init' stage
+#     bootcmd:
+#     - `mode: boot` scripts are executed
+#
+#   2. cloud-init 'config' stage
+#     write_files:
+#     - `00-lima.boot.sh` is created, but not executed
+#
+#   3. cloud-init 'final' stage
+#     scripts_per_boot:
+#     - `00-lima.boot.sh` is executed; remaining provisions are processed in the following order:
+#       - LIMA pre-defined boot scripts:
+#         - `boot/{00-..., ..., 25-...}`
+#         - `boot/30-install-packages.sh`
+#           - `mode: dependency` scripts are executed
+#         - `boot/{35-..., ...}`
+#       - `mode: data` files are copied
+#       - `mode: yq` files are processed
+#       - `mode: system` scripts are executed
+#       - `mode: user` scripts are executed
 
 # Probe scripts to check readiness.
 # The scripts run in user mode. They must start with a '#!' line.

--- a/templates/docker-rootful.yaml
+++ b/templates/docker-rootful.yaml
@@ -30,16 +30,15 @@ provision:
     #!/bin/bash
     set -eux -o pipefail
     command -v docker >/dev/null 2>&1 && exit 0
-    if [ ! -e /etc/systemd/system/docker.socket.d/override.conf ]; then
-      mkdir -p /etc/systemd/system/docker.socket.d
-      # Alternatively we could just add the user to the "docker" group, but that requires restarting the user session
-      cat <<-EOF >/etc/systemd/system/docker.socket.d/override.conf
-      [Socket]
-      SocketUser={{.User}}
-    EOF
-    fi
     export DEBIAN_FRONTEND=noninteractive
     curl -fsSL https://get.docker.com | sh
+- mode: yq
+  path: /etc/systemd/system/docker.service.d/override.conf
+  format: ini
+  expression: .Socket.SocketUser="{{.User}}"
+- mode: yq
+  path: "/etc/docker/daemon.json"
+  expression: .features.containerd-snapshotter = {{.Param.containerdSnapshotter}}
 probes:
 - script: |
     #!/bin/bash
@@ -68,3 +67,5 @@ message: |
   docker context use lima-{{.Name}}
   docker run hello-world
   ------
+param:
+  containerdSnapshotter: false

--- a/templates/docker.yaml
+++ b/templates/docker.yaml
@@ -35,6 +35,10 @@ provision:
     # NOTE: you may remove the lines below, if you prefer to use rootful docker, not rootless
     systemctl disable --now docker
     apt-get install -y uidmap dbus-user-session
+- mode: yq
+  path: "{{.Home}}/.config/docker/daemon.json"
+  expression: .features.containerd-snapshotter = {{.Param.containerdSnapshotter}}
+  owner: "{{.User}}"
 - mode: user
   script: |
     #!/bin/bash
@@ -70,3 +74,5 @@ message: |
   docker context use lima-{{.Name}}
   docker run hello-world
   ------
+param:
+  containerdSnapshotter: false

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -148,8 +148,11 @@ See [Building Ansible inventories](https://docs.ansible.com/ansible/latest/inven
 - `boot.sh`: Boot script
 - `boot/*`: Boot script modules
 - `util/*`: Utility command scripts, executed in the boot script modules
+- `provision.data/*`: Custom provision files (data)
+- `provision.dependency/*`: Custom provision scripts (dependency)
 - `provision.system/*`: Custom provision scripts (system)
 - `provision.user/*`: Custom provision scripts (user)
+- `provision.yq/*`: Custom provision scripts (yq)
 - `etc_environment`: Environment variables to be added to `/etc/environment` (also loaded during `boot.sh`)
 
 Max file name length = 30


### PR DESCRIPTION
~~based on #3908~~
```yaml
# Create or edit a file in the guest filesystem by using `yq`.
# The file specified by `path` will be updated with the specified `expression` using `yq --inplace`.
# If the file does not exist, it will be created using `yq --null-input`.
# `format` is optional and defaults to "auto".
# One of the following is expected to work:
#   "auto", "csv", "ini", "json", "props", "tsv", "toml", "xml", "yaml"
# See https://github.com/mikefarah/yq for more info.
# Any missing directories will be created as needed.
# The file permissions will be set to the specified value.
# The file and directory creation will be performed as the specified owner.
# If the existing file is not writable by the specified owner, the operation will fail.
# `path` and `expression` are required.
# `owner` and `permissions` are optional. Defaults to "root:root" and 644.
- mode: yq
  path: "{{.Home}}/.config/docker/daemon.json"
  expression: ".features.containerd-snapshotter = {{.Param.containerdSnapshotter}}"
  format: auto
  owner: "{{.User}}"
  permissions: 644
```

updated:
- ~~based on #3908~~
- dropped `provisionTool`
- applied reviews