### PR TITLE
Improve GPRC performance with optimised configs for client and server

### DIFF
--- a/pkg/guestagent/api/client/client.go
+++ b/pkg/guestagent/api/client/client.go
@@ -21,14 +21,18 @@ type GuestAgentClient struct {
 
 func NewGuestAgentClient(dialFn func(ctx context.Context) (net.Conn, error)) (*GuestAgentClient, error) {
 	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(NewCredentials()),
+		grpc.WithInitialWindowSize(512 << 20),
+		grpc.WithInitialConnWindowSize(512 << 20),
+		grpc.WithReadBufferSize(8 << 20),
+		grpc.WithWriteBufferSize(8 << 20),
 		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(math.MaxInt64),
-			grpc.MaxCallSendMsgSize(math.MaxInt64),
+			grpc.MaxCallRecvMsgSize(math.MaxInt32),
+			grpc.MaxCallSendMsgSize(math.MaxInt32),
 		),
 		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 			return dialFn(ctx)
 		}),
-		grpc.WithTransportCredentials(NewCredentials()),
 	}
 
 	resolver.SetDefaultScheme("passthrough")

--- a/pkg/guestagent/api/server/server.go
+++ b/pkg/guestagent/api/server/server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/lima-vm/lima/v2/pkg/guestagent"
@@ -16,7 +17,14 @@ import (
 )
 
 func StartServer(lis net.Listener, guest *GuestServer) error {
-	server := grpc.NewServer()
+	server := grpc.NewServer(
+		grpc.InitialWindowSize(512<<20),
+		grpc.InitialConnWindowSize(512<<20),
+		grpc.ReadBufferSize(8<<20),
+		grpc.WriteBufferSize(8<<20),
+		grpc.MaxConcurrentStreams(2048),
+		grpc.KeepaliveParams(keepalive.ServerParameters{Time: 0, Timeout: 0, MaxConnectionIdle: 0}),
+	)
 	api.RegisterGuestServiceServer(server, guest)
 	return server.Serve(lis)
 }


### PR DESCRIPTION
**GRPC**
```
-----------------------------------------------------------
Server listening on 5201 (test #1)
-----------------------------------------------------------
Accepted connection from ::1, port 39068
[  5] local ::1 port 5201 connected to ::1 port 39078
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec   412 MBytes  3.46 Gbits/sec                  
[  5]   1.00-2.00   sec   439 MBytes  3.68 Gbits/sec                  
[  5]   2.00-3.00   sec   438 MBytes  3.68 Gbits/sec                  
[  5]   3.00-4.00   sec   435 MBytes  3.65 Gbits/sec                  
[  5]   4.00-5.00   sec   428 MBytes  3.59 Gbits/sec                  
[  5]   5.00-6.00   sec   436 MBytes  3.66 Gbits/sec                  
[  5]   6.00-7.00   sec   428 MBytes  3.59 Gbits/sec                  
[  5]   7.00-8.00   sec   423 MBytes  3.55 Gbits/sec                  
[  5]   8.00-9.00   sec   418 MBytes  3.51 Gbits/sec                  
[  5]   9.00-10.00  sec   428 MBytes  3.59 Gbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-10.00  sec  4.18 GBytes  3.59 Gbits/sec                  receiver
```


**SSH with vsock**

```
-----------------------------------------------------------
Server listening on 5201 (test #1)
-----------------------------------------------------------
Accepted connection from ::1, port 42904
[  5] local ::1 port 5201 connected to ::1 port 42920
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec   418 MBytes  3.51 Gbits/sec                  
[  5]   1.00-2.00   sec   436 MBytes  3.66 Gbits/sec                  
[  5]   2.00-3.00   sec   440 MBytes  3.69 Gbits/sec                  
[  5]   3.00-4.00   sec   384 MBytes  3.22 Gbits/sec                  
[  5]   4.00-5.00   sec   372 MBytes  3.12 Gbits/sec                  
[  5]   5.00-6.00   sec   434 MBytes  3.64 Gbits/sec                  
[  5]   6.00-7.00   sec   438 MBytes  3.68 Gbits/sec                  
[  5]   7.00-8.00   sec   443 MBytes  3.72 Gbits/sec                  
[  5]   8.00-9.00   sec   443 MBytes  3.72 Gbits/sec                  
[  5]   9.00-10.00  sec   442 MBytes  3.71 Gbits/sec                  
[  5]  10.00-10.00  sec  1.62 MBytes  3.83 Gbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-10.00  sec  4.15 GBytes  3.57 Gbits/sec                  receiver
```

Aimed to bridge the performance gap between GRPC and SSH with VSOCK. 