### PR TITLE
Early flags check before "PersistentPreRunE"

### DIFF
--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -125,6 +125,7 @@ func newApp() *cobra.Command {
 	// TODO: "survey" does not support using cygwin terminal on windows yet
 	rootCmd.PersistentFlags().Bool("tty", isatty.IsTerminal(os.Stdout.Fd()), "Enable TUI interactions such as opening an editor. Defaults to true when stdout is a terminal. Set to false for automation.")
 	rootCmd.PersistentFlags().BoolP("yes", "y", false, "Alias of --tty=false")
+	rootCmd.MarkFlagsMutuallyExclusive("tty", "yes")
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
 		if err := processGlobalFlags(rootCmd); err != nil {
 			return err
@@ -148,10 +149,6 @@ func newApp() *cobra.Command {
 		}
 		if nfs {
 			return errors.New("must not run on NFS dir")
-		}
-
-		if cmd.Flags().Changed("yes") && cmd.Flags().Changed("tty") {
-			return errors.New("cannot use both --tty and --yes flags at the same time")
 		}
 
 		if cmd.Flags().Changed("yes") {


### PR DESCRIPTION
## Summary
Utilize Cobra's "MarkFlagsMutuallyExclusive()" on root command. This shifts validation to flag parsing and remove the manual check from "PersistentPreRunE", which can be applied to all subcommands before hooks fire.

## Test
Simple manual test:
```
$ limactl start --tty --yes
FATA[0000] if any flags in the group [tty yes] are set none of the others can be; [tty yes] were all set
```

## Reference
* [MarkFlagsMutuallyExclusive()](https://pkg.go.dev/github.com/spf13/cobra#Command.MarkFlagsMutuallyExclusive)