### PR TITLE
add Oracle Linux 10 support

### DIFF
--- a/hack/update-template-oraclelinux.sh
+++ b/hack/update-template-oraclelinux.sh
@@ -27,13 +27,17 @@ Description:
 
   Published Oracle Linux image information is fetched from the following URLs:
 
-    OL8:
+	OL8:
 	  x86_64: https://yum.oracle.com/templates/OracleLinux/ol8-template.json
 	  aarch64: https://yum.oracle.com/templates/OracleLinux/ol8_aarch64-cloud-template.json
 	  
 	OL9:
 	  x86_64: https://yum.oracle.com/templates/OracleLinux/ol9-template.json
 	  aarch64: https://yum.oracle.com/templates/OracleLinux/ol9_aarch64-cloud-template.json
+
+	OL10:
+	  x86_64: https://yum.oracle.com/templates/OracleLinux/ol10-template.json
+	  aarch64: https://yum.oracle.com/templates/OracleLinux/ol10_aarch64-cloud-template.json
 
   The downloaded files will be cached in the Lima cache directory.
 

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -102,6 +102,15 @@ elif command -v dnf >/dev/null 2>&1; then
 			dnf install ${dnf_install_flags} oracle-epel-release-el9
 			dnf config-manager --disable ol9_developer_EPEL >/dev/null 2>&1
 			epel_install_flags="${epel_install_flags} --enablerepo ol9_developer_EPEL"
+		elif grep -q "Oracle Linux Server release 10" /etc/system-release; then
+			oraclelinux_version="$(awk '{print $5}' /etc/system-release)"
+			oraclelinux_version_major=$(echo "$oraclelinux_version" | cut -d. -f1)
+			oraclelinux_version_minor=$(echo "$oraclelinux_version" | cut -d. -f2)
+			oraclelinux_epel_repo="ol${oraclelinux_version_major}_u${oraclelinux_version_minor}_developer_EPEL"
+			# shellcheck disable=SC2086
+			dnf install ${dnf_install_flags} oracle-epel-release-el${oraclelinux_version_major}
+			dnf config-manager --disable "$oraclelinux_epel_repo" >/dev/null 2>&1 || true
+			epel_install_flags="${epel_install_flags} --enablerepo $oraclelinux_epel_repo"
 		elif grep -q -E "release (9|10)" /etc/system-release; then
 			# shellcheck disable=SC2086
 			dnf install ${dnf_install_flags} epel-release

--- a/templates/README.md
+++ b/templates/README.md
@@ -27,7 +27,8 @@ Distro:
 - [`opensuse-leap-15`](./opensuse-leap-15.yaml): openSUSE Leap 15
 - [`opensuse-leap-16`](./opensuse-leap-16.yaml), `opensuse-leap.yaml`, `opensuse.yaml`: ⭐openSUSE Leap 16
 - [`oraclelinux-8`](./oraclelinux-8.yaml): Oracle Linux 8
-- [`oraclelinux-9`](./oraclelinux-9.yaml), `oraclelinux.yaml`: Oracle Linux 9
+- [`oraclelinux-9`](./oraclelinux-9.yaml): Oracle Linux 9
+- [`oraclelinux-10`](./oraclelinux-10.yaml), `oraclelinux.yaml`: Oracle Linux 10
 - [`rocky-8`](./rocky-8.yaml): Rocky Linux 8
 - [`rocky-9`](./rocky-9.yaml): Rocky Linux 9
 - [`rocky-10`](./rocky-10.yaml), `rocky.yaml`: Rocky Linux 10

--- a/templates/_images/oraclelinux-10.yaml
+++ b/templates/_images/oraclelinux-10.yaml
@@ -1,0 +1,11 @@
+# Oracle image license: https://www.oracle.com/downloads/licenses/oracle-linux-license.html
+# Image source: https://yum.oracle.com/oracle-linux-templates.html
+
+images:
+- location: "https://yum.oracle.com/templates/OracleLinux/OL10/u0/x86_64/OL10U0_x86_64-kvm-b266.qcow2"
+  arch: "x86_64"
+  digest: "sha256:f88b0f73a5a48cbcb23a72cae33c93847c10fd183de6527ddf1ae807a84ca19e"
+- location: "https://yum.oracle.com/templates/OracleLinux/OL10/u0/aarch64/OL10U0_aarch64-kvm-cloud-b143.qcow2"
+  arch: "aarch64"
+  digest: "sha256:cd6c154d08c61630160791ba247a0fc61a613dd7c5addec8b91672252fe49ed2"
+mountTypesUnsupported: [9p]

--- a/templates/oraclelinux-10.yaml
+++ b/templates/oraclelinux-10.yaml
@@ -1,0 +1,5 @@
+minimumLimaVersion: 1.1.0
+
+base:
+- template://_images/oraclelinux-10
+- template://_default/mounts

--- a/templates/oraclelinux.yaml
+++ b/templates/oraclelinux.yaml
@@ -1,1 +1,1 @@
-oraclelinux-9.yaml
+oraclelinux-10.yaml


### PR DESCRIPTION
With Oracle Linux 10, EPEL repo is named like this: ol10_u0_developer_EPEL, instead of ol9_developer_EPEL for previous version.