### PR TITLE
guestagent: reuse netlink connections

### DIFF
--- a/cmd/lima-guestagent/daemon_linux.go
+++ b/cmd/lima-guestagent/daemon_linux.go
@@ -70,6 +70,8 @@ func daemonAction(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	defer agent.Close()
+
 	err = os.RemoveAll(socket)
 	if err != nil {
 		return err

--- a/pkg/guestagent/guestagent.go
+++ b/pkg/guestagent/guestagent.go
@@ -5,6 +5,7 @@ package guestagent
 
 import (
 	"context"
+	"io"
 
 	"github.com/lima-vm/lima/v2/pkg/guestagent/api"
 )
@@ -14,4 +15,5 @@ type Agent interface {
 	Events(ctx context.Context, ch chan *api.Event)
 	LocalPorts(ctx context.Context) ([]*api.IPPort, error)
 	HandleInotify(event *api.Inotify)
+	io.Closer
 }

--- a/pkg/guestagent/sockets/sockets_linux_test.go
+++ b/pkg/guestagent/sockets/sockets_linux_test.go
@@ -104,7 +104,10 @@ func TestParseMessages_ShortDataSkipped(t *testing.T) {
 }
 
 func TestListS_Integration(t *testing.T) {
-	_, err := List()
+	lister, err := NewLister()
+	assert.NilError(t, err, "NewLister error")
+	defer lister.Close()
+	_, err = lister.List()
 	if err != nil {
 		t.Skipf("skipping: cannot query netlink inet_diag (%v)", err)
 	}


### PR DESCRIPTION
Prior to this commit, `pkg/guestagent/sockets` opened and closed a netlink connection on each invocation of `sockets.List()`.