### PR TITLE
Add meta field to lima.yaml for user annotations

### DIFF
--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -45,6 +45,7 @@ var knownYamlProperties = []string{
 	"Images",
 	"Memory",
 	"Message",
+	"Meta",
 	"MinimumLimaVersion",
 	"Mounts",
 	"MountType",

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -35,6 +35,7 @@ var knownYamlProperties = []string{
 	"HostResolver",
 	"Images",
 	"Message",
+	"Meta",
 	"Mounts",
 	"MountType",
 	"Param",

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -52,11 +52,12 @@ type LimaYAML struct {
 	PropagateProxyEnv *bool          `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty" jsonschema:"nullable"`
 	CACertificates    CACertificates `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
 	// Deprecated: Use VMOpts.VZ.Rosetta instead.
-	Rosetta              Rosetta `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
-	Plain                *bool   `yaml:"plain,omitempty" json:"plain,omitempty" jsonschema:"nullable"`
-	TimeZone             *string `yaml:"timezone,omitempty" json:"timezone,omitempty" jsonschema:"nullable"`
-	NestedVirtualization *bool   `yaml:"nestedVirtualization,omitempty" json:"nestedVirtualization,omitempty" jsonschema:"nullable"`
-	User                 User    `yaml:"user,omitempty" json:"user,omitempty"`
+	Rosetta              Rosetta        `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
+	Plain                *bool          `yaml:"plain,omitempty" json:"plain,omitempty" jsonschema:"nullable"`
+	TimeZone             *string        `yaml:"timezone,omitempty" json:"timezone,omitempty" jsonschema:"nullable"`
+	NestedVirtualization *bool          `yaml:"nestedVirtualization,omitempty" json:"nestedVirtualization,omitempty" jsonschema:"nullable"`
+	User                 User           `yaml:"user,omitempty" json:"user,omitempty"`
+	Meta                 map[string]any `yaml:"meta,omitempty" json:"meta,omitempty" jsonschema:"nullable"`
 }
 
 type BaseTemplates []LocatorWithDigest


### PR DESCRIPTION
This field will not be used by Lima itself; users can add whatever objects they want.

Possible uses are:

* adding labels that can be used as selectors (see also #3240)

  ```
  limactl edit mysql --set '.meta.database = true'
  limactl list --yq 'select(.config.meta.database).name'
  ```

* adding anything that would normally be just a comment, like a description or keywords

  This makes it possible to query and manipulate the data with applications instead of being solely for human consumption (see also https://github.com/lima-vm/lima/issues/4097#issuecomment-3340228977).

---

I first called the field `metadata`, but it just feels too long, especially since in filter expressions it becomes `.config.metadata`.

It is unfortunate that most of the interesting data for filtering in the `list` command is inside the `.config` object, making all expressions longer and harder to read. The `.name` and `.status` properties are about the only things outside of `.config` that I regularly use.