### PR TITLE
vzNAT: fix regression

### DIFF
--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -36,6 +36,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/networks/usernet"
 	"github.com/lima-vm/lima/v2/pkg/osutil"
 	"github.com/lima-vm/lima/v2/pkg/ptr"
+	"github.com/lima-vm/lima/v2/pkg/reflectutil"
 	"github.com/lima-vm/lima/v2/pkg/version/versionutil"
 )
 
@@ -95,6 +96,18 @@ func validateConfig(ctx context.Context, cfg *limatype.LimaYAML) error {
 	}
 	if err := validateMountType(cfg); err != nil {
 		return err
+	}
+
+	for i, nw := range cfg.Networks {
+		if unknown := reflectutil.UnknownNonEmptyFields(nw,
+			"Lima",
+			"Socket",
+			"MACAddress",
+			"Metric",
+			"Interface",
+		); len(unknown) > 0 {
+			logrus.Warnf("vmType %s: ignoring networks[%d]: %+v", *cfg.VMType, i, unknown)
+		}
 	}
 
 	if cfg.VMOpts.QEMU.MinimumVersion != nil {

--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -238,25 +238,6 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 		); len(unknown) > 0 {
 			logrus.Warnf("vmType %s: ignoring networks[%d]: %+v", *cfg.VMType, i, unknown)
 		}
-
-		field := fmt.Sprintf("networks[%d]", i)
-		switch {
-		case nw.Lima != "":
-			if nw.VZNAT != nil && *nw.VZNAT {
-				return fmt.Errorf("field `%s.lima` and field `%s.vzNAT` are mutually exclusive", field, field)
-			}
-		case nw.Socket != "":
-			if nw.VZNAT != nil && *nw.VZNAT {
-				return fmt.Errorf("field `%s.socket` and field `%s.vzNAT` are mutually exclusive", field, field)
-			}
-		case nw.VZNAT != nil && *nw.VZNAT:
-			if nw.Lima != "" {
-				return fmt.Errorf("field `%s.vzNAT` and field `%s.lima` are mutually exclusive", field, field)
-			}
-			if nw.Socket != "" {
-				return fmt.Errorf("field `%s.vzNAT` and field `%s.socket` are mutually exclusive", field, field)
-			}
-		}
 	}
 
 	switch audioDevice := *cfg.Audio.Device; audioDevice {

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -449,11 +449,24 @@ func validateNetwork(y *limatype.LimaYAML) error {
 			if nw.Socket != "" {
 				errs = errors.Join(errs, fmt.Errorf("field `%s.lima` and field `%s.socket` are mutually exclusive", field, field))
 			}
+			if nw.VZNAT != nil && *nw.VZNAT {
+				errs = errors.Join(errs, fmt.Errorf("field `%s.lima` and field `%s.vzNAT` are mutually exclusive", field, field))
+			}
 		case nw.Socket != "":
+			if nw.VZNAT != nil && *nw.VZNAT {
+				errs = errors.Join(errs, fmt.Errorf("field `%s.socket` and field `%s.vzNAT` are mutually exclusive", field, field))
+			}
 			if fi, err := os.Stat(nw.Socket); err != nil && !errors.Is(err, os.ErrNotExist) {
 				errs = errors.Join(errs, err)
 			} else if err == nil && fi.Mode()&os.ModeSocket == 0 {
 				errs = errors.Join(errs, fmt.Errorf("field `%s.socket` %q points to a non-socket file", field, nw.Socket))
+			}
+		case nw.VZNAT != nil && *nw.VZNAT:
+			if nw.Lima != "" {
+				errs = errors.Join(errs, fmt.Errorf("field `%s.vzNAT` and field `%s.lima` are mutually exclusive", field, field))
+			}
+			if nw.Socket != "" {
+				errs = errors.Join(errs, fmt.Errorf("field `%s.vzNAT` and field `%s.socket` are mutually exclusive", field, field))
 			}
 		default:
 			errs = errors.Join(errs, fmt.Errorf("field `%s.lima` or  field `%s.socket must be set", field, field))


### PR DESCRIPTION
Support for vzNAT was broken in PR #3901.

Even though vzNAT is specific to the `vz` driver,
`pkg/limayaml/validate` has to be aware of the `vzNAT` field for the compatibility reason.

Fix #3914