### PR TITLE
Add `yq` subcommands to `limactl` and `lima-guestagent`

### DIFF
--- a/cmd/lima-guestagent/main_linux.go
+++ b/cmd/lima-guestagent/main_linux.go
@@ -4,8 +4,10 @@
 package main
 
 import (
+	"os"
 	"strings"
 
+	yq "github.com/mikefarah/yq/v4/cmd"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -14,6 +16,25 @@ import (
 )
 
 func main() {
+	// `lima-guestagent yq` executes the embedded `yq` command instead.
+	if len(os.Args) > 1 && os.Args[1] == "yq" {
+		os.Args = os.Args[1:]
+
+		cmd := yq.New()
+		args := os.Args[1:]
+		_, _, err := cmd.Find(args)
+		if err != nil && args[0] != "__complete" {
+			// default command when nothing matches...
+			newArgs := []string{"eval"}
+			cmd.SetArgs(append(newArgs, os.Args[1:]...))
+		}
+
+		if err := cmd.Execute(); err != nil {
+			os.Exit(1)
+		}
+		return
+	}
+
 	if err := newApp().Execute(); err != nil {
 		logrus.Fatal(err)
 	}

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/mattn/go-isatty"
+	yq "github.com/mikefarah/yq/v4/cmd"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -32,6 +33,24 @@ const (
 )
 
 func main() {
+	// `limactl yq` executes the embedded `yq` command instead.
+	if len(os.Args) > 1 && os.Args[1] == "yq" {
+		os.Args = os.Args[1:]
+
+		cmd := yq.New()
+		args := os.Args[1:]
+		_, _, err := cmd.Find(args)
+		if err != nil && args[0] != "__complete" {
+			// default command when nothing matches...
+			newArgs := []string{"eval"}
+			cmd.SetArgs(append(newArgs, os.Args[1:]...))
+		}
+
+		if err := cmd.Execute(); err != nil {
+			os.Exit(1)
+		}
+		return
+	}
 	if runtime.GOOS == "windows" {
 		extras, hasExtra := os.LookupEnv("_LIMA_WINDOWS_EXTRA_PATH")
 		if hasExtra && strings.TrimSpace(extras) != "" {


### PR DESCRIPTION
Adding it to `lime-guestagent` allows us to use `yq` in provisioning scripts without having to install it from a package repository or downloading it from GitHub.

Adding it to `limactl` makes it available to integration tests without having to install it. It` is essentially free because we already use `yqlib` inside `limactl` anyways, so the executable size doesn't really change.

The size of the (compressed) guestagent for aarch64 increases from 12MB to 14MB, which seems acceptable.

These are "hidden" commands that don't show up in --help output.

```console
❯ limactl yq --version
yq (https://github.com/mikefarah/yq/) version v4.47.1

❯ limactl yq -n '.foo="bar"'
foo: bar

❯ lima lima-guestagent yq -n '.foo="bar"'
foo: bar
```

This PR is meant to support the "yq provisioning mode" proposed in #3892, but I think is also valuable on its own.

---

I was initially thinking about making this a busybox-style "multi-call" binary, so you could put a symlink called `yq` into `/usr/local/bin` and have it work as a regular `yq` binary. But I'm worried about shadowing a `yq` version installed by the user with a shadow manager, so didn't add this functionality.