### PR TITLE
Add port monitoring test script

### DIFF
--- a/hack/bats/extras/port-monitor.bats
+++ b/hack/bats/extras/port-monitor.bats
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# This test verifies that when a container is destroyed, its ports can be reused
+# immediately and are not subject to being freed by a polling loop. See #4066.
+
+# This test should not be run in CI as it is not totally reliable: there is always a chance that the server will
+# take longer to actually respond to requests after opening the port. The test works around it by retrying once
+# on curl exit code 52, but have been observed at least once to fail by refusing to connect.
+
+load "../helpers/load"
+
+: "${TEMPLATE:=default}" # Alternative: "docker"
+
+NAME=nginx
+
+local_setup_file() {
+    limactl delete --force "$NAME" || :
+    limactl start --yes --name "$NAME" --mount "$BATS_TMPDIR" "template://${TEMPLATE}" 3>&- 4>&-
+}
+
+local_teardown_file() {
+    limactl delete --force "$NAME"
+}
+
+ctrctl() {
+    if [[ $(limactl ls "$NAME" --yq .config.containerd.user) == true ]]; then
+        limactl shell $NAME nerdctl "$@"
+    else
+        limactl shell $NAME docker "$@"
+    fi
+}
+
+nginx_start() {
+    echo "$COUNTER" >"${BATS_TEST_TMPDIR}/index.html"
+    ctrctl run -d --name nginx -p 8080:80 -v "${BATS_TEST_TMPDIR}:/usr/share/nginx/html:ro" nginx
+}
+
+nginx_stop() {
+    ctrctl stop nginx
+    ctrctl rm nginx
+}
+
+verify_port() {
+    run curl --silent http://127.0.0.1:8080
+    # If nginx is not quite ready and doesn't send any response at all, give it one extra chance
+    if [[ $status -eq 52 ]]; then
+        sleep 0.5
+        run curl --silent http://127.0.0.1:8080
+    fi
+    assert_success
+    assert_output "$COUNTER"
+}
+
+@test 'Verify that the container is working' {
+    COUNTER=0
+    ctrctl pull --quiet nginx
+    nginx_start
+    verify_port
+}
+
+@test 'Stop and restart the container multiple times' {
+    for COUNTER in {1..100}; do
+        nginx_stop
+        nginx_start
+        verify_port
+    done
+}


### PR DESCRIPTION
It verifies that when a container is destroyed, its ports can be reused immediately and are not subject to being freed by a polling loop.

I wrote this to validate #4066, but I think we should keep things like this in the repo, just in case we need them again. They also serve as samples to write other similar tests in the future.

It should not be run in CI; it is not totally reliable: there is always a chance that the server will take longer to actually respond to requests after opening the port. The test works around it by retrying once on curl exit code 52, but I have it seen fail once by refusing to connect.

Anyways, running the test on `master` fails:

```console
❯ time TEMPLATE=docker ./lib/bats-core/bin/bats -T extras/port-monitor.bats
port-monitor.bats
 ✗ Verify that the container is working [4038]
   (from function `assert_success' in file lib/bats-assert/src/assert_success.bash, line 45,
    from function `verify_port' in file extras/port-monitor.bats, line 47,
    in test file extras/port-monitor.bats, line 55)
     `verify_port' failed
   docker.io/library/nginx:latest
   7f19e4ccde1a38c72b96b0be4824dc0eb06dcd11445fc030faa0a5ff4191171f

   -- command failed --
   status : 7
   output :
   --

 ✗ Stop and restart the container multiple times [558]
   (from function `assert_success' in file lib/bats-assert/src/assert_success.bash, line 45,
    from function `verify_port' in file extras/port-monitor.bats, line 47,
    in test file extras/port-monitor.bats, line 62)
     `verify_port' failed
   nginx
   nginx
   4866814feab1b4dfdec7833af5206c945dc4fff58248883f2f5e4cbb16cf882f

   -- command failed --
   status : 7
   output :
   --


2 tests, 2 failures in 53 seconds

TEMPLATE=docker ./lib/bats-core/bin/bats -T extras/port-monitor.bats  3.20s user 2.77s system 11% cpu 53.326 total
```

I've been running on the #4066 PR branch multiple times, with both `containerd` and `docker`, and it seems to be passing regularly:

```console
❯ time TEMPLATE=docker ./lib/bats-core/bin/bats -T extras/port-monitor.bats
port-monitor.bats
 ✓ Verify that the container is working [4930]
 ✓ Stop and restart the container multiple times [54854]

2 tests, 0 failures in 101 seconds

TEMPLATE=docker ./lib/bats-core/bin/bats -T extras/port-monitor.bats  16.64s user 14.79s system 31% cpu 1:41.11 total

❯ time TEMPLATE=default ./lib/bats-core/bin/bats -T extras/port-monitor.bats
port-monitor.bats
 ✓ Verify that the container is working [5298]
 ✓ Stop and restart the container multiple times [67924]

2 tests, 0 failures in 120 seconds

TEMPLATE=default ./lib/bats-core/bin/bats -T extras/port-monitor.bats  17.57s user 15.77s system 27% cpu 2:00.04 total
```