### PR TITLE
limactl help and info flag should show available plugins

### DIFF
--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -31,10 +31,14 @@ func fieldNames() []string {
 		f := t.Field(i)
 		if f.Anonymous {
 			for j := range f.Type.NumField() {
-				names = append(names, f.Type.Field(j).Name)
+				if tag := f.Tag.Get("lima"); tag != "deprecated" {
+					names = append(names, f.Type.Field(j).Name)
+				}
 			}
 		} else {
-			names = append(names, t.Field(i).Name)
+			if tag := f.Tag.Get("lima"); tag != "deprecated" {
+				names = append(names, t.Field(i).Name)
+			}
 		}
 	}
 	return names

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/fsutil"
 	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
 	"github.com/lima-vm/lima/v2/pkg/osutil"
+	"github.com/lima-vm/lima/v2/pkg/plugin"
 	"github.com/lima-vm/lima/v2/pkg/version"
 )
 
@@ -165,6 +166,10 @@ func newApp() *cobra.Command {
 	}
 	rootCmd.AddGroup(&cobra.Group{ID: "basic", Title: "Basic Commands:"})
 	rootCmd.AddGroup(&cobra.Group{ID: "advanced", Title: "Advanced Commands:"})
+	rootCmd.AddGroup(&cobra.Group{ID: "plugin", Title: "Available Plugins (Experimental):"})
+
+	// Discover and add plugins as commands
+	addPluginCommands(rootCmd)
 	rootCmd.AddCommand(
 		newCreateCommand(),
 		newStartCommand(),
@@ -215,14 +220,6 @@ func handleExitError(err error) {
 
 // executeWithPluginSupport handles command execution with plugin support.
 func executeWithPluginSupport(rootCmd *cobra.Command, args []string) error {
-	if len(args) > 0 {
-		cmd, _, err := rootCmd.Find(args)
-		if err != nil || cmd == rootCmd {
-			// Function calls os.Exit() if it found and executed the plugin
-			runExternalPlugin(rootCmd.Context(), args[0], args[1:])
-		}
-	}
-
 	rootCmd.SetArgs(args)
 	return rootCmd.Execute()
 }
@@ -232,7 +229,7 @@ func runExternalPlugin(ctx context.Context, name string, args []string) {
 		ctx = context.Background()
 	}
 
-	if err := updatePathEnv(); err != nil {
+	if err := plugin.UpdatePathForPlugins(); err != nil {
 		logrus.Warnf("failed to update PATH environment: %v", err)
 		// PATH update failure shouldn't prevent plugin execution
 	}
@@ -257,23 +254,29 @@ func runExternalPlugin(ctx context.Context, name string, args []string) {
 	logrus.Fatalf("external command %q failed: %v", execPath, err)
 }
 
-func updatePathEnv() error {
-	exe, err := os.Executable()
+func addPluginCommands(rootCmd *cobra.Command) {
+	plugins, err := plugin.DiscoverPlugins()
 	if err != nil {
-		return fmt.Errorf("failed to get executable path: %w", err)
+		logrus.Debugf("Failed to discover plugins: %v", err)
+		return
 	}
 
-	binDir := filepath.Dir(exe)
-	currentPath := os.Getenv("PATH")
-	newPath := binDir + string(filepath.ListSeparator) + currentPath
+	for _, p := range plugins {
+		pluginCmd := &cobra.Command{
+			Use:     p.Name,
+			Short:   p.Description,
+			GroupID: "plugin",
+			Run: func(cmd *cobra.Command, args []string) {
+				pluginName := cmd.Use
+				runExternalPlugin(cmd.Context(), pluginName, args)
+			},
+		}
 
-	if err := os.Setenv("PATH", newPath); err != nil {
-		return fmt.Errorf("failed to set PATH environment: %w", err)
+		pluginCmd.SilenceUsage = true
+		pluginCmd.SilenceErrors = true
+
+		rootCmd.AddCommand(pluginCmd)
 	}
-
-	logrus.Debugf("updated PATH to prioritize %s", binDir)
-
-	return nil
 }
 
 // WrapArgsError annotates cobra args error with some context, so the error message is more user-friendly.

--- a/pkg/limainfo/limainfo.go
+++ b/pkg/limainfo/limainfo.go
@@ -7,13 +7,17 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"path/filepath"
+	"runtime"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/lima-vm/lima/v2/pkg/envutil"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/limayaml"
+	"github.com/lima-vm/lima/v2/pkg/plugin"
 	"github.com/lima-vm/lima/v2/pkg/registry"
 	"github.com/lima-vm/lima/v2/pkg/templatestore"
 	"github.com/lima-vm/lima/v2/pkg/usrlocalsharelima"
@@ -29,6 +33,10 @@ type LimaInfo struct {
 	VMTypesEx       map[string]DriverExt         `json:"vmTypesEx"`   // since Lima v2.0.0
 	GuestAgents     map[limatype.Arch]GuestAgent `json:"guestAgents"` // since Lima v1.1.0
 	ShellEnvBlock   []string                     `json:"shellEnvBlock"`
+	HostOS          string                       `json:"hostOS"`       // since Lima v2.0.0
+	HostArch        string                       `json:"hostArch"`     // since Lima v2.0.0
+	IdentityFile    string                       `json:"identityFile"` // since Lima v2.0.0
+	Plugins         []plugin.Plugin              `json:"plugins"`      // since Lima v2.0.0
 }
 
 type DriverExt struct {
@@ -72,6 +80,8 @@ func New(ctx context.Context) (*LimaInfo, error) {
 		VMTypesEx:       vmTypesEx,
 		GuestAgents:     make(map[limatype.Arch]GuestAgent),
 		ShellEnvBlock:   envutil.GetDefaultBlockList(),
+		HostOS:          runtime.GOOS,
+		HostArch:        limatype.NewArch(runtime.GOARCH),
 	}
 	info.Templates, err = templatestore.Templates()
 	if err != nil {
@@ -81,6 +91,11 @@ func New(ctx context.Context) (*LimaInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	configDir, err := dirnames.LimaConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	info.IdentityFile = filepath.Join(configDir, filenames.UserPrivateKey)
 	for _, arch := range limatype.ArchTypes {
 		bin, err := usrlocalsharelima.GuestAgentBinary(limatype.LINUX, arch)
 		if err != nil {
@@ -95,5 +110,15 @@ func New(ctx context.Context) (*LimaInfo, error) {
 			Location: bin,
 		}
 	}
+
+	plugins, err := plugin.DiscoverPlugins()
+	if err != nil {
+		logrus.WithError(err).Debug("Failed to discover plugins")
+		// Don't fail the entire info command if plugin discovery fails
+		info.Plugins = []plugin.Plugin{}
+	} else {
+		info.Plugins = plugins
+	}
+
 	return info, nil
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/usrlocalsharelima"
+)
+
+type Plugin struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Description string `json:"description,omitempty"`
+}
+
+func DiscoverPlugins() ([]Plugin, error) {
+	var plugins []Plugin
+	seen := make(map[string]bool)
+
+	dirs := getPluginDirectories()
+
+	for _, dir := range dirs {
+		pluginsInDir, err := scanDirectory(dir)
+		if err != nil {
+			logrus.Debugf("Failed to scan directory %s: %v", dir, err)
+			continue
+		}
+
+		for _, plugin := range pluginsInDir {
+			if !seen[plugin.Name] {
+				plugins = append(plugins, plugin)
+				seen[plugin.Name] = true
+			}
+		}
+	}
+
+	return plugins, nil
+}
+
+func getPluginDirectories() []string {
+	var dirs []string
+
+	selfPaths := []string{}
+
+	selfViaArgs0, err := usrlocalsharelima.ExecutableViaArgs0()
+	if err != nil {
+		logrus.WithError(err).Debug("failed to find executable")
+	} else {
+		selfPaths = append(selfPaths, selfViaArgs0)
+	}
+
+	selfViaOS, err := os.Executable()
+	if err != nil {
+		logrus.WithError(err).Debug("failed to find os.Executable()")
+	} else {
+		selfFinalPathViaOS, err := filepath.EvalSymlinks(selfViaOS)
+		if err != nil {
+			logrus.WithError(err).Debug("failed to resolve symlinks")
+			selfFinalPathViaOS = selfViaOS
+		}
+
+		if len(selfPaths) == 0 || selfFinalPathViaOS != selfPaths[0] {
+			selfPaths = append(selfPaths, selfFinalPathViaOS)
+		}
+	}
+
+	for _, self := range selfPaths {
+		binDir := filepath.Dir(self)
+		dirs = append(dirs, binDir)
+	}
+
+	pathEnv := os.Getenv("PATH")
+	if pathEnv != "" {
+		pathDirs := filepath.SplitList(pathEnv)
+		dirs = append(dirs, pathDirs...)
+	}
+
+	if prefixDir, err := usrlocalsharelima.Prefix(); err == nil {
+		libexecDir := filepath.Join(prefixDir, "libexec", "lima")
+		if _, err := os.Stat(libexecDir); err == nil {
+			dirs = append(dirs, libexecDir)
+		}
+	}
+
+	return dirs
+}
+
+func scanDirectory(dir string) ([]Plugin, error) {
+	var plugins []Plugin
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !strings.HasPrefix(name, "limactl-") {
+			continue
+		}
+
+		pluginName := strings.TrimPrefix(name, "limactl-")
+
+		if strings.Contains(pluginName, ".") {
+			if filepath.Ext(name) == ".exe" {
+				pluginName = strings.TrimSuffix(pluginName, ".exe")
+			} else {
+				continue
+			}
+		}
+
+		fullPath := filepath.Join(dir, name)
+
+		if !isExecutable(fullPath) {
+			continue
+		}
+
+		plugin := Plugin{
+			Name: pluginName,
+			Path: fullPath,
+		}
+
+		if desc := extractDescFromScript(fullPath); desc != "" {
+			plugin.Description = desc
+		}
+
+		plugins = append(plugins, plugin)
+	}
+
+	return plugins, nil
+}
+
+func isExecutable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	mode := info.Mode()
+	if mode&0o111 != 0 {
+		return true
+	}
+
+	if filepath.Ext(path) == ".exe" {
+		return true
+	}
+
+	return false
+}
+
+func extractDescFromScript(path string) string {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		logrus.Debugf("Failed to read plugin script %s: %v", path, err)
+		return ""
+	}
+
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		// Look for pattern: # <limactl-desc>Description text</limactl-desc>
+		if strings.HasPrefix(line, "#") && strings.Contains(line, "<limactl-desc>") && strings.Contains(line, "</limactl-desc>") {
+			start := strings.Index(line, "<limactl-desc>") + len("<limactl-desc>")
+			end := strings.Index(line, "</limactl-desc>")
+
+			if start < end {
+				desc := strings.TrimSpace(line[start:end])
+				logrus.Debugf("Plugin %s: extracted description from script: %q", filepath.Base(path), desc)
+				return desc
+			}
+		}
+	}
+
+	logrus.Debugf("Plugin %s: no <limactl-desc> found in script", filepath.Base(path))
+
+	return ""
+}
+
+func UpdatePathForPlugins() error {
+	pluginDirs := getPluginDirectories()
+	newPath := strings.Join(pluginDirs, string(filepath.ListSeparator))
+	return os.Setenv("PATH", newPath)
+}

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -225,11 +225,14 @@ func ReadPIDFile(path string) (int, error) {
 }
 
 type FormatData struct {
-	limatype.Instance
-	HostOS       string
-	HostArch     string
-	LimaHome     string
-	IdentityFile string
+	limatype.Instance `yaml:",inline"`
+
+	// Using these host attributes is deprecated; they will be removed in Lima 3.0
+	// The values are available from `limactl info` as hostOS, hostArch, limaHome, and identifyFile.
+	HostOS       string `json:"HostOS" yaml:"HostOS" lima:"deprecated"`
+	HostArch     string `json:"HostArch" yaml:"HostArch" lima:"deprecated"`
+	LimaHome     string `json:"LimaHome" yaml:"LimaHome" lima:"deprecated"`
+	IdentityFile string `json:"IdentityFile" yaml:"IdentityFile" lima:"deprecated"`
 }
 
 var FormatHelp = "\n" +

--- a/pkg/usrlocalsharelima/usrlocalsharelima.go
+++ b/pkg/usrlocalsharelima/usrlocalsharelima.go
@@ -19,14 +19,14 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 )
 
-// executableViaArgs0 returns the absolute path to the executable used to start this process.
+// ExecutableViaArgs0 returns the absolute path to the executable used to start this process.
 // It will also append the file extension on Windows, if necessary.
 // This function is different from os.Executable(), which will use /proc/self/exe on Linux
 // and therefore will resolve any symlink used to locate the executable. This function will
 // return the symlink instead because we want to be able to locate ../share/lima relative
 // to the location of the symlink, and not the actual executable. This is important when
 // using Homebrew.
-var executableViaArgs0 = sync.OnceValues(func() (string, error) {
+var ExecutableViaArgs0 = sync.OnceValues(func() (string, error) {
 	if os.Args[0] == "" {
 		return "", errors.New("os.Args[0] has not been set")
 	}
@@ -47,7 +47,7 @@ var executableViaArgs0 = sync.OnceValues(func() (string, error) {
 func Dir() (string, error) {
 	selfPaths := []string{}
 
-	selfViaArgs0, err := executableViaArgs0()
+	selfViaArgs0, err := ExecutableViaArgs0()
 	if err != nil {
 		logrus.WithError(err).Warn("failed to find executable from os.Args[0]")
 	} else {

--- a/website/content/en/docs/config/plugin/cli.md
+++ b/website/content/en/docs/config/plugin/cli.md
@@ -1,12 +1,71 @@
 ---
-title: CLI plugins
+title: CLI plugins (Experimental)
 weight: 2
 ---
 
  | ⚡ Requirement | Lima >= 2.0 |
  |----------------|-------------|
 
-Lima supports a plugin-like command aliasing system similar to `git`, `kubectl`, and `docker`. When you run a `limactl` command that doesn't exist, Lima will automatically look for an external program named `limactl-<command>` in your system's PATH.
+Lima supports a plugin-like command aliasing system similar to `git`, `kubectl`, and `docker`. When you run a `limactl` command that doesn't exist, Lima will automatically look for an external program named `limactl-<command>` in your system's PATH and additional directories.
+
+## Plugin Discovery
+
+Lima discovers plugins by scanning for executables named `limactl-<plugin-name>` in the following locations:
+
+1. **Directory containing the `limactl` binary** (including symlink support)
+2. **All directories in your `$PATH` environment variable**
+3. **`<PREFIX>/libexec/lima`** - For plugins installed by package managers or distribution packages
+
+The plugin discovery respects symlinks, which is particularly important for Homebrew installations where `limactl` may be symlinked.
+
+## Plugin Information
+
+Available plugins are automatically displayed in:
+
+- **`limactl --help`** - Shows all discovered plugins with descriptions in an "Available Plugins (Experimental)" section
+```bash
+Available Plugins (Experimental):
+  ps                  Sample limactl-ps alias that shows running instances
+  sh
+```
+
+
+- **`limactl info`** - Includes plugin information in the JSON output
+```json
+{
+   "plugins": [
+      {
+         "name": "ps",
+         "path": "/opt/homebrew/bin/limactl-ps"
+      },
+      {
+         "name": "sh",
+         "path": "/opt/homebrew/bin/limactl-sh"
+      }
+   ]
+}
+
+```
+
+### Plugin Descriptions
+
+Lima extracts plugin descriptions from script comments using the `<limactl-desc>` format. Include a description comment in your plugin script:
+
+```bash
+#!/bin/sh
+# <limactl-desc>Docker wrapper that connects to Docker daemon running in Lima instance</limactl-desc>
+set -eu
+
+# Rest of your script...
+```
+
+**Format Requirements:**
+- Must be a comment line starting with `#`
+- Must contain exactly `<limactl-desc>Description text</limactl-desc>`
+- The description text should be concise and descriptive
+- Only the first matching line will be used
+
+If no `<limactl-desc>` comment is found, the plugin will appear in the help output without a description.
 
 ## Creating Custom Aliases
 
@@ -50,7 +109,10 @@ limactl sh myinstance bash   # Equivalent to: limactl shell myinstance bash
 ## How It Works
 
 1. When you run `limactl <unknown-command>`, Lima first tries to find a built-in command
-2. If no built-in command is found, Lima searches for `limactl-<unknown-command>` in your PATH
+2. If no built-in command is found, Lima searches for `limactl-<unknown-command>` in:
+   - The directory containing the `limactl` binary
+   - All directories in your `$PATH`
+   - `<PREFIX>/libexec/lima` (if it exists)
 3. If found, Lima executes the external program and passes all remaining arguments to it
 4. If not found, Lima shows the standard "unknown command" error
 
@@ -58,3 +120,22 @@ This system allows you to:
 - Create personal shortcuts and aliases
 - Extend Lima's functionality without modifying the core application
 - Share custom commands with your team by distributing scripts
+- Package plugins with Lima distributions in the `libexec/lima` directory
+
+## Security Considerations
+
+**Security Note**: Lima will execute any executable named `limactl-*` found in the search directories. Ensure that:
+- You trust the source of any plugins in your `$PATH` or `libexec/lima`
+- You understand that plugin discovery automatically runs `--help` on found executables to generate descriptions
+- Malicious executables with the `limactl-` prefix could be executed if placed in the search directories
+
+## Package Installation
+
+Distribution packages and package managers can install plugins in `<PREFIX>/libexec/lima/` where `<PREFIX>` is typically `/usr/local` or `/opt/homebrew`. This allows plugins to be:
+- Managed by the package manager
+- Isolated from user's `$PATH`
+- Automatically discovered by Lima
+
+## Experimental Status
+
+**Experimental Feature**: The CLI plugin system is currently experimental and may change in future versions. Breaking changes to the plugin API or discovery mechanism may occur without notice.


### PR DESCRIPTION
```
change adds functionality to display Plugins in the info and list commands
```

Fixes https://github.com/lima-vm/lima/issues/3608#issuecomment-3257711223