### PR TITLE
Allow passing guestagent location to instance.StartWithPath

### DIFF
--- a/cmd/limactl/clone.go
+++ b/cmd/limactl/clone.go
@@ -113,7 +113,7 @@ func cloneAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return instance.Start(ctx, newInst, "", false, false)
+	return instance.Start(ctx, newInst, false, false)
 }
 
 func cloneBashComplete(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -166,7 +166,7 @@ func editAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return instance.Start(ctx, inst, "", false, false)
+	return instance.Start(ctx, inst, false, false)
 }
 
 func askWhetherToStart() (bool, error) {

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -106,7 +106,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		err = instance.Start(ctx, inst, "", false, false)
+		err = instance.Start(ctx, inst, false, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -548,7 +548,7 @@ func createAction(cmd *cobra.Command, args []string) error {
 	if len(inst.Errors) > 0 {
 		return fmt.Errorf("errors inspecting instance: %+v", inst.Errors)
 	}
-	if _, err = instance.Prepare(cmd.Context(), inst); err != nil {
+	if _, err = instance.Prepare(cmd.Context(), inst, ""); err != nil {
 		return err
 	}
 	logrus.Infof("Run `limactl start %s` to start the instance.", inst.Name)
@@ -606,7 +606,7 @@ func startAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return instance.Start(ctx, inst, "", launchHostAgentForeground, progress)
+	return instance.Start(ctx, inst, launchHostAgentForeground, progress)
 }
 
 func createBashComplete(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/instance/restart.go
+++ b/pkg/instance/restart.go
@@ -25,7 +25,7 @@ func Restart(ctx context.Context, inst *limatype.Instance, showProgress bool) er
 		return err
 	}
 
-	if err := Start(ctx, inst, "", launchHostAgentForeground, showProgress); err != nil {
+	if err := Start(ctx, inst, launchHostAgentForeground, showProgress); err != nil {
 		return err
 	}
 
@@ -40,7 +40,7 @@ func RestartForcibly(ctx context.Context, inst *limatype.Instance, showProgress 
 		return err
 	}
 
-	if err := Start(ctx, inst, "", launchHostAgentForeground, showProgress); err != nil {
+	if err := Start(ctx, inst, launchHostAgentForeground, showProgress); err != nil {
 		return err
 	}
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -70,12 +70,11 @@ func CheckInternalOrExternal(name string) string {
 }
 
 func Get(name string) (*ExternalDriver, driver.Driver, bool) {
-	if err := discoverDrivers(); err != nil {
-		logrus.Warnf("Error discovering drivers: %v", err)
-	}
-
 	internalDriver, exists := internalDrivers[name]
 	if !exists {
+		if err := discoverDrivers(); err != nil {
+			logrus.Warnf("Error discovering drivers: %v", err)
+		}
 		externalDriver, exists := ExternalDrivers[name]
 		if exists {
 			return externalDriver, nil, exists
@@ -102,18 +101,6 @@ func registerExternalDriver(name, path string) {
 }
 
 func discoverDrivers() error {
-	stdDriverDir, err := usrlocalsharelima.LibexecLima()
-	if err != nil {
-		return err
-	}
-
-	logrus.Debugf("Discovering external drivers in %s", stdDriverDir)
-	if _, err := os.Stat(stdDriverDir); err == nil {
-		if err := discoverDriversInDir(stdDriverDir); err != nil {
-			logrus.Warnf("Error discovering external drivers in %q: %v", stdDriverDir, err)
-		}
-	}
-
 	if driverPaths := os.Getenv("LIMA_DRIVERS_PATH"); driverPaths != "" {
 		paths := filepath.SplitList(driverPaths)
 		for _, path := range paths {
@@ -137,6 +124,17 @@ func discoverDrivers() error {
 		}
 	}
 
+	stdDriverDir, err := usrlocalsharelima.LibexecLima()
+	if err != nil {
+		return err
+	}
+
+	logrus.Debugf("Discovering external drivers in %s", stdDriverDir)
+	if _, err := os.Stat(stdDriverDir); err == nil {
+		if err := discoverDriversInDir(stdDriverDir); err != nil {
+			logrus.Warnf("Error discovering external drivers in %q: %v", stdDriverDir, err)
+		}
+	}
 	return nil
 }
 

--- a/website/content/en/docs/dev/drivers.md
+++ b/website/content/en/docs/dev/drivers.md
@@ -40,8 +40,8 @@ This creates external driver binaries in `_output/libexec/lima/` with the naming
 
 Lima discovers external drivers from these locations:
 
-1. **Standard directory**: `<LIMA-PREFIX>/libexec/lima/`, where `<LIMA_PREFIX>` is the location path where the Lima binary is present
-2. **Custom directories**: Set path to the external driver's directory via `LIMA_DRIVERS_PATH` environment variable
+1. **Custom directories**: Set path to the external driver's directory via `LIMA_DRIVERS_PATH` environment variable
+2. **Standard directory**: `<LIMA-PREFIX>/libexec/lima/`, where `<LIMA_PREFIX>` is the location path where the Lima binary is present
 
 The discovery process is handled by [`pkg/registry/registry.go`.](https://github.com/lima-vm/lima/blob/master/pkg/registry/registry.go)
 


### PR DESCRIPTION
This is similar to passing in the full path to limactl to allow an embedding application stored in a different location to launch a VM.

Simplified the internal calls by removing the limactl argument to instance.Start.

Also changed the order to look for external drivers first in LIMA_DRIVERS_PATH before looking in libexec, allowing the user to override the drivers in the default location. This also makes sure that the LIMA_DRIVERS_PATH drivers are found even when libexec cannot be located.