### PR TITLE
pkg/cidata: Enable mDNS in guest using `systemd`

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/06-enable-mdns-on-systemd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/06-enable-mdns-on-systemd.sh
@@ -12,7 +12,6 @@ fi
 
 # It depends on systemd-resolved
 command -v systemctl >/dev/null 2>&1 || exit 0
-systemctl is-enabled -q systemd-resolved.service || exit 0
 command -v resolvectl >/dev/null 2>&1 || exit 0
 
 # Configure systemd-resolved to enable mDNS resolution globally


### PR DESCRIPTION
This change allows resolving `<guest's hostname>.local` to guest ip by mDNS on macOS host.

e.g.
```console
$ limactl start --name shared-and-vznat --tty=false --network=lima:shared,vzNAT --containerd=none --log-level error
...
$ dns-sd -q lima-shared-and-vznat.local
DATE: ---Sat 01 Nov 2025---
15:31:14.555  ...STARTING...
Timestamp     A/R  Flags         IF  Name                          Type   Class  Rdata
15:31:14.555  Add  40000003      27  lima-shared-and-vznat.local.  Addr   IN     192.168.64.2
15:31:14.555  Add  40000002      31  lima-shared-and-vznat.local.  Addr   IN     192.168.105.3
^C
$ ping -c 1 lima-shared-and-vznat.local
PING lima-shared-and-vznat.local (192.168.64.2): 56 data bytes
64 bytes from 192.168.64.2: icmp_seq=0 ttl=64 time=0.568 ms

--- lima-shared-and-vznat.local ping statistics ---
1 packets transmitted, 1 packets received, 0.0% packet loss
round-trip min/avg/max/stddev = 0.568/0.568/0.568/0.000 ms
```