### PR TITLE
Host agent: retry requirements every second

### DIFF
--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -25,7 +25,9 @@ func (a *HostAgent) waitForRequirements(label string, requirements []requirement
 	for i, req := range requirements {
 	retryLoop:
 		for j := range retries {
-			logrus.Infof("Waiting for the %s requirement %d of %d: %q", label, i+1, len(requirements), req.description)
+			if j%10 == 0 {
+				logrus.Infof("Waiting for the %s requirement %d of %d: %q", label, i+1, len(requirements), req.description)
+			}
 			err := a.waitForRequirement(req)
 			if err == nil {
 				logrus.Infof("The %s requirement %d of %d is satisfied", label, i+1, len(requirements))
@@ -40,7 +42,7 @@ func (a *HostAgent) waitForRequirements(label string, requirements []requirement
 				errs = append(errs, fmt.Errorf("failed to satisfy the %s requirement %d of %d %q: %s: %w", label, i+1, len(requirements), req.description, req.debugHint, err))
 				break retryLoop
 			}
-			time.Sleep(10 * time.Second)
+			time.Sleep(time.Second)
 		}
 	}
 	return errors.Join(errs...)


### PR DESCRIPTION
This changes waiting for requirements (e.g. ssh) to retry every second instead of every ten; this can help with startup speed when they are actually met shortly after the previous check.

For example, in Rancher Desktop on my machine, SSH is usually ready about three seconds after the second check (at ~11 seconds vs ~14 seconds).