### PR TITLE
fix: handle write_file toolset issue (#4174)

### DIFF
--- a/hack/bats/tests/mcp.bats
+++ b/hack/bats/tests/mcp.bats
@@ -253,8 +253,6 @@ tools_call() {
 }
 
 @test 'write_file creates the directory if it does not yet exist' {
-    skip "see https://github.com/lima-vm/lima/issues/4174"
-
     limactl shell "$NAME" rm -rf /tmp/tmp
     tools_call write_file '{"path":"/tmp/tmp/tmp","content":"tmp"}'
     json=$output

--- a/pkg/mcp/toolset/filesystem.go
+++ b/pkg/mcp/toolset/filesystem.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -84,6 +85,11 @@ func (ts *ToolSet) WriteFile(_ context.Context,
 		return nil, nil, errors.New("instance not registered")
 	}
 	guestPath, err := ts.TranslateHostPath(args.Path)
+	if err != nil {
+		return nil, nil, err
+	}
+	dir := filepath.Dir(guestPath)
+	err = ts.sftp.MkdirAll(dir)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
### This PR fixes [4174](https://github.com/lima-vm/lima/issues/4174), 

**Issue:**
write_file doesn't create parent directories automatically

`f, err := ts.sftp.Create(guestPath)
if err != nil {
    return nil, nil, err
}`

The `sftp.Create()` function tries to create a file, but it doesn't create parent directories.So when written to files with no parent dierectories, `sftp.Create()` fails with "file does not exist".

**Fix:**
Ensure the parent directory exists before creating the file.
`dir := filepath.Dir(guestPath)
   err = ts.sftp.MkdirAll(dir)
    if err != nil {
        return nil, nil, err
    }`


`filepath.Dir(guestPath)` extracts the parent directory from the full path
`ts.sftp.MkdirAll(dir)` creates all parent directories
