### PR TITLE
CI: run spell checks for doc-only PRs too

### DIFF
--- a/.github/workflows/spell.yml
+++ b/.github/workflows/spell.yml
@@ -1,0 +1,22 @@
+# split from test.yml so as to run spell checks for doc-only PRs too
+name: spell
+
+on:
+  push:
+    branches:
+    - master
+    - 'release/**'
+  pull_request:
+
+jobs:
+  spell:
+    name: "Spell check"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630  # v2.1
+      with:
+        check_filenames: true
+        check_hidden: true
+        # by default, codespell uses configuration from the .codespellrc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,18 +101,6 @@ jobs:
     steps:
     - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee  # v1.0.4
 
-  spell:
-    name: "Spell check"
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
-    - uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630  # v2.1
-      with:
-        check_filenames: true
-        check_hidden: true
-        # by default, codespell uses configuration from the .codespellrc
-
   unit:
     name: "Unit tests"
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Spell checks were skipped for doc-only PRs, as test.yml is ignored for doc-only PRs.