### PR TITLE
refactor: fix modernize lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
   - ineffassign
   - intrange
   - misspell
+  - modernize
   - nakedret
   - noctx
   - nolintlint
@@ -71,6 +72,10 @@ linters:
         ifElseChain:
           # Min number of if-else blocks that makes the warning trigger.
           minThreshold: 3
+    modernize:
+      disable:
+      - omitzero
+      - stringsbuilder
     perfsprint:
       int-conversion: false
       err-error: false

--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -137,8 +137,7 @@ func ParsePortForward(spec string) (hostPort, guestPort string, isStatic bool, e
 
 	if len(parts) == 2 {
 		staticPart := strings.TrimSpace(parts[1])
-		if strings.HasPrefix(staticPart, "static=") {
-			staticValue := strings.TrimPrefix(staticPart, "static=")
+		if staticValue, ok := strings.CutPrefix(staticPart, "static="); ok {
 			isStatic, err = strconv.ParseBool(staticValue)
 			if err != nil {
 				return "", "", false, fmt.Errorf("invalid value for static parameter: %q", staticValue)

--- a/cmd/limactl/gendoc.go
+++ b/cmd/limactl/gendoc.go
@@ -105,7 +105,7 @@ func escapeMarkdown(text string) string {
 	lines := strings.Split(text, "\n")
 	for i := range lines {
 		// Need to escape backticks first, before adding more
-		for _, c := range strings.Split("\\`*_[]()#+-.|", "") {
+		for c := range strings.SplitSeq("\\`*_[]()#+-.|", "") {
 			lines[i] = strings.ReplaceAll(lines[i], c, "\\"+c)
 		}
 		if i < len(lines)-1 {

--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -25,8 +25,7 @@ import (
 
 func fieldNames() []string {
 	names := []string{}
-	var data store.FormatData
-	t := reflect.TypeOf(data)
+	t := reflect.TypeFor[store.FormatData]()
 	for i := range t.NumField() {
 		f := t.Field(i)
 		if f.Anonymous {

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -475,7 +475,7 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 
 func getCert(content string) Cert {
 	lines := []string{}
-	for _, line := range strings.Split(content, "\n") {
+	for line := range strings.SplitSeq(content, "\n") {
 		if line == "" {
 			continue
 		}
@@ -490,7 +490,7 @@ func getBootCmds(p []limatype.Provision) []BootCmds {
 	for _, f := range p {
 		if f.Mode == limatype.ProvisionModeBoot {
 			lines := []string{}
-			for _, line := range strings.Split(*f.Script, "\n") {
+			for line := range strings.SplitSeq(*f.Script, "\n") {
 				if line == "" {
 					continue
 				}

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -437,8 +437,7 @@ func canonicalLocalPath(s string) (string, error) {
 	if !IsLocal(s) {
 		return "", fmt.Errorf("got non-local path: %q", s)
 	}
-	if strings.HasPrefix(s, "file://") {
-		res := strings.TrimPrefix(s, "file://")
+	if res, ok := strings.CutPrefix(s, "file://"); ok {
 		if !filepath.IsAbs(res) {
 			return "", fmt.Errorf("got non-absolute path %q", res)
 		}

--- a/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
@@ -91,7 +91,7 @@ func (l *LimaKrunkitDriver) Start(ctx context.Context) (chan error, error) {
 	}
 
 	pidPath := filepath.Join(l.Instance.Dir, filenames.PIDFile(*l.Instance.Config.VMType))
-	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d\n", krunkitCmd.Process.Pid)), 0o644); err != nil {
+	if err := os.WriteFile(pidPath, fmt.Appendf(nil, "%d\n", krunkitCmd.Process.Pid), 0o644); err != nil {
 		logrus.WithError(err).Warn("Failed to write PID file")
 	}
 

--- a/pkg/driver/wsl2/vm_windows.go
+++ b/pkg/driver/wsl2/vm_windows.go
@@ -238,7 +238,7 @@ func getWslStatus(ctx context.Context, instName string) (string, error) {
 	var instState string
 	wslListColsRegex := regexp.MustCompile(`\s+`)
 	// wsl --list --verbose may have different headers depending on localization, just split by line
-	for _, rows := range strings.Split(strings.ReplaceAll(out, "\r\n", "\n"), "\n") {
+	for rows := range strings.SplitSeq(strings.ReplaceAll(out, "\r\n", "\n"), "\n") {
 		cols := wslListColsRegex.Split(strings.TrimSpace(rows), -1)
 		nameIdx := 0
 		// '*' indicates default instance

--- a/pkg/editutil/editutil.go
+++ b/pkg/editutil/editutil.go
@@ -27,7 +27,7 @@ func fileWarning(filename string) string {
 	s := "# WARNING: " + filename + " includes the following settings,\n"
 	s += "# which are applied before applying this YAML:\n"
 	s += "# -----------\n"
-	for _, line := range strings.Split(strings.TrimSuffix(string(b), "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSuffix(string(b), "\n"), "\n") {
 		s += "#"
 		if line != "" {
 			s += " " + line

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -1063,8 +1063,7 @@ func (a *HostAgent) watchCloudInitProgress(ctx context.Context) {
 
 		finalCmd := exec.CommandContext(ctx, a.sshConfig.Binary(), finalArgs...)
 		if finalOutput, err := finalCmd.Output(); err == nil {
-			lines := strings.Split(string(finalOutput), "\n")
-			for _, line := range lines {
+			for line := range strings.SplitSeq(string(finalOutput), "\n") {
 				if strings.TrimSpace(line) != "" {
 					if !cloudInitFinished {
 						cloudInitFinished = isCloudInitFinished(line)

--- a/pkg/limatmpl/embed.go
+++ b/pkg/limatmpl/embed.go
@@ -599,10 +599,7 @@ func binaryString(s string) string {
 	builder.Grow(len(encoded) + lineCount)
 
 	for i := 0; i < len(encoded); i += base64ChunkLength {
-		end := i + base64ChunkLength
-		if end > len(encoded) {
-			end = len(encoded)
-		}
+		end := min(i+base64ChunkLength, len(encoded))
 		builder.WriteString(encoded[i:end])
 		builder.WriteByte('\n')
 	}

--- a/pkg/networks/usernet/gvproxy.go
+++ b/pkg/networks/usernet/gvproxy.go
@@ -310,8 +310,8 @@ func resolveSearchDomain(file string) []string {
 	sc := bufio.NewScanner(f)
 	searchPrefix := "search "
 	for sc.Scan() {
-		if strings.HasPrefix(sc.Text(), searchPrefix) {
-			searchDomains := strings.Split(strings.TrimPrefix(sc.Text(), searchPrefix), " ")
+		if after, ok := strings.CutPrefix(sc.Text(), searchPrefix); ok {
+			searchDomains := strings.Split(after, " ")
 			logrus.Debugf("Using search domains: %v", searchDomains)
 			return searchDomains
 		}


### PR DESCRIPTION
This PR enables the [`modernize`](https://golangci-lint.run/docs/linters/configuration/#modernize) linter.

`stringsbuilder` and `omitzero` are disabled because it's not easy to fix. Will be fixed in future PRs.