### PR TITLE
Support for `libkrun` using `krunkit`

### DIFF
--- a/cmd/lima-driver-krunkit/main_darwin_arm64.go
+++ b/cmd/lima-driver-krunkit/main_darwin_arm64.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+
+	"github.com/lima-vm/lima/v2/pkg/driver/external/server"
+	"github.com/lima-vm/lima/v2/pkg/driver/krunkit"
+)
+
+// To be used as an external driver for Lima.
+func main() {
+	server.Serve(context.Background(), krunkit.New())
+}

--- a/pkg/driver/krunkit/errors_darwin_arm64.go
+++ b/pkg/driver/krunkit/errors_darwin_arm64.go
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package krunkit
+
+import "errors"
+
+var errUnimplemented = errors.New("unimplemented by the krunkit driver")

--- a/pkg/driver/krunkit/hack/install-vulkan-gpu.sh
+++ b/pkg/driver/krunkit/hack/install-vulkan-gpu.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux -o pipefail
+
+# Install required packages
+dnf install -y dnf-plugins-core dnf-plugin-versionlock llvm18-libs
+
+# Install Vulkan and Mesa base packages
+dnf install -y \
+	mesa-vulkan-drivers \
+	vulkan-loader-devel \
+	vulkan-headers \
+	vulkan-tools \
+	vulkan-loader \
+	glslc
+
+# Enable COPR repo with patched Mesa for Venus support
+dnf copr enable -y slp/mesa-krunkit fedora-40-aarch64
+
+# Downgrade to patched Mesa version from COPR
+dnf downgrade -y mesa-vulkan-drivers.aarch64 \
+	--repo=copr:copr.fedorainfracloud.org:slp:mesa-krunkit
+
+# Lock Mesa version to prevent automatic upgrades
+dnf versionlock add mesa-vulkan-drivers
+
+# Clean up
+dnf clean all
+
+echo "Krunkit GPU(Venus) setup complete. Verify Vulkan installation by running 'vulkaninfo --summary'."

