### PR TITLE
Make Probe.Script a pointer

### DIFF
--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -241,7 +241,7 @@ Also see "/var/log/cloud-init-output.log" in the guest.
 		if probe.Mode == limatype.ProbeModeReadiness {
 			req = append(req, requirement{
 				description: probe.Description,
-				script:      probe.Script,
+				script:      *probe.Script,
 				debugHint:   probe.Hint,
 			})
 		}

--- a/pkg/limatmpl/embed.go
+++ b/pkg/limatmpl/embed.go
@@ -634,7 +634,7 @@ func (tmpl *Template) embedAllScripts(ctx context.Context, embedAll bool) error 
 			continue
 		}
 		// Don't overwrite existing script. This should throw an error during validation.
-		if p.Script != "" {
+		if p.Script == nil || *p.Script != "" {
 			continue
 		}
 		isTemplate, _ := SeemsTemplateURL(p.File.URL)

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -271,7 +271,7 @@ const (
 type Probe struct {
 	Mode        ProbeMode          `yaml:"mode,omitempty" json:"mode,omitempty" jsonschema:"default=readiness"`
 	Description string             `yaml:"description,omitempty" json:"description,omitempty"`
-	Script      string             `yaml:"script,omitempty" json:"script,omitempty"`
+	Script      *string            `yaml:"script,omitempty" json:"script,omitempty"`
 	File        *LocatorWithDigest `yaml:"file,omitempty" json:"file,omitempty" jsonschema:"nullable"`
 	Hint        string             `yaml:"hint,omitempty" json:"hint,omitempty"`
 }

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -515,10 +515,13 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 		if probe.Description == "" {
 			probe.Description = fmt.Sprintf("user probe %d/%d", i+1, len(y.Probes))
 		}
-		if out, err := executeGuestTemplate(probe.Script, instDir, y.User, y.Param); err == nil {
-			probe.Script = out.String()
+		if probe.Script == nil {
+			probe.Script = ptr.Of("")
+		}
+		if out, err := executeGuestTemplate(*probe.Script, instDir, y.User, y.Param); err == nil {
+			probe.Script = ptr.Of(out.String())
 		} else {
-			logrus.WithError(err).Warnf("Couldn't process probing script %q as a template", probe.Script)
+			logrus.WithError(err).Warnf("Couldn't process probing script %q as a template", *probe.Script)
 		}
 	}
 

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -153,7 +153,7 @@ func TestFillDefault(t *testing.T) {
 			{Script: ptr.Of("#!/bin/true # {{.Param.ONE}}")},
 		},
 		Probes: []limatype.Probe{
-			{Script: "#!/bin/false # {{.Param.ONE}}"},
+			{Script: ptr.Of("#!/bin/false # {{.Param.ONE}}")},
 		},
 		Networks: []limatype.Network{
 			{Lima: "shared"},
@@ -239,7 +239,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Probes = slices.Clone(y.Probes)
 	expect.Probes[0].Mode = limatype.ProbeModeReadiness
 	expect.Probes[0].Description = "user probe 1/1"
-	expect.Probes[0].Script = "#!/bin/false # Eins"
+	expect.Probes[0].Script = ptr.Of("#!/bin/false # Eins")
 
 	expect.Networks = slices.Clone(y.Networks)
 	expect.Networks[0].MACAddress = MACAddress(fmt.Sprintf("%s#%d", filePath, 0))
@@ -370,7 +370,7 @@ func TestFillDefault(t *testing.T) {
 		},
 		Probes: []limatype.Probe{
 			{
-				Script:      "#!/bin/false",
+				Script:      ptr.Of("#!/bin/false"),
 				Mode:        limatype.ProbeModeReadiness,
 				Description: "User Probe",
 			},
@@ -578,7 +578,7 @@ func TestFillDefault(t *testing.T) {
 		},
 		Probes: []limatype.Probe{
 			{
-				Script:      "#!/bin/false",
+				Script:      ptr.Of("#!/bin/false"),
 				Mode:        limatype.ProbeModeReadiness,
 				Description: "Another Probe",
 			},

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -274,7 +274,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 				errs = errors.Join(errs, fmt.Errorf("field `probe[%d].file.digest` support is not yet implemented", i))
 			}
 		}
-		if !strings.HasPrefix(p.Script, "#!") {
+		if p.Script != nil && !strings.HasPrefix(*p.Script, "#!") {
 			errs = errors.Join(errs, fmt.Errorf("field `probe[%d].script` must start with a '#!' line", i))
 		}
 		switch p.Mode {
@@ -541,7 +541,7 @@ func validateParamIsUsed(y *limatype.LimaYAML) error {
 			}
 		}
 		for _, p := range y.Probes {
-			if re.MatchString(p.Script) {
+			if p.Script != nil && re.MatchString(*p.Script) {
 				keyIsUsed = true
 				break
 			}


### PR DESCRIPTION
## Summary
This PR includes the following 2 changes:
* Fill `provision.Script` with default value ( empty string `""` ) in `FillDefault()`
* Make Probe.Script a pointer

Check #4211 for related details.

## Notes
@jandubois -
This is suggested by you.
Would you mind to share your signed-off tag with me so I can put it in the commit as `Suggested-by: <your tag> ?