### PR TITLE
docs: replace `neofetch` with `uname -a`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ limactl start
 
 To run Linux commands:
 ```bash
-lima sudo apt-get install -y neofetch
-lima neofetch
+lima uname -a
 ```
 
 To run containers with containerd:

--- a/website/content/en/docs/examples/_index.md
+++ b/website/content/en/docs/examples/_index.md
@@ -5,8 +5,7 @@ weight: 3
 
 ## Running Linux commands
 ```bash
-lima sudo apt-get install -y neofetch
-lima neofetch
+lima uname -a
 ```
 
 ## Accessing host files


### PR DESCRIPTION
neofetch is no longer maintained: https://github.com/dylanaraps/neofetch

Alternatives like fastfetch are not as famous as neofetch.