### PR TITLE
docs: promote from CNCF Sandbox to Incubating

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ GUI:
 Lima follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
 - - -
-**We are a [Cloud Native Computing Foundation](https://cncf.io/) sandbox project.**
+**We are a [Cloud Native Computing Foundation](https://cncf.io/) incubating project.**
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://www.cncf.io/wp-content/uploads/2022/07/cncf-white-logo.svg">

--- a/website/content/en/docs/_index.md
+++ b/website/content/en/docs/_index.md
@@ -27,9 +27,16 @@ Related project: [sshocker (ssh with file sharing and port forwarding)](https://
 
 This project is unrelated to [The Lima driver project (driver for ARM Mali GPUs)](https://gitlab.freedesktop.org/lima).
 
-## Motivation
+## Project history
 
-The original goal of Lima was to promote [containerd](https://containerd.io) including [nerdctl (contaiNERD ctl)](https://github.com/containerd/nerdctl)
-to Mac users, but Lima can be used for non-container applications as well.
+Lima began in May 2021, aiming at promoting [containerd](https://containerd.io) including [nerdctl (contaiNERD ctl)](https://github.com/containerd/nerdctl)
+to Mac users.
+Later the project scope was expanded to support other containers
+and non-container applications as well.
 Lima also supports non-macOS hosts (Linux, NetBSD, etc.).
+
+Lima joined the [Cloud Native Computing Foundation (CNCF)](https://cncf.io)
+in September 2022 as a Sandbox project.
+The project was promoted to the Incubating level in October 2025.
+
 {{% /fixlinks %}}

--- a/website/layouts/shortcodes/blocks/cncf.html
+++ b/website/layouts/shortcodes/blocks/cncf.html
@@ -1,5 +1,5 @@
 <section class="text-center">
-  <h4>{{ .Site.Title }} is a <a class="text-secondary" href="https://cncf.io">CNCF</a> sandbox project</h4>
+  <h4>{{ .Site.Title }} is a <a class="text-secondary" href="https://cncf.io">CNCF</a> incubating project</h4>
 
   <img class="cncf-logo"
        src="/images/cncf-color-bg.svg" alt="Cloud Native Computing Foundation logo" />


### PR DESCRIPTION
CNCF TOC approved to promote Lima from Sandbox to Incubating on 2025-10-14:
- https://github.com/cncf/toc/issues/1348#issuecomment-3401064833

Fix #2068