### PR TITLE
Add `--start` Flag to `limactl shell`

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -63,11 +63,13 @@ func newShellCommand() *cobra.Command {
 	shellCmd.Flags().String("workdir", "", "Working directory")
 	shellCmd.Flags().Bool("reconnect", false, "Reconnect to the SSH session")
 	shellCmd.Flags().Bool("preserve-env", false, "Propagate environment variables to the shell")
+	shellCmd.Flags().Bool("start", false, "Start the instance if it is not already running")
 	return shellCmd
 }
 
 func shellAction(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+	flags := cmd.Flags()
 	// simulate the behavior of double dash
 	newArg := []string{}
 	if len(args) >= 2 && args[1] == "--" {
@@ -93,9 +95,16 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if inst.Status == limatype.StatusStopped {
-		startNow, err := askWhetherToStart()
+		startNow, err := flags.GetBool("start")
 		if err != nil {
 			return err
+		}
+
+		if !flags.Changed("start") {
+			startNow, err = askWhetherToStart()
+			if err != nil {
+				return err
+			}
 		}
 
 		if !startNow {


### PR DESCRIPTION
This PR is a follow up to #4108 and <https://github.com/lima-vm/lima/issues/3995#issuecomment-3481479484> which adds a new `--start` flag to the `shell` subcommand, which auto-starts the VM in case it isn't already running.

Note that, unlike #4108, I did not add any deprecation warning to the `--yes` flag since it was previously ignored by `limactl shell`.