### PR TITLE
Ask QEMU for virtio-scsi instead of virtio-scsi-pci

### DIFF
--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -751,7 +751,7 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	// cloud-init
 	args = append(args,
 		"-drive", "id=cdrom0,if=none,format=raw,readonly=on,file="+filepath.Join(cfg.InstanceDir, filenames.CIDataISO),
-		"-device", "virtio-scsi-pci,id=scsi0",
+		"-device", "virtio-scsi,id=scsi0",
 		"-device", "scsi-cd,bus=scsi0.0,drive=cdrom0")
 
 	// Kernel

--- a/templates/_images/opensuse-leap-16.yaml
+++ b/templates/_images/opensuse-leap-16.yaml
@@ -7,6 +7,5 @@ images:
 - location: https://download.opensuse.org/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-Cloud.qcow2
   arch: aarch64
 
-# s390x image will not boot until https://bugzilla.suse.com/show_bug.cgi?id=1252096 is resolved
 - location: https://download.opensuse.org/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-s390x-Cloud.qcow2
   arch: s390x


### PR DESCRIPTION
This allows QEMU to pick the specific driver itself. E.g. OpenSUSE Leap 16 for s390x does not have virtio-scsi-pci but does support virtio-scsi-ccw:

```console
❯ limactl start -y --vm-type qemu https://download.opensuse.org/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-s390x-Cloud.qcow2
...
❯ limactl shell leap-16.0.s390x-s390x uname -a
Linux lima-leap-16-0-s390x-s390x 6.12.0-160000.5-default #1 SMP Wed Sep 10 15:26:25 UTC 2025 (3545bbd) s390x s390x s390x GNU/Linux
```

Ref: https://github.com/lima-vm/lima/pull/4203#discussion_r2431392663
Ref: https://bugzilla.suse.com/show_bug.cgi?id=1252096#c10
