### PR TITLE
Exclude docs/README.md from ls-lint rules

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -32,6 +32,8 @@ ignore:
 - .ls-lint.yml
 - '_output'
 - '**/*.pb\.go'
+- docs/README.md
+- hack/bats/lib
 - hack/common.inc.sh
 - pkg/cidata/cidata.TEMPLATE.d
 - pkg/cidata/cidata.TEMPLATE.d/util/compare_version.sh


### PR DESCRIPTION
Also add exclusion for hack/bats/lib, in case `ls-lint` is ever called when the submodules are checked out.

This was broken in #4073, which didn't run the linting tests because it only included docs changes.