### PR TITLE
templates: update openSUSE Leap to 16

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -24,7 +24,8 @@ Distro:
 - [`debian-13`](./debian-13.yaml), `debian.yaml`: ⭐Debian GNU/Linux 13(trixie)
 - [`fedora-41`](./fedora-41.yaml): Fedora 41
 - [`fedora-42`](./fedora-42.yaml), `fedora.yaml`: ⭐Fedora 42
-- [`opensuse-leap`](./opensuse-leap.yaml), `opensuse.yaml`: ⭐openSUSE Leap
+- [`opensuse-leap-15`](./opensuse-leap-15.yaml): openSUSE Leap 15
+- [`opensuse-leap-16`](./opensuse-leap-16.yaml), `opensuse-leap.yaml`, `opensuse.yaml`: ⭐openSUSE Leap 16
 - [`oraclelinux-8`](./oraclelinux-8.yaml): Oracle Linux 8
 - [`oraclelinux-9`](./oraclelinux-9.yaml), `oraclelinux.yaml`: Oracle Linux 9
 - [`rocky-8`](./rocky-8.yaml): Rocky Linux 8

--- a/templates/_images/opensuse-leap-15.yaml
+++ b/templates/_images/opensuse-leap-15.yaml
@@ -1,0 +1,14 @@
+images:
+# Hint: run `limactl prune` to invalidate the Current cache
+
+- location: https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2
+  arch: x86_64
+
+- location: https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.aarch64-Cloud.qcow2
+  arch: aarch64
+
+# Hint: to allow 9p and virtiofs, replace the `kernel-default-base` package with `kernel-default` and reboot the VM.
+# https://github.com/lima-vm/lima/issues/3055
+mountType: reverse-sshfs
+
+mountTypesUnsupported: [9p, virtiofs]

--- a/templates/_images/opensuse-leap-16.yaml
+++ b/templates/_images/opensuse-leap-16.yaml
@@ -1,0 +1,12 @@
+images:
+# Hint: run `limactl prune` to invalidate the Current cache
+
+- location: https://download.opensuse.org/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-Cloud.qcow2
+  arch: x86_64
+
+- location: https://download.opensuse.org/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-Cloud.qcow2
+  arch: aarch64
+
+# s390x image will not boot until https://bugzilla.suse.com/show_bug.cgi?id=1252096 is resolved
+- location: https://download.opensuse.org/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-s390x-Cloud.qcow2
+  arch: s390x

--- a/templates/_images/opensuse-leap.yaml
+++ b/templates/_images/opensuse-leap.yaml
@@ -1,14 +1,1 @@
-images:
-# Hint: run `limactl prune` to invalidate the Current cache
-
-- location: https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2
-  arch: x86_64
-
-- location: https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.aarch64-Cloud.qcow2
-  arch: aarch64
-
-# Hint: to allow 9p and virtiofs, replace the `kernel-default-base` package with `kernel-default` and reboot the VM.
-# https://github.com/lima-vm/lima/issues/3055
-mountType: reverse-sshfs
-
-mountTypesUnsupported: [9p, virtiofs]
+opensuse-leap-16.yaml

--- a/templates/opensuse-leap-15.yaml
+++ b/templates/opensuse-leap-15.yaml
@@ -1,0 +1,5 @@
+minimumLimaVersion: 1.1.0
+
+base:
+- template://_images/opensuse-leap-15
+- template://_default/mounts

--- a/templates/opensuse-leap-16.yaml
+++ b/templates/opensuse-leap-16.yaml
@@ -1,0 +1,5 @@
+minimumLimaVersion: 1.1.0
+
+base:
+- template://_images/opensuse-leap-16
+- template://_default/mounts

--- a/templates/opensuse-leap.yaml
+++ b/templates/opensuse-leap.yaml
@@ -1,5 +1,1 @@
-minimumLimaVersion: 1.1.0
-
-base:
-- template://_images/opensuse-leap
-- template://_default/mounts
+opensuse-leap-16.yaml


### PR DESCRIPTION
<details>
<summary>
<s>Fails, as the zypper repos are no longer enabled by default (why?)</s>
</summary>

<p>

```
+ zypper --non-interactive install -y --no-recommends sshfs iptables fuse3
Loading repository data...
Warning: No repositories defined. Operating only with the installed resolvables. Nothing can be installed.
Reading installed packages...
'iptables' not found in package names. Trying capabilities.
No provider of 'iptables' found.
'fuse3' not found in package names. Trying capabilities.
No provider of 'fuse3' found.
'sshfs' not found in package names. Trying capabilities.
No provider of 'sshfs' found.
LIMA 2025-10-15T16:03:21+09:00| WARNING: Failed to execute /mnt/lima-cidata/boot/30-install-packages.sh
```

</p>

</details>