### PR TITLE
Restore DynamicSSHAddress functionality for WSL2

### DIFF
--- a/pkg/driver/wsl2/vm_windows.go
+++ b/pkg/driver/wsl2/vm_windows.go
@@ -135,7 +135,7 @@ func provisionVM(ctx context.Context, instanceDir, instanceName, distroName stri
 		for {
 			<-ctx.Done()
 			logrus.Info("Context closed, stopping vm")
-			if status, err := getWslStatus(instanceName); err == nil &&
+			if status, err := getWslStatus(ctx, instanceName); err == nil &&
 				status == limatype.StatusRunning {
 				_ = stopVM(ctx, distroName)
 			}
@@ -207,13 +207,13 @@ func unregisterVM(ctx context.Context, distroName string) error {
 // Windows Subsystem for Linux has no installed distributions.
 // Distributions can be installed by visiting the Microsoft Store:
 // https://aka.ms/wslstore
-func getWslStatus(instName string) (string, error) {
+func getWslStatus(ctx context.Context, instName string) (string, error) {
 	distroName := "lima-" + instName
 	out, err := executil.RunUTF16leCommand([]string{
 		"wsl.exe",
 		"--list",
 		"--verbose",
-	})
+	}, executil.WithContext(ctx))
 	if err != nil {
 		return "", fmt.Errorf("failed to run `wsl --list --verbose`, err: %w (out=%q)", err, out)
 	}

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -193,7 +193,7 @@ func (l *LimaWslDriver) InspectStatus(ctx context.Context, inst *limatype.Instan
 	inst.SSHLocalPort = 22
 
 	if inst.Status == limatype.StatusRunning {
-		sshAddr, err := l.SSHAddress(ctx)
+		sshAddr, err := getSSHAddress(ctx, inst.Name)
 		if err == nil {
 			inst.SSHAddress = sshAddr
 		} else {

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -182,7 +182,7 @@ func (l *LimaWslDriver) BootScripts() (map[string][]byte, error) {
 }
 
 func (l *LimaWslDriver) InspectStatus(ctx context.Context, inst *limatype.Instance) string {
-	status, err := getWslStatus(inst.Name)
+	status, err := getWslStatus(ctx, inst.Name)
 	if err != nil {
 		inst.Status = limatype.StatusBroken
 		inst.Errors = append(inst.Errors, err)
@@ -206,7 +206,7 @@ func (l *LimaWslDriver) InspectStatus(ctx context.Context, inst *limatype.Instan
 
 func (l *LimaWslDriver) Delete(ctx context.Context) error {
 	distroName := "lima-" + l.Instance.Name
-	status, err := getWslStatus(l.Instance.Name)
+	status, err := getWslStatus(ctx, l.Instance.Name)
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func (l *LimaWslDriver) Delete(ctx context.Context) error {
 
 func (l *LimaWslDriver) Start(ctx context.Context) (chan error, error) {
 	logrus.Infof("Starting WSL VM")
-	status, err := getWslStatus(l.Instance.Name)
+	status, err := getWslStatus(ctx, l.Instance.Name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Restores the functionality:
commit df5e35ab83abb06a7d6501bfad5a77b83b49de62

That was reverted (again):
commit 2076ff1d31f4857aa839c35982f097003bbe831f

```go
func (l *LimaWslDriver) SSHAddress(_ context.Context) (string, error) {
	return "127.0.0.1", nil
}
```

It was first removed in 1.0.7:
commit ebaa10069a9aacc6bdb4a56587c033092d5752cb

----

* https://github.com/lima-vm/lima/pull/3842

* https://github.com/lima-vm/lima/pull/3299