### PR TITLE
Add `--yq` option to `limactl list` and `limactl info`

### DIFF
--- a/pkg/uiutil/uiutil.go
+++ b/pkg/uiutil/uiutil.go
@@ -4,8 +4,12 @@
 package uiutil
 
 import (
+	"io"
+	"os"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/mattn/go-isatty"
 )
 
 var InterruptErr = terminal.InterruptErr
@@ -35,4 +39,15 @@ func Select(message string, options []string) (int, error) {
 		return -1, err
 	}
 	return ans, nil
+}
+
+// OutputIsTTY returns true if writer is going to stdout, and stdout is a terminal device,
+// not a regular file, stream, or pipe etc.
+func OutputIsTTY(writer io.Writer) bool {
+	// This setting is needed so we can write integration tests for the TTY output.
+	// It is probably not useful otherwise.
+	if os.Getenv("_LIMA_OUTPUT_IS_TTY") != "" {
+		return true
+	}
+	return writer == os.Stdout && (isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()))
 }

--- a/pkg/yqutil/yqutil.go
+++ b/pkg/yqutil/yqutil.go
@@ -39,8 +39,8 @@ func ValidateContent(content []byte) error {
 	return err
 }
 
-// EvaluateExpressionPlain evaluates the yq expression and returns the yq result.
-func EvaluateExpressionPlain(expression, content string) (string, error) {
+// EvaluateExpressionWithEncoder evaluates the yq expression and returns the yq result using a custom encoder.
+func EvaluateExpressionWithEncoder(expression, content string, encoder yqlib.Encoder) (string, error) {
 	if expression == "" {
 		return content, nil
 	}
@@ -50,10 +50,6 @@ func EvaluateExpressionPlain(expression, content string) (string, error) {
 	logging.SetBackend(backend)
 	yqlib.InitExpressionParser()
 
-	encoderPrefs := yqlib.ConfiguredYamlPreferences.Copy()
-	encoderPrefs.Indent = 2
-	encoderPrefs.ColorsEnabled = false
-	encoder := yqlib.NewYamlEncoder(encoderPrefs)
 	decoder := yqlib.NewYamlDecoder(yqlib.ConfiguredYamlPreferences)
 	out, err := yqlib.NewStringEvaluator().EvaluateAll(expression, content, encoder, decoder)
 	if err != nil {
@@ -82,6 +78,15 @@ func EvaluateExpressionPlain(expression, content string) (string, error) {
 	return out, nil
 }
 
+// EvaluateExpressionPlain evaluates the yq expression and returns the yq result.
+func EvaluateExpressionPlain(expression, content string, colorsEnabled bool) (string, error) {
+	encoderPrefs := yqlib.ConfiguredYamlPreferences.Copy()
+	encoderPrefs.Indent = 2
+	encoderPrefs.ColorsEnabled = colorsEnabled
+	encoder := yqlib.NewYamlEncoder(encoderPrefs)
+	return EvaluateExpressionWithEncoder(expression, content, encoder)
+}
+
 // EvaluateExpression evaluates the yq expression and returns the output formatted with yamlfmt.
 func EvaluateExpression(expression string, content []byte) ([]byte, error) {
 	if expression == "" {
@@ -101,7 +106,7 @@ func EvaluateExpression(expression string, content []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	out, err := EvaluateExpressionPlain(expression, string(contentModified))
+	out, err := EvaluateExpressionPlain(expression, string(contentModified), false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The `--yq` option is only compatible with JSON or YAML output and will apply the yq expression to the result before writing it to the output.

The following 2 commands are functionally identical (but may result in different formatting, see below):

```shell
limactl ls default --yq .dir
limactl ls default --format json | limactl yq .dir
```

The output of `limactl list --json` will be pretty-printed when it goes to a terminal. This means it is no longer one line per JSON object, but has much improved legibility. Output to a file or pipe maintains JSON Lines rules.

Also colorize the output of `limactl list`, `limactl info`, `limactl tmpl copy`, and `limactl tmpl yq` if the output goes to the terminal.

Unfortunately the output of `yamlfmt` cannot be colorized, so the terminal output may look slightly different from the output to a file or pipe (mostly the extra indentation of list elements), but this seems like a reasonable compromise.

Sample screenshot to show the difference:

<img width="2014" height="434" alt="CleanShot 2025-09-07 at 13 53 31@2x" src="https://github.com/user-attachments/assets/cdb21daa-6f02-4a92-bdd2-af0934f789d5" />

The colors come from https://github.com/mikefarah/yq/blob/master/pkg/yqlib/color_print.go and are not configurable.