### PR TITLE
`vz`: add "Base" to `knownYamlProperties`

### DIFF
--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -31,6 +31,7 @@ var knownYamlProperties = []string{
 	"AdditionalDisks",
 	"Arch",
 	"Audio",
+	"Base",
 	"CACertificates",
 	"Containerd",
 	"CopyToHost",


### PR DESCRIPTION
The driver doesn’t process the `.Base[]` field, but it shouldn’t print spammy warnings like the following:
```console
$ limactl prune --keep-referred
WARN[0000] vmType vz: ignoring `firmware.legacyBIOS`
WARN[0000] vmType vz: ignoring `firmware.legacyBIOS`
WARN[0000] failed to resolve vm for "_images/debian-11": failed to find the QEMU binary for the architecture "aarch64": exec: "qemu-system-aarch64": executable file not found in $PATH
WARN[0000] vmType vz: ignoring `firmware.legacyBIOS`
WARN[0000] vmType vz: ignoring [Base]
WARN[0000] vmType vz: ignoring [Base]
WARN[0000] vmType vz: ignoring [Base]
WARN[0000] vmType vz: ignoring [Base]
WARN[0000] vmType vz: ignoring [Base]
WARN[0000] vmType vz: ignoring [Base]
WARN[0000] vmType vz: ignoring [Base]
WARN[0000] vmType vz: ignoring [Base]
WARN[0000] vmType vz: ignoring [Base]
WARN[0000] vmType vz: ignoring [Base]
WARN[0000] vmType vz: ignoring [Base]
WARN[0000] vmType vz: ignoring [Base]
WARN[0000] vmType vz: ignoring [Base]
...
```