### PR TITLE
The main containerd config is soon version 3

### DIFF
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -63,20 +63,20 @@ provision:
     #!/bin/bash
     set -eux -o pipefail
     [ -e /etc/containerd/conf.d/k8s.toml ] && exit 0
-    grep "version = 2" /etc/containerd/config.toml || exit 1
     mkdir -p /etc/containerd/conf.d
     # Configuring the systemd cgroup driver
     # Overriding the sandbox (pause) image
-    cat <<EOF >>/etc/containerd/conf.d/k8s.toml
-      [plugins]
-        [plugins."io.containerd.grpc.v1.cri"]
-          sandbox_image = "$(kubeadm config images list | grep pause | sort -r | head -n1)"
-          [plugins."io.containerd.grpc.v1.cri".containerd]
-            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-                runtime_type = "io.containerd.runc.v2"
-                [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-                  SystemdCgroup = true
+    cat <<EOF >/etc/containerd/conf.d/k8s.toml
+    version = 2
+    [plugins]
+      [plugins."io.containerd.grpc.v1.cri"]
+        sandbox_image = "$(kubeadm config images list | grep pause | sort -r | head -n1)"
+        [plugins."io.containerd.grpc.v1.cri".containerd]
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+              runtime_type = "io.containerd.runc.v2"
+              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+                SystemdCgroup = true
     EOF
     systemctl restart containerd
 # See <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/>


### PR DESCRIPTION
Also the indent of the config was too much

----

The configuration was not read, because it used the old config for config version 2 (it is now config version 3)

The configuration is automatically updated from the old version, so we can use the same as the upstream docs:

https://kubernetes.io/docs/setup/production-environment/container-runtimes/#containerd

* https://github.com/kubernetes/website/issues/48976

----

It is a very minor difference in "pause" versions and it only mattered for Windows, and then systemd...

```diff
@@ -47,7 +47,7 @@
     use_local_image_pull = false
 
     [plugins.'io.containerd.cri.v1.images'.pinned_images]
-      sandbox = 'registry.k8s.io/pause:3.10'
+      sandbox = 'registry.k8s.io/pause:3.10.1'
 
     [plugins.'io.containerd.cri.v1.images'.registry]
       config_path = ''
@@ -105,6 +105,7 @@
             NoNewKeyring = false
             Root = ''
             ShimCgroup = ''
+            SystemdCgroup = true
 
     [plugins.'io.containerd.cri.v1.runtime'.cni]
       bin_dir = ''
```

But you still get a warning from `kubeadm`, since it hasn't fully handed over the sandbox detection to the CRI:

https://github.com/kubernetes/kubernetes/blob/release-1.34/cmd/kubeadm/app/preflight/checks.go#L830

The setting of the cgroup is from here, it has been hardcoded to systemd in kubeadm not not so in containerd:

https://github.com/containerd/containerd/blob/main/docs/cri/config.md