### PR TITLE
Makefile: native, artifact: include limactl-plugins and additional-drivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ exe: _output/bin/limactl$(exe)
 
 .PHONY: minimal native
 minimal: clean limactl native-guestagent default_template
-native: clean limactl helpers native-guestagent templates template_experimentals
+native: clean limactl limactl-plugins helpers native-guestagent templates template_experimentals additional-drivers
 
 ################################################################################
 # These configs were once customizable but should no longer be changed.
@@ -641,9 +641,10 @@ ARTIFACT_ADDITIONAL_GUESTAGENTS_PATH_COMMON = _artifacts/lima-additional-guestag
 artifact: $(addprefix $(ARTIFACT_PATH_COMMON),$(ARTIFACT_FILE_EXTENSIONS)) \
 	$(addprefix $(ARTIFACT_ADDITIONAL_GUESTAGENTS_PATH_COMMON),$(ARTIFACT_FILE_EXTENSIONS))
 
-ARTIFACT_DES =  _output/bin/limactl$(exe) $(LIMA_DEPS) $(HELPERS_DEPS) \
+ARTIFACT_DES =  _output/bin/limactl$(exe) limactl-plugins $(LIMA_DEPS) $(HELPERS_DEPS) \
 	$(NATIVE_GUESTAGENT) \
 	$(TEMPLATES) $(TEMPLATE_EXPERIMENTALS) \
+	additional-drivers \
 	$(DOCUMENTATION) _output/share/doc/lima/templates \
 	_output/share/man/man1/limactl.1
 


### PR DESCRIPTION
Fix #4289
Fix #4290


`make minimal` still excludes them


- - -
```console
$ make artifacts
$ tar tzvf _artifacts/lima-2.0.0-rc.0-2-g7ec355ea-Darwin-arm64.tar.gz
[...]
drwxr-xr-x  0 suda   staff        0 Nov  5 03:26 ./libexec/lima/
-rwxr-xr-x  0 suda   staff  6479154 Nov  5 03:26 ./libexec/lima/limactl-mcp
-rwxr-xr-x  0 suda   staff 25480194 Nov  5 03:26 ./libexec/lima/lima-driver-krunkit
[...]
```

lima-driver-krunkit is huge, so rethinking about it ...
Maybe we should split it to `lima-additional-drivers` package?