### PR TITLE
Avoid relying on extra kubernetes packages

### DIFF
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -47,14 +47,6 @@ provision:
     echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${VERSION}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
     curl -fsSL https://pkgs.k8s.io/core:/stable:/v${VERSION}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     apt-get update
-    # cri-tools
-    apt-get install -y cri-tools
-    cat  <<EOF | sudo tee /etc/crictl.yaml
-    runtime-endpoint: unix:///run/containerd/containerd.sock
-    EOF
-    # cni-plugins
-    apt-get install -y kubernetes-cni
-    rm -f /etc/cni/net.d/*.conf*
     apt-get install -y kubelet kubeadm kubectl && apt-mark hold kubelet kubeadm kubectl
     systemctl enable --now kubelet
 # See <https://kubernetes.io/docs/setup/production-environment/container-runtimes/>
@@ -77,6 +69,8 @@ provision:
               runtime_type = "io.containerd.runc.v2"
               [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
                 SystemdCgroup = true
+      [plugins."io.containerd.cri.v1.runtime".cni]
+        bin_dirs = ["/usr/local/libexec/cni","/opt/cni/bin"]
     EOF
     systemctl restart containerd
 # See <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/>
@@ -140,7 +134,7 @@ probes:
   script: |
     #!/bin/bash
     set -eux -o pipefail
-    if ! timeout 30s bash -c "images=\"$(kubeadm config images list)\"; until for image in \$images; do sudo crictl image -q \$image | grep -q sha256; done; do sleep 3; done"; then
+    if ! timeout 30s bash -c "images=\"$(kubeadm config images list)\"; until for image in \$images; do sudo ctr -n k8s.io image inspect \$image >/dev/null; done; do sleep 3; done"; then
       echo >&2 "k8s images are not pulled yet"
       exit 1
     fi


### PR DESCRIPTION
The second-party package of "cri-tools" (crictl) and also the third-party package "kubernetes-cni" (cni-plugins) will go away.

So **don't** rely on them being installed, but just use "ctr" and "/usr/local/libexec/cni" instead from the `nerdctl-full` install.

* https://github.com/lima-vm/lima/issues/4186

* https://github.com/kubernetes/release/issues/4156

---

Note: the packages are still installed by default, in Kubernetes version 1.34...

But this way, the k8s installation will continue to work - even if they are **not**

The main difference from before, is that there will be small warning printed:

`WARN[0000] Image connect using default endpoints: [unix:///run/containerd/containerd.sock unix:///run/crio/crio.sock unix:///var/run/cri-dockerd.sock]. As the default settings are now deprecated, you should set the endpoint instead.`

It has been deprecated for 5 years, but the user is supposed to configure it:

https://kubernetes.io/docs/tasks/debug/debug-cluster/crictl/ (in `/etc/crictl.yaml`)

And the other cni-plugins are upgraded from version 1.7.1 to version 1.8.0.

It can now use the standard version from `nerdctl`, instead of from kubelet.