### PR TITLE
Allow partial validation of templates with missing drivers

### DIFF
--- a/cmd/limactl/template.go
+++ b/cmd/limactl/template.go
@@ -262,7 +262,6 @@ func templateValidateAction(cmd *cobra.Command, args []string) error {
 		}
 		if err := driverutil.ResolveVMType(ctx, y, filePath); err != nil {
 			logrus.Warnf("failed to resolve VM type for %q: %v", filePath, err)
-			continue
 		}
 		if err := limayaml.Validate(y, false); err != nil {
 			return fmt.Errorf("failed to validate YAML file %q: %w", arg, err)


### PR DESCRIPTION
Right now we just show a warning and skip validation. That means we won't alert the user to any errors in the generic parts of the template, which seems contrary to the purpose of a validation command.

For testing I removed the `images:` from the `experimental/wsl2.yaml`:

```console
❯ l tmpl validate templates/experimental/wsl2.yaml
WARN[0000] failed to resolve VM type for "/Users/jan/.lima/wsl2.yaml": vmType "wsl2" is not a registered driver
```

After this commit we will catch it:

```console
❯ l tmpl validate templates/experimental/wsl2.yaml
WARN[0000] failed to resolve VM type for "/Users/jan/.lima/wsl2.yaml": vmType "wsl2" is not a registered driver
FATA[0000] failed to validate YAML file "templates/experimental/wsl2.yaml": field `images` must be set
```