### PR TITLE
Change `limactl list --format json` not to include empty objects

### DIFF
--- a/hack/bats/helpers/load.bash
+++ b/hack/bats/helpers/load.bash
@@ -60,5 +60,3 @@ teardown() {
 assert_output_lines_count() {
     assert_equal "${#lines[@]}" "$1"
 }
-
-

--- a/hack/bats/tests/01-list.bats
+++ b/hack/bats/tests/01-list.bats
@@ -79,10 +79,10 @@ local_setup() {
 }
 
 @test '--json is shorthand for --format json' {
-    run -0 limactl ls --format json foo bar
+    run -0 limactl ls foo bar --format json
     format_json=$output
 
-    run -0 limactl ls --json foo bar
+    run -0 limactl ls foo bar --json
     assert_output "$format_json"
 }
 
@@ -91,7 +91,7 @@ local_setup() {
     run -0 limactl ls foo bar --format json
     json=$output
 
-    run -0 limactl ls --format yaml foo bar
+    run -0 limactl ls foo bar --format yaml
     yaml=$output
 
     assert_line --regexp '^name: foo'


### PR DESCRIPTION
Unlike the YAML encoder, the JSON encoder will encode empty structs even when they have the `json:",omitempty"` tag (it will only emit nil pointers to structs).

This commit repeatedly removes empty objects until the result no longer gets any shorter. It doesn't check for the omitempty tag, but we have that tag set on every struct.

Example: this removes `"vmOpts":{"qemu":{},"vz":{"rosetta":{}}}`.