### PR TITLE
`usrlocalsharelima`: execute `Dir()` once

### DIFF
--- a/pkg/usrlocalsharelima/usrlocalsharelima.go
+++ b/pkg/usrlocalsharelima/usrlocalsharelima.go
@@ -44,7 +44,7 @@ var executableViaArgs0 = sync.OnceValues(func() (string, error) {
 // Dir returns the location of the <PREFIX>/lima/share directory, relative to the location
 // of the current executable. It checks for multiple possible filesystem layouts and returns
 // the first candidate that contains the native guest agent binary.
-func Dir() (string, error) {
+var Dir = sync.OnceValues(func() (string, error) {
 	selfPaths := []string{}
 
 	selfViaArgs0, err := executableViaArgs0()
@@ -119,7 +119,7 @@ func Dir() (string, error) {
 
 	return "", fmt.Errorf("failed to find \"lima-guestagent.%s-%s\" binary for %v, attempted %v",
 		ostype, arch, selfPaths, gaCandidates)
-}
+})
 
 // GuestAgentBinary returns the absolute path of the guest agent binary, possibly with ".gz" suffix.
 func GuestAgentBinary(ostype limatype.OS, arch limatype.Arch) (string, error) {


### PR DESCRIPTION
Stop spamming info messages on using `--debug`.
e.g.:
```console
$ limactl prune --keep-referred --debug
DEBU[0000] Mixing "/Users/norio/.lima/_config/override.yaml" into "/Users/norio/.lima/debug/lima.yaml"
INFO[0000] debug mode detected, adding more guest agent candidates: /Users/norio/ghq/github.com/lima-vm/lima/_output/share/lima/lima-guestagent.Linux-aarch64
DEBU[0000] Discovering external drivers in /Users/norio/ghq/github.com/lima-vm/lima/_output/libexec/lima
INFO[0000] debug mode detected, adding more guest agent candidates: /Users/norio/ghq/github.com/lima-vm/lima/_output/share/lima/lima-guestagent.Linux-aarch64
DEBU[0000] Discovering external drivers in /Users/norio/ghq/github.com/lima-vm/lima/_output/libexec/lima
...
```