### PR TITLE
Implement "Dual" port forwarder (SSH for TCP, GRPC for UDP)

### DIFF
--- a/hack/test-templates/test-misc.yaml
+++ b/hack/test-templates/test-misc.yaml
@@ -111,6 +111,9 @@ user:
   # Ubuntu has identical /bin/bash and /usr/bin/bash
   shell: /usr/bin/bash
 
+portForwardTypes:
+  any: grpc
+
 portForwards:
 - guestPort: 80
   hostPort: 9090

--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -55,6 +55,7 @@ var knownYamlProperties = []string{
 	"OS",
 	"Param",
 	"Plain",
+	"PortForwardTypes",
 	"PortForwards",
 	"Probes",
 	"PropagateProxyEnv",

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -39,6 +39,7 @@ var knownYamlProperties = []string{
 	"MountType",
 	"Param",
 	"Plain",
+	"PortForwardTypes",
 	"PortForwards",
 	"Probes",
 	"PropagateProxyEnv",

--- a/pkg/hostagent/hostagent_test.go
+++ b/pkg/hostagent/hostagent_test.go
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hostagent
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+)
+
+func TestResolvePortForwardTypes(t *testing.T) {
+	tests := []struct {
+		name             string
+		portForwardTypes map[limatype.Proto]limatype.PortForwardType
+		portForwards     []limatype.PortForward
+		env              map[string]string
+		expected         map[limatype.Proto]limatype.PortForwardType
+		expectedErr      string
+	}{
+		{
+			name: "default",
+			portForwardTypes: map[limatype.Proto]limatype.PortForwardType{
+				limatype.ProtoTCP: limatype.PortForwardTypeSSH,
+				limatype.ProtoUDP: limatype.PortForwardTypeGRPC,
+			},
+			portForwards: nil,
+			env:          nil,
+			expected: map[limatype.Proto]limatype.PortForwardType{
+				limatype.ProtoTCP: limatype.PortForwardTypeSSH,
+				limatype.ProtoUDP: limatype.PortForwardTypeGRPC,
+			},
+		},
+		{
+			name: "grpc only via config",
+			portForwardTypes: map[limatype.Proto]limatype.PortForwardType{
+				limatype.ProtoAny: limatype.PortForwardTypeGRPC,
+			},
+			portForwards: nil,
+			env:          nil,
+			expected: map[limatype.Proto]limatype.PortForwardType{
+				limatype.ProtoTCP: limatype.PortForwardTypeGRPC,
+				limatype.ProtoUDP: limatype.PortForwardTypeGRPC,
+			},
+		},
+		{
+			name: "ssh only via env",
+			portForwardTypes: map[limatype.Proto]limatype.PortForwardType{
+				limatype.ProtoTCP: limatype.PortForwardTypeSSH,
+				limatype.ProtoUDP: limatype.PortForwardTypeGRPC,
+			},
+			portForwards: nil,
+			env: map[string]string{
+				"LIMA_SSH_PORT_FORWARDER": "true",
+			},
+			expected: map[limatype.Proto]limatype.PortForwardType{
+				limatype.ProtoTCP: limatype.PortForwardTypeSSH,
+				// No UDP support in SSH port forwarder
+			},
+		},
+		{
+			name: "grpc only via env",
+			portForwardTypes: map[limatype.Proto]limatype.PortForwardType{
+				limatype.ProtoTCP: limatype.PortForwardTypeSSH,
+				limatype.ProtoUDP: limatype.PortForwardTypeGRPC,
+			},
+			portForwards: nil,
+			env: map[string]string{
+				"LIMA_SSH_PORT_FORWARDER": "false",
+			},
+			expected: map[limatype.Proto]limatype.PortForwardType{
+				limatype.ProtoTCP: limatype.PortForwardTypeGRPC,
+				limatype.ProtoUDP: limatype.PortForwardTypeGRPC,
+			},
+		},
+		{
+			name: "disable tcp via portForwards",
+			portForwardTypes: map[limatype.Proto]limatype.PortForwardType{
+				limatype.ProtoTCP: limatype.PortForwardTypeSSH,
+				limatype.ProtoUDP: limatype.PortForwardTypeGRPC,
+			},
+			portForwards: []limatype.PortForward{
+				{
+					Ignore:         true,
+					Proto:          limatype.ProtoTCP,
+					GuestPortRange: [2]int{1, 65535},
+				},
+			},
+			env: nil,
+			expected: map[limatype.Proto]limatype.PortForwardType{
+				limatype.ProtoUDP: limatype.PortForwardTypeGRPC,
+			},
+		},
+		{
+			name: "disable tcp via portForwards, with any in portForwardTypes",
+			portForwardTypes: map[limatype.Proto]limatype.PortForwardType{
+				limatype.ProtoAny: limatype.PortForwardTypeGRPC,
+			},
+			portForwards: []limatype.PortForward{
+				{
+					Ignore:         true,
+					Proto:          limatype.ProtoTCP,
+					GuestPortRange: [2]int{1, 65535},
+				},
+			},
+			env: nil,
+			expected: map[limatype.Proto]limatype.PortForwardType{
+				limatype.ProtoUDP: limatype.PortForwardTypeGRPC,
+			},
+		},
+		{
+			name: "conflict between any and tcp",
+			portForwardTypes: map[limatype.Proto]limatype.PortForwardType{
+				limatype.ProtoAny: limatype.PortForwardTypeGRPC,
+				limatype.ProtoTCP: limatype.PortForwardTypeSSH,
+			},
+			portForwards: nil,
+			env:          nil,
+			expectedErr:  "conflicting port forward types for proto",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for envK, envV := range tt.env {
+				t.Setenv(envK, envV)
+			}
+			got, err := resolvePortForwardTypes(tt.portForwardTypes, tt.portForwards)
+			if tt.expectedErr != "" {
+				assert.ErrorContains(t, err, tt.expectedErr)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.expected)
+		})
+	}
+}

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -21,28 +21,29 @@ type LimaYAML struct {
 	Arch               *Arch         `yaml:"arch,omitempty" json:"arch,omitempty" jsonschema:"nullable"`
 	Images             []Image       `yaml:"images,omitempty" json:"images,omitempty" jsonschema:"nullable"`
 	// Deprecated: Use vmOpts.qemu.cpuType instead.
-	CPUType               CPUType       `yaml:"cpuType,omitempty" json:"cpuType,omitempty" jsonschema:"nullable"`
-	CPUs                  *int          `yaml:"cpus,omitempty" json:"cpus,omitempty" jsonschema:"nullable"`
-	Memory                *string       `yaml:"memory,omitempty" json:"memory,omitempty" jsonschema:"nullable"` // go-units.RAMInBytes
-	Disk                  *string       `yaml:"disk,omitempty" json:"disk,omitempty" jsonschema:"nullable"`     // go-units.RAMInBytes
-	AdditionalDisks       []Disk        `yaml:"additionalDisks,omitempty" json:"additionalDisks,omitempty" jsonschema:"nullable"`
-	Mounts                []Mount       `yaml:"mounts,omitempty" json:"mounts,omitempty"`
-	MountTypesUnsupported []string      `yaml:"mountTypesUnsupported,omitempty" json:"mountTypesUnsupported,omitempty" jsonschema:"nullable"`
-	MountType             *MountType    `yaml:"mountType,omitempty" json:"mountType,omitempty" jsonschema:"nullable"`
-	MountInotify          *bool         `yaml:"mountInotify,omitempty" json:"mountInotify,omitempty" jsonschema:"nullable"`
-	SSH                   SSH           `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
-	Firmware              Firmware      `yaml:"firmware,omitempty" json:"firmware,omitempty"`
-	Audio                 Audio         `yaml:"audio,omitempty" json:"audio,omitempty"`
-	Video                 Video         `yaml:"video,omitempty" json:"video,omitempty"`
-	Provision             []Provision   `yaml:"provision,omitempty" json:"provision,omitempty"`
-	UpgradePackages       *bool         `yaml:"upgradePackages,omitempty" json:"upgradePackages,omitempty" jsonschema:"nullable"`
-	Containerd            Containerd    `yaml:"containerd,omitempty" json:"containerd,omitempty"`
-	GuestInstallPrefix    *string       `yaml:"guestInstallPrefix,omitempty" json:"guestInstallPrefix,omitempty" jsonschema:"nullable"`
-	Probes                []Probe       `yaml:"probes,omitempty" json:"probes,omitempty"`
-	PortForwards          []PortForward `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
-	CopyToHost            []CopyToHost  `yaml:"copyToHost,omitempty" json:"copyToHost,omitempty"`
-	Message               string        `yaml:"message,omitempty" json:"message,omitempty"`
-	Networks              []Network     `yaml:"networks,omitempty" json:"networks,omitempty" jsonschema:"nullable"`
+	CPUType               CPUType                   `yaml:"cpuType,omitempty" json:"cpuType,omitempty" jsonschema:"nullable"`
+	CPUs                  *int                      `yaml:"cpus,omitempty" json:"cpus,omitempty" jsonschema:"nullable"`
+	Memory                *string                   `yaml:"memory,omitempty" json:"memory,omitempty" jsonschema:"nullable"` // go-units.RAMInBytes
+	Disk                  *string                   `yaml:"disk,omitempty" json:"disk,omitempty" jsonschema:"nullable"`     // go-units.RAMInBytes
+	AdditionalDisks       []Disk                    `yaml:"additionalDisks,omitempty" json:"additionalDisks,omitempty" jsonschema:"nullable"`
+	Mounts                []Mount                   `yaml:"mounts,omitempty" json:"mounts,omitempty"`
+	MountTypesUnsupported []string                  `yaml:"mountTypesUnsupported,omitempty" json:"mountTypesUnsupported,omitempty" jsonschema:"nullable"`
+	MountType             *MountType                `yaml:"mountType,omitempty" json:"mountType,omitempty" jsonschema:"nullable"`
+	MountInotify          *bool                     `yaml:"mountInotify,omitempty" json:"mountInotify,omitempty" jsonschema:"nullable"`
+	SSH                   SSH                       `yaml:"ssh,omitempty" json:"ssh,omitempty"` // REQUIRED (FIXME)
+	Firmware              Firmware                  `yaml:"firmware,omitempty" json:"firmware,omitempty"`
+	Audio                 Audio                     `yaml:"audio,omitempty" json:"audio,omitempty"`
+	Video                 Video                     `yaml:"video,omitempty" json:"video,omitempty"`
+	Provision             []Provision               `yaml:"provision,omitempty" json:"provision,omitempty"`
+	UpgradePackages       *bool                     `yaml:"upgradePackages,omitempty" json:"upgradePackages,omitempty" jsonschema:"nullable"`
+	Containerd            Containerd                `yaml:"containerd,omitempty" json:"containerd,omitempty"`
+	GuestInstallPrefix    *string                   `yaml:"guestInstallPrefix,omitempty" json:"guestInstallPrefix,omitempty" jsonschema:"nullable"`
+	Probes                []Probe                   `yaml:"probes,omitempty" json:"probes,omitempty"`
+	PortForwardTypes      map[Proto]PortForwardType `yaml:"portForwardTypes,omitempty" json:"portForwardTypes,omitempty" jsonschema:"nullable"`
+	PortForwards          []PortForward             `yaml:"portForwards,omitempty" json:"portForwards,omitempty"`
+	CopyToHost            []CopyToHost              `yaml:"copyToHost,omitempty" json:"copyToHost,omitempty"`
+	Message               string                    `yaml:"message,omitempty" json:"message,omitempty"`
+	Networks              []Network                 `yaml:"networks,omitempty" json:"networks,omitempty" jsonschema:"nullable"`
 	// `network` was deprecated in Lima v0.7.0, removed in Lima v0.14.0. Use `networks` instead.
 	Env          map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 	Param        map[string]string `yaml:"param,omitempty" json:"param,omitempty"`
@@ -282,6 +283,14 @@ const (
 	ProtoTCP Proto = "tcp"
 	ProtoUDP Proto = "udp"
 	ProtoAny Proto = "any"
+)
+
+type PortForwardType = string
+
+const (
+	PortForwardTypeSSH  PortForwardType = "ssh"
+	PortForwardTypeGRPC PortForwardType = "grpc"
+	PortForwardTypeNone PortForwardType = "none"
 )
 
 type PortForward struct {

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -519,6 +519,18 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 		}
 	}
 
