### PR TITLE
pkg/driver: Add `Driver.AdditionalSetupForSSH()`

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -88,6 +88,11 @@ type Driver interface {
 	FillConfig(ctx context.Context, cfg *limatype.LimaYAML, filePath string) error
 
 	SSHAddress(ctx context.Context) (string, error)
+
+	// AdditionalSetupForSSH provides additional setup required for SSH connection.
+	// It is called after VM is started, before first SSH connection.
+	// It returns an error if the setup fails.
+	AdditionalSetupForSSH(ctx context.Context) error
 }
 
 type ConfiguredDriver struct {

--- a/pkg/driver/external/client/methods.go
+++ b/pkg/driver/external/client/methods.go
@@ -323,3 +323,16 @@ func (d *DriverClient) BootScripts() (map[string][]byte, error) {
 	d.logger.Debugf("Boot scripts retrieved successfully: %d scripts", len(resp.Scripts))
 	return resp.Scripts, nil
 }
+
+func (d *DriverClient) AdditionalSetupForSSH(ctx context.Context) error {
+	d.logger.Debug("Performing additional setup for SSH connection")
+
+	_, err := d.DriverSvc.AdditionalSetupForSSH(ctx, &emptypb.Empty{})
+	if err != nil {
+		d.logger.Errorf("Failed to perform additional setup for SSH: %v", err)
+		return err
+	}
+
+	d.logger.Debug("Additional setup for SSH completed successfully")
+	return nil
+}

--- a/pkg/driver/external/driver.pb.desc
+++ b/pkg/driver/external/driver.pb.desc
@@ -1,5 +1,5 @@
 
-ý
+Æ
 driver.protogoogle/protobuf/empty.proto"Ž
 BootScriptsResponse;
 scripts (2!.BootScriptsResponse.ScriptsEntryRscripts:
@@ -30,7 +30,7 @@ connection")
 ListSnapshotsResponse
 	snapshots (	R	snapshots"B
 ForwardGuestAgentResponse%
-should_forward (RshouldForward2©	
+should_forward (RshouldForward2ò	
 Driver:
 Validate.google.protobuf.Empty.google.protobuf.Empty8
 Create.google.protobuf.Empty.google.protobuf.Empty<
@@ -52,4 +52,5 @@ CreateDisk.google.protobuf.Empty.google.protobuf.Empty1
 	Configure.SetConfigRequest.google.protobuf.Empty-
 Info.google.protobuf.Empty.InfoResponse9
 
-SSHAddress.google.protobuf.Empty.SSHAddressResponseB0Z.github.com/lima-vm/lima/v2/pkg/driver/externalbproto3
+SSHAddress.google.protobuf.Empty.SSHAddressResponseG
+AdditionalSetupForSSH.google.protobuf.Empty.google.protobuf.EmptyB0Z.github.com/lima-vm/lima/v2/pkg/driver/externalbproto3

--- a/pkg/driver/external/driver.pb.go
+++ b/pkg/driver/external/driver.pb.go
@@ -592,7 +592,7 @@ const file_driver_proto_rawDesc = "" +
 	"\x15ListSnapshotsResponse\x12\x1c\n" +
 	"\tsnapshots\x18\x01 \x01(\tR\tsnapshots\"B\n" +
 	"\x19ForwardGuestAgentResponse\x12%\n" +
-	"\x0eshould_forward\x18\x01 \x01(\bR\rshouldForward2\xa9\t\n" +
+	"\x0eshould_forward\x18\x01 \x01(\bR\rshouldForward2\xf2\t\n" +
 	"\x06Driver\x12:\n" +
 	"\bValidate\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\x128\n" +
 	"\x06Create\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\x12<\n" +
@@ -614,7 +614,8 @@ const file_driver_proto_rawDesc = "" +
 	"\tConfigure\x12\x11.SetConfigRequest\x1a\x16.google.protobuf.Empty\x12-\n" +
 	"\x04Info\x12\x16.google.protobuf.Empty\x1a\r.InfoResponse\x129\n" +
 	"\n" +
-	"SSHAddress\x12\x16.google.protobuf.Empty\x1a\x13.SSHAddressResponseB0Z.github.com/lima-vm/lima/v2/pkg/driver/externalb\x06proto3"
+	"SSHAddress\x12\x16.google.protobuf.Empty\x1a\x13.SSHAddressResponse\x12G\n" +
+	"\x15AdditionalSetupForSSH\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.EmptyB0Z.github.com/lima-vm/lima/v2/pkg/driver/externalb\x06proto3"
 
 var (
 	file_driver_proto_rawDescOnce sync.Once
@@ -666,27 +667,29 @@ var file_driver_proto_depIdxs = []int32{
 	4,  // 17: Driver.Configure:input_type -> SetConfigRequest
 	13, // 18: Driver.Info:input_type -> google.protobuf.Empty
 	13, // 19: Driver.SSHAddress:input_type -> google.protobuf.Empty
-	13, // 20: Driver.Validate:output_type -> google.protobuf.Empty
-	13, // 21: Driver.Create:output_type -> google.protobuf.Empty
-	13, // 22: Driver.CreateDisk:output_type -> google.protobuf.Empty
-	3,  // 23: Driver.Start:output_type -> StartResponse
-	13, // 24: Driver.Stop:output_type -> google.protobuf.Empty
-	13, // 25: Driver.Delete:output_type -> google.protobuf.Empty
-	0,  // 26: Driver.BootScripts:output_type -> BootScriptsResponse
-	13, // 27: Driver.RunGUI:output_type -> google.protobuf.Empty
-	13, // 28: Driver.ChangeDisplayPassword:output_type -> google.protobuf.Empty
-	6,  // 29: Driver.GetDisplayConnection:output_type -> GetDisplayConnectionResponse
-	13, // 30: Driver.CreateSnapshot:output_type -> google.protobuf.Empty
-	13, // 31: Driver.ApplySnapshot:output_type -> google.protobuf.Empty
-	13, // 32: Driver.DeleteSnapshot:output_type -> google.protobuf.Empty
-	10, // 33: Driver.ListSnapshots:output_type -> ListSnapshotsResponse
-	11, // 34: Driver.ForwardGuestAgent:output_type -> ForwardGuestAgentResponse
-	13, // 35: Driver.GuestAgentConn:output_type -> google.protobuf.Empty
-	13, // 36: Driver.Configure:output_type -> google.protobuf.Empty
-	2,  // 37: Driver.Info:output_type -> InfoResponse
-	1,  // 38: Driver.SSHAddress:output_type -> SSHAddressResponse
-	20, // [20:39] is the sub-list for method output_type
-	1,  // [1:20] is the sub-list for method input_type
+	13, // 20: Driver.AdditionalSetupForSSH:input_type -> google.protobuf.Empty
+	13, // 21: Driver.Validate:output_type -> google.protobuf.Empty
+	13, // 22: Driver.Create:output_type -> google.protobuf.Empty
+	13, // 23: Driver.CreateDisk:output_type -> google.protobuf.Empty
+	3,  // 24: Driver.Start:output_type -> StartResponse
+	13, // 25: Driver.Stop:output_type -> google.protobuf.Empty
+	13, // 26: Driver.Delete:output_type -> google.protobuf.Empty
+	0,  // 27: Driver.BootScripts:output_type -> BootScriptsResponse
+	13, // 28: Driver.RunGUI:output_type -> google.protobuf.Empty
+	13, // 29: Driver.ChangeDisplayPassword:output_type -> google.protobuf.Empty
+	6,  // 30: Driver.GetDisplayConnection:output_type -> GetDisplayConnectionResponse
+	13, // 31: Driver.CreateSnapshot:output_type -> google.protobuf.Empty
+	13, // 32: Driver.ApplySnapshot:output_type -> google.protobuf.Empty
+	13, // 33: Driver.DeleteSnapshot:output_type -> google.protobuf.Empty
+	10, // 34: Driver.ListSnapshots:output_type -> ListSnapshotsResponse
+	11, // 35: Driver.ForwardGuestAgent:output_type -> ForwardGuestAgentResponse
+	13, // 36: Driver.GuestAgentConn:output_type -> google.protobuf.Empty
+	13, // 37: Driver.Configure:output_type -> google.protobuf.Empty
+	2,  // 38: Driver.Info:output_type -> InfoResponse
+	1,  // 39: Driver.SSHAddress:output_type -> SSHAddressResponse
+	13, // 40: Driver.AdditionalSetupForSSH:output_type -> google.protobuf.Empty
+	21, // [21:41] is the sub-list for method output_type
+	1,  // [1:21] is the sub-list for method input_type
 	1,  // [1:1] is the sub-list for extension type_name
 	1,  // [1:1] is the sub-list for extension extendee
 	0,  // [0:1] is the sub-list for field type_name

--- a/pkg/driver/external/driver.proto
+++ b/pkg/driver/external/driver.proto
@@ -28,6 +28,10 @@ service Driver {
   rpc Configure(SetConfigRequest) returns (google.protobuf.Empty);
   rpc Info(google.protobuf.Empty) returns (InfoResponse);
   rpc SSHAddress(google.protobuf.Empty) returns (SSHAddressResponse);
+
+  // AdditionalSetupForSSH provides additional setup required for SSH connection.
+  // It is called after VM is started, before first SSH connection.
+  rpc AdditionalSetupForSSH(google.protobuf.Empty) returns (google.protobuf.Empty);
 }
 
 message BootScriptsResponse {

--- a/pkg/driver/external/server/methods.go
+++ b/pkg/driver/external/server/methods.go
@@ -284,3 +284,14 @@ func (s *DriverServer) ForwardGuestAgent(_ context.Context, _ *emptypb.Empty) (*
 	s.logger.Debug("Received ForwardGuestAgent request")
 	return &pb.ForwardGuestAgentResponse{ShouldForward: s.driver.ForwardGuestAgent()}, nil
 }
+
+func (s *DriverServer) AdditionalSetupForSSH(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty, error) {
+	s.logger.Debug("Received AdditionalSetupForSSH request")
+	err := s.driver.AdditionalSetupForSSH(ctx)
+	if err != nil {
+		s.logger.Errorf("AdditionalSetupForSSH failed: %v", err)
+		return &emptypb.Empty{}, err
+	}
+	s.logger.Debug("AdditionalSetupForSSH succeeded")
+	return &emptypb.Empty{}, nil
+}

--- a/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
@@ -353,3 +353,7 @@ func (l *LimaKrunkitDriver) Unregister(_ context.Context) error {
 func (l *LimaKrunkitDriver) GuestAgentConn(_ context.Context) (net.Conn, string, error) {
 	return nil, "unix", nil
 }
+
+func (l *LimaKrunkitDriver) AdditionalSetupForSSH(_ context.Context) error {
+	return nil
+}

--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -720,3 +720,7 @@ func (l *LimaQemuDriver) ForwardGuestAgent() bool {
 	// if driver is not providing, use host agent
 	return l.vSockPort == 0 && l.virtioPort == ""
 }
+
+func (l *LimaQemuDriver) AdditionalSetupForSSH(_ context.Context) error {
+	return nil
+}

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -357,3 +357,7 @@ func (l *LimaWslDriver) ForwardGuestAgent() bool {
 	// If driver is not providing, use host agent
 	return l.vSockPort == 0 && l.virtioPort == ""
 }
+
+func (l *LimaWslDriver) AdditionalSetupForSSH(_ context.Context) error {
+	return nil
+}

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -380,6 +380,10 @@ func (a *HostAgent) Run(ctx context.Context) error {
 		return err
 	}
 
+	if err := a.driver.AdditionalSetupForSSH(ctx); err != nil {
+		return err
+	}
+
 	// WSL instance SSH address isn't known until after VM start
 	if a.driver.Info().Features.DynamicSSHAddress {
 		sshAddr, err := a.driver.SSHAddress(ctx)

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -52,6 +52,7 @@ func (m *mockDriver) FillConfig(_ context.Context, _ *limatype.LimaYAML, _ strin
 func (m *mockDriver) InspectStatus(_ context.Context, _ *limatype.Instance) string       { return "" }
 func (m *mockDriver) SSHAddress(_ context.Context) (string, error)                       { return "", nil }
 func (m *mockDriver) BootScripts() (map[string][]byte, error)                            { return nil, nil }
+func (m *mockDriver) AdditionalSetupForSSH(_ context.Context) error                      { return nil }
 
 func TestRegister(t *testing.T) {
 	BackupRegistry(t)


### PR DESCRIPTION
## pkg/driver: Add `Driver.AdditionalSetupForSSH()`
`AdditionalSetupForSSH` provides additional setup required for SSH connection.
It is called after the VM is started, before the first SSH connection.
It returns an error if the setup fails.

## pkg/driver/vz: Change waiting `waitSSHLocalPortAccessible` in `Driver.AdditionalSetupForSSH()` instead of `startVM`.
`waitSSHLocalPortAccessible` is being used for waiting configuration SSH over VSOCK.
It makes `LimaVzDriver.Start()` to return as soon as possible.

Replaces #4248