### PR TITLE
Fix hostresolver setting for VZ, but disable it by default

### DIFF
--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -275,11 +275,11 @@ func templateArgs(ctx context.Context, bootScripts bool, instDir, name string, i
 		for _, addr := range instConfig.DNS {
 			args.DNSAddresses = append(args.DNSAddresses, addr.String())
 		}
-	case firstUsernetIndex != -1 || *instConfig.VMType == limatype.VZ:
-		args.DNSAddresses = append(args.DNSAddresses, args.SlirpDNS)
 	case *instConfig.HostResolver.Enabled:
 		args.UDPDNSLocalPort = udpDNSLocalPort
 		args.TCPDNSLocalPort = tcpDNSLocalPort
+		args.DNSAddresses = append(args.DNSAddresses, args.SlirpDNS)
+	case firstUsernetIndex != -1 || *instConfig.VMType == limatype.VZ:
 		args.DNSAddresses = append(args.DNSAddresses, args.SlirpDNS)
 	default:
 		args.DNSAddresses, err = osutil.DNSAddresses()

--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -166,6 +166,10 @@ func (l *LimaQemuDriver) FillConfig(ctx context.Context, cfg *limatype.LimaYAML,
 		cfg.CPUType = nil
 	}
 
+	if cfg.HostResolver.Enabled == nil {
+		cfg.HostResolver.Enabled = ptr.Of(true)
+	}
+
 	mountTypesUnsupported := make(map[string]struct{})
 	for _, f := range cfg.MountTypesUnsupported {
 		mountTypesUnsupported[f] = struct{}{}

--- a/pkg/driverutil/vm.go
+++ b/pkg/driverutil/vm.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/ptr"
 	"github.com/lima-vm/lima/v2/pkg/registry"
 )
 
@@ -45,6 +46,10 @@ func validateConfigAgainstDriver(ctx context.Context, y *limatype.LimaYAML, file
 
 	if err := intDriver.FillConfig(ctx, y, filePath); err != nil {
 		return err
+	}
+
+	if y.HostResolver.Enabled == nil {
+		y.HostResolver.Enabled = ptr.Of(false)
 	}
 
 	return nil

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -538,9 +538,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 	if o.HostResolver.Enabled != nil {
 		y.HostResolver.Enabled = o.HostResolver.Enabled
 	}
-	if y.HostResolver.Enabled == nil {
-		y.HostResolver.Enabled = ptr.Of(true)
-	}
+	// Default will be filled in by driver (false, except for QEMU)
 
 	if y.HostResolver.IPv6 == nil {
 		y.HostResolver.IPv6 = d.HostResolver.IPv6

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -139,6 +139,7 @@ func TestFillDefault(t *testing.T) {
 	// their values are retained and defaults for their fields are applied correctly.
 	y = limatype.LimaYAML{
 		HostResolver: limatype.HostResolver{
+			Enabled: ptr.Of(true),
 			Hosts: map[string]string{
 				"MY.Host": "host.lima.internal",
 			},

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -565,7 +565,7 @@ propagateProxyEnv: null
 # can only work when using a vmnet network interface and the host has working
 # IPv6 configured as well.
 hostResolver:
-  # 🟢 Builtin default: true
+  # 🟢 Builtin default: false (except for vmType: qemu, where it is true)
   enabled: null
   # 🟢 Builtin default: false
   ipv6: null

--- a/website/content/en/docs/config/network/user.md
+++ b/website/content/en/docs/config/network/user.md
@@ -23,7 +23,7 @@ The loopback addresses of the host is `192.168.5.2` and is accessible from the g
 
 ## DNS (192.168.5.3)
 
-If `hostResolver.enabled` in `lima.yaml` is true, then the hostagent is going to run a DNS server over tcp and udp - each on a separate randomly selected free port. This server does a local lookup using the native host resolver, so it will deal correctly with VPN configurations and split-DNS setups, as well as mDNS, local `/etc/hosts` etc. For this the hostagent has to be compiled with `CGO_ENABLED=1` as default Go resolver is [broken](https://github.com/golang/go/issues/12524).
+If `hostResolver.enabled` in `lima.yaml` is true (default for `qemu` driver), then the hostagent is going to run a DNS server over tcp and udp - each on a separate randomly selected free port. This server does a local lookup using the native host resolver, so it will deal correctly with VPN configurations and split-DNS setups, as well as mDNS, local `/etc/hosts` etc. For this the hostagent has to be compiled with `CGO_ENABLED=1` as default Go resolver is [broken](https://github.com/golang/go/issues/12524).
 
 These tcp and udp ports are then forwarded via iptables rules to `192.168.5.3:53`, overriding the DNS provided by QEMU via slirp.
 
@@ -43,4 +43,6 @@ DNS over tcp is rarely used. It is usually only used either when user explicitly
 
 During initial cloud-init bootstrap, `iptables` may not yet be installed. In that case the repo server is determined using the slirp DNS. After `iptables` has been installed, the forwarding rule is applied, switching over to the hostagent DNS.
 
-If `hostResolver.enabled` is false, then DNS servers can be configured manually in `lima.yaml` via the `dns` setting. If that list is empty, then Lima will either use the slirp DNS (on Linux), or the nameservers from the first host interface in service order that has an assigned IPv4 address (on macOS).
+If `hostResolver.enabled` is false (default for all drivers except `qemu`), then DNS servers can be configured manually in `lima.yaml` via the `dns` setting. If that list is empty, then Lima will either use the slirp DNS (on Linux), or the nameservers from the first host interface in service order that has an assigned IPv4 address (on macOS).
+
+The host resolver is not needed with the `vz` driver because the `gvisor-tap-vsock` implementation used by `usernet` has the same functionality built-in.


### PR DESCRIPTION
Since it was implicitly disabled for VZ, we cannot simply fix the bug, but change the default to match the previous de-facto default.

This PR now disables HostResolver by default, except for QEMU.

This implements option (1) from #4089.