### PR TITLE
Drop the log message that qemu is properly signed

### DIFF
--- a/pkg/driver/qemu/entitlementutil/entitlementutil.go
+++ b/pkg/driver/qemu/entitlementutil/entitlementutil.go
@@ -107,7 +107,5 @@ func AskToSignIfNotSignedProperly(ctx context.Context, qExe string) {
 		} else {
 			logrus.Warn("If QEMU does not start up, you may have to sign the QEMU binary with the \"com.apple.security.hypervisor\" entitlement manually. See https://github.com/lima-vm/lima/issues/1742 .")
 		}
-	} else {
-		logrus.Infof("QEMU binary %q seems properly signed with the \"com.apple.security.hypervisor\" entitlement", qExe)
 	}
 }


### PR DESCRIPTION
The message is pretty much useless. It should at best be a debug message, but I don't think it is needed at all, as long as there is a log message when something is wrong.