### PR TITLE
Use errors.As() instead of type assertions

### DIFF
--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -564,8 +564,9 @@ func decompressLocal(ctx context.Context, decompressCmd, dst, src, ext, descript
 	bar.Start()
 	err = cmd.Run()
 	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
-			ee.Stderr = buf.Bytes()
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitErr.Stderr = buf.Bytes()
 		}
 	}
 	bar.Finish()

--- a/pkg/networks/usernet/udpfileconn.go
+++ b/pkg/networks/usernet/udpfileconn.go
@@ -16,7 +16,8 @@ type UDPFileConn struct {
 func (conn *UDPFileConn) Read(b []byte) (n int, err error) {
 	// Check if the connection has been closed
 	if err := conn.SetReadDeadline(time.Time{}); err != nil {
-		if opErr, ok := err.(*net.OpError); ok && opErr.Err.Error() == "use of closed network connection" {
+		var opErr *net.OpError
+		if errors.As(err, &opErr) && opErr.Err.Error() == "use of closed network connection" {
 			return 0, errors.New("UDPFileConn connection closed")
 		}
 	}


### PR DESCRIPTION
It is more idiomatic because it also works for wrapped errors.