### PR TITLE
pkg/sshutil: Add `IsControlMasterExisting()` to check if `ssh.sock` exists in the instance directory,

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -127,7 +127,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if restart {
+	if restart && sshutil.IsControlMasterExisting(inst.Dir) {
 		logrus.Infof("Exiting ssh session for the instance %q", instName)
 
 		sshConfig := &ssh.SSHConfig{

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -507,6 +507,11 @@ func (a *HostAgent) startHostAgentRoutines(ctx context.Context) error {
 		logrus.Info(msg)
 	}
 	a.cleanUp(func() error {
+		// Skip ExitMaster when the control socket does not exist.
+		// On Windows, the ControlMaster is used only for SSH port forwarding.
+		if !sshutil.IsControlMasterExisting(a.instDir) {
+			return nil
+		}
 		logrus.Debugf("shutting down the SSH master")
 		if exitMasterErr := ssh.ExitMaster(a.instSSHAddress, a.sshLocalPort, a.sshConfig); exitMasterErr != nil {
 			logrus.WithError(exitMasterErr).Warn("failed to exit SSH master")

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -325,6 +325,13 @@ func removeOptsFromSSHArgs(sshArgs []string, removeOpts ...string) []string {
 	return res
 }
 
+// IsControlMasterExisting returns true if the control socket file exists.
+func IsControlMasterExisting(instDir string) bool {
+	controlSock := filepath.Join(instDir, filenames.SSHSock)
+	_, err := os.Stat(controlSock)
+	return err == nil
+}
+
 // SSHOpts adds the following options to CommonOptions: User, ControlMaster, ControlPath, ControlPersist.
 func SSHOpts(ctx context.Context, sshExe SSHExe, instDir, username string, useDotSSH, forwardAgent, forwardX11, forwardX11Trusted bool) ([]string, error) {
 	controlSock := filepath.Join(instDir, filenames.SSHSock)


### PR DESCRIPTION
to skip `ssh.ExitMaster()` when the control socket does not exist.  
On Windows, the ControlMaster is used only for SSH port forwarding.