--- a/pkg/driver/krunkit/krunkit_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_darwin_arm64.go
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package krunkit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	"github.com/docker/go-units"
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/driver/vz"
+	"github.com/lima-vm/lima/v2/pkg/imgutil/proxyimgutil"
+	"github.com/lima-vm/lima/v2/pkg/iso9660util"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/limayaml"
+	"github.com/lima-vm/lima/v2/pkg/networks"
+	"github.com/lima-vm/lima/v2/pkg/networks/usernet"
+	"github.com/lima-vm/lima/v2/pkg/store"
+)
+
+const logLevelInfo = "3"
+
+// Cmdline constructs the command line arguments for krunkit based on the instance configuration.
+func Cmdline(inst *limatype.Instance) (*exec.Cmd, error) {
+	memBytes, err := units.RAMInBytes(*inst.Config.Memory)
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{
+		// Memory in MiB
+		"--memory", strconv.FormatInt(memBytes/units.MiB, 10),
+		"--cpus", fmt.Sprintf("%d", *inst.Config.CPUs),
+		"--device", fmt.Sprintf("virtio-serial,logFilePath=%s", filepath.Join(inst.Dir, filenames.SerialLog)),
+		"--krun-log-level", logLevelInfo,
+		"--restful-uri", "none://",
+
+		// First virtio-blk device is the boot disk
+		"--device", fmt.Sprintf("virtio-blk,path=%s,format=raw", filepath.Join(inst.Dir, filenames.DiffDisk)),
+		"--device", fmt.Sprintf("virtio-blk,path=%s", filepath.Join(inst.Dir, filenames.CIDataISO)),
+	}
+
+	// Add additional disks
+	if len(inst.Config.AdditionalDisks) > 0 {
+		ctx := context.Background()
+		diskUtil := proxyimgutil.NewDiskUtil(ctx)
+		for _, d := range inst.Config.AdditionalDisks {
+			disk, derr := store.InspectDisk(d.Name)
+			if derr != nil {
+				return nil, fmt.Errorf("failed to load disk %q: %w", d.Name, derr)
+			}
+			if disk.Instance != "" {
+				return nil, fmt.Errorf("failed to run attach disk %q, in use by instance %q", disk.Name, disk.Instance)
+			}
+			if lerr := disk.Lock(inst.Dir); lerr != nil {
+				return nil, fmt.Errorf("failed to lock disk %q: %w", d.Name, lerr)
+			}
+			extraDiskPath := filepath.Join(disk.Dir, filenames.DataDisk)
+			logrus.Infof("Mounting disk %q on %q", disk.Name, disk.MountPoint)
+			if cerr := diskUtil.ConvertToRaw(ctx, extraDiskPath, extraDiskPath, nil, true); cerr != nil {
+				return nil, fmt.Errorf("failed to convert extra disk %q to raw: %w", extraDiskPath, cerr)
+			}
+			args = append(args, "--device", fmt.Sprintf("virtio-blk,path=%s,format=raw", extraDiskPath))
+		}
+	}
+
+	// Network commands
+	networkArgs, err := buildNetworkArgs(inst)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build network arguments: %w", err)
+	}
+
+	// File sharing commands
+	if *inst.Config.MountType == limatype.VIRTIOFS {
+		for i, mount := range inst.Config.Mounts {
+			if _, err := os.Stat(mount.Location); errors.Is(err, os.ErrNotExist) {
+				if err := os.MkdirAll(mount.Location, 0o750); err != nil {
+					return nil, err
+				}
+			}
+			tag := fmt.Sprintf("mount%d", i)
+			mountArg := fmt.Sprintf("virtio-fs,sharedDir=%s,mountTag=%s", mount.Location, tag)
+			args = append(args, "--device", mountArg)
+		}
+	}
+
+	args = append(args, networkArgs...)
+	cmd := exec.CommandContext(context.Background(), vmType, args...)
+
+	return cmd, nil
+}
+
+func buildNetworkArgs(inst *limatype.Instance) ([]string, error) {
+	var args []string
+
+	// Configure default usernetwork with limayaml.MACAddress(inst.Dir) for eth0 interface
+	firstUsernetIndex := limayaml.FirstUsernetIndex(inst.Config)
+	if firstUsernetIndex == -1 {
+		// slirp network using gvisor netstack
+		krunkitSock, err := usernet.SockWithDirectory(inst.Dir, "", usernet.FDSock)
+		if err != nil {
+			return nil, err
+		}
+		client, err := vz.PassFDToUnix(krunkitSock)
+		if err != nil {
+			return nil, err
+		}
+
+		args = append(args, "--device", fmt.Sprintf("virtio-net,type=unixgram,fd=%d,mac=%s", client.Fd(), limayaml.MACAddress(inst.Dir)))
+	}
+
+	for _, nw := range inst.Networks {
+		var sock string
+		var mac string
+		if nw.Lima != "" {
+			nwCfg, err := networks.LoadConfig()
+			if err != nil {
+				return nil, err
+			}
+			switch nw.Lima {
+			case networks.ModeUserV2:
+				sock, err = usernet.Sock(nw.Lima, usernet.QEMUSock)
+				if err != nil {
+					return nil, err
+				}
+				mac = limayaml.MACAddress(inst.Dir)
+			case networks.ModeShared, networks.ModeBridged:
+				socketVMNetInstalled, err := nwCfg.IsDaemonInstalled(networks.SocketVMNet)
+				if err != nil {
+					return nil, err
+				}
+				if !socketVMNetInstalled {
+					return nil, errors.New("socket_vmnet is not installed")
+				}
+				sock, err = networks.Sock(nw.Lima)
+				if err != nil {
+					return nil, err
+				}
+				mac = nw.MACAddress
+			default:
+				return nil, fmt.Errorf("invalid network spec %+v", nw)
+			}
+		} else if nw.Socket != "" {
+			sock = nw.Socket
+			mac = nw.MACAddress
+		} else {
+			return nil, fmt.Errorf("invalid network spec %+v", nw)
+		}
+
+		device := fmt.Sprintf("virtio-net,type=unixstream,path=%s,mac=%s", sock, mac)
+		args = append(args, "--device", device)
+	}
+
+	if len(args) == 0 {
+		return args, errors.New("no socket_vmnet networks defined")
+	}
+
+	return args, nil
+}
+
+func EnsureDisk(ctx context.Context, inst *limatype.Instance) error {
+	diffDisk := filepath.Join(inst.Dir, filenames.DiffDisk)
+	if _, err := os.Stat(diffDisk); err == nil || !errors.Is(err, os.ErrNotExist) {
+		// disk is already ensured
+		return err
+	}
+
+	diskUtil := proxyimgutil.NewDiskUtil(ctx)
+
+	baseDisk := filepath.Join(inst.Dir, filenames.BaseDisk)
+
+	diskSize, _ := units.RAMInBytes(*inst.Config.Disk)
+	if diskSize == 0 {
+		return nil
+	}
+	isBaseDiskISO, err := iso9660util.IsISO9660(baseDisk)
+	if err != nil {
+		return err
+	}
+	if isBaseDiskISO {
+		// Create an empty data volume (sparse)
+		diffDiskF, err := os.Create(diffDisk)
+		if err != nil {
+			return err
+		}
+
+		err = diskUtil.MakeSparse(ctx, diffDiskF, 0)
+		if err != nil {
+			diffDiskF.Close()
+			return fmt.Errorf("failed to create sparse diff disk %q: %w", diffDisk, err)
+		}
+		return diffDiskF.Close()
+	}
+
+	// Krunkit also supports qcow2 disks but raw is faster to create and use.
+	if err = diskUtil.ConvertToRaw(ctx, baseDisk, diffDisk, &diskSize, false); err != nil {
+		return fmt.Errorf("failed to convert %q to a raw disk %q: %w", baseDisk, diffDisk, err)
+	}
+	return err
+}
+
+func startUsernet(ctx context.Context, inst *limatype.Instance) (*usernet.Client, context.CancelFunc, error) {
+	if firstUsernetIndex := limayaml.FirstUsernetIndex(inst.Config); firstUsernetIndex != -1 {
+		return usernet.NewClientByName(inst.Config.Networks[firstUsernetIndex].Lima), nil, nil
+	}
+	// Start a in-process gvisor-tap-vsock
+	endpointSock, err := usernet.SockWithDirectory(inst.Dir, "", usernet.EndpointSock)
+	if err != nil {
+		return nil, nil, err
+	}
+	krunkitSock, err := usernet.SockWithDirectory(inst.Dir, "", usernet.FDSock)
+	if err != nil {
+		return nil, nil, err
+	}
+	os.RemoveAll(endpointSock)
+	os.RemoveAll(krunkitSock)
+	ctx, cancel := context.WithCancel(ctx)
+	err = usernet.StartGVisorNetstack(ctx, &usernet.GVisorNetstackOpts{
+		MTU:      1500,
+		Endpoint: endpointSock,
+		FdSocket: krunkitSock,
+		Async:    true,
+		DefaultLeases: map[string]string{
+			networks.SlirpIPAddress: limayaml.MACAddress(inst.Dir),
+		},
+		Subnet: networks.SlirpNetwork,
+	})
+	if err != nil {
+		defer cancel()
+		return nil, nil, err
+	}
+	subnetIP, _, err := net.ParseCIDR(networks.SlirpNetwork)
+	return usernet.NewClient(endpointSock, subnetIP), cancel, err
+}

