### PR TITLE
templates: tumbleweed: allow 9p and virtiofs

### DIFF
--- a/templates/experimental/opensuse-tumbleweed.yaml
+++ b/templates/experimental/opensuse-tumbleweed.yaml
@@ -9,9 +9,3 @@ images:
 
 - location: https://download.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.aarch64-Cloud.qcow2
   arch: aarch64
-
-# Hint: to allow 9p and virtiofs, replace the `kernel-default-base` package with `kernel-default` and reboot the VM.
-# https://github.com/lima-vm/lima/issues/3055
-mountType: reverse-sshfs
-
-mountTypesUnsupported: [9p, virtiofs]


### PR DESCRIPTION
9p and virtiofs seem available by default now