### PR TITLE
template:k8s: fix "toml: table io.containerd.grpc.v1.cri already exists"

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh
@@ -45,6 +45,9 @@ if [ "${LIMA_CIDATA_CONTAINERD_SYSTEM}" = 1 ]; then
 	mkdir -p /etc/containerd /etc/buildkit
 	cat >"/etc/containerd/config.toml" <<EOF
   version = 2
+  # TODO: remove imports after upgrading containerd to v2.2, as
+  # conf.d is set by default since v2.2.
+  imports = ['/etc/containerd/conf.d/*.toml']
   [plugins."io.containerd.grpc.v1.cri"]
     enable_cdi = true
   [proxy_plugins]

--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -10,7 +10,7 @@
 # NAME       STATUS   ROLES                  AGE   VERSION
 # lima-k8s   Ready    control-plane,master   44s   v1.22.3
 
-minimumLimaVersion: 1.1.0
+minimumLimaVersion: 2.0.0
 
 base: template://_images/ubuntu-lts
 
@@ -62,11 +62,12 @@ provision:
   script: |
     #!/bin/bash
     set -eux -o pipefail
-    grep SystemdCgroup /etc/containerd/config.toml && exit 0
+    [ -e /etc/containerd/conf.d/k8s.toml ] && exit 0
     grep "version = 2" /etc/containerd/config.toml || exit 1
+    mkdir -p /etc/containerd/conf.d
     # Configuring the systemd cgroup driver
     # Overriding the sandbox (pause) image
-    cat <<EOF >>/etc/containerd/config.toml
+    cat <<EOF >>/etc/containerd/conf.d/k8s.toml
       [plugins]
         [plugins."io.containerd.grpc.v1.cri"]
           sandbox_image = "$(kubeadm config images list | grep pause | sort -r | head -n1)"


### PR DESCRIPTION
Fix #4110

The config is now split to `/etc/containerd/conf.d/k8s.toml` to avoid putting `io.containerd.grpc.v1.cri` section twice.