### PR TITLE
Disable env access and file load operations in yqlib

### DIFF
--- a/hack/bats/tests/list.bats
+++ b/hack/bats/tests/list.bats
@@ -264,3 +264,13 @@ local_setup() {
     run -0 limactl ls --quiet --yq 'select(.name == "foo")'
     assert_output "foo"
 }
+
+@test '--yq cannot access environment variables' {
+    run_e -1 limactl ls --yq 'env(HOME)'
+    assert_fatal "env operations have been disabled"
+}
+
+@test '--yq cannot load files' {
+    run_e -1 limactl ls --yq "load(\"${BASH_SOURCE[0]}\")"
+    assert_fatal "file operations have been disabled"
+}

--- a/hack/bats/tests/yq.bats
+++ b/hack/bats/tests/yq.bats
@@ -35,3 +35,15 @@ load "../helpers/load"
     run -0 "$YQ" -n -o json -I 0 .foo=42
     assert_output '{"foo":42}'
 }
+
+@test 'yq multi-call command has support for env access' {
+    export FOO=bar
+    run -0 limactl yq -n 'env(FOO)'
+    assert_output "bar"
+}
+
+@test 'yq multi-call command has support for --security-disable-env-ops' {
+    export FOO=bar
+    run_e -1 limactl yq -n --security-disable-env-ops 'env(FOO)'
+    assert_stderr "Error: env operations have been disabled"
+}

--- a/pkg/yqutil/yqutil.go
+++ b/pkg/yqutil/yqutil.go
@@ -50,6 +50,10 @@ func EvaluateExpressionWithEncoder(expression, content string, encoder yqlib.Enc
 	logging.SetBackend(backend)
 	yqlib.InitExpressionParser()
 
+	// Disable access to environment variables and file loading functions
+	yqlib.ConfiguredSecurityPreferences.DisableEnvOps = true
+	yqlib.ConfiguredSecurityPreferences.DisableFileOps = true
+
 	decoder := yqlib.NewYamlDecoder(yqlib.ConfiguredYamlPreferences)
 	out, err := yqlib.NewStringEvaluator().EvaluateAll(expression, content, encoder, decoder)
 	if err != nil {


### PR DESCRIPTION
Before:

```console
❯ l ls --yq 'env(HOME)'
/Users/jan

❯ l ls --yq 'load("/usr/local/share/lima/templates/ubuntu.yaml")'
{
    "minimumLimaVersion": "2.0.0",
    "base": [
        "template:_images/ubuntu-25.10",
        "template:_default/mounts"
    ]
}
```

After:

```console
❯ l ls --yq 'env(HOME)'
FATA[0000] env operations have been disabled

❯ l ls --yq 'load("/usr/local/share/lima/templates/ubuntu.yaml")'
FATA[0000] file operations have been disabled
```

Addresses objections to using YQ expressions for `limactl list --filter` in #4187.