+	portForwardTypes := make(map[limatype.Proto]limatype.PortForwardType)
+	maps.Copy(portForwardTypes, d.PortForwardTypes)
+	maps.Copy(portForwardTypes, y.PortForwardTypes)
+	maps.Copy(portForwardTypes, o.PortForwardTypes)
+	if portForwardTypes[limatype.ProtoTCP] == "" && portForwardTypes[limatype.ProtoAny] == "" {
+		portForwardTypes[limatype.ProtoTCP] = limatype.PortForwardTypeSSH
+	}
+	if portForwardTypes[limatype.ProtoUDP] == "" && portForwardTypes[limatype.ProtoAny] == "" {
+		portForwardTypes[limatype.ProtoUDP] = limatype.PortForwardTypeGRPC
+	}
+	y.PortForwardTypes = portForwardTypes
+
 	y.PortForwards = slices.Concat(o.PortForwards, y.PortForwards, d.PortForwards)
 	for i := range y.PortForwards {
 		FillPortForwardDefaults(&y.PortForwards[i], instDir, y.User, y.Param)

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -121,6 +121,10 @@ func TestFillDefault(t *testing.T) {
 			Shell:   ptr.Of("/bin/bash"),
 			UID:     ptr.Of(uint32(uid)),
 		},
+		PortForwardTypes: map[limatype.Proto]limatype.PortForwardType{
+			limatype.ProtoTCP: limatype.PortForwardTypeSSH,
+			limatype.ProtoUDP: limatype.PortForwardTypeGRPC,
+		},
 	}
 
 	defaultPortForward := limatype.PortForward{
@@ -248,6 +252,10 @@ func TestFillDefault(t *testing.T) {
 	expect.Networks[0].Metric = ptr.Of(uint32(100))
 
 	expect.DNS = slices.Clone(y.DNS)
+	expect.PortForwardTypes = map[limatype.Proto]limatype.PortForwardType{
+		limatype.ProtoTCP: limatype.PortForwardTypeSSH,
+		limatype.ProtoUDP: limatype.PortForwardTypeGRPC,
+	}
 	expect.PortForwards = []limatype.PortForward{
 		defaultPortForward,
 		defaultPortForward,
@@ -385,6 +393,10 @@ func TestFillDefault(t *testing.T) {
 		},
 		DNS: []net.IP{
 			net.ParseIP("1.1.1.1"),
+		},
+		PortForwardTypes: map[limatype.Proto]limatype.PortForwardType{
+			limatype.ProtoTCP: limatype.PortForwardTypeSSH,
+			limatype.ProtoUDP: limatype.PortForwardTypeGRPC,
 		},
 		PortForwards: []limatype.PortForward{{
 			GuestIP:           IPv4loopback1,
@@ -599,6 +611,10 @@ func TestFillDefault(t *testing.T) {
 		},
 		DNS: []net.IP{
 			net.ParseIP("2.2.2.2"),
+		},
+		PortForwardTypes: map[limatype.Proto]limatype.PortForwardType{
+			limatype.ProtoTCP: limatype.PortForwardTypeSSH,
+			limatype.ProtoUDP: limatype.PortForwardTypeGRPC,
 		},
 		PortForwards: []limatype.PortForward{{
 			GuestIP:           IPv4loopback1,

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -465,6 +465,10 @@ networks:
 # Needs `vmType: vz`
 # - vzNAT: true
 
+# Port forwarder types.
+# 🟢 Builtin default: {tcp: ssh, udp: grpc}
+portForwardTypes: null
+
 # Port forwarding rules. Forwarding between ports 22 and ssh.localPort cannot be overridden.
 # Rules are checked sequentially until the first one matches.
 # portForwards:

--- a/website/content/en/docs/config/environment-variables.md
+++ b/website/content/en/docs/config/environment-variables.md
@@ -117,12 +117,13 @@ This page documents the environment variables used in Lima.
 
 ### `LIMA_SSH_PORT_FORWARDER`
 
-- **Description**: Specifies to use the SSH port forwarder (slow) instead of gRPC (fast, previously unstable)
-- **Default**: `false` (since v1.1.0)
+- **Description**: Specifies to disable the gRPC port forwarder. See [Port Forwarding](./port.md) for the details.
+- **Default**: not set (since v2.0.0)
 - **Usage**: 
   ```sh
   export LIMA_SSH_PORT_FORWARDER=false
   ```
+- **Note**: Deprecated since v2.0.0.
 - **The history of the default value**:
   | Version | Default value       |
   |---------|---------------------|
@@ -130,6 +131,7 @@ This page documents the environment variables used in Lima.
   | v1.0.0  | `false`             |
   | v1.0.1  | `true`              |
   | v1.1.0  | `false`             |
+  | v2.0.0  | not set             |
 
 ### `LIMA_USERNET_RESOLVE_IP_ADDRESS_TIMEOUT`
 

--- a/website/content/en/docs/config/port.md
+++ b/website/content/en/docs/config/port.md
@@ -7,29 +7,56 @@ Lima supports automatic port-forwarding of localhost ports from guest to host.
 
 ## Port forwarding types
 
-Lima supports two port forwarders: SSH and GRPC.
+Lima supports the following port forwarders:
+- Dual (SSH for TCP, GRPC for UDP)
+- SSH
+- GRPC
 
 The default port forwarder is shown in the following table.
 
-| Version | Default |
-| --------| ------- |
-| v0.1.0  | SSH     |
-| v1.0.0  | GRPC    |
-| v1.0.1  | SSH     |
-| v1.1.0  | GRPC    |
+| Version | Default | Reason to change the default                             |
+| --------| ------- | -------------------------------------------------------- |
+| v0.1.0  | SSH     | (The initial implementation.)                            |
+| v1.0.0  | GRPC    | GRPC implementation outperforms SSH.                     |
+| v1.0.1  | SSH     | GRPC implementation turned out to have stability issues. |
+| v1.1.0  | GRPC    | The stability issues were fixed.                         |
+| v2.0.0  | Dual    | SSH outperforms GRPC when VSOCK is available.            |
 
-The default was once changed to GRPC in Lima v1.0, but it was reverted to SSH in v1.0.1 due to stability reasons.
-The default was further reverted to GRPC in Lima v1.1, as the stability issues were resolved.
+### Using Dual forwarder
+
+| ⚡ Requirement | Lima >= 2.0 |
+|---------------|-------------|
+
+The dual forwarder uses SSH for TCP and GRPC for UDP to mix the advantages of the both forwarders.
+
+```yaml
+portForwardTypes:
+  tcp: ssh
+  udp: grpc
+```
+
+This is the default mode since Lima v2.0.
 
 ### Using SSH
 
-SSH based port forwarding was previously the default mode.
+SSH-only port forwarding was previously the default mode.
 
-To explicitly use SSH forwarding use the below command
-
-```bash
-LIMA_SSH_PORT_FORWARDER=true limactl start
+{{< tabpane text=true >}}
+{{% tab header="Lima v2.0+" %}}
+```yaml
+portForwardTypes:
+  tcp: ssh
+  udp: none
 ```
+{{% /tab %}}
+{{% tab header="Lima v1.x" %}}
+```bash
+# Deprecated
+export LIMA_SSH_PORT_FORWARDER=true
+limactl start
+```
+{{% /tab %}}
+{{< /tabpane >}}
 
 #### Advantages
 
@@ -62,11 +89,21 @@ export LIMA_SSH_OVER_VSOCK=false
 In this model, lima uses existing GRPC communication (Host <-> Guest) to tunnel port forwarding requests.
 For each port forwarding request, a GRPC tunnel is created and this will be used for transmitting data
 
-To enable this feature, set `LIMA_SSH_PORT_FORWARDER` to `false`:
-
-```bash
-LIMA_SSH_PORT_FORWARDER=false limactl start
+{{< tabpane text=true >}}
+{{% tab header="Lima v2.0+" %}}
+```yaml
+portForwardTypes:
+  any: grpc
 ```
+{{% /tab %}}
+{{% tab header="Lima v1.x" %}}
+```bash
+# Deprecated
+export LIMA_SSH_PORT_FORWARDER=false
+limactl start
+```
+{{% /tab %}}
+{{< /tabpane >}}
 
 #### Advantages
 

--- a/website/content/en/docs/releases/deprecated.md
+++ b/website/content/en/docs/releases/deprecated.md
@@ -9,6 +9,7 @@ The following features are deprecated:
 - Loading non-strict YAMLs (i.e., YAMLs with unknown properties)
 - `limactl show-ssh` command (Use `ssh -F ~/.lima/default/ssh.config lima-default` instead)
 - Ansible provisioning mode (Use `ansible-playbook playbook.yaml` after the start instead)
+- `LIMA_SSH_PORT_FORWARDER` environment variable: deprecated in Lima v2.0, in favor of [the new "dual" port forwarder](../config/port.md) that mixes SSH and gRPC implementations.
 
 ## Removed features
 - YAML property `network`: deprecated in [Lima v0.7.0](https://github.com/lima-vm/lima/commit/07e68230e70b21108d2db3ca5e0efd0e43842fbd)


### PR DESCRIPTION
This new default forwarder uses SSH for TCP, as SSH now outperforms GRPC when VSOCK is available.
GRPC is used for UDP, as SSH does not support UDP.

Fix #4074

- - -

Doc preview: https://deploy-preview-4210--lima-vm.netlify.app/docs/config/port/