### PR TITLE
fix: semgrep-dangerous-exec-command

### DIFF
--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -290,6 +290,14 @@ type features struct {
 }
 
 func inspectFeatures(ctx context.Context, exe, machine string) (*features, error) {
+	// Validate executable path to prevent command injection
+	if !filepath.IsAbs(exe) {
+		return nil, fmt.Errorf("executable path must be absolute: %q", exe)
+	}
+	if _, err := os.Stat(exe); err != nil {
+		return nil, fmt.Errorf("executable path does not exist or is not accessible: %q", exe)
+	}
+	
 	var (
 		f      features
 		stdout bytes.Buffer


### PR DESCRIPTION
Pull Request — Semgrep Rule Fix
Rule ID: dangerous-exec-command
Rule Message: Detected non-static command inside Command. Audit the input to 'exec.Command'. If unverified user data can reach this call site, this is a code injection vulnerability. A malicious actor can inject a malicious script to execute arbitrary code.
File Path: /tools/scanResult/unzipped-904865649/pkg/driver/qemu/qemu.go
Line: 322