### PR TITLE
docs: explain usage of limactl tunnel with user-v2 network

### DIFF
--- a/website/content/en/docs/config/network/user-v2.md
+++ b/website/content/en/docs/config/network/user-v2.md
@@ -40,6 +40,46 @@ networks:
 
 An instance's IP address is resolvable from another instance as `lima-<NAME>.internal.` (e.g., `lima-default.internal.`).
 
-_Note_
+> **Note**
+>
+> Enabling user-v2 network will disable the [default user-mode network]({{< ref "/docs/config/network/user" >}}).
 
-- Enabling this network will disable the [default user-mode network]({{< ref "/docs/config/network/user" >}})
+## Accessing VMs from the host
+
+By default, the `lima-<NAME>.internal` hostnames are only resolvable from within the guest VMs.
+To access the guest network from the host, use `limactl tunnel` to create a SOCKS proxy:
+
+```bash
+limactl tunnel <INSTANCE>
+```
+
+The command will output the proxy address (the port is randomly assigned):
+```console
+$ limactl tunnel default
+Set `ALL_PROXY=socks5h://127.0.0.1:<PORT>`, etc.
+The instance can be connected from the host as <http://lima-default.internal> via a web browser.
+```
+
+You can then access any VM on the user-v2 network from the host using the SOCKS proxy:
+
+{{< tabpane text=true >}}
+{{% tab header="curl" %}}
+```bash
+curl --proxy socks5h://127.0.0.1:<PORT> http://lima-default.internal
+```
+{{% /tab %}}
+{{% tab header="Environment variable" %}}
+```bash
+export ALL_PROXY=socks5h://127.0.0.1:<PORT>
+curl http://lima-default.internal
+```
+{{% /tab %}}
+{{% tab header="Web browser" %}}
+Configure your browser to use the SOCKS5 proxy at `127.0.0.1:<PORT>`,
+then navigate to `http://lima-default.internal`.
+{{% /tab %}}
+{{< /tabpane >}}
+
+> **Note**
+>
+> `limactl tunnel` is experimental.


### PR DESCRIPTION
Add documentation for using limactl tunnel to access VMs on the user-v2 network from the host via a SOCKS proxy.

Fixes #4179
<img width="1900" height="2344" alt="localhost_1313_docs_config_network_user-v2_ (1)" src="https://github.com/user-attachments/assets/55882936-1d6c-4243-b3c2-824137d5f04e" />
