### PR TITLE
driver(external): wait for `Start()` to complete on the server side 

### DIFF
--- a/pkg/driver/external/driver.pb.go
+++ b/pkg/driver/external/driver.pb.go
@@ -154,6 +154,11 @@ func (x *InfoResponse) GetInfoJson() []byte {
 	return nil
 }
 
+// StartResponse is a streamed response for Start() RPC. It tries to mimic
+// errChan from pkg/driver/driver.go. The server sends an initial response
+// with success=true when Start() is initiated. If errors occur, they are
+// sent as success=false with the error field populated. When the error channel
+// closes, a final success=true message is sent.
 type StartResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`

--- a/pkg/driver/external/driver.proto
+++ b/pkg/driver/external/driver.proto
@@ -46,6 +46,11 @@ message InfoResponse{
   bytes info_json = 1;
 }
 
+// StartResponse is a streamed response for Start() RPC. It tries to mimic
+// errChan from pkg/driver/driver.go. The server sends an initial response 
+// with success=true when Start() is initiated. If errors occur, they are 
+// sent as success=false with the error field populated. When the error channel 
+// closes, a final success=true message is sent.
 message StartResponse {
   bool success = 1;
   string error = 2;

--- a/pkg/driver/external/server/server.go
+++ b/pkg/driver/external/server/server.go
@@ -207,6 +207,9 @@ func handlePreConfiguredDriverAction(ctx context.Context, driver driver.Driver) 
 	}
 }
 
+// Start begins the driver startup process. It sends an initial response to unblock
+// the client and then streams subsequent errors(if any), as the driver initializes.
+// A final success message is streamed upon successful completion.
 func Start(extDriver *registry.ExternalDriver, instName string) error {
 	extDriver.Logger.Debugf("Starting external driver at %s", extDriver.Path)
 	if instName == "" {


### PR DESCRIPTION
Fixes #4343

[Edit]: Also fixes #4348 