--- a/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
@@ -1,0 +1,355 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package krunkit
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/driver"
+	"github.com/lima-vm/lima/v2/pkg/executil"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/limayaml"
+	"github.com/lima-vm/lima/v2/pkg/networks/usernet"
+	"github.com/lima-vm/lima/v2/pkg/osutil"
+	"github.com/lima-vm/lima/v2/pkg/ptr"
+)
+
+type LimaKrunkitDriver struct {
+	Instance     *limatype.Instance
+	SSHLocalPort int
+
+	usernetClient *usernet.Client
+	stopUsernet   context.CancelFunc
+	krunkitCmd    *exec.Cmd
+	krunkitWaitCh chan error
+}
+
+type KrunkitOpts struct {
+	GPUAccel *bool `yaml:"gpuAccel,omitempty"`
+}
+
+func NewKrunkitOpts(cfg *limatype.LimaYAML) (*KrunkitOpts, error) {
+	var krunkitOpts KrunkitOpts
+	if err := limayaml.Convert(cfg.VMOpts[vmType], &krunkitOpts, "vmOpts.krunkit"); err != nil {
+		return nil, err
+	}
+
+	return &krunkitOpts, nil
+}
+
+var (
+	_      driver.Driver   = (*LimaKrunkitDriver)(nil)
+	vmType limatype.VMType = "krunkit"
+
+	//go:embed hack/install-vulkan-gpu.sh
+	gpuProvisionScript string
+)
+
+func New() *LimaKrunkitDriver {
+	return &LimaKrunkitDriver{}
+}
+
+func (l *LimaKrunkitDriver) Configure(inst *limatype.Instance) *driver.ConfiguredDriver {
+	l.Instance = inst
+	l.SSHLocalPort = inst.SSHLocalPort
+
+	return &driver.ConfiguredDriver{
+		Driver: l,
+	}
+}
+
+func (l *LimaKrunkitDriver) CreateDisk(ctx context.Context) error {
+	return EnsureDisk(ctx, l.Instance)
+}
+
+func (l *LimaKrunkitDriver) Start(ctx context.Context) (chan error, error) {
+	var err error
+	l.usernetClient, l.stopUsernet, err = startUsernet(ctx, l.Instance)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start usernet: %w", err)
+	}
+
+	krunkitCmd, err := Cmdline(l.Instance)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct krunkit command line: %w", err)
+	}
+	// Detach krunkit process from parent Lima process
+	krunkitCmd.SysProcAttr = executil.BackgroundSysProcAttr
+
+	logPath := filepath.Join(l.Instance.Dir, "krunkit.log")
+	logfile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open krunkit logfile: %w", err)
+	}
+	krunkitCmd.Stderr = logfile
+
+	logrus.Infof("Starting krun VM (hint: to watch the progress, see %q)", logPath)
+	logrus.Infof("krunkitCmd.Args: %v", krunkitCmd.Args)
+
+	if err := krunkitCmd.Start(); err != nil {
+		logfile.Close()
+		return nil, errors.New("failed to start krunkitCmd")
+	}
+
+	pidPath := filepath.Join(l.Instance.Dir, filenames.PIDFile(*l.Instance.Config.VMType))
+	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d\n", krunkitCmd.Process.Pid)), 0o644); err != nil {
+		logrus.WithError(err).Warn("Failed to write PID file")
+	}
+
+	l.krunkitCmd = krunkitCmd
+	l.krunkitWaitCh = make(chan error, 1)
+	go func() {
+		defer func() {
+			logfile.Close()
+			os.RemoveAll(pidPath)
+			close(l.krunkitWaitCh)
+		}()
+		l.krunkitWaitCh <- krunkitCmd.Wait()
+	}()
+
+	err = l.usernetClient.ConfigureDriver(ctx, l.Instance, l.SSHLocalPort)
+	if err != nil {
+		l.krunkitWaitCh <- fmt.Errorf("failed to configure usernet: %w", err)
+	}
+
+	return l.krunkitWaitCh, nil
+}
+
+func (l *LimaKrunkitDriver) Stop(_ context.Context) error {
+	if l.krunkitCmd == nil {
+		return nil
+	}
+
+	if err := l.krunkitCmd.Process.Signal(syscall.SIGTERM); err != nil {
+		logrus.WithError(err).Warn("Failed to send interrupt signal")
+	}
+
+	go func() {
+		if l.usernetClient != nil {
+			_ = l.usernetClient.UnExposeSSH(l.Instance.SSHLocalPort)
+		}
+		if l.stopUsernet != nil {
+			l.stopUsernet()
+		}
+	}()
+
+	timeout := time.After(30 * time.Second)
+	select {
+	case <-l.krunkitWaitCh:
+		return nil
+	case <-timeout:
+		if err := l.krunkitCmd.Process.Kill(); err != nil {
+			return err
+		}
+
+		<-l.krunkitWaitCh
+		return nil
+	}
+}
+
+func (l *LimaKrunkitDriver) Validate(_ context.Context) error {
+	return validateConfig(l.Instance.Config)
+}
+
+func validateConfig(cfg *limatype.LimaYAML) error {
+	if cfg == nil {
+		return errors.New("configuration is nil")
+	}
+	macOSProductVersion, err := osutil.ProductVersion()
+	if err != nil {
+		return err
+	}
+	if macOSProductVersion.LessThan(*semver.New("13.0.0")) {
+		return errors.New("krunkit driver requires macOS 13 or higher to run")
+	}
+	if cfg.Arch != nil && !limayaml.IsNativeArch(*cfg.Arch) {
+		return fmt.Errorf("unsupported arch: %q (krunkit requires native arch)", *cfg.Arch)
+	}
+	if _, err := exec.LookPath(vmType); err != nil {
+		return errors.New("krunkit CLI not found in PATH. Install it via:\nbrew tap slp/krunkit\nbrew install krunkit")
+	}
+
+	if cfg.MountType != nil && (*cfg.MountType != limatype.VIRTIOFS && *cfg.MountType != limatype.REVSSHFS) {
+		return fmt.Errorf("field `mountType` must be %q or %q for krunkit driver, got %q", limatype.VIRTIOFS, limatype.REVSSHFS, *cfg.MountType)
+	}
+
+	// If GPU acceleration is requested, ensure Fedora image/template is used
+	krunkitOpts, err := NewKrunkitOpts(cfg)
+	if err != nil {
+		return err
+	}
+	if krunkitOpts.GPUAccel != nil && *krunkitOpts.GPUAccel {
+		if !isFedoraConfigured(cfg) {
+			logrus.Warn("gpuAccel: true requires a Fedora image (use a Fedora base template or image)")
+		}
+	}
+
+	return nil
+}
+
+func isFedoraConfigured(cfg *limatype.LimaYAML) bool {
+	for _, b := range cfg.Base {
+		if strings.Contains(strings.ToLower(b.URL), "fedora") {
+			return true
+		}
+	}
+	for _, img := range cfg.Images {
+		if strings.Contains(strings.ToLower(img.Location), "fedora") {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *LimaKrunkitDriver) FillConfig(_ context.Context, cfg *limatype.LimaYAML, _ string) error {
+	if cfg.MountType == nil {
+		cfg.MountType = ptr.Of(limatype.VIRTIOFS)
+	} else {
+		*cfg.MountType = limatype.VIRTIOFS
+	}
+
+	if cfg.Arch == nil {
+		cfg.Arch = ptr.Of(limatype.AARCH64)
+	} else {
+		*cfg.Arch = limatype.AARCH64
+	}
+
+	cfg.VMType = ptr.Of(vmType)
+
+	krunkitOpts, err := NewKrunkitOpts(cfg)
+	if err != nil {
+		return err
+	}
+
+	if krunkitOpts.GPUAccel == nil {
+		krunkitOpts.GPUAccel = ptr.Of(false)
+	}
+
+	if *krunkitOpts.GPUAccel {
+		gpuInstallScript := limatype.Provision{
+			Mode:   limatype.ProvisionModeData,
+			Script: ptr.Of(gpuProvisionScript),
+			ProvisionData: limatype.ProvisionData{
+				Content:     ptr.Of(gpuProvisionScript),
+				Path:        ptr.Of("/usr/local/bin/install-vulkan-gpu.sh"),
+				Permissions: ptr.Of("0755"),
+				Overwrite:   ptr.Of(false),
+				Owner:       cfg.User.Name,
+			},
+		}
+		cfg.Provision = append(cfg.Provision, gpuInstallScript)
+		cfg.Message = "To enable GPU support for krunkit, run the following command inside the VM:\n\033[32msudo install-vulkan-gpu.sh\033[0m\n"
+	}
+
+	return validateConfig(cfg)
+}
+
+func (l *LimaKrunkitDriver) BootScripts() (map[string][]byte, error) {
+	// Override default reboot-if-required with a no-op because Fedora does not support this well and
+	// takes a long time to start up.
+	krunkitOpts, err := NewKrunkitOpts(l.Instance.Config)
+	if err != nil {
+		return nil, err
+	}
+	if krunkitOpts.GPUAccel == nil || !*krunkitOpts.GPUAccel {
+		return nil, nil
+	}
+	scripts := map[string][]byte{
+		"00-reboot-if-required.sh": []byte(`#!/bin/sh
+set -eu
+# Disabled by krunkit driver
+exit 0
+`),
+	}
+	return scripts, nil
+}
+
+func (l *LimaKrunkitDriver) Create(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaKrunkitDriver) Info() driver.Info {
+	var info driver.Info
+	info.Name = vmType
+	if l.Instance != nil && l.Instance.Dir != "" {
+		info.InstanceDir = l.Instance.Dir
+	}
+
+	info.Features = driver.DriverFeatures{
+		DynamicSSHAddress:    false,
+		SkipSocketForwarding: false,
+		CanRunGUI:            false,
+	}
+	return info
+}
+
+func (l *LimaKrunkitDriver) SSHAddress(_ context.Context) (string, error) {
+	return "127.0.0.1", nil
+}
+
+func (l *LimaKrunkitDriver) ForwardGuestAgent() bool {
+	return true
+}
+
+func (l *LimaKrunkitDriver) Delete(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaKrunkitDriver) InspectStatus(_ context.Context, _ *limatype.Instance) string {
+	return ""
+}
+
+func (l *LimaKrunkitDriver) RunGUI() error {
+	return nil
+}
+
+func (l *LimaKrunkitDriver) ChangeDisplayPassword(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaKrunkitDriver) DisplayConnection(_ context.Context) (string, error) {
+	return "", errUnimplemented
+}
+
+func (l *LimaKrunkitDriver) CreateSnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaKrunkitDriver) ApplySnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaKrunkitDriver) DeleteSnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaKrunkitDriver) ListSnapshots(_ context.Context) (string, error) {
+	return "", errUnimplemented
+}
+
+func (l *LimaKrunkitDriver) Register(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaKrunkitDriver) Unregister(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaKrunkitDriver) GuestAgentConn(_ context.Context) (net.Conn, string, error) {
+	return nil, "unix", nil
+}

