### PR TITLE
Use driver feature instead of checking the name

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -105,6 +105,7 @@ type Info struct {
 type DriverFeatures struct {
 	CanRunGUI            bool `json:"canRunGui,omitempty"`
 	DynamicSSHAddress    bool `json:"dynamicSSHAddress"`
+	StaticSSHPort        bool `json:"staticSSHPort"`
 	SkipSocketForwarding bool `json:"skipSocketForwarding"`
 	NoCloudInit          bool `json:"noCloudInit"`
 	RosettaEnabled       bool `json:"rosettaEnabled"`

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -309,6 +309,7 @@ func (l *LimaWslDriver) Info() driver.Info {
 
 	info.Features = driver.DriverFeatures{
 		DynamicSSHAddress:    true,
+		StaticSSHPort:        true,
 		SkipSocketForwarding: true,
 		NoCloudInit:          true,
 		CanRunGUI:            l.canRunGUI(),

--- a/pkg/driverutil/instance.go
+++ b/pkg/driverutil/instance.go
@@ -22,7 +22,6 @@ func CreateConfiguredDriver(inst *limatype.Instance, sshLocalPort int) (*driver.
 		return nil, fmt.Errorf("unknown or unsupported VM type: %s", *limaDriver)
 	}
 
-	inst.SSHLocalPort = sshLocalPort
 	if extDriver != nil {
 		extDriver.Logger.Debugf("Using external driver %q", extDriver.Name)
 		if extDriver.Client == nil || extDriver.Command == nil {
@@ -36,9 +35,15 @@ func CreateConfiguredDriver(inst *limatype.Instance, sshLocalPort int) (*driver.
 			extDriver.InstanceName = inst.Name
 		}
 
+		if !extDriver.Client.Info().Features.StaticSSHPort {
+			inst.SSHLocalPort = sshLocalPort
+		}
 		return extDriver.Client.Configure(inst), nil
 	}
 
 	logrus.Debugf("Using internal driver %q", intDriver.Info().Name)
+	if !intDriver.Info().Features.StaticSSHPort {
+		inst.SSHLocalPort = sshLocalPort
+	}
 	return intDriver.Configure(inst), nil
 }

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -140,9 +140,6 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 	if err != nil {
 		return nil, err
 	}
-	if *inst.Config.VMType == limatype.WSL2 {
-		sshLocalPort = inst.SSHLocalPort
-	}
 
 	var udpDNSLocalPort, tcpDNSLocalPort int
 	if *inst.Config.HostResolver.Enabled {
@@ -160,6 +157,7 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 	if err != nil {
 		return nil, fmt.Errorf("failed to create driver instance: %w", err)
 	}
+	sshLocalPort = inst.SSHLocalPort
 
 	vSockPort := limaDriver.Info().VsockPort
 	virtioPort := limaDriver.Info().VirtioPort


### PR DESCRIPTION
Other container drivers with dynamic addresses and static ports also want to set the port after start.

This means that we have to provide their names too in "limatype", instead of making it fully external.

```go
if *inst.Config.VMType == limatype.WSL2 || *inst.Config.VMType == limatype.AC || *inst.Config.VMType == limatype.DC
```

There is some weird hard-coded path handling left, that could be the topic of another PR perhaps?