### PR TITLE
templates: k8s: pin Kubernetes version to 1.34

### DIFF
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -54,7 +54,9 @@ provision:
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
     apt-get install -y apt-transport-https ca-certificates curl
-    VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt | sed -e 's/v//' | cut -d'.' -f1-2)
+    # 1.35 fails: https://github.com/lima-vm/lima/issues/4473
+    VERSION=1.34
+    # VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt | sed -e 's/v//' | cut -d'.' -f1-2)
     echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${VERSION}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
     curl -fsSL https://pkgs.k8s.io/core:/stable:/v${VERSION}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     apt-get update


### PR DESCRIPTION
After the release of Kubernetes v1.35, the test began to fail as containerd dies on the removal of the CNI config.

Fix #4473