### PR TITLE
Add two fields for images exported from containers

### DIFF
--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -74,6 +74,8 @@ func Prepare(ctx context.Context, inst *limatype.Instance) (*Prepared, error) {
 	kernel := filepath.Join(inst.Dir, filenames.Kernel)
 	kernelCmdline := filepath.Join(inst.Dir, filenames.KernelCmdline)
 	initrd := filepath.Join(inst.Dir, filenames.Initrd)
+	entrypoint := filepath.Join(inst.Dir, filenames.Entrypoint)
+	stopsignal := filepath.Join(inst.Dir, filenames.StopSignal)
 	if _, err := os.Stat(baseDisk); errors.Is(err, os.ErrNotExist) {
 		var ensuredBaseDisk bool
 		errs := make([]error, len(inst.Config.Images))
@@ -98,6 +100,18 @@ func Prepare(ctx context.Context, inst *limatype.Instance) (*Prepared, error) {
 			if f.Initrd != nil {
 				// vz does not need initrd to be decompressed
 				if _, err := fileutils.DownloadFile(ctx, initrd, *f.Initrd, false, "the initrd", *inst.Config.Arch); err != nil {
+					errs[i] = err
+					continue
+				}
+			}
+			if f.Entrypoint != nil {
+				if err := os.WriteFile(entrypoint, []byte(*f.Entrypoint), 0o644); err != nil {
+					errs[i] = err
+					continue
+				}
+			}
+			if f.Stopsignal != nil {
+				if err := os.WriteFile(stopsignal, []byte(*f.Stopsignal), 0o644); err != nil {
 					errs[i] = err
 					continue
 				}

--- a/pkg/limatype/filenames/filenames.go
+++ b/pkg/limatype/filenames/filenames.go
@@ -41,6 +41,8 @@ const (
 	Kernel                  = "kernel"
 	KernelCmdline           = "kernel.cmdline"
 	Initrd                  = "initrd"
+	Entrypoint              = "entrypoint"
+	StopSignal              = "stopsignal"
 	QMPSock                 = "qmp.sock"
 	SerialLog               = "serial.log" // default serial (ttyS0, but ttyAMA0 on qemu-system-{arm,aarch64})
 	SerialSock              = "serial.sock"

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -146,9 +146,11 @@ type Kernel struct {
 }
 
 type Image struct {
-	File   `yaml:",inline"`
-	Kernel *Kernel `yaml:"kernel,omitempty" json:"kernel,omitempty"`
-	Initrd *File   `yaml:"initrd,omitempty" json:"initrd,omitempty"`
+	File       `yaml:",inline"`
+	Kernel     *Kernel `yaml:"kernel,omitempty" json:"kernel,omitempty"`
+	Initrd     *File   `yaml:"initrd,omitempty" json:"initrd,omitempty"`
+	Entrypoint *string `yaml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
+	Stopsignal *string `yaml:"stopsignal,omitempty" json:"stopsignal,omitempty"`
 }
 
 type Disk struct {

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -52,6 +52,10 @@ kernel:
 - `kernel.cmdline`: the kernel cmdline
 - `initrd`: the initrd
 
+container:
+- `entrypoint`: the entrypoint to use (optional)
+- `stopsignal`: the stopsignal to use (optional)
+
 QEMU:
 - `qemu.pid`: QEMU PID
 - `qmp.sock`: QMP socket


### PR DESCRIPTION
The original container image has some optional metadata in the ENTRYPOINT and STOPSIGNAL fields, that could be needed later...

But these are not exported in the generic rootfs, by default.

Make it possible to pass these at runtime, for instance to select between OpenRC and systemd - or SIGTERM and systemd.

Some drivers include their config in the rootfs, like wsl.conf.

Required by: (currently hardcoded)

* https://github.com/lima-vm/lima/pull/3840


---

Example for systemd

```Dockerfile
ENTRYPOINT [ "/usr/local/bin/entrypoint", "/sbin/init" ]
```

Where /sbin/init was symlinked over to /lib/systemd/systemd

It could also be just the init directly, without a shell wrapper.

```Dockerfile
STOPSIGNAL SIGRTMIN+3
```

The defaults are to run either with the VM's `init`, or with `--init`

And to use acpi or similar for VMs, or SIGTERM for containers