### PR TITLE
Fix #4173: glob returns an error instead of an empty list

### DIFF
--- a/hack/bats/tests/mcp.bats
+++ b/hack/bats/tests/mcp.bats
@@ -296,8 +296,7 @@ tools_call() {
 }
 
 @test 'glob returns an empty list when the pattern does not match' {
-    skip "see https://github.com/lima-vm/lima/issues/4173"
-
+   
     tools_call glob '{"pattern":"nothing.to.see"}'
 
     run_yq '.structuredContent.matches[]' <<<"$output"

--- a/pkg/mcp/toolset/filesystem.go
+++ b/pkg/mcp/toolset/filesystem.go
@@ -130,6 +130,9 @@ func (ts *ToolSet) Glob(_ context.Context,
 	}
 	pattern := path.Join(guestPath, args.Pattern)
 	matches, err := ts.sftp.Glob(pattern)
+	if matches == nil {
+		matches = []string{}
+	}
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
**Issue:**
`matches, err := ts.sftp.Glob(pattern)` , sftp.Glob returns nil when the pattern has no hits, causing to fail schema validation with errors like
```
$ echo '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"glob","arguments":{"pattern":"XXX*"}}}' >&"${MCP[1]}"

$ read -t 1 -r line <&"${MCP[0]}"; jq . <<<"$line"
{
  "jsonrpc": "2.0",
  "id": 3,
  "error": {
    "code": 0,
    "message": "validating tool output: validating root: validating /properties/matches: type: <invalid reflect.Value> has type \"null\", want \"array\""
  }
}
```

**Fix**

```
if matches == nil {
		matches = []string{}
}
```

Replacing the nil value with an empty slice

**Result after fix**
```
$ echo '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"glob","arguments":{"pattern":"XXX*"}}}' >&"${MCP[1]}"

$ read -t 1 -r line <&"${MCP[0]}"; jq . <<<"$line"
{
  "jsonrpc": "2.0",
  "id": 3,
  "result": {
    "content": [
      {
        "type": "text",
        "text": "{\"matches\":[]}"
      }
    ],
    "structuredContent": {
      "matches": []
    }
  }
}

```


