### PR TITLE
Fix revive.package-directory-mismatch lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,6 +102,7 @@ linters:
       - name: indent-error-flow
       - name: package-comments
         disabled: true
+      - name: package-directory-mismatch
       - name: range
       - name: receiver-naming
       - name: redefines-builtin-id

--- a/cmd/limactl/clone.go
+++ b/cmd/limactl/clone.go
@@ -16,7 +16,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/instance"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/limayaml"
-	networks "github.com/lima-vm/lima/v2/pkg/networks/reconcile"
+	"github.com/lima-vm/lima/v2/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/v2/pkg/store"
 	"github.com/lima-vm/lima/v2/pkg/yqutil"
 )
@@ -124,7 +124,7 @@ func cloneOrRenameAction(cmd *cobra.Command, args []string) error {
 	if !startNow {
 		return nil
 	}
-	err = networks.Reconcile(ctx, newInst.Name)
+	err = reconcile.Reconcile(ctx, newInst.Name)
 	if err != nil {
 		return err
 	}

--- a/cmd/limactl/delete.go
+++ b/cmd/limactl/delete.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/lima-vm/lima/v2/pkg/autostart"
 	"github.com/lima-vm/lima/v2/pkg/instance"
-	networks "github.com/lima-vm/lima/v2/pkg/networks/reconcile"
+	"github.com/lima-vm/lima/v2/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/v2/pkg/store"
 )
 
@@ -60,7 +60,7 @@ func deleteAction(cmd *cobra.Command, args []string) error {
 		}
 		logrus.Infof("Deleted %q (%q)", instName, inst.Dir)
 	}
-	return networks.Reconcile(cmd.Context(), "")
+	return reconcile.Reconcile(cmd.Context(), "")
 }
 
 func deleteBashComplete(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -21,7 +21,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/limayaml"
-	networks "github.com/lima-vm/lima/v2/pkg/networks/reconcile"
+	"github.com/lima-vm/lima/v2/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/v2/pkg/store"
 	"github.com/lima-vm/lima/v2/pkg/uiutil"
 	"github.com/lima-vm/lima/v2/pkg/yqutil"
@@ -155,7 +155,7 @@ func editAction(cmd *cobra.Command, args []string) error {
 	if !startNow {
 		return nil
 	}
-	err = networks.Reconcile(ctx, inst.Name)
+	err = reconcile.Reconcile(ctx, inst.Name)
 	if err != nil {
 		return err
 	}

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -24,7 +24,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/instance"
 	"github.com/lima-vm/lima/v2/pkg/ioutilx"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
-	networks "github.com/lima-vm/lima/v2/pkg/networks/reconcile"
+	"github.com/lima-vm/lima/v2/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/v2/pkg/sshutil"
 	"github.com/lima-vm/lima/v2/pkg/store"
 )
@@ -101,7 +101,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		err = networks.Reconcile(ctx, inst.Name)
+		err = reconcile.Reconcile(ctx, inst.Name)
 		if err != nil {
 			return err
 		}

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -25,7 +25,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/limayaml"
-	networks "github.com/lima-vm/lima/v2/pkg/networks/reconcile"
+	"github.com/lima-vm/lima/v2/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/v2/pkg/registry"
 	"github.com/lima-vm/lima/v2/pkg/store"
 	"github.com/lima-vm/lima/v2/pkg/templatestore"
@@ -580,7 +580,7 @@ func startAction(cmd *cobra.Command, args []string) error {
 		logrus.Warnf("expected status %q, got %q", limatype.StatusStopped, inst.Status)
 	}
 	ctx := cmd.Context()
-	err = networks.Reconcile(ctx, inst.Name)
+	err = reconcile.Reconcile(ctx, inst.Name)
 	if err != nil {
 		return err
 	}

--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lima-vm/lima/v2/pkg/instance"
-	networks "github.com/lima-vm/lima/v2/pkg/networks/reconcile"
+	"github.com/lima-vm/lima/v2/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/v2/pkg/store"
 )
 
@@ -48,7 +48,7 @@ func stopAction(cmd *cobra.Command, args []string) error {
 	}
 	// TODO: should we also reconcile networks if graceful stop returned an error?
 	if err == nil {
-		err = networks.Reconcile(ctx, "")
+		err = reconcile.Reconcile(ctx, "")
 	}
 	return err
 }

--- a/pkg/instance/restart.go
+++ b/pkg/instance/restart.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/lima-vm/lima/v2/pkg/limatype"
-	networks "github.com/lima-vm/lima/v2/pkg/networks/reconcile"
+	"github.com/lima-vm/lima/v2/pkg/networks/reconcile"
 )
 
 const (
@@ -21,7 +21,7 @@ func Restart(ctx context.Context, inst *limatype.Instance, showProgress bool) er
 		return err
 	}
 
-	if err := networks.Reconcile(ctx, inst.Name); err != nil {
+	if err := reconcile.Reconcile(ctx, inst.Name); err != nil {
 		return err
 	}
 
@@ -36,7 +36,7 @@ func RestartForcibly(ctx context.Context, inst *limatype.Instance, showProgress 
 	logrus.Info("Restarting the instance forcibly")
 	StopForcibly(inst)
 
-	if err := networks.Reconcile(ctx, inst.Name); err != nil {
+	if err := reconcile.Reconcile(ctx, inst.Name); err != nil {
 		return err
 	}
 

--- a/pkg/networks/reconcile/reconcile.go
+++ b/pkg/networks/reconcile/reconcile.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright The Lima Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package networks
+package reconcile
 
 import (
 	"bytes"


### PR DESCRIPTION
This PR renames the package `networks` to `reconcile` to match the directory name. This is suggested by the `revive.package-directory-mismatch` rule:

```console
❯ golangci-lint run
pkg/networks/reconcile/reconcile.go:4:9: package-directory-mismatch: package name "networks" does not match directory name "reconcile" (revive)
package networks
        ^
1 issues:
* revive: 1
```