### PR TITLE
guestagent: create the parent (install) directory

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/25-guestagent-base.sh
@@ -18,6 +18,7 @@ if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
 fi
 
 # Install or update the guestagent binary
+mkdir -p "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin
 install -m 755 "${LIMA_CIDATA_MNT}"/lima-guestagent "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/lima-guestagent
 
 # Launch the guestagent service


### PR DESCRIPTION
With a custom image, we're running into an issue where the default `LIMA_CIDATA_GUEST_INSTALL_PREFIX: /usr/local` cannot be used.

```
...
[  151.799405] cloud-init[2878]: + install -m 755 /mnt/lima-cidata/lima-guestagent /usr/local/bin/lima-guestagent
[  151.815180] cloud-init[2878]: install: cannot create regular file '/usr/local/bin/lima-guestagent': Read-only file system
...
```

An override with the following also fails because the parent (install) directory does not exist:

```
env:
  LIMA_CIDATA_GUEST_INSTALL_PREFIX: /etc/lima
```

```
[  154.451232] cloud-init[2991]: + install -m 755 /mnt/lima-cidata/lima-guestagent /etc/lima/bin/lima-guestagent
[  154.466815] cloud-init[2991]: install: cannot create regular file '/etc/lima/bin/lima-guestagent': No such file or directory
```