### PR TITLE
Convert limatype.VMOpts to an abstract map

### DIFF
--- a/pkg/driver/vz/vm_darwin.go
+++ b/pkg/driver/vz/vm_darwin.go
@@ -602,7 +602,12 @@ func attachFolderMounts(inst *limatype.Instance, vmConfig *vz.VirtualMachineConf
 		}
 	}
 
-	if *inst.Config.VMOpts.VZ.Rosetta.Enabled {
+	var vzOpts limatype.VZOpts
+	if err := limayaml.Convert(inst.Config.VMOpts[limatype.VZ], &vzOpts, "vmOpts.vz"); err != nil {
+		logrus.WithError(err).Warnf("Couldn't convert %q", inst.Config.VMOpts[limatype.VZ])
+	}
+
+	if vzOpts.Rosetta.Enabled != nil && *vzOpts.Rosetta.Enabled {
 		logrus.Info("Setting up Rosetta share")
 		directorySharingDeviceConfig, err := createRosettaDirectoryShareConfiguration()
 		if err != nil {

--- a/pkg/limatmpl/embed.go
+++ b/pkg/limatmpl/embed.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/limayaml"
 	"github.com/lima-vm/lima/v2/pkg/version/versionutil"
 	"github.com/lima-vm/lima/v2/pkg/yqutil"
 )
@@ -179,9 +180,17 @@ func (tmpl *Template) mergeBase(base *Template) error {
 			tmpl.copyField(minimumLimaVersion, minimumLimaVersion)
 		}
 	}
-	if tmpl.Config.VMOpts.QEMU.MinimumVersion != nil && base.Config.VMOpts.QEMU.MinimumVersion != nil {
-		tmplVersion := *semver.New(*tmpl.Config.VMOpts.QEMU.MinimumVersion)
-		baseVersion := *semver.New(*base.Config.VMOpts.QEMU.MinimumVersion)
+	var tmplOpts limatype.QEMUOpts
+	if err := limayaml.Convert(tmpl.Config.VMOpts[limatype.QEMU], &tmplOpts, "vmOpts.qemu"); err != nil {
+		return err
+	}
+	var baseOpts limatype.QEMUOpts
+	if err := limayaml.Convert(base.Config.VMOpts[limatype.QEMU], &baseOpts, "vmOpts.qemu"); err != nil {
+		return err
+	}
+	if tmplOpts.MinimumVersion != nil && baseOpts.MinimumVersion != nil {
+		tmplVersion := *semver.New(*tmplOpts.MinimumVersion)
+		baseVersion := *semver.New(*baseOpts.MinimumVersion)
 		if tmplVersion.LessThan(baseVersion) {
 			const minimumQEMUVersion = "vmOpts.qemu.minimumVersion"
 			tmpl.copyField(minimumQEMUVersion, minimumQEMUVersion)

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -20,7 +20,7 @@ type LimaYAML struct {
 	OS                 *OS           `yaml:"os,omitempty" json:"os,omitempty" jsonschema:"nullable"`
 	Arch               *Arch         `yaml:"arch,omitempty" json:"arch,omitempty" jsonschema:"nullable"`
 	Images             []Image       `yaml:"images,omitempty" json:"images,omitempty" jsonschema:"nullable"`
-	// Deprecated: Use VMOpts.Qemu.CPUType instead.
+	// Deprecated: Use vmOpts.qemu.cpuType instead.
 	CPUType               CPUType       `yaml:"cpuType,omitempty" json:"cpuType,omitempty" jsonschema:"nullable"`
 	CPUs                  *int          `yaml:"cpus,omitempty" json:"cpus,omitempty" jsonschema:"nullable"`
 	Memory                *string       `yaml:"memory,omitempty" json:"memory,omitempty" jsonschema:"nullable"` // go-units.RAMInBytes
@@ -51,7 +51,7 @@ type LimaYAML struct {
 	// `useHostResolver` was deprecated in Lima v0.8.1, removed in Lima v0.14.0. Use `hostResolver.enabled` instead.
 	PropagateProxyEnv *bool          `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty" jsonschema:"nullable"`
 	CACertificates    CACertificates `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
-	// Deprecated: Use VMOpts.VZ.Rosetta instead.
+	// Deprecated: Use vmOpts.vz.rosetta instead.
 	Rosetta              Rosetta `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
 	Plain                *bool   `yaml:"plain,omitempty" json:"plain,omitempty" jsonschema:"nullable"`
 	TimeZone             *string `yaml:"timezone,omitempty" json:"timezone,omitempty" jsonschema:"nullable"`
@@ -110,10 +110,7 @@ type User struct {
 	UID     *uint32 `yaml:"uid,omitempty" json:"uid,omitempty" jsonschema:"nullable"`
 }
 
-type VMOpts struct {
-	QEMU QEMUOpts `yaml:"qemu,omitempty" json:"qemu,omitempty"`
-	VZ   VZOpts   `yaml:"vz,omitempty" json:"vz,omitempty"`
-}
+type VMOpts map[VMType]any
 
 type QEMUOpts struct {
 	MinimumVersion *string `yaml:"minimumVersion,omitempty" json:"minimumVersion,omitempty" jsonschema:"nullable"`

--- a/pkg/limayaml/limayaml_test.go
+++ b/pkg/limayaml/limayaml_test.go
@@ -51,6 +51,7 @@ func TestDefaultYAML(t *testing.T) {
 	y.Images = nil                // remove default images
 	y.Mounts = nil                // remove default mounts
 	y.Base = nil                  // remove default base templates
+	y.VMOpts = nil                // remove default vmopts mapping
 	y.MinimumLimaVersion = nil    // remove minimum Lima version
 	y.MountTypesUnsupported = nil // remove default workaround for kernel 6.9-6.11
 	t.Log(dumpJSON(t, y))

--- a/pkg/limayaml/marshal.go
+++ b/pkg/limayaml/marshal.go
@@ -82,3 +82,20 @@ func Unmarshal(data []byte, y *limatype.LimaYAML, comment string) error {
 	}
 	return nil
 }
+
+// Convert converts from x to y, using YAML.
+// If x is nil, then y is left unmodified.
+func Convert(x, y any, comment string) error {
+	if x == nil {
+		return nil
+	}
+	b, err := yaml.Marshal(x)
+	if err != nil {
+		return err
+	}
+	err = yaml.Unmarshal(b, y)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal YAML (%s): %w", comment, err)
+	}
+	return nil
+}

--- a/pkg/limayaml/marshal_test.go
+++ b/pkg/limayaml/marshal_test.go
@@ -4,13 +4,22 @@
 package limayaml
 
 import (
+	"strings"
 	"testing"
+	"text/template"
 
+	"github.com/goccy/go-yaml"
 	"gotest.tools/v3/assert"
 
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/ptr"
 )
+
+func dumpYAML(t *testing.T, d any) string {
+	b, err := yaml.Marshal(d)
+	assert.NilError(t, err)
+	return string(b)
+}
 
 func TestMarshalEmpty(t *testing.T) {
 	_, err := Marshal(&limatype.LimaYAML{}, false)
@@ -38,4 +47,138 @@ mounts:
 - location: "null"
 ...
 `)
+}
+
+type Opts struct {
+	Foo int
+	Bar string
+}
+
+var (
+	opts = Opts{Foo: 1, Bar: "two"}
+	text = `{"foo":1,"bar":"two"}`
+	code any
+)
+
+func TestConvert(t *testing.T) {
+	err := yaml.Unmarshal([]byte(text), &code)
+	assert.NilError(t, err)
+	o := opts
+	var a any
+	err = Convert(o, &a, "")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, a, code)
+	err = Convert(a, &o, "")
+	assert.NilError(t, err)
+	assert.Equal(t, o, opts)
+}
+
+func TestVMOpts(t *testing.T) {
+	text := `
+vmType: null
+`
+	var y limatype.LimaYAML
+	err := Unmarshal([]byte(text), &y, "lima.yaml")
+	assert.NilError(t, err)
+	var o limatype.VMOpts
+	err = Convert(y.VMOpts, &o, "vmOpts")
+	assert.NilError(t, err)
+	t.Log(dumpYAML(t, o))
+}
+
+func TestQEMUOpts(t *testing.T) {
+	text := `
+vmType: "qemu"
+vmOpts:
+  qemu:
+    minimumVersion: null
+    cpuType:
+`
+	var y limatype.LimaYAML
+	err := Unmarshal([]byte(text), &y, "lima.yaml")
+	assert.NilError(t, err)
+	var o limatype.QEMUOpts
+	err = Convert(y.VMOpts[limatype.QEMU], &o, "vmOpts.qemu")
+	assert.NilError(t, err)
+	t.Log(dumpYAML(t, o))
+}
+
+func TestVZOpts(t *testing.T) {
+	text := `
+vmType: "vz"
+vmOpts:
+  vz:
+    rosetta:
+      enabled: null
+      binfmt: null
+`
+	var y limatype.LimaYAML
+	err := Unmarshal([]byte(text), &y, "lima.yaml")
+	assert.NilError(t, err)
+	var o limatype.VZOpts
+	err = Convert(y.VMOpts[limatype.VZ], &o, "vmOpts.vz")
+	assert.NilError(t, err)
+	t.Log(dumpYAML(t, o))
+}
+
+func TestVMOptsNull(t *testing.T) {
+	text := `
+vmOpts: null
+`
+	var y limatype.LimaYAML
+	err := Unmarshal([]byte(text), &y, "lima.yaml")
+	assert.NilError(t, err)
+	var o limatype.VMOpts
+	err = Convert(y.VMOpts, &o, "vmOpts")
+	assert.NilError(t, err)
+	var oq limatype.QEMUOpts
+	err = Convert(y.VMOpts[limatype.QEMU], &oq, "vmOpts.qemu")
+	assert.NilError(t, err)
+	var ov limatype.VZOpts
+	err = Convert(y.VMOpts[limatype.VZ], &ov, "vmOpts.vz")
+	assert.NilError(t, err)
+}
+
+type FormatData struct {
+	limatype.Instance `yaml:",inline"`
+}
+
+func TestVZOptsRosettaMessage(t *testing.T) {
+	text := `
+vmType: "vz"
+vmOpts:
+  vz:
+    rosetta:
+      enabled: true
+      binfmt: false
+
+message: |
+  {{- if .Instance.Config.VMOpts.vz.rosetta.enabled}}
+  Rosetta is enabled in this VM, so you can run x86_64 containers on Apple Silicon.
+  {{- end}}
+`
+	want := `vmType: vz
+vmOpts:
+  vz:
+    rosetta:
+      binfmt: false
+      enabled: true
+message: |
+  
+  Rosetta is enabled in this VM, so you can run x86_64 containers on Apple Silicon.
+`
+	var y limatype.LimaYAML
+	err := Unmarshal([]byte(text), &y, "lima.yaml")
+	assert.NilError(t, err)
+	tmpl, err := template.New("format").Parse(y.Message)
+	assert.NilError(t, err)
+	inst := limatype.Instance{Config: &y}
+	var message strings.Builder
+	data := FormatData{Instance: inst}
+	err = tmpl.Execute(&message, data)
+	assert.NilError(t, err)
+	y.Message = message.String()
+	b, err := Marshal(&y, false)
+	assert.NilError(t, err)
+	assert.Equal(t, string(b), want)
 }

--- a/templates/docker-rootful.yaml
+++ b/templates/docker-rootful.yaml
@@ -69,7 +69,7 @@ message: |
   docker context use lima-{{.Name}}
   docker run hello-world
   ------
-  {{- if .Instance.Config.VMOpts.VZ.Rosetta.Enabled}}
+  {{- if .Instance.Config.VMOpts.vz.rosetta.enabled}}
   Rosetta is enabled in this VM, so you can run x86_64 containers on Apple Silicon.
   You can use Rosetta AOT Caching with the CDI spec:
   - To run a container, add `--device=lima-vm.io/rosetta=cached` to your `docker run` command:

--- a/templates/docker.yaml
+++ b/templates/docker.yaml
@@ -76,7 +76,7 @@ message: |
   docker context use lima-{{.Name}}
   docker run hello-world
   ------
-  {{- if .Instance.Config.VMOpts.VZ.Rosetta.Enabled}}
+  {{- if .Instance.Config.VMOpts.vz.rosetta.enabled}}
   Rosetta is enabled in this VM, so you can run x86_64 containers on Apple Silicon.
   You can use Rosetta AOT Caching with the CDI spec:
   - To run a container, add `--device=lima-vm.io/rosetta=cached` to your `docker run` command:


### PR DESCRIPTION
The format of the VMOpts is known _only_ to the driver, everyone
else will see a basic `map[string]any` or something similar to it.

Note: the `string` is the driver type, the `any` is the actual Opts

Converting from the abstract format to the actual format is done
using YAML, just like it was before when the format was known.

Issue #3506

Note: the use of QEMUOpts is **not** addressed here, only VMOpts.

There needs to be a follow up, to move the struct into the driver.

Same for VZ. The VZOpts struct should also move into the driver.

Depends:

* #3992