### PR TITLE
driver: remove AcceptConfig

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -79,10 +79,13 @@ type Driver interface {
 	Info() Info
 
 	// Configure sets the configuration for the instance.
+	// TODO: merge Configure and FillConfig?
+	// Or come up with a better name to clarify the difference.
 	Configure(inst *limatype.Instance) *ConfiguredDriver
 
-	AcceptConfig(cfg *limatype.LimaYAML, filePath string) error
-	FillConfig(cfg *limatype.LimaYAML, filePath string) error
+	// FillConfig fills and validates the configuration for the instance.
+	// The config is not set to the instance.
+	FillConfig(ctx context.Context, cfg *limatype.LimaYAML, filePath string) error
 
 	SSHAddress(ctx context.Context) (string, error)
 }

--- a/pkg/driver/external/client/methods.go
+++ b/pkg/driver/external/client/methods.go
@@ -115,11 +115,7 @@ func (d *DriverClient) Delete(ctx context.Context) error {
 	return nil
 }
 
-func (d *DriverClient) AcceptConfig(_ *limatype.LimaYAML, _ string) error {
-	return errors.New("pre-configured driver action not implemented in client driver")
-}
-
-func (d *DriverClient) FillConfig(_ *limatype.LimaYAML, _ string) error {
+func (d *DriverClient) FillConfig(_ context.Context, _ *limatype.LimaYAML, _ string) error {
 	return errors.New("pre-configured driver action not implemented in client driver")
 }
 

--- a/pkg/driver/external/server/server.go
+++ b/pkg/driver/external/server/server.go
@@ -57,7 +57,7 @@ func Serve(ctx context.Context, driver driver.Driver) {
 	inspectStatus := flag.Bool("inspect-status", false, "Inspect status of the driver")
 	flag.Parse()
 	if *preConfiguredDriverAction {
-		handlePreConfiguredDriverAction(driver)
+		handlePreConfiguredDriverAction(ctx, driver)
 		return
 	}
 	if *inspectStatus {
@@ -188,7 +188,7 @@ func handleInspectStatus(driver driver.Driver) {
 	}
 }
 
-func handlePreConfiguredDriverAction(driver driver.Driver) {
+func handlePreConfiguredDriverAction(ctx context.Context, driver driver.Driver) {
 	decoder := json.NewDecoder(os.Stdin)
 	encoder := json.NewEncoder(os.Stdout)
 
@@ -198,11 +198,7 @@ func handlePreConfiguredDriverAction(driver driver.Driver) {
 	}
 
 	config := &payload.Config
-	if err := driver.AcceptConfig(config, payload.FilePath); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to accept config: %v", err)
-	}
-
-	if err := driver.FillConfig(config, payload.FilePath); err != nil {
+	if err := driver.FillConfig(ctx, config, payload.FilePath); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to fill config: %v", err)
 	}
 

--- a/pkg/driverutil/vm.go
+++ b/pkg/driverutil/vm.go
@@ -41,10 +41,7 @@ func validateConfigAgainstDriver(ctx context.Context, y *limatype.LimaYAML, file
 		return handlePreConfiguredDriverAction(ctx, y, extDriver.Path, filePath)
 	}
 
-	if err := intDriver.AcceptConfig(y, filePath); err != nil {
-		return err
-	}
-	if err := intDriver.FillConfig(y, filePath); err != nil {
+	if err := intDriver.FillConfig(ctx, y, filePath); err != nil {
 		return err
 	}
 

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -47,12 +47,11 @@ func (m *mockDriver) GuestAgentConn(_ context.Context) (net.Conn, string, error)
 func (m *mockDriver) Info() driver.Info {
 	return driver.Info{Name: m.Name}
 }
-func (m *mockDriver) Configure(_ *limatype.Instance) *driver.ConfiguredDriver      { return nil }
-func (m *mockDriver) AcceptConfig(_ *limatype.LimaYAML, _ string) error            { return nil }
-func (m *mockDriver) FillConfig(_ *limatype.LimaYAML, _ string) error              { return nil }
-func (m *mockDriver) InspectStatus(_ context.Context, _ *limatype.Instance) string { return "" }
-func (m *mockDriver) SSHAddress(_ context.Context) (string, error)                 { return "", nil }
-func (m *mockDriver) BootScripts() (map[string][]byte, error)                      { return nil, nil }
+func (m *mockDriver) Configure(_ *limatype.Instance) *driver.ConfiguredDriver            { return nil }
+func (m *mockDriver) FillConfig(_ context.Context, _ *limatype.LimaYAML, _ string) error { return nil }
+func (m *mockDriver) InspectStatus(_ context.Context, _ *limatype.Instance) string       { return "" }
+func (m *mockDriver) SSHAddress(_ context.Context) (string, error)                       { return "", nil }
+func (m *mockDriver) BootScripts() (map[string][]byte, error)                            { return nil, nil }
 
 func TestRegister(t *testing.T) {
 	BackupRegistry(t)


### PR DESCRIPTION
The `AcceptConfig` method is not meaningful because it is always followed by an invocation of `FillConfig`.

Also, it contained remnant of `ResolveVMType` that is no longer supported in Lima v2.0, since #3901.
(Discussed in the `#lima-gsoc` slack on Aug 8.)

Fix #3919 
Fix #3920