### PR TITLE
Embedded files with tabs or return characters must be base64 encoded

### DIFF
--- a/pkg/limatmpl/embed.go
+++ b/pkg/limatmpl/embed.go
@@ -566,7 +566,7 @@ func encodeScriptReason(script string) string {
 	start := 0
 	line := 1
 	for i, r := range script {
-		if !(unicode.IsPrint(r) || r == '\n' || r == '\r' || r == '\t') {
+		if !(unicode.IsPrint(r) || r == '\n') {
 			return fmt.Sprintf("unprintable character %q at offset %d", r, i)
 		}
 		// maxLineLength includes final newline

--- a/pkg/limatmpl/embed_test.go
+++ b/pkg/limatmpl/embed_test.go
@@ -503,6 +503,11 @@ func TestEncodeScriptReason(t *testing.T) {
 		reason := encodeScriptReason("abc\a123")
 		assert.Equal(t, reason, "unprintable character '\\a' at offset 3")
 	})
+	t.Run("contains a tab character", func(t *testing.T) {
+		// newline character is included in character count
+		reason := encodeScriptReason("foo\tbar")
+		assert.Equal(t, reason, "unprintable character '\\t' at offset 3")
+	})
 	t.Run("long line", func(t *testing.T) {
 		// newline character is included in character count
 		reason := encodeScriptReason("line 1\nline 2\n01234567\n")


### PR DESCRIPTION
Looks like a bug in yqlib; it is not enforcing double-quotes around strings containing \t characters.

Fixes #4268

Filed upstream issue https://github.com/mikefarah/yq/issues/2506