### PR TITLE
Add global `LIMA_BATS_ALL_TESTS_RETRIES` variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -362,14 +362,9 @@ jobs:
       with:
         template: templates/k8s.yaml
     - name: "Run BATS k8s tests"
-      # Wish we could use BATS_TEST_RETRIES=3 as an environment variable here,
-      # but bats does not seem to support it.
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
-      with:
-        timeout_minutes: 30
-        retry_on: error
-        max_attempts: 3
-        command: ./hack/bats/lib/bats-core/bin/bats --timing ./hack/bats/extras/k8s.bats
+      run: ./hack/bats/lib/bats-core/bin/bats --timing ./hack/bats/extras/k8s.bats
+      env:
+        LIMA_BATS_ALL_TESTS_RETRIES: 3
 
   colima:
     name: "Colima tests (QEMU, Linux host)"

--- a/hack/bats/helpers/load.bash
+++ b/hack/bats/helpers/load.bash
@@ -8,6 +8,16 @@ set -o errexit -o nounset -o pipefail
 # The upstream PR https://github.com/bats-core/bats-core/pull/1118 is still open, so our submodule points to the PR commit.
 export BATS_RUN_ERREXIT=1
 
+# BATS_TEST_RETRIES must be set for the individual test and cannot be imported from the
+# parent environment because the BATS test runner sets it to 0 before running the test.
+BATS_TEST_RETRIES=${LIMA_BATS_ALL_TESTS_RETRIES:-0}
+
+# Known flaky tests should call `flaky` inside the @test to allow retries up to
+# LIMA_BATS_FLAKY_TESTS_RETRIES even when the LIMA_BATS_ALL_TESTS_RETRIES is lower.
+flaky() {
+    BATS_TEST_RETRIES=${LIMA_BATS_FLAKY_TESTS_RETRIES:-$BATS_TEST_RETRIES}
+}
+
 # Don't run the tests in ~/.lima because they may destroy _config, _templates etc.
 export LIMA_HOME=${LIMA_BATS_LIMA_HOME:-$HOME/.lima-bats}
 


### PR DESCRIPTION
It will rerun all tests up to this number on failure.

Also provides a `flaky` function to set the retries to `LIMA_BATS_FLAKY_TESTS_RETRIES` to allow a greater number of retries to known flaky tests.

So in CI you could set both, to e.g. retry all tests at least once, but retry flaky tests up to 5 times.

```console
❯ cat hack/bats/tests/chaos-monkey.bats
load "../helpers/load"

@test "flaky test that fails randomly" {
    flaky
    echo "Attempt ${BATS_TEST_TRY_NUMBER}/$((BATS_TEST_RETRIES + 1))" >&3
    ((RANDOM % 10 < 3))
}

❯ LIMA_BATS_ALL_TESTS_RETRIES=2 ./hack/bats/lib/bats-core/bin/bats -T ./hack/bats/tests/chaos-monkey.bats
chaos-monkey.bats
   flaky test that fails randomly                                                                                                                           1/1 in 0 sec
Attempt 1/3
   flaky test that fails randomly                                                                                                                           1/1 in 0 sec
Attempt 2/3
 ✗ flaky test that fails randomly [4]
Attempt 3/3
   (in test file hack/bats/tests/chaos-monkey.bats, line 6)
     `(( RANDOM % 10 < 3))' failed

1 test, 1 failure in 0 seconds

❯ LIMA_BATS_FLAKY_TESTS_RETRIES=7 ./hack/bats/lib/bats-core/bin/bats -T ./hack/bats/tests/chaos-monkey.bats
chaos-monkey.bats
   flaky test that fails randomly                                                                                                                           1/1 in 0 sec
Attempt 1/8
   flaky test that fails randomly                                                                                                                           1/1 in 1 sec
Attempt 2/8
 ✓ flaky test that fails randomly [5]
Attempt 3/8

1 test, 0 failures in 1 seconds
```
