### PR TITLE
Make `limactl ls --format yaml` use the same schema as the json output

### DIFF
--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -28,10 +28,14 @@ func fieldNames() []string {
 		f := t.Field(i)
 		if f.Anonymous {
 			for j := range f.Type.NumField() {
-				names = append(names, f.Type.Field(j).Name)
+				if tag := f.Tag.Get("lima"); tag != "deprecated" {
+					names = append(names, f.Type.Field(j).Name)
+				}
 			}
 		} else {
-			names = append(names, t.Field(i).Name)
+			if tag := f.Tag.Get("lima"); tag != "deprecated" {
+				names = append(names, t.Field(i).Name)
+			}
 		}
 	}
 	return names

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -225,11 +225,12 @@ func ReadPIDFile(path string) (int, error) {
 }
 
 type FormatData struct {
-	limatype.Instance
-	HostOS       string
-	HostArch     string
-	LimaHome     string
-	IdentityFile string
+	limatype.Instance `yaml:",inline"`
+
+	HostOS       string `json:"HostOS" yaml:"HostOS"`
+	HostArch     string `json:"HostArch" yaml:"HostArch"`
+	LimaHome     string `json:"LimaHome" yaml:"LimaHome"`
+	IdentityFile string `json:"IdentityFile" yaml:"IdentityFile"`
 }
 
 var FormatHelp = "\n" +

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -227,10 +227,12 @@ func ReadPIDFile(path string) (int, error) {
 type FormatData struct {
 	limatype.Instance `yaml:",inline"`
 
-	HostOS       string `json:"HostOS" yaml:"HostOS"`
-	HostArch     string `json:"HostArch" yaml:"HostArch"`
-	LimaHome     string `json:"LimaHome" yaml:"LimaHome"`
-	IdentityFile string `json:"IdentityFile" yaml:"IdentityFile"`
+	// Using these host attributes is deprecated; they will be removed in Lima 3.0
+	// The values are available from `limactl info` as hostOS, hostArch, limaHome, and identifyFile.
+	HostOS       string `json:"HostOS" yaml:"HostOS" lima:"deprecated"`
+	HostArch     string `json:"HostArch" yaml:"HostArch" lima:"deprecated"`
+	LimaHome     string `json:"LimaHome" yaml:"LimaHome" lima:"deprecated"`
+	IdentityFile string `json:"IdentityFile" yaml:"IdentityFile" lima:"deprecated"`
 }
 
 var FormatHelp = "\n" +


### PR DESCRIPTION
Fixes #3984

It makes sure YAML uses the same key names as JSON for the 4 host properties, and it inlines the instance properties into the root object:

```console
❯ l ls default --format json | yq .HostOS
darwin

❯ l ls default --format yaml | yq .HostOS
darwin

❯ l ls default --format json | yq .config.user
{"name": "jan", "comment": "Jan Dubois", "home": "/home/jan.linux", "shell": "/bin/bash", "uid": 501}

❯ l ls default --format yaml | yq .config.user
name: jan
comment: Jan Dubois
home: /home/jan.linux
shell: /bin/bash
uid: 501
```