### PR TITLE
nerdctl: update from v2.1.6 to v2.2.0-rc.0

### DIFF
--- a/pkg/limayaml/containerd.yaml
+++ b/pkg/limayaml/containerd.yaml
@@ -1,11 +1,11 @@
 # nerdctl version must be >= 2.1.6 since Lima v2.0.0.
 # Port forwarding in rootful mode no longer works with older versions of nerdctl.
 archives:
-- location: https://github.com/containerd/nerdctl/releases/download/v2.1.6/nerdctl-full-2.1.6-linux-amd64.tar.gz
+- location: https://github.com/containerd/nerdctl/releases/download/v2.2.0-rc.0/nerdctl-full-2.2.0-rc.0-linux-amd64.tar.gz
   arch: x86_64
-  digest: sha256:c30545867913696210991fe055761ae2e2d36344da2a351bcd1073fb5c71e232
-- location: https://github.com/containerd/nerdctl/releases/download/v2.1.6/nerdctl-full-2.1.6-linux-arm64.tar.gz
+  digest: sha256:958b13e8689b263154066e8eb52cd8211197100a7d4ed697fd94c08c23e26969
+- location: https://github.com/containerd/nerdctl/releases/download/v2.2.0-rc.0/nerdctl-full-2.2.0-rc.0-linux-arm64.tar.gz
   arch: aarch64
-  digest: sha256:2f98346ed3dcaf47cfd6461a5685e582284329a1ece1d952ade881b9fe7491e8
+  digest: sha256:1948967361d60958f8345d39f5900a5e94775a4eb23c49d70ae1bae3e78abb25
 # No arm-v7
 # No riscv64


### PR DESCRIPTION
https://github.com/containerd/nerdctl/releases/tag/v2.2.0-rc.0