### PR TITLE
pkg/portfwd: Refactor `Forwarder.OnEvent()`

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -813,7 +813,8 @@ func (a *HostAgent) processGuestAgentEvents(ctx context.Context, client *guestag
 		if useSSHFwd {
 			a.portForwarder.OnEvent(ctx, ev)
 		} else {
-			a.grpcPortForwarder.OnEvent(ctx, client, ev)
+			dialContext := portfwd.DialContextToGRPCTunnel(client)
+			a.grpcPortForwarder.OnEvent(ctx, dialContext, ev)
 		}
 	}
 


### PR DESCRIPTION
Change `client` parameter to `dialContext` that supports dialers other than using `guestagentclient.GuestAgentClient`.

Splitted out from #4175