### PR TITLE
`docker{,-rootful}.yaml`: Enable the containerd image store by default

### DIFF
--- a/templates/docker-rootful.yaml
+++ b/templates/docker-rootful.yaml
@@ -68,4 +68,4 @@ message: |
   docker run hello-world
   ------
 param:
-  containerdSnapshotter: false
+  containerdSnapshotter: true

--- a/templates/docker.yaml
+++ b/templates/docker.yaml
@@ -75,4 +75,4 @@ message: |
   docker run hello-world
   ------
 param:
-  containerdSnapshotter: false
+  containerdSnapshotter: true


### PR DESCRIPTION
~~To support building multi-platform images.~~
~~Use `--set .param.containerdSnapshotter=false` flag to disable it.~~

https://github.com/lima-vm/lima/pull/3858#discussion_r2282194496
> https://docs.docker.com/desktop/features/containerd/
> > The containerd image store is enabled by default in Docker Desktop version 4.34 and later, but only for clean installs or if you perform a factory reset.
>
> 4.34 was released on 2024-08-29
> https://docs.docker.com/desktop/release-notes/#4340

edit: remove "To support...", and "Use ..."