### PR TITLE
dns: simplify newStaticClientConfig implementation

### DIFF
--- a/pkg/hostagent/dns/dns.go
+++ b/pkg/hostagent/dns/dns.go
@@ -7,7 +7,6 @@ package dns
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"runtime"
 	"strconv"
@@ -69,12 +68,8 @@ func (s *Server) Shutdown() {
 
 func newStaticClientConfig(ips []string) (*dns.ClientConfig, error) {
 	logrus.Tracef("newStaticClientConfig creating config for the following IPs: %v", ips)
-	s := ``
-	for _, ip := range ips {
-		s += fmt.Sprintf("nameserver %s\n", ip)
-	}
-	r := strings.NewReader(s)
-	return dns.ClientConfigFromReader(r)
+	config := "nameserver " + strings.Join(ips, "\nnameserver ") + "\n"
+	return dns.ClientConfigFromReader(strings.NewReader(config))
 }
 
 func (h *Handler) lookupCnameToHost(cname string) string {


### PR DESCRIPTION
This PR refactors unexported function `newStaticClientConfig` in the `hostagent/dns` package.

The PR silents one `modernize` (will be enabled later) lint issue:
```console
$ golangci-lint run --enable-only modernize

pkg/hostagent/dns/dns.go:74:3: stringsbuilder: using string += string in a loop is inefficient (modernize)
                s += fmt.Sprintf("nameserver %s\n", ip)
                ^
```