### PR TITLE
limactl ls: avoid printing useless SSH address

### DIFF
--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -293,7 +293,6 @@ func PrintInstances(w io.Writer, instances []*limatype.Instance, format string, 
 
 		columns := 1 // NAME
 		columns += 2 // STATUS
-		columns += 2 // SSH
 		// can we still fit the remaining columns (7)
 		if width == 0 || (columns+7)*columnWidth > width && !all {
 			hideType = len(types) == 1
@@ -323,7 +322,7 @@ func PrintInstances(w io.Writer, instances []*limatype.Instance, format string, 
 		_ = columns
 
 		w := tabwriter.NewWriter(w, 4, 8, 4, ' ', 0)
-		fmt.Fprint(w, "NAME\tSTATUS\tSSH")
+		fmt.Fprint(w, "NAME\tSTATUS")
 		if !hideType {
 			fmt.Fprint(w, "\tVMTYPE")
 		}
@@ -346,10 +345,9 @@ func PrintInstances(w io.Writer, instances []*limatype.Instance, format string, 
 			if strings.HasPrefix(dir, homeDir) {
 				dir = strings.Replace(dir, homeDir, "~", 1)
 			}
-			fmt.Fprintf(w, "%s\t%s\t%s",
+			fmt.Fprintf(w, "%s\t%s",
 				instance.Name,
 				instance.Status,
-				fmt.Sprintf("%s:%d", instance.SSHAddress, instance.SSHLocalPort),
 			)
 			if !hideType {
 				fmt.Fprintf(w, "\t%s",

--- a/pkg/store/instance_test.go
+++ b/pkg/store/instance_test.go
@@ -33,38 +33,38 @@ var instance = limatype.Instance{
 	SSHAddress: "127.0.0.1",
 }
 
-var table = "NAME    STATUS     SSH            CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    0       0B        0B      dir\n"
+var table = "NAME    STATUS     CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    0       0B        0B      dir\n"
 
-var tableEmu = "NAME    STATUS     SSH            ARCH       CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    unknown    0       0B        0B      dir\n"
+var tableEmu = "NAME    STATUS     ARCH       CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    unknown    0       0B        0B      dir\n"
 
-var tableHome = "NAME    STATUS     SSH            CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    0       0B        0B      ~" + separator + "dir\n"
+var tableHome = "NAME    STATUS     CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    0       0B        0B      ~" + separator + "dir\n"
 
-var tableAll = "NAME    STATUS     SSH            VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
+var tableAll = "NAME    STATUS     VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
 
 // for width 60, everything is hidden
-var table60 = "NAME    STATUS     SSH            CPUS    MEMORY    DISK\n" +
-	"foo     Stopped    127.0.0.1:0    0       0B        0B\n"
+var table60 = "NAME    STATUS     CPUS    MEMORY    DISK\n" +
+	"foo     Stopped    0       0B        0B\n"
 
-// for width 80, identical is hidden (type/arch)
-var table80i = "NAME    STATUS     SSH            CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    0       0B        0B      dir\n"
+// for width 70, identical is hidden (type/arch)
+var table80i = "NAME    STATUS     CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    0       0B        0B      dir\n"
 
-// for width 80, different arch is still shown (not dir)
-var table80d = "NAME    STATUS     SSH            ARCH       CPUS    MEMORY    DISK\n" +
-	"foo     Stopped    127.0.0.1:0    unknown    0       0B        0B\n"
+// for width 70, different arch is still shown (not dir)
+var table80d = "NAME    STATUS     ARCH       CPUS    MEMORY    DISK\n" +
+	"foo     Stopped    unknown    0       0B        0B\n"
 
 // for width 100, nothing is hidden
-var table100 = "NAME    STATUS     SSH            VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
+var table100 = "NAME    STATUS     VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
 
-// for width 80, directory is hidden (if not identical)
-var tableTwo = "NAME    STATUS     SSH            VMTYPE    ARCH       CPUS    MEMORY    DISK\n" +
-	"foo     Stopped    127.0.0.1:0    qemu      x86_64     0       0B        0B\n" +
-	"bar     Stopped    127.0.0.1:0    vz        aarch64    0       0B        0B\n"
+// for width 70, directory is hidden (if not identical)
+var tableTwo = "NAME    STATUS     VMTYPE    ARCH       CPUS    MEMORY    DISK\n" +
+	"foo     Stopped    qemu      x86_64     0       0B        0B\n" +
+	"bar     Stopped    vz        aarch64    0       0B        0B\n"
 
 func TestPrintInstanceTable(t *testing.T) {
 	var buf bytes.Buffer
@@ -105,21 +105,21 @@ func TestPrintInstanceTable60(t *testing.T) {
 	assert.Equal(t, table60, buf.String())
 }
 
-func TestPrintInstanceTable80SameArch(t *testing.T) {
+func TestPrintInstanceTable70SameArch(t *testing.T) {
 	var buf bytes.Buffer
 	instances := []*limatype.Instance{&instance}
-	options := PrintOptions{TerminalWidth: 80}
+	options := PrintOptions{TerminalWidth: 70}
 	err := PrintInstances(&buf, instances, "table", &options)
 	assert.NilError(t, err)
 	assert.Equal(t, table80i, buf.String())
 }
 
-func TestPrintInstanceTable80DiffArch(t *testing.T) {
+func TestPrintInstanceTable70DiffArch(t *testing.T) {
 	var buf bytes.Buffer
 	instance1 := instance
 	instance1.Arch = limatype.NewArch("unknown")
 	instances := []*limatype.Instance{&instance1}
-	options := PrintOptions{TerminalWidth: 80}
+	options := PrintOptions{TerminalWidth: 70}
 	err := PrintInstances(&buf, instances, "table", &options)
 	assert.NilError(t, err)
 	assert.Equal(t, table80d, buf.String())
@@ -154,7 +154,7 @@ func TestPrintInstanceTableTwo(t *testing.T) {
 	instance2.VMType = limatype.VZ
 	instance2.Arch = limatype.AARCH64
 	instances := []*limatype.Instance{&instance1, &instance2}
-	options := PrintOptions{TerminalWidth: 80}
+	options := PrintOptions{TerminalWidth: 70}
 	err := PrintInstances(&buf, instances, "table", &options)
 	assert.NilError(t, err)
 	assert.Equal(t, tableTwo, buf.String())


### PR DESCRIPTION
Fix #4181