### PR TITLE
Use consistent naming for VMOpts and vmOpts

### DIFF
--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -20,7 +20,7 @@ type LimaYAML struct {
 	OS                 *OS           `yaml:"os,omitempty" json:"os,omitempty" jsonschema:"nullable"`
 	Arch               *Arch         `yaml:"arch,omitempty" json:"arch,omitempty" jsonschema:"nullable"`
 	Images             []Image       `yaml:"images,omitempty" json:"images,omitempty" jsonschema:"nullable"`
-	// Deprecated: Use VMOpts.Qemu.CPUType instead.
+	// Deprecated: Use VMOpts.QEMU.CPUType instead.
 	CPUType               CPUType       `yaml:"cpuType,omitempty" json:"cpuType,omitempty" jsonschema:"nullable"`
 	CPUs                  *int          `yaml:"cpus,omitempty" json:"cpus,omitempty" jsonschema:"nullable"`
 	Memory                *string       `yaml:"memory,omitempty" json:"memory,omitempty" jsonschema:"nullable"` // go-units.RAMInBytes

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -386,7 +386,7 @@ os: null
 # DEPRECATED: Use vmOpts.qemu.cpuType instead. See the vmOpts.qemu.cpuType section above for configuration.
 cpuType:
 
-# DEPRECATED: Use vmOpts.vz.rosetta instead. See the vmOpts.qemu.cpuType section above for configuration.
+# DEPRECATED: Use vmOpts.vz.rosetta instead. See the vmOpts.vz.rosetta section above for configuration.
 rosetta:
   enabled: null
   binfmt: null


### PR DESCRIPTION
go:   VMOpts.QEMU.CPUType, VMOpts.VZ.Rosetta
yaml: vmOpts.qemu.cpuType, vmOpts.vz.rosetta

Found while moving VMOpts to a separate type.

It is only in the comments actually, but anyway.