### PR TITLE
Add foundational BATS tests for `limactl yq` and `limactl list`

### DIFF
--- a/hack/bats/helpers/limactl.bash
+++ b/hack/bats/helpers/limactl.bash
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Create a dummy Lima instance for testing purposes. It cannot be started because it doesn't have an actual image.
+# This function intentionally doesn't use create/editflags, but modifies the template with yq instead.
+create_dummy_instance() {
+    local name=$1
+    local expr=$2
+
+    # Template does not validate without an image, and the image must point to a file that exists (for clonefile).
+    local template="{images: [location: /etc/profile]}"
+    if [[ -n $expr ]]; then
+        template="$(limactl yq "$expr" <<<"$template")"
+    fi
+    limactl create --name "$name" - <<<"$template"
+}

--- a/hack/bats/helpers/load.bash
+++ b/hack/bats/helpers/load.bash
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
 set -o errexit -o nounset -o pipefail
 
 # Don't run the tests in ~/.lima because they may destroy _config, _templates etc.
@@ -17,7 +20,14 @@ source "$PATH_BATS_ROOT/lib/bats-support/load.bash"
 source "$PATH_BATS_ROOT/lib/bats-assert/load.bash"
 source "$PATH_BATS_ROOT/lib/bats-file/load.bash"
 
+source "$PATH_BATS_HELPERS/limactl.bash"
+source "$PATH_BATS_HELPERS/logs.bash"
+
 bats_require_minimum_version 1.5.0
