### PR TITLE
Make Provision.Script a pointer

### DIFF
--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -400,7 +400,7 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 		case limatype.ProvisionModeSystem, limatype.ProvisionModeUser, limatype.ProvisionModeDependency:
 			layout = append(layout, iso9660util.Entry{
 				Path:   fmt.Sprintf("provision.%s/%08d", f.Mode, i),
-				Reader: strings.NewReader(f.Script),
+				Reader: strings.NewReader(*f.Script),
 			})
 		case limatype.ProvisionModeData:
 			layout = append(layout, iso9660util.Entry{
@@ -490,7 +490,7 @@ func getBootCmds(p []limatype.Provision) []BootCmds {
 	for _, f := range p {
 		if f.Mode == limatype.ProvisionModeBoot {
 			lines := []string{}
-			for _, line := range strings.Split(f.Script, "\n") {
+			for _, line := range strings.Split(*f.Script, "\n") {
 				if line == "" {
 					continue
 				}

--- a/pkg/limatmpl/embed.go
+++ b/pkg/limatmpl/embed.go
@@ -663,7 +663,7 @@ func (tmpl *Template) embedAllScripts(ctx context.Context, embedAll bool) error 
 				continue
 			}
 		default:
-			if p.Script != "" {
+			if p.Script != nil && *p.Script != "" {
 				continue
 			}
 		}

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -238,7 +238,7 @@ const (
 type Provision struct {
 	Mode                            ProvisionMode      `yaml:"mode,omitempty" json:"mode,omitempty" jsonschema:"default=system"`
 	SkipDefaultDependencyResolution *bool              `yaml:"skipDefaultDependencyResolution,omitempty" json:"skipDefaultDependencyResolution,omitempty"`
-	Script                          string             `yaml:"script,omitempty" json:"script,omitempty"`
+	Script                          *string            `yaml:"script,omitempty" json:"script,omitempty"`
 	File                            *LocatorWithDigest `yaml:"file,omitempty" json:"file,omitempty" jsonschema:"nullable"`
 	Playbook                        string             `yaml:"playbook,omitempty" json:"playbook,omitempty"` // DEPRECATED
 	// All ProvisionData fields must be nil unless Mode is ProvisionModeData

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -439,12 +439,11 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 				provision.Permissions = ptr.Of("644")
 			}
 		}
-		// TODO Turn Script into a pointer; it is a plain string for historical reasons only
-		if provision.Script != "" {
-			if out, err := executeGuestTemplate(provision.Script, instDir, y.User, y.Param); err == nil {
-				provision.Script = out.String()
+		if provision.Script != nil && *provision.Script != "" {
+			if out, err := executeGuestTemplate(*provision.Script, instDir, y.User, y.Param); err == nil {
+				*provision.Script = out.String()
 			} else {
-				logrus.WithError(err).Warnf("Couldn't process provisioning script %q as a template", provision.Script)
+				logrus.WithError(err).Warnf("Couldn't process provisioning script %q as a template", *provision.Script)
 			}
 		}
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -150,7 +150,7 @@ func TestFillDefault(t *testing.T) {
 		},
 		MountType: ptr.Of(limatype.NINEP),
 		Provision: []limatype.Provision{
-			{Script: "#!/bin/true # {{.Param.ONE}}"},
+			{Script: ptr.Of("#!/bin/true # {{.Param.ONE}}")},
 		},
 		Probes: []limatype.Probe{
 			{Script: "#!/bin/false # {{.Param.ONE}}"},
@@ -234,7 +234,7 @@ func TestFillDefault(t *testing.T) {
 
 	expect.Provision = slices.Clone(y.Provision)
 	expect.Provision[0].Mode = limatype.ProvisionModeSystem
-	expect.Provision[0].Script = "#!/bin/true # Eins"
+	expect.Provision[0].Script = ptr.Of("#!/bin/true # Eins")
 
 	expect.Probes = slices.Clone(y.Probes)
 	expect.Probes[0].Mode = limatype.ProbeModeReadiness
@@ -364,7 +364,7 @@ func TestFillDefault(t *testing.T) {
 		},
 		Provision: []limatype.Provision{
 			{
-				Script: "#!/bin/true",
+				Script: ptr.Of("#!/bin/true"),
 				Mode:   limatype.ProvisionModeUser,
 			},
 		},
@@ -572,7 +572,7 @@ func TestFillDefault(t *testing.T) {
 		MountInotify: ptr.Of(true),
 		Provision: []limatype.Provision{
 			{
-				Script: "#!/bin/true",
+				Script: ptr.Of("#!/bin/true"),
 				Mode:   limatype.ProvisionModeSystem,
 			},
 		},


### PR DESCRIPTION
## Summary

As the TODO in limayaml/defaults.go claims, change the type of
"Script" under "type Provision struct" from "string" to "*string".

Update all callers to pass a pointer and handle "nil" in comparisons,
validation, and marshalling.