### PR TITLE
fix: make nerdctl.lima respect LIMA_INSTANCE

### DIFF
--- a/cmd/nerdctl.lima
+++ b/cmd/nerdctl.lima
@@ -1,4 +1,10 @@
 #!/bin/sh
 set -eu
+
+# Environment Variables
+# LIMA_INSTANCE: Specifies the name of the Lima instance to use. Default is "default".
+
+: "${LIMA_INSTANCE:=default}"
+
 # Use --preserve-env to pass through environment variables from host machine into guest instance
-exec limactl shell --preserve-env default nerdctl "$@"
+exec limactl shell --preserve-env "$LIMA_INSTANCE" nerdctl "$@"


### PR DESCRIPTION
### What this PR changes
This PR removes the hardcoded default instance name from `nerdctl.lima` and updates the script to respect the `$LIMA_INSTANCE` environment variable. 

### Related Issue
Fixes #4428
