### PR TITLE
Merge mounts in FillDefault based on mountPoint instead of location

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -631,21 +631,39 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 	// Combine all mounts; highest priority entry determines writable status.
 	// Only works for exact matches; does not normalize case or resolve symlinks.
 	mounts := make([]limatype.Mount, 0, len(d.Mounts)+len(y.Mounts)+len(o.Mounts))
-	location := make(map[string]int)
+	mountPoint := make(map[string]int)
 	for _, mount := range slices.Concat(d.Mounts, y.Mounts, o.Mounts) {
 		if out, err := executeHostTemplate(mount.Location, instDir, y.Param); err == nil {
 			mount.Location = filepath.Clean(out.String())
 		} else {
 			logrus.WithError(err).Warnf("Couldn't process mount location %q as a template", mount.Location)
 		}
-		if mount.MountPoint != nil {
+		// Expand a path that begins with `~`. Relative paths are not modified, and rejected by Validate() later.
+		if localpathutil.IsTildePath(mount.Location) {
+			if location, err := localpathutil.Expand(mount.Location); err == nil {
+				mount.Location = location
+			} else {
+				logrus.WithError(err).Warnf("Couldn't expand location %q", mount.Location)
+			}
+		}
+		if mount.MountPoint == nil {
+			mountLocation := mount.Location
+			if runtime.GOOS == "windows" {
+				var err error
+				mountLocation, err = ioutilx.WindowsSubsystemPath(ctx, mountLocation)
+				if err != nil {
+					logrus.WithError(err).Warnf("Couldn't convert location %q into mount target", mount.Location)
+				}
+			}
+			mount.MountPoint = ptr.Of(mountLocation)
+		} else {
 			if out, err := executeGuestTemplate(*mount.MountPoint, instDir, y.User, y.Param); err == nil {
 				mount.MountPoint = ptr.Of(out.String())
 			} else {
 				logrus.WithError(err).Warnf("Couldn't process mount point %q as a template", *mount.MountPoint)
 			}
 		}
-		if i, ok := location[mount.Location]; ok {
+		if i, ok := mountPoint[*mount.MountPoint]; ok {
 			if mount.SSHFS.Cache != nil {
 				mounts[i].SSHFS.Cache = mount.SSHFS.Cache
 			}
@@ -677,7 +695,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 				mounts[i].MountPoint = mount.MountPoint
 			}
 		} else {
-			location[mount.Location] = len(mounts)
+			mountPoint[*mount.MountPoint] = len(mounts)
 			mounts = append(mounts, mount)
 		}
 	}
@@ -712,26 +730,6 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 			} else {
 				mounts[i].NineP.Cache = ptr.Of(Default9pCacheForRO)
 			}
-		}
-
-		// Expand a path that begins with `~`. Relative paths are not modified, and rejected by Validate() later.
-		if localpathutil.IsTildePath(mount.Location) {
-			if location, err := localpathutil.Expand(mount.Location); err == nil {
-				mounts[i].Location = location
-			} else {
-				logrus.WithError(err).Warnf("Couldn't expand location %q", mount.Location)
-			}
-		}
-		if mount.MountPoint == nil {
-			mountLocation := mounts[i].Location
-			if runtime.GOOS == "windows" {
-				var err error
-				mountLocation, err = ioutilx.WindowsSubsystemPath(ctx, mountLocation)
-				if err != nil {
-					logrus.WithError(err).Warnf("Couldn't convert location %q into mount target", mounts[i].Location)
-				}
-			}
-			mounts[i].MountPoint = ptr.Of(mountLocation)
 		}
 	}
 


### PR DESCRIPTION
Based on findings in https://github.com/lima-vm/lima/pull/4042#issuecomment-3301297669

The template merge code already merged mounts correctly based on `mountPoint`, but `FillDefault` still merged based on `location`[^1].

[^1]: The whole `FillDefault()` logic should be implemented via template merging, but that will be a bigger job.

Using `master` without this PR:

```console
❯ cat tmpl.yaml
base: template://default
mounts:
- location: /foo
  mountPoint: /foo
- location: /foo
  mountPoint: /bar
- location: /baz
  mountPoint: /bar

❯ l create -y tmpl.yaml
...

❯ l yq .mounts ~/.lima/tmpl/lima.yaml
- location: /foo
  mountPoint: /foo
- location: /foo
  mountPoint: /bar
- location: "~"

❯ l ls tmpl --yq '.config.mounts[] | [.location, .mountPoint]'
[
    "/foo",
    "/bar"
]
[
    "/Users/jan",
    "/Users/jan"
]
```

So template merging has (correctly) dropped mounting the `/baz` location because the `/bar` mount point was already fully defined.

And then the `/foo` mount point has been incorrectly dropped because it shared a mount location with the `/bar` mount point.

This is fixed in this PR:

```console
❯ l yq .mounts ~/.lima/tmpl/lima.yaml
- location: /foo
  mountPoint: /foo
- location: /foo
  mountPoint: /bar
- location: "~"

❯ l ls tmpl --yq '.config.mounts[] | [.location, .mountPoint]'
[
    "/foo",
    "/foo"
]
[
    "/foo",
    "/bar"
]
[
    "/Users/jan",
    "/Users/jan"
]
```

So template merging is unchanged and has correctly removed the `/baz` location, but both the `/foo` and `/bar` mount points have been correctly preserved.