### PR TITLE
Add runtime option for the docker container driver

### DIFF
--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -107,12 +107,17 @@ type User struct {
 }
 
 type VMOpts struct {
-	QEMU QEMUOpts `yaml:"qemu,omitempty" json:"qemu,omitempty"`
+	QEMU   QEMUOpts   `yaml:"qemu,omitempty" json:"qemu,omitempty"`
+	Docker DockerOpts `yaml:"docker,omitempty" json:"docker,omitempty"`
 }
 
 type QEMUOpts struct {
 	MinimumVersion *string `yaml:"minimumVersion,omitempty" json:"minimumVersion,omitempty" jsonschema:"nullable"`
 	CPUType        CPUType `yaml:"cpuType,omitempty" json:"cpuType,omitempty" jsonschema:"nullable"`
+}
+
+type DockerOpts struct {
+	Runtime *string `yaml:"runtime,omitempty" json:"runtime,omitempty" jsonschema:"nullable"`
 }
 
 type Rosetta struct {

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -329,6 +329,11 @@ vmOpts:
     #   armv7l:  "max" # (or "host" when running on armv7l host)
     #   riscv64: "max" # (or "host" when running on riscv64 host)
     #   x86_64:  "max" # (or "host" when running on x86_64 host; additional options are appended on Intel Mac)
+  docker:
+    # The container runtime to use when running.
+    # Will be ignored if the vmType is not "docker"
+    # 🟢 Builtin default: none (use daemon default)
+    runtime: null
 
 # OS: "Linux".
 # 🟢 Builtin default: "Linux"


### PR DESCRIPTION
Make it possible to select between "runc" and "runv", etc.

Validation is done later (by the driver), if actually used.

Required by: (currently hardcoded)

* https://github.com/lima-vm/lima/pull/3840