### PR TITLE
Decouple diffdisk (misnomer) from basedisk

### DIFF
--- a/pkg/driver/vz/vm_darwin.go
+++ b/pkg/driver/vz/vm_darwin.go
@@ -489,9 +489,15 @@ func attachDisks(ctx context.Context, inst *limatype.Instance, vmConfig *vz.Virt
 	baseDiskPath := filepath.Join(inst.Dir, filenames.BaseDisk)
 	diffDiskPath := filepath.Join(inst.Dir, filenames.DiffDisk)
 	ciDataPath := filepath.Join(inst.Dir, filenames.CIDataISO)
-	isBaseDiskCDROM, err := iso9660util.IsISO9660(baseDiskPath)
-	if err != nil {
-		return err
+	var (
+		isBaseDiskCDROM bool
+		err             error
+	)
+	if _, stErr := os.Stat(baseDiskPath); !errors.Is(stErr, os.ErrNotExist) {
+		isBaseDiskCDROM, err = iso9660util.IsISO9660(baseDiskPath)
+		if err != nil {
+			return err
+		}
 	}
 	var configurations []vz.StorageDeviceConfiguration
 

--- a/pkg/driverutil/disk.go
+++ b/pkg/driverutil/disk.go
@@ -19,6 +19,8 @@ import (
 )
 
 // EnsureDisk ensures that the diff disk exists with the specified size and format.
+// EnsureDisk usually just converts baseDisk (can be qcow2) to diffDisk (raw), unless baseDisk is an ISO9660 image.
+// Note that "diffDisk" is a misnomer, it is actually created as a full disk since Lima v2.1.
 func EnsureDisk(ctx context.Context, instDir, diskSize string, diskImageFormat image.Type) error {
 	diffDisk := filepath.Join(instDir, filenames.DiffDisk)
 	if _, err := os.Stat(diffDisk); err == nil || !errors.Is(err, os.ErrNotExist) {
@@ -29,33 +31,43 @@ func EnsureDisk(ctx context.Context, instDir, diskSize string, diskImageFormat i
 	diskUtil := proxyimgutil.NewDiskUtil(ctx)
 
 	baseDisk := filepath.Join(instDir, filenames.BaseDisk)
+	srcDisk := baseDisk
 
 	diskSizeInBytes, _ := units.RAMInBytes(diskSize)
 	if diskSizeInBytes == 0 {
 		return nil
 	}
-	isBaseDiskISO, err := iso9660util.IsISO9660(baseDisk)
-	if err != nil {
-		return err
-	}
-	srcDisk := baseDisk
-	if isBaseDiskISO {
-		srcDisk = diffDisk
-
-		// Create an empty data volume for the diff disk
-		diffDiskF, err := os.Create(diffDisk)
+	var isBaseDiskISO bool
+	if _, err := os.Stat(baseDisk); !errors.Is(err, os.ErrNotExist) {
+		isBaseDiskISO, err = iso9660util.IsISO9660(baseDisk)
 		if err != nil {
 			return err
 		}
+		if isBaseDiskISO {
+			srcDisk = diffDisk
 
-		if err = diffDiskF.Close(); err != nil {
+			// Create an empty data volume for the diff disk
+			diffDiskF, err := os.Create(diffDisk)
+			if err != nil {
+				return err
+			}
+
+			if err = diffDiskF.Close(); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Check whether to use ASIF format
+
+	if err := diskUtil.Convert(ctx, diskImageFormat, srcDisk, diffDisk, &diskSizeInBytes, false); err != nil {
+		return fmt.Errorf("failed to convert %q to a disk %q: %w", srcDisk, diffDisk, err)
+	}
+
+	if !isBaseDiskISO {
+		if err := os.RemoveAll(baseDisk); err != nil {
 			return err
 		}
 	}
-	// Check whether to use ASIF format
-
-	if err = diskUtil.Convert(ctx, diskImageFormat, srcDisk, diffDisk, &diskSizeInBytes, false); err != nil {
-		return fmt.Errorf("failed to convert %q to a disk %q: %w", srcDisk, diffDisk, err)
-	}
-	return err
+	return nil
 }

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -29,6 +29,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/imgutil/proxyimgutil"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/limayaml"
 	"github.com/lima-vm/lima/v2/pkg/registry"
 	"github.com/lima-vm/lima/v2/pkg/store"
 	"github.com/lima-vm/lima/v2/pkg/usrlocal"
@@ -66,11 +67,12 @@ func Prepare(ctx context.Context, inst *limatype.Instance, guestAgent string) (*
 		return nil, err
 	}
 
-	// Check if the instance has been created (the base disk already exists)
-	baseDisk := filepath.Join(inst.Dir, filenames.BaseDisk)
-	_, err = os.Stat(baseDisk)
-	created := err == nil
+	// Check if the instance has been created
+	created := limayaml.IsExistingInstanceDir(inst.Dir)
 
+	// baseDisk is usually immediately renamed to diffDisk (misnomer) by the VM driver,
+	// except when baseDisk is an ISO9660 image.
+	baseDisk := filepath.Join(inst.Dir, filenames.BaseDisk)
 	kernel := filepath.Join(inst.Dir, filenames.Kernel)
 	kernelCmdline := filepath.Join(inst.Dir, filenames.KernelCmdline)
 	initrd := filepath.Join(inst.Dir, filenames.Initrd)

--- a/pkg/limatype/filenames/filenames.go
+++ b/pkg/limatype/filenames/filenames.go
@@ -36,8 +36,8 @@ const (
 	CIDataISO               = "cidata.iso"
 	CIDataISODir            = "cidata"
 	CloudConfig             = "cloud-config.yaml"
-	BaseDisk                = "basedisk"
-	DiffDisk                = "diffdisk"
+	BaseDisk                = "basedisk" // usually immediately converted/renamed to diffDisk by the VM driver
+	DiffDisk                = "diffdisk" // misnomer; actually a full disk since Lima v2.1
 	Kernel                  = "kernel"
 	KernelCmdline           = "kernel.cmdline"
 	Initrd                  = "initrd"

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -44,8 +44,11 @@ Ansible:
 - `ansible-inventory.yaml`: the Ansible node inventory. See [ansible](#ansible).
 
 disk:
-- `basedisk`: the base image
-- `diffdisk`: the diff image (QCOW2)
+- `basedisk`: the historical base image. Can be missing since Lima v2.1.
+  - The main `limactl` process prepares this `basedisk`, however, a [VM driver](./drivers.md) may convert and rename `basedisk` to `diffdisk` immediately.
+- `diffdisk`: the image, historically a QCOW2 diff from `basedisk`.
+  - `diffdisk` is a misnomer; it does not necessarily have a reference to `basedisk`.
+    Notably, when a `basedisk` is an ISO9660 image, or the VM driver does not support differencing, `diffdisk` is an independent image.
 
 kernel:
 - `kernel`: the kernel


### PR DESCRIPTION
Fix #1706.

Now basedisk is immediately renamed/converted to diffdisk (not a diff despite the name) by the VM driver,
except when basedisk is an ISO9660 image.

Decoupling diffdisk from basedisk will eliminate the overhead of differencing I/O and save some disk space.

I cannot remember why I designed the disk to be split into basedisk and diffdisk. 
Maybe it was to allow `limactl factory-reset` to retain the initial state, although the command was apparently never implemented in that way.
Maybe it was to allow multiple instances to share the same basedisk, although it was never implemented in that way, either.