### PR TITLE
Display the error when the plugin command failed to run

### DIFF
--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -242,16 +242,18 @@ func runExternalPlugin(ctx context.Context, name string, args []string) {
 		return
 	}
 
-	logrus.Debugf("found external command: %s", execPath)
-
 	cmd := exec.CommandContext(ctx, execPath, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
 
-	handleExitCoder(cmd.Run())
-	os.Exit(0) //nolint:revive // it's intentional to call os.Exit in this function
+	err = cmd.Run()
+	handleExitCoder(err)
+	if err == nil {
+		os.Exit(0) //nolint:revive // it's intentional to call os.Exit in this function
+	}
+	logrus.Fatalf("external command %q failed: %v", execPath, err)
 }
 
 func updatePathEnv() error {


### PR DESCRIPTION
Which is different from running, and failing. One reason this can happen if the plugin is a shell script without a hash-bang line.

Also removed a `Debugf()` call because there is no way to change the logging level when invoking a plugin.

```console
❯ limactl foo
FATA[0000] external command "/Users/jan/bin/limactl-foo" failed: fork/exec /Users/jan/bin/limactl-foo: exec format error
```