### PR TITLE
docs/talks: add presentation at EuroBSDCon 2025

### DIFF
--- a/website/content/en/docs/talks/_index.md
+++ b/website/content/en/docs/talks/_index.md
@@ -60,3 +60,9 @@ Read the [slides](https://static.sched.com/hosted_files/kccncna2024/74/KCCNC-SLC
 [Akihiro Suda](https://github.com/AkihiroSuda) presented Lima in the CNCF project pavilion.
 
 Read the [slides](https://github.com/AkihiroSuda/AkihiroSuda/blob/master/slides/2025/20250402%20%5BKubeCon%20EU%20Pavilion%5D%20Lima.pdf).
+
+### EuroBSDCon 2025
+
+[Leonardo Taccari](https://github.com/iamleot) presented Lima in the NetBSD devsummit at EuroBSDCon 2025.
+
+Read the [slides](https://www.NetBSD.org/gallery/presentations/leot/eurobsdcon2025-devsummit-lima/lima.pdf).


### PR DESCRIPTION
Add my presentation at the NetBSD devsummit at EuroBSDCon 2025.

Unfortunately there are no recordings available but the slides also links to MP4 showing Lima running on NetBSD as host.

Signed-off-by: Leonardo Taccari <leot@NetBSD.org>
