### PR TITLE
Add allow-env and block-env option for limactl shell

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -64,6 +64,8 @@ func newShellCommand() *cobra.Command {
 	shellCmd.Flags().Bool("reconnect", false, "Reconnect to the SSH session")
 	shellCmd.Flags().Bool("preserve-env", false, "Propagate environment variables to the shell")
 	shellCmd.Flags().Bool("start", false, "Start the instance if it is not already running")
+	shellCmd.Flags().StringSlice("allow-env", []string{}, "Comma-separated list of environment variable patterns to allow when --preserve-env is set (overrides LIMA_SHELLENV_ALLOW)")
+	shellCmd.Flags().StringSlice("block-env", []string{}, "Comma-separated list of environment variable patterns to allow when --preserve-env is set (overrides LIMA_SHELLENV_BLOCK)")
 	return shellCmd
 }
 
@@ -216,8 +218,16 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	allowListRaw, err := cmd.Flags().GetStringSlice("allow-env")
+	if err != nil {
+		return err
+	}
+	blockListRaw, err := cmd.Flags().GetStringSlice("block-env")
+	if err != nil {
+		return err
+	}
 	if preserveEnv {
-		filteredEnv := envutil.FilterEnvironment()
+		filteredEnv := envutil.FilterEnvironment(allowListRaw, blockListRaw)
 		if len(filteredEnv) > 0 {
 			envPrefix = "env "
 			for _, envVar := range filteredEnv {

--- a/pkg/envutil/envutil_test.go
+++ b/pkg/envutil/envutil_test.go
@@ -88,8 +88,8 @@ func TestGetBlockAndAllowLists(t *testing.T) {
 		t.Setenv("LIMA_SHELLENV_BLOCK", "")
 		t.Setenv("LIMA_SHELLENV_ALLOW", "")
 
-		blockList := getBlockList()
-		allowList := getAllowList()
+		blockList := getBlockList([]string{})
+		allowList := getAllowList([]string{})
 
 		assert.Assert(t, isUsingDefaultBlockList())
 		assert.DeepEqual(t, blockList, defaultBlockList)
@@ -99,7 +99,7 @@ func TestGetBlockAndAllowLists(t *testing.T) {
 	t.Run("custom blocklist", func(t *testing.T) {
 		t.Setenv("LIMA_SHELLENV_BLOCK", "PATH,HOME")
 
-		blockList := getBlockList()
+		blockList := getBlockList([]string{})
 		assert.Assert(t, !isUsingDefaultBlockList())
 		expected := []string{"PATH", "HOME"}
 		assert.DeepEqual(t, blockList, expected)
@@ -108,7 +108,7 @@ func TestGetBlockAndAllowLists(t *testing.T) {
 	t.Run("additive blocklist", func(t *testing.T) {
 		t.Setenv("LIMA_SHELLENV_BLOCK", "+CUSTOM_VAR")
 
-		blockList := getBlockList()
+		blockList := getBlockList([]string{})
 		assert.Assert(t, isUsingDefaultBlockList())
 		expected := slices.Concat(GetDefaultBlockList(), []string{"CUSTOM_VAR"})
 		assert.DeepEqual(t, blockList, expected)
@@ -117,7 +117,7 @@ func TestGetBlockAndAllowLists(t *testing.T) {
 	t.Run("allowlist", func(t *testing.T) {
 		t.Setenv("LIMA_SHELLENV_ALLOW", "FOO,BAR")
 
-		allowList := getAllowList()
+		allowList := getAllowList([]string{})
 		expected := []string{"FOO", "BAR"}
 		assert.DeepEqual(t, allowList, expected)
 	})


### PR DESCRIPTION
## Summary
Implement allow-env and block-env option for limactl shell command, which is equivalent of setting
environment variable "LIMA_SHELLENV_ALLOW" and
"LIMA_SHELLENV_BLOCK".

## Related issue
#4263