### PR TITLE
Remove deprecated Opts from limayaml

### DIFF
--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -449,11 +449,7 @@ func defaultCPUType() limatype.CPUType {
 func resolveCPUType(y *limatype.LimaYAML) string {
 	cpuType := defaultCPUType()
 	var overrideCPUType bool
-	var qemuOpts limatype.QEMUOpts
-	if err := limayaml.Convert(y.VMOpts[limatype.QEMU], &qemuOpts, "vmOpts.qemu"); err != nil {
-		logrus.WithError(err).Warnf("Couldn't convert %q", y.VMOpts[limatype.QEMU])
-	}
-	for k, v := range qemuOpts.CPUType {
+	for k, v := range CPUType {
 		if !slices.Contains(limatype.ArchTypes, *y.Arch) {
 			logrus.Warnf("field `vmOpts.qemu.cpuType` uses unsupported arch %q", k)
 			continue
@@ -464,11 +460,7 @@ func resolveCPUType(y *limatype.LimaYAML) string {
 		}
 	}
 	if overrideCPUType {
-		qemuOpts.CPUType = cpuType
-		if y.VMOpts == nil {
-			y.VMOpts = limatype.VMOpts{}
-		}
-		y.VMOpts[limatype.QEMU] = qemuOpts
+		CPUType = cpuType
 	}
 
 	return cpuType[*y.Arch]
@@ -498,12 +490,8 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 		if version.LessThan(softMin) {
 			logrus.Warnf("QEMU %v is too old, %v or later is recommended", version, softMin)
 		}
-		var qemuOpts limatype.QEMUOpts
-		if err := limayaml.Convert(y.VMOpts[limatype.QEMU], &qemuOpts, "vmOpts.qemu"); err != nil {
-			logrus.WithError(err).Warnf("Couldn't convert %q", y.VMOpts[limatype.QEMU])
-		}
-		if qemuOpts.MinimumVersion != nil && version.LessThan(*semver.New(*qemuOpts.MinimumVersion)) {
-			logrus.Fatalf("QEMU %v is too old, template requires %q or later", version, *qemuOpts.MinimumVersion)
+		if MinimumVersion != nil && version.LessThan(*semver.New(*MinimumVersion)) {
+			logrus.Fatalf("QEMU %v is too old, template requires %q or later", version, *MinimumVersion)
 		}
 	}
 

--- a/pkg/driver/vz/vm_darwin.go
+++ b/pkg/driver/vz/vm_darwin.go
@@ -602,12 +602,7 @@ func attachFolderMounts(inst *limatype.Instance, vmConfig *vz.VirtualMachineConf
 		}
 	}
 
-	var vzOpts limatype.VZOpts
-	if err := limayaml.Convert(inst.Config.VMOpts[limatype.VZ], &vzOpts, "vmOpts.vz"); err != nil {
-		logrus.WithError(err).Warnf("Couldn't convert %q", inst.Config.VMOpts[limatype.VZ])
-	}
-
-	if vzOpts.Rosetta.Enabled != nil && *vzOpts.Rosetta.Enabled {
+	if RosettaEnabled != nil && *RosettaEnabled {
 		logrus.Info("Setting up Rosetta share")
 		directorySharingDeviceConfig, err := createRosettaDirectoryShareConfiguration()
 		if err != nil {

--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -71,6 +71,16 @@ var knownYamlProperties = []string{
 
 const Enabled = true
 
+type Opts struct {
+	Rosetta limatype.Rosetta `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
+}
+
+// TODO: move from globals to Config.
+var (
+	RosettaEnabled *bool
+	RosettaBinFmt  *bool
+)
+
 type LimaVzDriver struct {
 	Instance *limatype.Instance
 
@@ -108,7 +118,7 @@ func (l *LimaVzDriver) Configure(inst *limatype.Instance) *driver.ConfiguredDriv
 		}
 	}
 
-	var vzOpts limatype.VZOpts
+	var vzOpts Opts
 	if l.Instance.Config.VMOpts[limatype.VZ] != nil {
 		if err := limayaml.Convert(l.Instance.Config.VMOpts[limatype.VZ], &vzOpts, "vmOpts.vz"); err != nil {
 			logrus.WithError(err).Warnf("Couldn't convert %q", l.Instance.Config.VMOpts[limatype.VZ])
@@ -138,7 +148,7 @@ func (l *LimaVzDriver) FillConfig(ctx context.Context, cfg *limatype.LimaYAML, _
 		cfg.MountType = ptr.Of(limatype.VIRTIOFS)
 	}
 
-	var vzOpts limatype.VZOpts
+	var vzOpts Opts
 	if err := limayaml.Convert(cfg.VMOpts[limatype.VZ], &vzOpts, "vmOpts.vz"); err != nil {
 		logrus.WithError(err).Warnf("Couldn't convert %q", cfg.VMOpts[limatype.VZ])
 	}
@@ -168,6 +178,9 @@ func (l *LimaVzDriver) FillConfig(ctx context.Context, cfg *limatype.LimaYAML, _
 		cfg.VMOpts = limatype.VMOpts{}
 	}
 	cfg.VMOpts[limatype.VZ] = opts
+
+	RosettaEnabled = vzOpts.Rosetta.Enabled
+	RosettaBinFmt = vzOpts.Rosetta.BinFmt
 
 	return validateConfig(ctx, cfg)
 }

--- a/pkg/limatmpl/embed.go
+++ b/pkg/limatmpl/embed.go
@@ -18,6 +18,7 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/sirupsen/logrus"
 
+	"github.com/lima-vm/lima/v2/pkg/driver/qemu"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
@@ -180,11 +181,11 @@ func (tmpl *Template) mergeBase(base *Template) error {
 			tmpl.copyField(minimumLimaVersion, minimumLimaVersion)
 		}
 	}
-	var tmplOpts limatype.QEMUOpts
+	var tmplOpts qemu.Opts
 	if err := limayaml.Convert(tmpl.Config.VMOpts[limatype.QEMU], &tmplOpts, "vmOpts.qemu"); err != nil {
 		return err
 	}
-	var baseOpts limatype.QEMUOpts
+	var baseOpts qemu.Opts
 	if err := limayaml.Convert(base.Config.VMOpts[limatype.QEMU], &baseOpts, "vmOpts.qemu"); err != nil {
 		return err
 	}

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -73,6 +73,7 @@ type (
 	VMType    = string
 )
 
+// Deprecated: qemu driver internal
 type CPUType = map[Arch]string
 
 const (
@@ -112,15 +113,7 @@ type User struct {
 
 type VMOpts map[VMType]any
 
-type QEMUOpts struct {
-	MinimumVersion *string `yaml:"minimumVersion,omitempty" json:"minimumVersion,omitempty" jsonschema:"nullable"`
-	CPUType        CPUType `yaml:"cpuType,omitempty" json:"cpuType,omitempty" jsonschema:"nullable"`
-}
-
-type VZOpts struct {
-	Rosetta Rosetta `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
-}
-
+// Deprecated: vz driver internal
 type Rosetta struct {
 	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty" jsonschema:"nullable"`
 	BinFmt  *bool `yaml:"binfmt,omitempty" json:"binfmt,omitempty" jsonschema:"nullable"`

--- a/pkg/limayaml/marshal_test.go
+++ b/pkg/limayaml/marshal_test.go
@@ -86,41 +86,6 @@ vmType: null
 	t.Log(dumpYAML(t, o))
 }
 
-func TestQEMUOpts(t *testing.T) {
-	text := `
-vmType: "qemu"
-vmOpts:
-  qemu:
-    minimumVersion: null
-    cpuType:
-`
-	var y limatype.LimaYAML
-	err := Unmarshal([]byte(text), &y, "lima.yaml")
-	assert.NilError(t, err)
-	var o limatype.QEMUOpts
-	err = Convert(y.VMOpts[limatype.QEMU], &o, "vmOpts.qemu")
-	assert.NilError(t, err)
-	t.Log(dumpYAML(t, o))
-}
-
-func TestVZOpts(t *testing.T) {
-	text := `
-vmType: "vz"
-vmOpts:
-  vz:
-    rosetta:
-      enabled: null
-      binfmt: null
-`
-	var y limatype.LimaYAML
-	err := Unmarshal([]byte(text), &y, "lima.yaml")
-	assert.NilError(t, err)
-	var o limatype.VZOpts
-	err = Convert(y.VMOpts[limatype.VZ], &o, "vmOpts.vz")
-	assert.NilError(t, err)
-	t.Log(dumpYAML(t, o))
-}
-
 func TestVMOptsNull(t *testing.T) {
 	text := `
 vmOpts: null
@@ -130,12 +95,6 @@ vmOpts: null
 	assert.NilError(t, err)
 	var o limatype.VMOpts
 	err = Convert(y.VMOpts, &o, "vmOpts")
-	assert.NilError(t, err)
-	var oq limatype.QEMUOpts
-	err = Convert(y.VMOpts[limatype.QEMU], &oq, "vmOpts.qemu")
-	assert.NilError(t, err)
-	var ov limatype.VZOpts
-	err = Convert(y.VMOpts[limatype.VZ], &ov, "vmOpts.vz")
 	assert.NilError(t, err)
 }
 


### PR DESCRIPTION
Also remove the knowledge of the yaml structures
from the internal VM class, and make it use Config.

Follow-up from:
* #3899