### PR TITLE
`limactl prune --keep-referred`: Do not skip template on failing `driverutil.ResolveVMType()`

### DIFF
--- a/cmd/limactl/prune.go
+++ b/cmd/limactl/prune.go
@@ -101,8 +101,7 @@ func knownLocations(ctx context.Context) (map[string]limatype.File, error) {
 			return nil, err
 		}
 		if err := driverutil.ResolveVMType(ctx, y, t.Name); err != nil {
-			logrus.Warnf("failed to resolve vm for %q: %v", t.Name, err)
-			continue
+			logrus.Warnf("failed to resolve vmType for %q: %v", t.Name, err)
 		}
 		maps.Copy(locations, locationsFromLimaYAML(y))
 	}


### PR DESCRIPTION
`locationsFromLimaYAML()` should be called on the template, which fails `driverutil.ResolveVMType()` or not.  
It can be assumed that `driverutil.ResolveVMType()` does not affect any locations in the template.  
Prioritize that there is no omission in the current locations collection rather than changing locations by `driverutil.ResolveVMType()` in the future.