### PR TITLE
`limactl usernet`: handle signal to close GVisorNetstack

### DIFF
--- a/cmd/limactl/usernet.go
+++ b/cmd/limactl/usernet.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -77,10 +79,13 @@ func usernetAction(cmd *cobra.Command, _ []string) error {
 	os.RemoveAll(qemuSocket)
 	os.RemoveAll(fdSocket)
 
+	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
 	// Environment Variables
 	// LIMA_USERNET_RESOLVE_IP_ADDRESS_TIMEOUT: Specifies the timeout duration for resolving IP addresses in minutes. Default is 2 minutes.
 
-	return usernet.StartGVisorNetstack(cmd.Context(), &usernet.GVisorNetstackOpts{
+	return usernet.StartGVisorNetstack(ctx, &usernet.GVisorNetstackOpts{
 		MTU:           mtu,
 		Endpoint:      endpoint,
 		QemuSocket:    qemuSocket,

--- a/pkg/networks/usernet/udpfileconn.go
+++ b/pkg/networks/usernet/udpfileconn.go
@@ -16,8 +16,7 @@ type UDPFileConn struct {
 func (conn *UDPFileConn) Read(b []byte) (n int, err error) {
 	// Check if the connection has been closed
 	if err := conn.SetReadDeadline(time.Time{}); err != nil {
-		var opErr *net.OpError
-		if errors.As(err, &opErr) && opErr.Err.Error() == "use of closed network connection" {
+		if errors.Is(err, net.ErrClosed) {
 			return 0, errors.New("UDPFileConn connection closed")
 		}
 	}


### PR DESCRIPTION
`*_ep.sock`, `*_fd.sock`, and `*_qemu.sock` will be properly removed on exit with the following changes:
- Pass `signal.NotifyContext` to `usernet.StartGVisorNetstack`.
- Close `http.Server` instead of `net.Listener`.
- Fix mishandling of checking `http.ErrServerClosed`.
- Check `ctx.Done()` outside of the loop calling `listener.Accept()` in `listenFD`, and `listenQEMU`.
- Use `errors.Is(err, net.ErrClosed)` in `UDPFileConn.Read`.  
  Since https://github.com/golang/go/issues/4373 has been fixed.