### PR TITLE
Don't read VMOpts.VZ struct from cidata directly

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -107,4 +107,6 @@ type DriverFeatures struct {
 	DynamicSSHAddress    bool `json:"dynamicSSHAddress"`
 	SkipSocketForwarding bool `json:"skipSocketForwarding"`
 	NoCloudInit          bool `json:"noCloudInit"`
+	RosettaEnabled       bool `json:"rosettaEnabled"`
+	RosettaBinFmt        bool `json:"rosettaBinFmt"`
 }

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -163,11 +163,19 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 	vSockPort := limaDriver.Info().VsockPort
 	virtioPort := limaDriver.Info().VirtioPort
 	noCloudInit := limaDriver.Info().Features.NoCloudInit
+	rosettaEnabled := limaDriver.Info().Features.RosettaEnabled
+	rosettaBinFmt := limaDriver.Info().Features.RosettaBinFmt
+
+	// Disable Rosetta in Plain mode
+	if *inst.Config.Plain {
+		rosettaEnabled = false
+		rosettaBinFmt = false
+	}
 
 	if err := cidata.GenerateCloudConfig(ctx, inst.Dir, instName, inst.Config); err != nil {
 		return nil, err
 	}
-	if err := cidata.GenerateISO9660(ctx, limaDriver, inst.Dir, instName, inst.Config, udpDNSLocalPort, tcpDNSLocalPort, o.guestAgentBinary, o.nerdctlArchive, vSockPort, virtioPort, noCloudInit); err != nil {
+	if err := cidata.GenerateISO9660(ctx, limaDriver, inst.Dir, instName, inst.Config, udpDNSLocalPort, tcpDNSLocalPort, o.guestAgentBinary, o.nerdctlArchive, vSockPort, virtioPort, noCloudInit, rosettaEnabled, rosettaBinFmt); err != nil {
 		return nil, err
 	}
 

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -768,22 +768,6 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 	y.CACertificates.Files = unique(slices.Concat(d.CACertificates.Files, y.CACertificates.Files, o.CACertificates.Files))
 	y.CACertificates.Certs = unique(slices.Concat(d.CACertificates.Certs, y.CACertificates.Certs, o.CACertificates.Certs))
 
-	if runtime.GOOS == "darwin" && IsNativeArch(limatype.AARCH64) {
-		if y.VMOpts.VZ.Rosetta.Enabled == nil {
-			y.VMOpts.VZ.Rosetta.Enabled = d.VMOpts.VZ.Rosetta.Enabled
-		}
-		if o.VMOpts.VZ.Rosetta.Enabled != nil {
-			y.VMOpts.VZ.Rosetta.Enabled = o.VMOpts.VZ.Rosetta.Enabled
-		}
-	}
-
-	if y.VMOpts.VZ.Rosetta.BinFmt == nil {
-		y.VMOpts.VZ.Rosetta.BinFmt = d.VMOpts.VZ.Rosetta.BinFmt
-	}
-	if o.VMOpts.VZ.Rosetta.BinFmt != nil {
-		y.VMOpts.VZ.Rosetta.BinFmt = o.VMOpts.VZ.Rosetta.BinFmt
-	}
-
 	if y.NestedVirtualization == nil {
 		y.NestedVirtualization = d.NestedVirtualization
 	}
@@ -831,8 +815,6 @@ func fixUpForPlainMode(y *limatype.LimaYAML) {
 	y.Mounts = nil
 	y.Containerd.System = ptr.Of(false)
 	y.Containerd.User = ptr.Of(false)
-	y.VMOpts.VZ.Rosetta.BinFmt = ptr.Of(false)
-	y.VMOpts.VZ.Rosetta.Enabled = ptr.Of(false)
 	y.TimeZone = ptr.Of("")
 }
 


### PR DESCRIPTION
This is supposed to be provided by the driver, and passed to the
hostagent as features. The cidata and hostagent doesn't know VZ.

Note: this also excludes the VMOpts.VZ from default and override,
similar to the change made to VMOpts.QEMU already. It is unknown.