+
+run_e() {
+    run --separate-stderr "$@"
+}
 
 # If called from foo() this function will call local_foo() if it exist.
 call_local_function() {
@@ -46,3 +56,9 @@ setup() {
 teardown() {
     call_local_function
 }
+
+assert_output_lines_count() {
+    assert_equal "${#lines[@]}" "$1"
+}
+
+

--- a/hack/bats/helpers/logs.bash
+++ b/hack/bats/helpers/logs.bash
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Format the string the way strconv.Quote() would do.
+# If the input ends with an ellipsis then no closing quote will be added (and the … will be removed).
+quote_msg() {
+    local quoted
+    quoted=$(sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' <<<"$1")
+    if [[ $quoted == *… ]]; then
+        echo "${quoted%…}"
+    else
+        echo "${quoted}\""
+  fi
+}
+
+assert_fatal() {
+    assert_stderr_line --partial "level=fatal msg=$(quote_msg "$1")"
+}
+assert_error() {
+    assert_stderr_line --partial "level=error msg=$(quote_msg "$1")"
+}
+assert_warning() {
+    assert_stderr_line --partial "level=warning msg=$(quote_msg "$1")"
+}
+assert_info() {
+    assert_stderr_line --partial "level=info msg=$(quote_msg "$1")"
+}
+assert_debug() {
+    assert_stderr_line --partial "level=debug msg=$(quote_msg "$1")"
+}

--- a/hack/bats/tests/00-yq.bats
+++ b/hack/bats/tests/00-yq.bats
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load "../helpers/load"
+
+@test 'make sure the yq subcommand exists' {
+    run -0 limactl yq --version
+    assert_output --regexp '^yq .*mikefarah.* version v'
+}
+
+@test 'yq can evaluate yq expressions' {
+    run -0 limactl yq .foo=42 <<<""
+    assert_output 'foo: 42'
+}
+
+@test 'yq command understand yq options' {
+    run -0 limactl yq -n -o json -I 0 .foo=42
+    assert_output '{"foo":42}'
+}
+
+@test 'yq errors set non-zero exit code' {
+    run -1 limactl yq -n foo
+    assert_output --partial "invalid input"
+}
+
+@test 'yq works as a multi-call binary' {
+    # multi-call command detection strips all extensions
+    YQ="yq.lima.exe"
+    ln -sf "$(which limactl)" "${BATS_TEST_TMPDIR}/${YQ}"
+    export PATH="$BATS_TEST_TMPDIR:$PATH"
+
+    run -0 "$YQ" --version
+    assert_output --regexp '^yq .*mikefarah.* version v'
+
+    run -0 "$YQ" -n -o json -I 0 .foo=42
+    assert_output '{"foo":42}'
+}

--- a/hack/bats/tests/01-list.bats
+++ b/hack/bats/tests/01-list.bats
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load "../helpers/load"
+
+# Use a separate LIMA_HOME for this test that we can just wipe because it will never have running instances.
+# We cannot use $BATS_FILE_TMPDIR because `limactl create` will complain about max socket path name length.
+LOCAL_LIMA_HOME="${LIMA_HOME:?}/_bats"
+
+local_setup_file() {
+    export LIMA_HOME="${LOCAL_LIMA_HOME:?}"
+    rm -rf "${LIMA_HOME:?}"
+
+    run -0 create_dummy_instance "foo" '.disk = "1M"'
+    run -0 create_dummy_instance "bar" '.disk = "2M"'
+    run -0 create_dummy_instance "baz" '.disk = "3M"'
+}
+
+local_setup() {
+    export LIMA_HOME="${LOCAL_LIMA_HOME:?}"
+}
+
+# In Go templates "{{json .}}" will encode empty maps (e.g. "foo": {}) even if the
+# map has the "json:",omitempty" tag. "{{yaml .}}" does omit empty maps, so remove
+# them from the JSON output to make it comparable to the YAML one.
+#
+# TODO should we modify `limactl list` to remove empty maps by default
+# since we pass the output through yq anyways?
+canonical_json() {
+    local empty_maps='.. | select(tag == "!!map" and length == 0)'
+    while limactl yq --exit-status --input-format json "[${empty_maps}] | length > 0" <<<"$output" >/dev/null 2>&1; do
+        run -0 limactl yq --input-format json --output-format json --indent 0 "del(${empty_maps})" <<<"$output"
+    done
+
+}
+
+@test 'list with no running instances shows a warning and exits without error' {
+    export LIMA_HOME="$BATS_TEST_TMPDIR"
+    run_e -0 limactl list
+    assert_warning 'No instance found. Run `limactl create` to create an instance.'
+}
+
+@test 'check plain list output' {
+    # also verifies that `ls` is an alias for `list`
+    run -0 limactl ls
+
+    # instances will be sorted alphabetically
+    assert_line --index 0 --regexp '^NAME +STATUS.+DISK'
+    assert_line --index 1 --regexp '^bar +Stopped.+ 2MiB'
+    assert_line --index 2 --regexp '^baz +Stopped.+ 3MiB'
+    assert_line --index 3 --regexp '^foo +Stopped.+ 1MiB'
+    # there is no other output
+    assert_output_lines_count 4
+}
+
+@test 'only list selected instances' {
+    run -0 limactl ls foo bar
+
+    # instances will be sorted in the order they were specified
+    assert_line --index 0 --regexp '^NAME'
+    assert_line --index 1 --regexp '^foo'
+    assert_line --index 2 --regexp '^bar'
+    refute_line --partial baz
+    assert_output_lines_count 3
+}
+
+@test 'requesting non-existing instance is an error' {
+    run_e -1 limactl ls foo foobar bar
+    assert_warning 'No instance matching foobar found.'
+    assert_fatal 'unmatched instances'
+
+    # existing instances are still listed
+    assert_line --index 0 --regexp '^NAME'
+    assert_line --index 1 --regexp '^foo'
+    assert_line --index 2 --regexp '^bar'
+    assert_output_lines_count 3
+}
+
+@test '--quiet option shows only names, no header' {
+    run -0 limactl list --quiet foo bar
+    assert_line --index 0 foo
+    assert_line --index 1 bar
+    assert_output_lines_count 2
+}
+
+@test '--format json returns JSON output' {
+    run -0 limactl ls --format json foo bar
+
+    # test may be too strict in expecting "name" to be the first key on the line
+    assert_line --index 0 --regexp '^\{"name":"foo",'
+    assert_line --index 1 --regexp '^\{"name":"bar",'
+    assert_output_lines_count 2
+}
+
+@test '--json is shorthand for --format json' {
+    run -0 limactl ls --format json foo bar
+    format_json=$output
+
+    run -0 limactl ls --json foo bar
+    assert_output "$format_json"
+}
+
+@test '--format YAML returns YAML documents' {
+    # save canonical JSON output with empty maps removed, for comparison
+    run -0 limactl ls foo bar --format json
+    canonical_json
+    json=$output
+
+    run -0 limactl ls --format yaml foo bar
+    yaml=$output
+
+    assert_line --regexp '^name: foo'
+    assert_line --regexp '^name: bar'
+    refute_line --regexp '^name: baz'
+
+    # verify that the output consists of 2 documents
+    run -0 limactl yq 'true' <<<"$yaml"
+    assert_output_lines_count 2
+
+    # convert YAML to JSON
+    run -0 limactl yq --input-format yaml --output-format json  --indent 0 "." <<<"$yaml"
+    assert_output_lines_count 2
+
+    # verify it matches the canonical JSON output
+    assert_output "$json"
+
+}
+
+@test 'JSON output to terminal is colorized, but semantically identical' {
+    run -0 limactl ls foo bar --format json
+    json=$output
+
+    # colorize output even when stdout is not a tty
+    export _LIMA_OUTPUT_IS_TTY=1
+    run -0 limactl ls foo bar --format json
+    colorized=$output
+
+    # check if the output contains an ANSI "reset mode" sequence ("ESC[0m")
+    run -0 cat -v <<<"$output"
+    assert_output --partial "^[[0m"
+
+    # remove all ANSI formatting codes from the output
+    run -0 sed 's/\x1b\[[0-9;]*m//g' <<<"$colorized"
+
+    # Flatten the pretty-printed JSON to a single line per object with no extra whitespace.
+    # yq processes JSON objects in sequence (when input format is set to json) and
+    # does not require each object to be on a single line.
+    run -0 limactl yq --input-format json --output-format json  --indent 0 "." <<<"$output"
+    assert_output_lines_count 2
+
+    # compare to the regular --format json output
+    assert_output "$json"
+}
+
+@test 'YAML output to terminal is colorized, but semantically identical' {
+    # save canonical output without colors and empty maps removed
+    run -0 limactl ls foo bar --format json
+    canonical_json
+    json=$output
+
+    # colorize output even when stdout is not a tty
+    export _LIMA_OUTPUT_IS_TTY=1
+    run -0 limactl ls foo bar --format yaml
+    colorized=$output
+
+    # check if the output contains an ANSI "reset mode" sequence ("ESC[0m")
+    run -0 cat -v <<<"$output"
+    assert_output --partial "^[[0m"
+
+    # remove all ANSI formatting codes from the output
+    run -0 sed 's/\x1b\[[0-9;]*m//g' <<<"$colorized"
+    yaml=$output
+
+    # Verify that the output consists of 2 documents
+    run -0 limactl yq 'true' <<<"$yaml"
+    assert_output_lines_count 2
+
+    # convert the pretty-printed YAML to JSON Lines format with no whitespace
+    run -0 limactl yq --indent 0 --input-format yaml --output-format json "." <<<"$yaml"
+    assert_output_lines_count 2
+
+    # verify it matches the canonical JSON output
+    assert_output "$json"
+}
+
+@test '--all-fields includes all fields in the table' {
+    skip "only works with output to a terminal (#3986)"
+    # TODO provide a way to specify the width, e.g. with `--width 120`
+    # See https://github.com/lima-vm/lima/issues/3986
+}
+
+@test 'Use field names in Go template format' {
+    run -0 limactl ls foo bar --format '{{.Name}} {{.Disk}}'
+    assert_line --index 0 "foo 1048576"
+    assert_line --index 1 "bar 2097152"
+}
+
+@test '--list-fields list all available fields' {
+    run -0 limactl ls --list-fields
+    assert_line Name
+    assert_line CPUs
+    assert_line Memory
+    # All field names start with an uppercase letter and don't contain any spaces
+    refute_line --regexp '^[^A-Z]'
+    refute_line --partial ' '
+ }
+
+ @test '--list-fields does not list deprecated field, but they are still available' {
+    run -0 limactl ls --list-fields
+
+    # no deprecated fields are listed
+    refute_line "HostArch"
+    refute_line "HostOS"
+    refute_line "IdentityFile"
+    refute_line "LimaHome"
+
+    # all deprecated fields exist and produce output
+    run -0 limactl ls foo --format '{{.HostArch}}'
+    assert_output
+    run -0 limactl ls foo --format '{{.HostOS}}'
+    assert_output
+    run -0 limactl ls foo --format '{{.IdentityFile}}'
+    assert_output
+    run -0 limactl ls foo --format '{{.LimaHome}}'
+    assert_output "$LIMA_HOME"
+
+    # verify that a non-existing field throws an error and produces no output
+    # TODO the error message is not really end-user friendly, not sure if we can do something about it
+    run_e -1 limactl ls foo --format '{{.Unknown}}'
+    assert_stderr --regexp "level=fatal.*can't evaluate field Unknown"
+    refute_output
+}
+
+@test '--quiet option can only be used with format --table' {
+    # TODO the error message is incorrect, it can be used with --yq
+    run_e -1 limactl list --quiet --format json
+    assert_fatal "option --quiet can only be used with '--format table'"
+
+    run_e -1 limactl list --quiet --format yaml
+    assert_fatal "option --quiet can only be used with '--format table'"
+
+    run_e -1 limactl list --quiet --format '{{.Name}} {{.Disk}}'
+    assert_fatal "option --quiet can only be used with '--format table'"
+}
+
+@test '--yq option implies --format json' {
+    run -0 limactl ls baz --yq '.config'
+    assert_output --regexp '^\{"'
+
+    run -0 limactl yq '.disk' <<<"$output"
+    assert_output "3M"
+}
+
+@test '--yq option can be used with --format yaml' {
+    run -0 limactl ls baz --yq '.config' --format yaml
+    assert_line "disk: 3M"
+}
+
+@test '--yq option can be specified multiple times' {
+    run -0 limactl ls foo --yq '.config' --yq '.user' --yq '.uid'
+    assert_output "$UID"
+
+    run -0 limactl ls --yq 'select(.disk > 1024*1024)' --yq 'select(.name | test("z"))' --yq '.name'
+    assert_output "baz"
+}
+
+@test '--yq option is incompatible with --format table or Go templates' {
+    run_e -1 limactl ls --yq '.name' --format table
+    assert_fatal "option --yq only works with --format json or yaml"
+
+    run_e -1 limactl ls --yq '.name' --format '{{.Name}} {{.Disk}}'
+    assert_fatal "option --yq only works with --format json or yaml"
+}
+
+@test '--quiet option can be used with --yq' {
+    run -0 limactl ls --quiet
+    assert_line --index 0 "bar"
+    assert_output_lines_count 3
+
+    run -0 limactl ls --quiet --yq 'select(.name == "foo")'
+    assert_output "foo"
+}

--- a/hack/bats/tests/preserve-env.bats
+++ b/hack/bats/tests/preserve-env.bats
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load "../helpers/load"
 
 NAME=bats

--- a/hack/bats/tests/protect.bats
+++ b/hack/bats/tests/protect.bats
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load "../helpers/load"
 
 NAME=dummy
@@ -12,58 +15,57 @@ local_setup_file() {
 }
 
 @test 'create dummy instance' {
-    # needs an image that clonefile() can process; /dev/null doesn't work
-    limactl create --name "$NAME" - <<<"{images: [location: /etc/profile], disk: 1M}"
+    run -0 create_dummy_instance "$NAME" '.disk = "1M"'
 }
 
 @test 'protecting a non-existing instance fails' {
-    run -1 limactl protect "${NOTEXIST}"
-    assert_output --partial 'failed to inspect instance'
+    run_e -1 limactl protect "${NOTEXIST}"
+    assert_fatal "failed to inspect instance \"${NOTEXIST}\"…"
 }
 
 @test 'protecting the dummy instance succeeds' {
-    run -0 limactl protect "$NAME"
-    assert_output --regexp "Protected \\\\\"$NAME\\\\\""
-    assert_file_exists "$LIMA_HOME/$NAME/protected"
+    run_e -0 limactl protect "$NAME"
+    assert_info "Protected \"${NAME}\""
+    assert_file_exists "${LIMA_HOME}/${NAME}/protected"
 }
 
 @test 'protecting it again shows a warning, but succeeds' {
-    run -0 limactl protect "$NAME"
-    assert_output --partial 'already protected. Skipping'
-    assert_file_exists "$LIMA_HOME/$NAME/protected"
+    run_e -0 limactl protect "$NAME"
+    assert_warning "Instance \"${NAME}\" is already protected. Skipping."
+    assert_file_exists "${LIMA_HOME}/${NAME}/protected"
 }
 
 @test 'cloning a protected instance creates an unprotected clone' {
-    run -0 limactl clone --yes "$NAME" "$CLONE"
+    run_e -0 limactl clone --yes "$NAME" "$CLONE"
     # TODO there is currently no output from the clone command, which feels wrong
     refute_output
-    assert_file_not_exists "$LIMA_HOME/$CLONE/protected"
+    assert_file_not_exists "${LIMA_HOME}/${CLONE}/protected"
 }
 
 @test 'deleting the unprotected clone instance succeeds' {
-    run -0 limactl delete --force "$CLONE"
-    assert_output --regexp "Deleted \\\\\"$CLONE\\\\\""
+    run_e -0 limactl delete --force "$CLONE"
+    assert_info "Deleted \"${CLONE}\"…"
 }
 
 @test 'deleting protected dummy instance fails' {
-    run -1 limactl delete --force "$NAME"
-    assert_output --partial 'instance is protected'
+    run_e -1 limactl delete --force "$NAME"
+    assert_fatal "failed to delete instance \"${NAME}\": instance is protected…"
     assert_file_exists "$LIMA_HOME/$NAME/protected"
 }
 
 @test 'unprotecting the dummy instance succeeds' {
-    run -0 limactl unprotect "$NAME"
-    assert_output --regexp "Unprotected \\\\\"$NAME\\\\\""
+    run_e -0 limactl unprotect "$NAME"
+    assert_info "Unprotected \"${NAME}\""
     assert_file_not_exists "$LIMA_HOME/$NAME/protected"
 }
 
 @test 'unprotecting it again shows a warning, but succeeds' {
-    run -0 limactl unprotect "$NAME"
-    assert_output --partial "isn't protected. Skipping"
+    run_e -0 limactl unprotect "$NAME"
+    assert_warning "Instance \"${NAME}\" isn't protected. Skipping."
     assert_file_not_exists "$LIMA_HOME/$NAME/protected"
 }
 
 @test 'deleting unprotected dummy instance succeeds' {
-    run -0 limactl delete --force "$NAME"
-    assert_output --regexp "Deleted \\\\\"$NAME\\\\\""
+    run_e -0 limactl delete --force "$NAME"
+    assert_info "Deleted \"${NAME}\"…"
 }


### PR DESCRIPTION
They are the basis for more complex tests later, so have filenames starting with a digit, so they are processed first.

May still be missing some edge cases, but they can be added later.