### PR TITLE
rm docs/*.md; add docs/README.md for the website link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+Moved to <https://lima-vm.io/docs/>

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -1,1 +1,0 @@
-Moved to <https://lima-vm.io/docs/releases/deprecated/>

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -1,1 +1,0 @@
-Moved to <https://lima-vm.io/docs/releases/experimental/>

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,1 +1,0 @@
-Moved to <https://lima-vm.io/docs/dev/internals/>

--- a/docs/mount.md
+++ b/docs/mount.md
@@ -1,1 +1,0 @@
-Moved to <https://lima-vm.io/docs/config/mount/>

--- a/docs/multi-arch.md
+++ b/docs/multi-arch.md
@@ -1,1 +1,0 @@
-Moved to <https://lima-vm.io/docs/config/multi-arch/>

--- a/docs/network.md
+++ b/docs/network.md
@@ -1,1 +1,0 @@
-Moved to <https://lima-vm.io/docs/config/network/>

--- a/docs/talks.md
+++ b/docs/talks.md
@@ -1,1 +1,0 @@
-Moved to <https://lima-vm.io/docs/talks/>

--- a/docs/vmtype.md
+++ b/docs/vmtype.md
@@ -1,1 +1,0 @@
-Moved to <https://lima-vm.io/docs/config/vmtype/>


### PR DESCRIPTION
Two years have passed since migrating the *.md contents to the website, so the *.md files no longer need to be kept.