### PR TITLE
pkg/hostagent/requirements.go: Avoid command substitution when creating pipe inputs on executing requirements

### DIFF
--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -85,7 +85,7 @@ func prefixExportParam(script string) (string, error) {
 	}
 
 	// TODO we should have a symbolic constant for `/mnt/lima-cidata`
-	exportParam := `while read -r line; do [ -n "$line" ] && export "$line"; done<<EOF\n$(sudo cat /mnt/lima-cidata/param.env)\nEOF\n`
+	exportParam := `param_env="$(sudo cat /mnt/lima-cidata/param.env)"; while read -r line; do [ -n "$line" ] && export "$line"; done<<EOF\n${param_env}\nEOF\n`
 
 	// double up all '%' characters so we can pass them through unchanged in the format string of printf
 	interpreter = strings.ReplaceAll(interpreter, "%", "%%")


### PR DESCRIPTION
I hope this change can avoid error `stderr="\"\": read |0: bad file descriptor"`.

An example log in CI:
https://github.com/lima-vm/lima/actions/runs/19009478793/job/54288264005?pr=4275#step:10:206
> {"time":"2025-11-02T08:20:01.457239Z","status":{"running":true,"degraded":true,"errors":["failed to satisfy the optional requirement 1 of 2 \"systemd must be available\": systemd is required to run containerd, but does not seem to be available.\nMake sure that you use an image that supports systemd. If you do not want to run\ncontainerd, please make sure that both 'container.system' and 'containerd.user'\nare set to 'false' in the config file.\n; skipping further checks: stdout=\"\", stderr=\"\": failed to execute script \"systemd must be available\": stdout=\"\", stderr=\"\": read |0: bad file descriptor"],"sshLocalPort":49262}}

This error is speculated to occur because the stdin is closed before the EOF is detected when `read` reads stdin. This change tries to reduce the possibility of stdin being closed by separating command substitution from the process of creating stdin to `read`.