### PR TITLE
Add no_vz build flag to cmd/limactl/main_darwin.go

### DIFF
--- a/cmd/limactl/main_darwin.go
+++ b/cmd/limactl/main_darwin.go
@@ -1,4 +1,4 @@
-//go:build !external_vz
+//go:build !external_vz && !no_vz
 
 // SPDX-FileCopyrightText: Copyright The Lima Authors
 // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Ref https://github.com/lima-vm/lima/issues/4411.

Without this change, it still tries to compile vz even though it's known
to not work on macOS versions < macOS 13.
