### PR TITLE
Makefile: Include `TEMPLATE_IMAGES` in release artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -644,7 +644,7 @@ artifact: $(addprefix $(ARTIFACT_PATH_COMMON),$(ARTIFACT_FILE_EXTENSIONS)) \
 
 ARTIFACT_DES =  _output/bin/limactl$(exe) limactl-plugins $(LIMA_DEPS) $(HELPERS_DEPS) \
 	$(NATIVE_GUESTAGENT) \
-	$(TEMPLATES) $(TEMPLATE_IMAGES) $(TEMPLATE_EXPERIMENTALS) \
+	$(TEMPLATES) $(TEMPLATE_IMAGES) $(TEMPLATE_DEFAULTS) $(TEMPLATE_EXPERIMENTALS) \
 	additional-drivers \
 	$(DOCUMENTATION) _output/share/doc/lima/templates \
 	_output/share/man/man1/limactl.1


### PR DESCRIPTION
- fixes: https://github.com/lima-vm/lima/issues/4313

The `_images` directory was missing from the output release tarballs because `TEMPLATE_IMAGES` was not included in the `ARTIFACT_DES` dependencies for the artifact targets.

---

Not sure if it's the correct fix, but it makes the `_images` present in the tarballs created by `artifacts-darwin`

```
$ make artifacts-darwin
$ tar --list -f _artifacts/lima-2.0.0.m-Darwin-arm64.tar.gz | grep _images
./share/lima/templates/_images/
./share/lima/templates/_images/ubuntu-25.10.yaml
./share/lima/templates/_images/centos-stream-10.yaml
./share/lima/templates/_images/fedora-43.yaml
./share/lima/templates/_images/oraclelinux-9.yaml
./share/lima/templates/_images/oraclelinux-8.yaml
./share/lima/templates/_images/fedora-42.yaml
./share/lima/templates/_images/ubuntu-20.04.yaml
./share/lima/templates/_images/ubuntu-24.10.yaml
./share/lima/templates/_images/alpine.yaml
./share/lima/templates/_images/opensuse-leap-15.yaml
./share/lima/templates/_images/ubuntu-22.04.yaml
./share/lima/templates/_images/opensuse-leap.yaml
./share/lima/templates/_images/debian-11.yaml
./share/lima/templates/_images/ubuntu.yaml
./share/lima/templates/_images/fedora.yaml
./share/lima/templates/_images/almalinux-8.yaml
./share/lima/templates/_images/almalinux-10.yaml
./share/lima/templates/_images/archlinux.yaml
./share/lima/templates/_images/debian-13.yaml
./share/lima/templates/_images/rocky-8.yaml
./share/lima/templates/_images/rocky-9.yaml
./share/lima/templates/_images/opensuse-leap-16.yaml
./share/lima/templates/_images/debian-12.yaml
./share/lima/templates/_images/alpine-iso.yaml
./share/lima/templates/_images/oraclelinux-10.yaml
./share/lima/templates/_images/almalinux-9.yaml
./share/lima/templates/_images/almalinux-kitten-10.yaml
./share/lima/templates/_images/rocky-10.yaml
./share/lima/templates/_images/centos-stream-9.yaml
./share/lima/templates/_images/ubuntu-25.04.yaml
./share/lima/templates/_images/fedora-41.yaml
./share/lima/templates/_images/ubuntu-lts.yaml
./share/lima/templates/_images/ubuntu-24.04.yaml
```