### PR TITLE
Use --start flag to start VM for 'clone' and 'edit' commands

### DIFF
--- a/cmd/limactl/clone.go
+++ b/cmd/limactl/clone.go
@@ -34,6 +34,7 @@ Not to be confused with 'limactl copy' ('limactl cp').
 		ValidArgsFunction: cloneBashComplete,
 		GroupID:           advancedCommand,
 	}
+	cloneCommand.Flags().Bool("start", false, "Start the instance after cloning")
 	editflags.RegisterEdit(cloneCommand, "[limactl edit] ")
 	return cloneCommand
 }
@@ -48,6 +49,7 @@ func newRenameCommand() *cobra.Command {
 		ValidArgsFunction: cloneBashComplete,
 		GroupID:           advancedCommand,
 	}
+	renameCommand.Flags().Bool("start", false, "Start the instance after renaming")
 	editflags.RegisterEdit(renameCommand, "[limactl edit] ")
 	return renameCommand
 }
@@ -113,15 +115,18 @@ func cloneOrRenameAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if !tty {
-		// use "start" to start it
-		return nil
-	}
-	startNow, err := askWhetherToStart()
+	start, err := flags.GetBool("start")
 	if err != nil {
 		return err
 	}
-	if !startNow {
+
+	if tty && !flags.Changed("start") {
+		start, err = askWhetherToStart()
+		if err != nil {
+			return err
+		}
+	}
+	if !start {
 		return nil
 	}
 	err = reconcile.Reconcile(ctx, newInst.Name)

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -155,6 +155,11 @@ func newApp() *cobra.Command {
 		}
 
 		if cmd.Flags().Changed("yes") {
+			switch cmd.Name() {
+			case "clone", "edit", "rename":
+				logrus.Warn("--yes flag is deprecated (--tty=false is still supported and works in the same way. Also consider using --start)")
+			}
+
 			// Sets the value of the yesValue flag by using the yes flag.
 			yesValue, _ := cmd.Flags().GetBool("yes")
 			if yesValue {


### PR DESCRIPTION
This PR addresses [Issue #3995] regarding the confusing and inconsistent behavior of the --yes flag in limactl clone and limactl edit. The following changes have been made:

Changes

1. Deprecate `--yes` flag for the clone and edit commands. A warning is shown when used, recommending `--start` instead.
2. Add `--start` flag (default: true) to both commands, allowing users to explicitly control whether the instance is started after cloning or editing.