### PR TITLE
Prefer SysKill over external pkill

### DIFF
--- a/pkg/networks/usernet/recoincile.go
+++ b/pkg/networks/usernet/recoincile.go
@@ -4,7 +4,6 @@
 package usernet
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -21,6 +20,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/executil"
 	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
 	"github.com/lima-vm/lima/v2/pkg/lockutil"
+	"github.com/lima-vm/lima/v2/pkg/osutil"
 	"github.com/lima-vm/lima/v2/pkg/store"
 )
 
@@ -143,14 +143,9 @@ func Stop(ctx context.Context, name string) error {
 			return err
 		}
 
-		var stdout, stderr bytes.Buffer
-		cmd := exec.CommandContext(ctx, "/usr/bin/pkill", "-F", pidFile)
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		logrus.Debugf("Running: %v", cmd.Args)
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to run %v: stdout=%q, stderr=%q: %w",
-				cmd.Args, stdout.String(), stderr.String(), err)
+		if err := osutil.SysKill(pid, osutil.SigKill); err != nil {
+			logrus.Error(err)
+			return fmt.Errorf("failed to kill process with pid %d: %w", pid, err)
 		}
 	}
 


### PR DESCRIPTION
* NixOS is an example of this problem. Thanks to @devusb for the report in https://github.com/NixOS/nixpkgs/pull/458941.
~* This patch changes how we find the `pkill` executable to use `/usr/bin/env`, which is a similar approach used for `bash`.~ => Switched to use `SysKill` approach
* This is especially needed for `pkg/networks/usernet/recoincile.go`.
  We can see the error by running this command:
  ```console
  > limactl start --network=lima:user-v2
  > limactl stop
  ...
  INFO[0000] [hostagent] Shutting down QEMU with the power button
  INFO[0000] [hostagent] Sending QMP system_powerdown command
  INFO[0001] [hostagent] QEMU has exited
  INFO[0001] Waiting for the instance to shut down
  INFO[0002] The instance default has shut down
  FATA[0002] failed to stop usernet "user-v2": failed to run [/usr/bin/pkill -F /home/uname/.lima/_networks/user-v2/usernet_user-v2.pid]: stdout="", stderr="": fork/exec /usr/bin/pkill: no such file or directory
  ```
  
* ~I also apply this change in `pkg/networks/commands.go`.~
  Linux users do not need this change right now because that code part is skipped by `runtime.GOOS != "darwin"`.
  https://github.com/lima-vm/lima/blob/483a694d0d15ce701d89a0203360052b9d9c81af/pkg/networks/reconcile/reconcile.go#L237-L239
  ~However, we are making the update now for better consistency and to prepare for future changes.~

---

My environments

```console
> limactl --version
limactl version 1.2.1
> uname -rm
  6.12.56 x86_64
```