### PR TITLE
`limactl shell`, `ssh.config`: Remove `ControlMaster`, `ControlPath`, and `ControlPersist` options on Windows

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -338,6 +339,13 @@ func SSHArgsFromOpts(opts []string) []string {
 		args = append(args, "-o", o)
 	}
 	return args
+}
+
+// SSHOptsRemovingControlPath removes ControlMaster, ControlPath, and ControlPersist options from SSH options.
+func SSHOptsRemovingControlPath(opts []string) []string {
+	return slices.DeleteFunc(opts, func(s string) bool {
+		return strings.HasPrefix(s, "ControlMaster") || strings.HasPrefix(s, "ControlPath") || strings.HasPrefix(s, "ControlPersist")
+	})
 }
 
 func ParseOpenSSHVersion(version []byte) *semver.Version {


### PR DESCRIPTION
Remove ControlMaster, ControlPath, and ControlPersist options, because Cygwin-based SSH clients do not support multiplexing when executing commands.

References:
  https://inbox.sourceware.org/cygwin/c98988a5-7e65-4282-b2a1-bb8e350d5fab@acm.org/T/
  https://stackoverflow.com/questions/20959792/is-ssh-controlmaster-with-cygwin-on-windows-actually-possible

By removing these options:
  - Avoids execution failures when the control master is not yet available.
  - Prevents error messages such as:
    > mux_client_request_session: read from master failed: Connection reset by peer
    > ControlSocket ....sock already exists, disabling multiplexing

Only remove these options when writing the SSH config file and executing `limactl shell`, since multiplexing seems to work with port forwarding.