### PR TITLE
refactor: use constant for sleep delay

### DIFF
--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -42,7 +42,7 @@ func (a *HostAgent) waitForRequirements(label string, requirements []requirement
 				errs = append(errs, fmt.Errorf("failed to satisfy the %s requirement %d of %d %q: %s: %w", label, i+1, len(requirements), req.description, req.debugHint, err))
 				break retryLoop
 			}
-			time.Sleep(10 * time.Second)
+			time.Sleep(sleepDuration)
 		}
 	}
 	return errors.Join(errs...)


### PR DESCRIPTION
Looks like the `sleepDuration` constant was introduced but has never been used.

https://github.com/lima-vm/lima/blob/0288a6de9ac48a39b35971f7cfeb83982717c3f7/pkg/hostagent/requirements.go#L20-L24