### PR TITLE
Don't add reverse-sshfs mounts to cloud-init user-data

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -16,7 +16,7 @@ mounts:
   {{- if .RosettaEnabled }}{{/* Mount the rosetta volume before systemd-binfmt.service(8) starts */}}
 - [vz-rosetta, /mnt/lima-rosetta, virtiofs, defaults, "0", "0"]
   {{- end }}
-  {{- if .Mounts }}
+  {{- if and .Mounts (or (eq .MountType "9p") (eq .MountType "virtiofs")) }}
     {{- range $m := $.Mounts}}
 - [{{$m.Tag}}, {{$m.MountPoint}}, {{$m.Type}}, "{{$m.Options}}", "0", "0"]
     {{- end }}


### PR DESCRIPTION
The template checks the mount type, but when Rosetta is enabled, then all mounts will be added to user-data regardless of the mount type. We need to repeat the check condition exactly.