### PR TITLE
(chore): Fix typo in the default template

### DIFF
--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -327,7 +327,7 @@ minimumLimaVersion: 2.0.0
 # EXPERIMENTAL
 # Default settings can be imported from base templates. These will be merged in when the instance
 # is created, and the combined template is stored in the instance directory.
-# This setting ca be either a single string (URL), or a list of locators.
+# This setting can be either a single string (URL), or a list of locators.
 # A locator is again either a string (URL), or an object with "url" and "digest" properties, e.g.
 # base: [{url: ./base.yaml, digest: decafbad}, …]
 # The "digest" property is currently unused.


### PR DESCRIPTION
A quick fix for a typo in templates/default.yaml