### PR TITLE
Add libexecPaths to `limactl info` output

### DIFF
--- a/pkg/limainfo/limainfo.go
+++ b/pkg/limainfo/limainfo.go
@@ -29,14 +29,16 @@ type LimaInfo struct {
 	Templates       []templatestore.Template     `json:"templates"`
 	DefaultTemplate *limatype.LimaYAML           `json:"defaultTemplate"`
 	LimaHome        string                       `json:"limaHome"`
-	VMTypes         []string                     `json:"vmTypes"`     // since Lima v0.14.2
-	VMTypesEx       map[string]DriverExt         `json:"vmTypesEx"`   // since Lima v2.0.0
-	GuestAgents     map[limatype.Arch]GuestAgent `json:"guestAgents"` // since Lima v1.1.0
-	ShellEnvBlock   []string                     `json:"shellEnvBlock"`
-	HostOS          string                       `json:"hostOS"`       // since Lima v2.0.0
-	HostArch        string                       `json:"hostArch"`     // since Lima v2.0.0
-	IdentityFile    string                       `json:"identityFile"` // since Lima v2.0.0
-	Plugins         []plugins.Plugin             `json:"plugins"`      // since Lima v2.0.0
+	VMTypes         []string                     `json:"vmTypes"`       // since Lima v0.14.2
+	VMTypesEx       map[string]DriverExt         `json:"vmTypesEx"`     // since Lima v2.0.0
+	GuestAgents     map[limatype.Arch]GuestAgent `json:"guestAgents"`   // since Lima v1.1.0
+	ShellEnvBlock   []string                     `json:"shellEnvBlock"` // since Lima v2.0.0
+	HostOS          string                       `json:"hostOS"`        // since Lima v2.0.0
+	HostArch        string                       `json:"hostArch"`      // since Lima v2.0.0
+	IdentityFile    string                       `json:"identityFile"`  // since Lima v2.0.0
+	Plugins         []plugins.Plugin             `json:"plugins"`       // since Lima v2.0.0
+	LibexecPaths    []string                     `json:"libexecPaths"`  // since Lima v2.0.0
+	SharePaths      []string                     `json:"sharePaths"`    // since Lima v2.0.0
 }
 
 type DriverExt struct {
@@ -92,6 +94,14 @@ func New(ctx context.Context) (*LimaInfo, error) {
 		return nil, err
 	}
 	configDir, err := dirnames.LimaConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	info.LibexecPaths, err = usrlocal.LibexecLima()
+	if err != nil {
+		return nil, err
+	}
+	info.SharePaths, err = usrlocal.ShareLima()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Also added the "since Lima v2.0.0" comment to the `shellEnvBlock` entry.

Will need to be rebased if #4298 is merged first