### PR TITLE
Bump k8s flannel version from 0.26.2 to 0.26.7

### DIFF
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -110,7 +110,7 @@ provision:
     EOF
     kubeadm init --config kubeadm-config.yaml
     # Installing a Pod network add-on
-    kubectl apply -f https://github.com/flannel-io/flannel/releases/download/v0.26.2/kube-flannel.yml
+    kubectl apply -f https://github.com/flannel-io/flannel/releases/download/v0.26.7/kube-flannel.yml
     # Control plane node isolation
     kubectl taint nodes --all node-role.kubernetes.io/control-plane-
     # Replace the server address with localhost, so that it works also from the host


### PR DESCRIPTION
This also changes the registry used, from docker.io to ghcr.io

For the "flannel" and "flannel-cni-plugin" images being used.

```
ghcr.io/flannel-io/flannel:v0.26.7
ghcr.io/flannel-io/flannel-cni-plugin:v1.6.2-flannel1
```

The plugin is installed in `/opt/cni/bin`, on the node itself.