### PR TITLE
fix: nil pointer dereference panic in shellAction

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -94,6 +94,12 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		}
 		return err
 	}
+	if inst.Config == nil {
+		if len(inst.Errors) > 0 {
+			return fmt.Errorf("instance %q has configuration errors: %w", instName, errors.Join(inst.Errors...))
+		}
+		return fmt.Errorf("instance %q has no configuration", instName)
+	}
 	if inst.Status == limatype.StatusStopped {
 		startNow, err := flags.GetBool("start")
 		if err != nil {


### PR DESCRIPTION
The shellAction function panics with a nil pointer dereference when attempting to shell into an instance that has configuration validation errors:

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x2 addr=0x98 pc=0x...]

This occurs because store.Inspect() returns an instance with inst.Config set to nil when validation fails, but the code at lines 171, 252-256 accesses inst.Config fields without checking for nil.

Example scenario: An instance created with Lima 1.2.1 using QEMU has mountType: 9p in its config. On newer Lima versions, if vmType defaults to vz (or is set explicitly), the config fails validation since VZ only supports reverse-sshfs or
virtiofs mount types. The validation error leaves inst.Config as nil, causing the panic.

This fix adds an early nil check for inst.Config (after store.Inspect at line 90) to return a clear error message instead of panicking:

    instance "docker" has configuration errors: field 'mountType' must be
    "reverse-sshfs" or "virtiofs" for VZ driver, got "9p"
