### PR TITLE
CI: split the BATS tests into a separate job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -301,11 +301,6 @@ jobs:
         - ../hack/test-templates/test-misc.yaml  # TODO: merge net-user-v2 into test-misc
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
-      with:
-        # BATS tests don't expect lima version warnings like:
-        # msg="treating lima version \"ea336ae\" from \"/Users/runner/.lima-bats/dummy/lima-version\" as very latest release"
-        fetch-depth: 0
-        submodules: true
     - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
       with:
         go-version: 1.25.x
@@ -324,9 +319,6 @@ jobs:
         sudo modprobe kvm
         # `sudo usermod -aG kvm $(whoami)` does not take an effect on GHA
         sudo chown $(whoami) /dev/kvm
-    - name: "Run BATS integration tests"
-      run: make bats
-      if: matrix.template == '../hack/test-templates/test-misc.yaml'
     - name: Install ansible-playbook
       run: |
         sudo apt-get install -y --no-install-recommends ansible
@@ -346,6 +338,38 @@ jobs:
         suffix: ${{ matrix.template }}
     - name: "Show cache"
       run: ./hack/debug-cache.sh
+
+  bats:
+    name: "Integration tests (BATS)"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      with:
+        # BATS tests don't expect lima version warnings like:
+        # msg="treating lima version \"ea336ae\" from \"/Users/runner/.lima-bats/dummy/lima-version\" as very latest release"
+        fetch-depth: 0
+        submodules: true
+    - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+      with:
+        go-version: 1.25.x
+    - name: Make
+      run: make
+    - name: Install
+      run: sudo make install
+    - name: Install test dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends ovmf qemu-system-x86 qemu-utils
+        sudo modprobe kvm
+        # `sudo usermod -aG kvm $(whoami)` does not take an effect on GHA
+        sudo chown $(whoami) /dev/kvm
+    - name: Cache image used by templates/default.yaml
+      uses: ./.github/actions/setup_cache_for_template
+      with:
+        template: templates/default.yaml
+    - name: "Run BATS integration tests"
+      run: make bats
 
   colima:
     name: "Colima tests (QEMU, Linux host)"


### PR DESCRIPTION
The BATS tests should not be associated with `test-misc.yaml`.