### PR TITLE
vz: Before calling `stopUsernet`, ensure it’s not `nil`.

### DIFF
--- a/pkg/driver/vz/vm_darwin.go
+++ b/pkg/driver/vz/vm_darwin.go
@@ -118,7 +118,9 @@ func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int) (*v
 					wrapper.stopped = true
 					wrapper.mu.Unlock()
 					_ = usernetClient.UnExposeSSH(inst.SSHLocalPort)
-					stopUsernet()
+					if stopUsernet != nil {
+						stopUsernet()
+					}
 					errCh <- errors.New("vz driver state stopped")
 				default:
 					logrus.Debugf("[VZ] - vm state change: %q", newState)


### PR DESCRIPTION
Fix crashing on using external usernet:
```console
$ limactl restart docker --progress
INFO[0000] Sending SIGINT to hostagent process 83134    
INFO[0000] Waiting for the host agent and the driver processes to shut down 
INFO[0000] [hostagent] Received SIGINT, shutting down the host agent 
INFO[0000] [hostagent] Shutting down the host agent     
INFO[0000] [hostagent] Shutting down VZ                 
INFO[0000] [hostagent] [VZ] - vm state change: stopped  
INFO[0001] [hostagent] panic: runtime error: invalid memory address or nil pointer dereference 
INFO[0001] [hostagent] [signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10117ee7c] 
INFO[0001] [hostagent] goroutine 49 [running]:          
INFO[0001] [hostagent] github.com/lima-vm/lima/v2/pkg/driver/vz.startVM.func2() 
INFO[0001] [hostagent] 	/Users/norio/ghq/github.com/lima-vm/lima/pkg/driver/vz/vm_darwin.go:146 +0x47c 
INFO[0001] [hostagent] created by github.com/lima-vm/lima/v2/pkg/driver/vz.startVM in goroutine 1 
INFO[0001] [hostagent] 	/Users/norio/ghq/github.com/lima-vm/lima/pkg/driver/vz/vm_darwin.go:81 +0x190 
```
introduced on #3949 
