### PR TITLE
templates: default: remove /tmp/lima

### DIFF
--- a/pkg/yqutil/yqutil_test.go
+++ b/pkg/yqutil/yqutil_test.go
@@ -67,7 +67,7 @@ func TestEvaluateExpressionComplex(t *testing.T) {
 	content := `
 # Expose host directories to the guest, the mount point might be accessible from all UIDs in the guest
 # 🟢 Builtin default: null (Mount nothing)
-# 🔵 This file: Mount the home as read-only, /tmp/lima as writable
+# 🔵 This file: Mount the home as read-only
 mounts:
 - location: "~"
   # Configure the mountPoint inside the guest.
@@ -80,7 +80,7 @@ mounts:
 	expected := `
 # Expose host directories to the guest, the mount point might be accessible from all UIDs in the guest
 # 🟢 Builtin default: null (Mount nothing)
-# 🔵 This file: Mount the home as read-only, /tmp/lima as writable
+# 🔵 This file: Mount the home as read-only
 mounts:
 - location: "~"
   # Configure the mountPoint inside the guest.

--- a/templates/_default/mounts.yaml
+++ b/templates/_default/mounts.yaml
@@ -1,6 +1,7 @@
 mounts:
 - location: "~"
 
-- location: "{{.GlobalTempDir}}/lima"
-  mountPoint: /tmp/lima
-  writable: true
+# # /tmp/lima is no longer mounted by default since Lima v2.0.
+# - location: "{{.GlobalTempDir}}/lima"
+#  mountPoint: /tmp/lima
+#  writable: true

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -38,7 +38,8 @@ disk: null
 # {{.GlobalTempDir}}, and {{.TempDir}}. The global temp dir is always "/tmp" on Unix.
 # "mountPoint" can use these template variables: {{.Home}}, {{.Name}}, {{.Hostname}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
 # 🟢 Builtin default: [] (Mount nothing)
-# 🔵 This file: Mount the home as read-only, /tmp/lima as writable  (inherited via the `base` mechanism later in this file)
+# 🔵 This file: Mount the home as read-only (inherited via the `base` mechanism later in this file)
+#    Until Lima v1.2, /tmp/lima was mounted too as writable.
 mounts: []
 # - location: "~"
 #  # Configure the mountPoint inside the guest.
@@ -79,10 +80,6 @@ mounts: []
 #    # See https://www.kernel.org/doc/Documentation/filesystems/9p.txt
 #    # 🟢 Builtin default: "fscache" for non-writable mounts, "mmap" for writable mounts
 #    cache: null
-# - location: "/tmp/lima"
-#  # 🟢 Builtin default: false
-#  # 🔵 This file: true (only for "/tmp/lima")
-#  writable: true
 
 # List of mount types not supported by the kernel of this distro.
 # Also used to resolve the default mount type when not explicitly specified.

--- a/website/content/en/docs/config/_index.md
+++ b/website/content/en/docs/config/_index.md
@@ -10,7 +10,7 @@ The current default spec:
 - CPU: 4 cores
 - Memory: 4 GiB
 - Disk: 100 GiB
-- Mounts: `~` (read-only), `/tmp/lima` (writable)
+- Mounts: `~` (read-only), `/tmp/lima` (writable; removed in Lima v2.0)
 - SSH: 127.0.0.1:<Random port>
 
 For environment variables, see [Environment Variables](./environment-variables/).

--- a/website/content/en/docs/examples/_index.md
+++ b/website/content/en/docs/examples/_index.md
@@ -10,7 +10,7 @@ lima uname -a
 
 ## Accessing host files
 
-By default, the VM has read-only accesses to `/Users/<USERNAME>` and read-write accesses to `/tmp/lima`.
+By default, the VM has read-only accesses to `/Users/<USERNAME>`.
 
 To allow writing to `/Users/<USERNAME>`:
 ```bash
@@ -19,6 +19,14 @@ limactl edit --mount-writable --mount-type=virtiofs
 
 Specifying `--mount-type=virtiofs` is not necessary here, but it is highly recommended
 for the best performance and stability.
+
+{{% alert title="Hint" color=success %}}
+Lima prior to v2.0 mounts `/tmp/lima` too in read-write mode.
+
+This directory is no longer mounted by default since Lima v2.0.
+To mount `/tmp/lima` in Lima v2.0 and later, set `--mount /tmp/lima:w`.
+The `:w` suffix indicates read-write mode.
+{{% /alert %}}
 
 ## Running containers
 {{< tabpane text=true >}}


### PR DESCRIPTION
`/tmp/lima` is no longer mounted by default, so as to allow multiple users to run Lima instances independently.

Fix #3648

To restore the previous behavior, add the following to your YAML config:

```yaml
mounts:
- location: "{{.GlobalTempDir}}/lima"
  mountPoint: /tmp/lima
  writable: true
```

or, use the following CLI flag:

```bash
limactl create --mount /tmp/lima:w
```