### PR TITLE
Don't trim whitespace from boot commands

### DIFF
--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -489,14 +489,7 @@ func getBootCmds(p []limatype.Provision) []BootCmds {
 	var bootCmds []BootCmds
 	for _, f := range p {
 		if f.Mode == limatype.ProvisionModeBoot {
-			lines := []string{}
-			for line := range strings.SplitSeq(*f.Script, "\n") {
-				if line == "" {
-					continue
-				}
-				lines = append(lines, strings.TrimSpace(line))
-			}
-			bootCmds = append(bootCmds, BootCmds{Lines: lines})
+			bootCmds = append(bootCmds, BootCmds{Lines: strings.Split(*f.Script, "\n")})
 		}
 	}
 	return bootCmds


### PR DESCRIPTION
It breaks here-docs.

The original code was likely copied from the getCert() function above, but skipping empty lines and stripping whitespace is not appropriate for a shell script.

Fixes #4319