### PR TITLE
Don't use special message for errUnimplemented

### DIFF
--- a/pkg/driver/krunkit/errors_darwin_arm64.go
+++ b/pkg/driver/krunkit/errors_darwin_arm64.go
@@ -5,4 +5,4 @@ package krunkit
 
 import "errors"
 
-var errUnimplemented = errors.New("unimplemented by the krunkit driver")
+var errUnimplemented = errors.New("unimplemented")

--- a/pkg/osutil/osutil_windows.go
+++ b/pkg/osutil/osutil_windows.go
@@ -55,5 +55,5 @@ func SignalName(sig os.Signal) string {
 }
 
 func Sysctl(_ context.Context, _ string) (string, error) {
-	return "", errors.New("sysctl: unimplemented on Windows")
+	return "", errors.New("unimplemented")
 }


### PR DESCRIPTION
One day we might want to combine these in lima core.

Instead of having each driver and os do their own...

It's a bit annoying to have one "errors.go" file for each?

```go
import "errors"

var errUnimplemented = errors.New("unimplemented")
```