--- a/templates/experimental/krunkit.yaml
+++ b/templates/experimental/krunkit.yaml
@@ -1,0 +1,21 @@
+# Use this template only if you want to use GPU(Venus) inside the krunkit VM
+# or else Krunkit can also work with the default Lima template.
+
+vmType: krunkit
+
+# For AI workloads, at least 4GiB memory and 4 CPUs are recommended.
+memory: 4GiB
+cpus: 4
+arch: aarch64
+
+# Fedora 40+ is preferred because of better support for MESA & Vulkan,
+# which is good for GPU acceleration and AI workloads
+base:
+- template://_images/fedora
+- template://_default/mounts
+
+mountType: virtiofs
+
+vmOpts:
+  krunkit:
+    gpuAccel: true

--- a/website/content/en/docs/config/vmtype/krunkit.md
+++ b/website/content/en/docs/config/vmtype/krunkit.md
@@ -1,0 +1,88 @@
+---
+title: Krunkit
+weight: 4
+---
+
+> Warning
+> "krunkit" is experimental
+
+| ⚡ Requirement | Lima >= 2.0, macOS >= 13 (Ventura+), Apple Silicon (arm64) |
+| ------------- | ----------------------------------------------------------- |
+
+Krunkit runs super‑light VMs on macOS/ARM64 with a focus on GPU access. It builds on [libkrun](https://github.com/containers/libkrun), a library that embeds a VMM so apps can launch processes in a hardware‑isolated VM (HVF on macOS, KVM on Linux). The standout feature is GPU support in the guest via Mesa’s Venus Vulkan driver ([venus](https://docs.mesa3d.org/drivers/venus.html)), enabling Vulkan workloads inside the VM. See the project: [containers/krunkit](https://github.com/containers/krunkit).
+
+## Install krunkit (host)
+```bash
+brew tap slp/krunkit
+brew install krunkit
+```
+For reference: https://github.com/slp/homebrew-krun
+
+
+## Using the driver with Lima
+Build the driver binary and point Lima to it. See also [Virtual Machine Drivers](../../dev/drivers).
+
+```bash
+git clone https://github.com/lima-vm/lima && cd lima
+
+# From the Lima source tree
+# <PREFIX> is your installation prefix. With Homebrew, use: $(brew --prefix)
+go build -o <PREFIX>/libexec/lima/lima-driver-krunkit ./cmd/lima-driver-krunkit/main_darwin_arm64.go
+limactl info   # "vmTypes" should include "krunkit"
+```
+
+
+## Quick start
+
+- Non‑GPU (general workloads)
+```bash
+limactl start default --vm-type=krunkit
+```
+
+- GPU (Vulkan via Venus)
+  - Recommended distro: Fedora 40+ (smoothest Mesa/Vulkan setup; uses COPR “slp/mesa-krunkit” for patched mesa-vulkan-drivers).
+  - Start from the krunkit template and follow the logs to complete GPU setup.
+
+{{< tabpane text=true >}}
+{{% tab header="CLI" %}}
+```bash
+# GPU (Vulkan via Venus on Fedora)
+limactl start template:experimental/krunkit
+```
+{{% /tab %}}
+{{% tab header="YAML" %}}
+```yaml
+vmType: krunkit
+
+# For AI workloads, at least 4GiB memory and 4 CPUs are recommended.
+memory: 4GiB
+cpus: 4
+arch: aarch64
+
+# Fedora 40+ is preferred for Mesa & Vulkan (Venus) support
+base:
+- template://_images/fedora
+
+mounts:
+- location: "~"
+  writable: true
+
+mountType: virtiofs
+
+vmOpts:
+  krunkit:
+    gpuAccel: true
+```
+{{% /tab %}}
+{{< /tabpane >}}
+
+After the VM is READY, inside the VM:
+```bash
+sudo install-vulkan-gpu.sh
+```
+
+## Notes and caveats
+- macOS Ventura or later on Apple Silicon is required.
+- GPU mode requires a Fedora image/template; Fedora 40+ recommended for Mesa/Vulkan (Venus).
+- To verify GPU/Vulkan in the guest, use tools like `vulkaninfo` after running the install script.
+- Driver architecture details: see [Virtual Machine Drivers](../../dev/drivers).


### PR DESCRIPTION
This PR adds support for [libkrun](https://github.com/containers/libkrun) using their [krunkit](https://github.com/containers/krunkit) CLI, a dynamic library that enables programs to run processes in lightweight, isolated environments using KVM virtualization on Linux and HVF on macOS/ARM64. The key feature is to access GPU via Vulkan(Venus) inside the VM.

### Implementation Details
- **Networking:** Network connectivity is established using `gvisor-tap-vsock` for slirp functionality. Additional support for `userv2`, `shared`, and `bridged` networking modes is also included.

- **File Sharing:** `virtiofs` is implemented for high-performance file sharing between the host and the guest VM.

- **Guest-Host Agent Communication:** Host-to-guest agent communication currently relies on ssh. There exists a krunkit bug (see containers/krunkit#79) that fails to create the necessary Unix socket file for virtio-vsock communication.

### GPU Acceleration (Venus) and OS Recommendation
A primary usecase for this integration is to support GPU-accelerated VMs via krunkit, which uses the Venus driver to provide guest-side Vulkan API access. While krunkit can boot the default Ubuntu Lima template, full GPU (Vulkan) acceleration will be unavailable. This is because a specific version of Mesa is required, which is not easily available on Ubuntu.
**_Fedora 40+ is the recommended as the guest OS for this feature because of patched Mesa Drivers._**
Using COPR avoids the complex and error-prone process of manually compiling Mesa from source, which would be required on other systems.

### GPU Provisioning
A provisioning script is included to set up the GPU drivers inside the guest VM. This script must be run manually by the user after the VM boots using `sudo install_vulkan_gpu.sh`. It is not run automatically during startup as the process adds a significant delay to the boot time.

<details><summary>Fedora boot</summary>
<p>

`Lima logs:`
```zsh
➜  lima2 git:(driver/krun) ✗ lm start template:experimental/krunkit
WARN[0000] Template locator "template://_images/fedora" should be written "template:_images/fedora" since Lima v2.0 
? Creating an instance "krunkit" Proceed with the current configuration
INFO[0000] Starting the instance "krunkit" with external VM driver "krunkit" 
INFO[0000] Attempting to download the image              arch=aarch64 digest="sha256:e10658419a8d50231037dc781c3155aa94180a8c7a74e5cac2a6b09eaa9342b7" location="https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-42-1.1.aarch64.qcow2"
INFO[0000] Using cache "/Users/ansumansahoo/Library/Caches/lima/download/by-url-sha256/00425856146573364f10307e5a719b2ef77636bfe0424c3edf90115f305224cf/data" 
INFO[0002] Attempting to download the nerdctl archive    arch=aarch64 digest="sha256:2f98346ed3dcaf47cfd6461a5685e582284329a1ece1d952ade881b9fe7491e8" location="https://github.com/containerd/nerdctl/releases/download/v2.1.6/nerdctl-full-2.1.6-linux-arm64.tar.gz"
INFO[0002] Using cache "/Users/ansumansahoo/Library/Caches/lima/download/by-url-sha256/d82077f1308e8d063805c4c1f761e1c3fd636e18cab7e25919a18e7a0838afa2/data" 
INFO[0002] [hostagent] hostagent socket created at /Users/ansumansahoo/.lima/krunkit/ha.sock 
INFO[0003] SSH Local Port: 60263                        
INFO[0002] [hostagent] Waiting for the essential requirement 1 of 3: "ssh" 
INFO[0012] [hostagent] Waiting for the essential requirement 1 of 3: "ssh" 
INFO[0013] [hostagent] The essential requirement 1 of 3 is satisfied 
INFO[0013] [hostagent] Waiting for the essential requirement 2 of 3: "user session is ready for ssh" 
INFO[0013] [hostagent] The essential requirement 2 of 3 is satisfied 
INFO[0013] [hostagent] Waiting for the essential requirement 3 of 3: "Explicitly start ssh ControlMaster" 
INFO[0013] [hostagent] The essential requirement 3 of 3 is satisfied 
INFO[0013] [hostagent] Waiting for the optional requirement 1 of 2: "systemd must be available" 
INFO[0013] [hostagent] Forwarding "/run/lima-guestagent.sock" (guest) to "/Users/ansumansahoo/.lima/krunkit/ga.sock" (host) 
INFO[0014] [hostagent] time="2025-10-29T02:57:01+05:30" level=info msg="Getting guest agent connection" 
INFO[0013] [hostagent] Guest agent is running           
INFO[0013] [hostagent] Forwarding TCP from 0.0.0.0:5355 to 127.0.0.1:5355 
INFO[0013] [hostagent] The optional requirement 1 of 2 is satisfied 
INFO[0013] [hostagent] Not forwarding TCP 127.0.0.54:53 
INFO[0013] [hostagent] Not forwarding TCP 127.0.0.53:53 
INFO[0013] [hostagent] Waiting for the optional requirement 2 of 2: "containerd binaries to be installed" 
INFO[0013] [hostagent] Not forwarding TCP 0.0.0.0:22    
INFO[0013] [hostagent] Forwarding TCP from [::]:5355 to 127.0.0.1:5355 
INFO[0013] [hostagent] Not forwarding TCP [::]:22       
ERRO[0013] [hostagent] failed to listen tcp: listen tcp 127.0.0.1:5355: bind: address already in use 
INFO[0013] [hostagent] Forwarding UDP from 0.0.0.0:5355 to 127.0.0.1:5355 
INFO[0013] [hostagent] Not forwarding UDP 127.0.0.54:53 
ERRO[0013] [hostagent] failed to listen to TCP connection: listen tcp 127.0.0.1:5355: bind: address already in use 
INFO[0013] [hostagent] Not forwarding UDP 127.0.0.53:53 
INFO[0013] [hostagent] Forwarding UDP from 127.0.0.1:323 to 127.0.0.1:323 
INFO[0013] [hostagent] Forwarding UDP from [::]:5355 to 127.0.0.1:5355 
INFO[0013] [hostagent] Forwarding UDP from [::1]:323 to 127.0.0.1:323 
ERRO[0013] [hostagent] failed to listen udp: listen udp 127.0.0.1:5355: bind: address already in use 
ERRO[0013] [hostagent] failed to listen udp: listen udp 127.0.0.1:5355: bind: address already in use 
ERRO[0013] [hostagent] failed to listen udp: listen udp 0.0.0.0:323: bind: address already in use 
ERRO[0013] [hostagent] failed to listen udp: listen udp 0.0.0.0:323: bind: address already in use 
INFO[0019] [hostagent] The optional requirement 2 of 2 is satisfied 
INFO[0019] [hostagent] Waiting for the guest agent to be running 
INFO[0019] [hostagent] Waiting for the final requirement 1 of 1: "boot scripts must have finished" 
INFO[0020] [hostagent] Forwarding TCP from 127.0.0.1:35945 to 127.0.0.1:35945 
INFO[0031] [hostagent] The final requirement 1 of 1 is satisfied 
INFO[0032] READY. Run `limactl shell krunkit` to open the shell. 
INFO[0032] Message from the instance "krunkit":         
To enable GPU support for krunkit, run the following command inside the VM:
sudo install_vulkan_gpu.sh
```

`Venus support inside VM:`
```zsh
ansumansahoo@lima-krunkit lima2]$ vulkaninfo --summary
WARNING: [Loader Message] Code 0 : Layer VK_LAYER_MESA_device_select uses API version 1.3 which is older than the application specified API version of 1.4. May cause issues.
'DISPLAY' environment variable not set... skipping surface info
ERROR: [../src/panfrost/vulkan/panvk_physical_device.c:608] Code 0 : WARNING: panvk is not a conformant vulkan implementation, pass PAN_I_WANT_A_BROKEN_VULKAN_DRIVER=1 if you know what you're doing. (VK_ERROR_INCOMPATIBLE_DRIVER)
==========
VULKANINFO
==========

Vulkan Instance Version: 1.4.313


Instance Extensions: count = 24
-------------------------------
VK_EXT_acquire_drm_display             : extension revision 1
VK_EXT_acquire_xlib_display            : extension revision 1
VK_EXT_debug_report                    : extension revision 10
VK_EXT_debug_utils                     : extension revision 2
VK_EXT_direct_mode_display             : extension revision 1
VK_EXT_display_surface_counter         : extension revision 1
VK_EXT_headless_surface                : extension revision 1
VK_EXT_surface_maintenance1            : extension revision 1
VK_EXT_swapchain_colorspace            : extension revision 4
VK_KHR_device_group_creation           : extension revision 1
VK_KHR_display                         : extension revision 23
VK_KHR_external_fence_capabilities     : extension revision 1
VK_KHR_external_memory_capabilities    : extension revision 1
VK_KHR_external_semaphore_capabilities : extension revision 1
VK_KHR_get_display_properties2         : extension revision 1
VK_KHR_get_physical_device_properties2 : extension revision 2
VK_KHR_get_surface_capabilities2       : extension revision 1
VK_KHR_portability_enumeration         : extension revision 1
VK_KHR_surface                         : extension revision 25
VK_KHR_surface_protected_capabilities  : extension revision 1
VK_KHR_wayland_surface                 : extension revision 6
VK_KHR_xcb_surface                     : extension revision 6
VK_KHR_xlib_surface                    : extension revision 6
VK_LUNARG_direct_driver_loading        : extension revision 1

Instance Layers: count = 1
--------------------------
VK_LAYER_MESA_device_select Linux device selection layer 1.3.211  version 1

Devices:
========
GPU0:
        apiVersion         = 1.2.0
        driverVersion      = 24.1.5
        vendorID           = 0x106b
        deviceID           = 0xf060207
        deviceType         = PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
        deviceName         = Virtio-GPU Venus (Apple M1)
        driverID           = DRIVER_ID_MESA_VENUS
        driverName         = venus
        driverInfo         = Mesa 24.1.5
        conformanceVersion = 1.3.0.0
        deviceUUID         = 47063303-a64b-0845-3bf5-01d1daa8649b
        driverUUID         = 05a3cceb-1991-3628-23bd-764bdc583f20
GPU1:
        apiVersion         = 1.3.278
        driverVersion      = 0.0.1
        vendorID           = 0x10005
        deviceID           = 0x0000
        deviceType         = PHYSICAL_DEVICE_TYPE_CPU
        deviceName         = llvmpipe (LLVM 18.1.6, 128 bits)
        driverID           = DRIVER_ID_MESA_LLVMPIPE
        driverName         = llvmpipe
        driverInfo         = Mesa 24.1.5 (LLVM 18.1.6)
        conformanceVersion = 1.3.1.1
        deviceUUID         = 6d657361-3234-2e31-2e35-000000000000
        driverUUID         = 6c6c766d-7069-7065-5555-494400000000
```
</p>
</details> 

<details><summary>Ubuntu boot</summary>
<p>

`Lima logs:`
```zsh
➜  lima2 git:(driver/krun) lm start default --vm-type=krunkit    
WARN[0000] Template locator "template://_images/ubuntu" should be written "template:_images/ubuntu" since Lima v2.0 
WARN[0000] Template locator "template://_default/mounts" should be written "template:_default/mounts" since Lima v2.0 
? Creating an instance "default" Proceed with the current configuration
INFO[0002] Starting the instance "default" with external VM driver "krunkit" 
INFO[0002] Attempting to download the image              arch=aarch64 digest="sha256:a7b84e640e4dd1f1de036653fbdc18dc0600b5293e89c0958fc7de507c550cca" location="https://cloud-images.ubuntu.com/releases/questing/release-20251007/ubuntu-25.10-server-cloudimg-arm64.img"
INFO[0002] Using cache "/Users/ansumansahoo/Library/Caches/lima/download/by-url-sha256/39f3c49d722d2c017f53b829658abcd810fcb283b1265cfc8125b6aeceedda85/data" 
INFO[0006] Attempting to download the nerdctl archive    arch=aarch64 digest="sha256:2f98346ed3dcaf47cfd6461a5685e582284329a1ece1d952ade881b9fe7491e8" location="https://github.com/containerd/nerdctl/releases/download/v2.1.6/nerdctl-full-2.1.6-linux-arm64.tar.gz"
INFO[0006] Using cache "/Users/ansumansahoo/Library/Caches/lima/download/by-url-sha256/d82077f1308e8d063805c4c1f761e1c3fd636e18cab7e25919a18e7a0838afa2/data" 
INFO[0006] [hostagent] hostagent socket created at /Users/ansumansahoo/.lima/default/ha.sock 
INFO[0007] SSH Local Port: 60989                        
INFO[0006] [hostagent] Waiting for the essential requirement 1 of 3: "ssh" 
INFO[0016] [hostagent] Waiting for the essential requirement 1 of 3: "ssh" 
INFO[0019] [hostagent] The essential requirement 1 of 3 is satisfied 
INFO[0019] [hostagent] Waiting for the essential requirement 2 of 3: "user session is ready for ssh" 
INFO[0019] [hostagent] The essential requirement 2 of 3 is satisfied 
INFO[0019] [hostagent] Waiting for the essential requirement 3 of 3: "Explicitly start ssh ControlMaster" 
INFO[0019] [hostagent] The essential requirement 3 of 3 is satisfied 
INFO[0019] [hostagent] Waiting for the optional requirement 1 of 2: "systemd must be available" 
INFO[0019] [hostagent] Forwarding "/run/lima-guestagent.sock" (guest) to "/Users/ansumansahoo/.lima/default/ga.sock" (host) 
INFO[0020] [hostagent] time="2025-10-29T04:00:52+05:30" level=info msg="Getting guest agent connection" 
INFO[0019] [hostagent] The optional requirement 1 of 2 is satisfied 
INFO[0019] [hostagent] Waiting for the optional requirement 2 of 2: "containerd binaries to be installed" 
INFO[0019] [hostagent] Guest agent is running           
INFO[0019] [hostagent] Not forwarding TCP 0.0.0.0:22    
INFO[0019] [hostagent] Not forwarding TCP 127.0.0.53:53 
INFO[0019] [hostagent] Not forwarding TCP 127.0.0.54:53 
INFO[0019] [hostagent] Not forwarding TCP [::]:22       
INFO[0019] [hostagent] Not forwarding UDP 127.0.0.54:53 
INFO[0019] [hostagent] Not forwarding UDP 127.0.0.53:53 
INFO[0019] [hostagent] Not forwarding UDP 192.168.5.15:68 
INFO[0019] [hostagent] Forwarding UDP from 127.0.0.1:323 to 127.0.0.1:323 
INFO[0019] [hostagent] Forwarding UDP from [::1]:323 to 127.0.0.1:323 
ERRO[0019] [hostagent] failed to listen udp: listen udp 0.0.0.0:323: bind: address already in use 
ERRO[0019] [hostagent] failed to listen udp: listen udp 0.0.0.0:323: bind: address already in use 
ERRO[0019] [hostagent] failed to listen udp: listen udp 0.0.0.0:323: bind: address already in use 
ERRO[0019] [hostagent] failed to listen udp: listen udp 0.0.0.0:323: bind: address already in use 
INFO[0049] [hostagent] Forwarding TCP from 127.0.0.1:44421 to 127.0.0.1:44421 
INFO[0059] [hostagent] Waiting for the optional requirement 2 of 2: "containerd binaries to be installed" 
INFO[0059] [hostagent] The optional requirement 2 of 2 is satisfied 
INFO[0059] [hostagent] Waiting for the guest agent to be running 
INFO[0059] [hostagent] Waiting for the final requirement 1 of 1: "boot scripts must have finished" 
INFO[0059] [hostagent] The final requirement 1 of 1 is satisfied 
INFO[0060] READY. Run `lima` to open the shell. 
```

`Venus support inside VM:`

```zsh
ansumansahoo@lima-default:/Users/ansumansahoo/Documents/GOLANG/lima2$ vulkaninfo --summary
'DISPLAY' environment variable not set... skipping surface info
WARNING: [../src/asahi/vulkan/hk_physical_device.c:1147] Code 0 : failed to open device /dev/dri/renderD128 (VK_ERROR_INCOMPATIBLE_DRIVER)
WARNING: [../src/panfrost/vulkan/panvk_physical_device.c:74] Code 0 : failed to open device /dev/dri/renderD128 (VK_ERROR_INCOMPATIBLE_DRIVER)
TU: error: ../src/freedreno/vulkan/tu_knl.cc:387: failed to open device /dev/dri/renderD128 (VK_ERROR_INCOMPATIBLE_DRIVER)
MESA: error: Opening /dev/dri/renderD128 failed: Permission denied
==========
VULKANINFO
==========

Vulkan Instance Version: 1.4.321


Instance Extensions: count = 24
-------------------------------
VK_EXT_acquire_drm_display             : extension revision 1
VK_EXT_acquire_xlib_display            : extension revision 1
VK_EXT_debug_report                    : extension revision 10
VK_EXT_debug_utils                     : extension revision 2
VK_EXT_direct_mode_display             : extension revision 1
VK_EXT_display_surface_counter         : extension revision 1
VK_EXT_headless_surface                : extension revision 1
VK_EXT_surface_maintenance1            : extension revision 1
VK_EXT_swapchain_colorspace            : extension revision 5
VK_KHR_device_group_creation           : extension revision 1
VK_KHR_display                         : extension revision 23
VK_KHR_external_fence_capabilities     : extension revision 1
VK_KHR_external_memory_capabilities    : extension revision 1
VK_KHR_external_semaphore_capabilities : extension revision 1
VK_KHR_get_display_properties2         : extension revision 1
VK_KHR_get_physical_device_properties2 : extension revision 2
VK_KHR_get_surface_capabilities2       : extension revision 1
VK_KHR_portability_enumeration         : extension revision 1
VK_KHR_surface                         : extension revision 25
VK_KHR_surface_protected_capabilities  : extension revision 1
VK_KHR_wayland_surface                 : extension revision 6
VK_KHR_xcb_surface                     : extension revision 6
VK_KHR_xlib_surface                    : extension revision 6
VK_LUNARG_direct_driver_loading        : extension revision 1

Instance Layers: count = 3
--------------------------
VK_LAYER_INTEL_nullhw       INTEL NULL HW                1.1.73   version 1
VK_LAYER_MESA_device_select Linux device selection layer 1.4.303  version 1
VK_LAYER_MESA_overlay       Mesa Overlay layer           1.4.303  version 1

Devices:
========
GPU0:
        apiVersion         = 1.4.318
        driverVersion      = 25.2.3
        vendorID           = 0x10005
        deviceID           = 0x0000
        deviceType         = PHYSICAL_DEVICE_TYPE_CPU
        deviceName         = llvmpipe (LLVM 20.1.8, 128 bits)
        driverID           = DRIVER_ID_MESA_LLVMPIPE
        driverName         = llvmpipe
        driverInfo         = Mesa 25.2.3-1ubuntu1 (LLVM 20.1.8)
        conformanceVersion = 1.3.1.1
        deviceUUID         = 6d657361-3235-2e32-2e33-2d3175627500
        driverUUID         = 6c6c766d-7069-7065-5555-494400000000

```
</p>
</details> 