### PR TITLE
pkg/portfwd: Remove `SO_REUSEPORT`

### DIFF
--- a/pkg/portfwd/control_others.go
+++ b/pkg/portfwd/control_others.go
@@ -17,11 +17,6 @@ func Control(_, _ string, c syscall.RawConn) (err error) {
 		if err != nil {
 			return
 		}
-
-		err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
-		if err != nil {
-			return
-		}
 	})
 	if controlErr != nil {
 		err = controlErr


### PR DESCRIPTION
Since we’re using a single accepting go routine on the port forwarder’s listener, `SO_REUSEPORT` is unnecessary.

Applying this change prevents the port forwarder from binding if the listening port is already listened by another process with `SO_REUSEPORT`, resulting in a "bind: address already in use" error.

Previously, if the listening port was listened by another process with `SO_REUSEPORT`, the port forwarder succeeded in binding, but the client’s connection could be handled by another process, leading to port forwarding issues without errors.