### PR TITLE
Also check "data" provisioning scripts for param usage

### DIFF
--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -521,6 +521,10 @@ func validateParamIsUsed(y *LimaYAML) error {
 				keyIsUsed = true
 				break
 			}
+			if p.Content != nil && re.MatchString(*p.Content) {
+				keyIsUsed = true
+				break
+			}
 			if p.Playbook != "" {
 				playbook, err := os.ReadFile(p.Playbook)
 				if err != nil {


### PR DESCRIPTION
Fixes:

```console
❯ cat test.tmpl
images: [{location: foo.raw}]
provision:
- mode: data
  path: /etc/foo
  content: |
    FOO={{.Param.FOO}}
param:
  FOO: bar

❯ limactl tmpl copy --fill test.tmpl -
FATA[0000] field `param` key "FOO" is not used in any provision, probe, copyToHost, or portForward
```

With this PR:

```
❯ limactl tmpl copy --fill test.tmpl - | yq '.provision[0].content'
FOO=bar
```
