### PR TITLE
add kcp template

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -57,6 +57,7 @@ Container orchestration:
 - [`faasd`](./faasd.yaml): [Faasd](https://docs.openfaas.com/deployment/edge/)
 - [`k0s`](./k0s.yaml): [k0s](https://k0sproject.io/) Zero Friction Kubernetes
 - [`k3s`](./k3s.yaml): Kubernetes via k3s
+- [`kcp`](./kcp.yaml): [kcp](https://github.com/kcp-dev/kcp) Kubernetes-like control plane that delivers isolated workspaces and centralized multi-tenant APIs.
 - [`k8s`](./k8s.yaml): Kubernetes via kubeadm
 - [`experimental/u7s`](./experimental/u7s.yaml): [Usernetes](https://github.com/rootless-containers/usernetes): Rootless Kubernetes
 

--- a/templates/kcp.yaml
+++ b/templates/kcp.yaml
@@ -1,0 +1,69 @@
+# Deploy kubernetes via kcp (Kubernetes Control Plane)
+# $ limactl start ./kcp.yaml
+# $ limactl shell kcp kubectl
+#
+# It can be accessed from the host by exporting the kubeconfig file;
+# the ports are already forwarded automatically by lima:
+#
+# $ export KUBECONFIG=$(limactl list kcp --format 'unix://{{.Dir}}/copied-from-guest/kubeconfig.yaml')
+# $ kubectl get workspaces
+#
+# For more details of KCP, please refer to https://github.com/kcp-dev/kcp
+
+minimumLimaVersion: 1.1.0
+
+base: template://_images/ubuntu-lts
+
+# Mounts are disabled in this template, but can be enabled optionally.
+mounts: []
+
+containerd:
+  system: false
+  user: false
+
+provision:
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    command -v kcp >/dev/null 2>&1 && exit 0
+
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y curl wget
+
+    KCP_VERSION=$(curl -s https://api.github.com/repos/kcp-dev/kcp/releases/latest | grep tag_name | cut -d '"' -f 4)
+    KCP_VERSION_NO_V=${KCP_VERSION#v}
+
+    wget https://github.com/kcp-dev/kcp/releases/download/${KCP_VERSION}/kcp_${KCP_VERSION_NO_V}_linux_arm64.tar.gz
+    tar -xzf kcp_${KCP_VERSION_NO_V}_linux_arm64.tar.gz
+    mv bin/kcp /usr/local/bin/
+    chmod +x /usr/local/bin/kcp
+    rm -f kcp_${KCP_VERSION_NO_V}_linux_arm64.tar.gz
+
+    mkdir -p /var/.kcp/
+    sudo chmod 755 /var/.kcp
+    nohup kcp start --root-directory=/var/.kcp/ --bind-address=127.0.0.1 > /var/log/kcp.log 2>&1 &
+
+probes:
+- script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! timeout 30s bash -c "until sudo test -f /var/.kcp/admin.kubeconfig; do sleep 3; done"; then
+            echo >&2 "kcp is not running yet"
+            exit 1
+    fi
+  hint: |
+    The kcp control plane is not ready yet.
+    Run "limactl shell kcp sudo journalctl -f" to check the system logs.
+
+copyToHost:
+- guest: "/var/.kcp/admin.kubeconfig"
+  host: "{{.Dir}}/copied-from-guest/kubeconfig.yaml"
+  deleteOnStop: true
+message: |
+  To run `kubectl` on the host (assumes kubectl is installed), run the following commands:
+  ------
+  export KUBECONFIG="{{.Dir}}/copied-from-guest/kubeconfig.yaml"
+  kubectl get workspaces
+  ------


### PR DESCRIPTION
```
Change adds KCP templates to enable Lima to support multi-tenant Kubernetes control planes out of the box.
```