### PR TITLE
pkg/driver/qemu: Cancel Context on exiting QEMU command

### DIFF
--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -370,6 +370,7 @@ func (l *LimaQemuDriver) Start(_ context.Context) (chan error, error) {
 	l.qWaitCh = make(chan error, 1)
 	go func() {
 		defer close(l.qWaitCh)
+		defer cancel()
 		l.qWaitCh <- qCmd.Wait()
 	}()
 	l.vhostCmds = vhostCmds


### PR DESCRIPTION
By applying this change, go routines started in `LimaQemuDriver.Start` can stop on exiting QEMU command by waiting Context.

refs: https://github.com/lima-vm/lima/pull/4394#issuecomment-3681881048