### PR TITLE
docs: add usage examples for limactl network and snapshot commands

### DIFF
--- a/cmd/limactl/network.go
+++ b/cmd/limactl/network.go
@@ -21,6 +21,20 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/yqutil"
 )
 
+const networkExample = `  List all networks:
+  $ limactl network list
+
+  Create a network:
+  $ limactl network create foo --gateway 192.168.42.1/24
+
+  Connect VM instances to the newly created network:
+  $ limactl create --network lima:foo --name vm1
+  $ limactl create --network lima:foo --name vm2
+
+  Delete a network:
+  $ limactl network delete --force foo
+`
+
 const networkCreateExample = `  Create a network:
   $ limactl network create foo --gateway 192.168.42.1/24
 
@@ -33,7 +47,7 @@ func newNetworkCommand() *cobra.Command {
 	networkCommand := &cobra.Command{
 		Use:     "network",
 		Short:   "Lima network management",
-		Example: networkCreateExample,
+		Example: networkExample,
 		GroupID: advancedCommand,
 	}
 	networkCommand.AddCommand(
@@ -46,8 +60,14 @@ func newNetworkCommand() *cobra.Command {
 
 func newNetworkListCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "list",
-		Short:             "List networks",
+		Use:   "list",
+		Short: "List networks",
+		Example: `  List all networks:
+  $ limactl network list
+
+  List networks in JSON format:
+  $ limactl network list --json
+`,
 		Aliases:           []string{"ls"},
 		Args:              WrapArgsError(cobra.ArbitraryArgs),
 		RunE:              networkListAction,
@@ -233,8 +253,14 @@ func networkApplyYQ(yq string) error {
 
 func newNetworkDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "delete NETWORK [NETWORK, ...]",
-		Short:             "Delete one or more Lima networks",
+		Use:   "delete NETWORK [NETWORK, ...]",
+		Short: "Delete one or more Lima networks",
+		Example: `  Delete a network:
+  $ limactl network delete --force foo
+
+  Delete multiple networks:
+  $ limactl network delete --force foo bar
+`,
 		Aliases:           []string{"remove", "rm"},
 		Args:              WrapArgsError(cobra.MinimumNArgs(1)),
 		RunE:              networkDeleteAction,

--- a/cmd/limactl/snapshot.go
+++ b/cmd/limactl/snapshot.go
@@ -19,6 +19,18 @@ func newSnapshotCommand() *cobra.Command {
 	snapshotCmd := &cobra.Command{
 		Use:   "snapshot",
 		Short: "Manage instance snapshots",
+		Example: `  List all snapshots of an instance:
+  $ limactl snapshot list default
+
+  Create a snapshot:
+  $ limactl snapshot create default --tag snap1
+
+  Apply (restore) a snapshot:
+  $ limactl snapshot apply default --tag snap1
+
+  Delete a snapshot:
+  $ limactl snapshot delete default --tag snap1
+`,
 		PersistentPreRun: func(*cobra.Command, []string) {
 			logrus.Warn("`limactl snapshot` is experimental")
 		},
@@ -34,9 +46,12 @@ func newSnapshotCommand() *cobra.Command {
 
 func newSnapshotCreateCommand() *cobra.Command {
 	createCmd := &cobra.Command{
-		Use:               "create INSTANCE",
-		Aliases:           []string{"save"},
-		Short:             "Create (save) a snapshot",
+		Use:     "create INSTANCE",
+		Aliases: []string{"save"},
+		Short:   "Create (save) a snapshot",
+		Example: `  Create a snapshot of an instance:
+  $ limactl snapshot create default --tag snap1
+`,
 		Args:              cobra.MinimumNArgs(1),
 		RunE:              snapshotCreateAction,
 		ValidArgsFunction: snapshotBashComplete,
@@ -69,9 +84,12 @@ func snapshotCreateAction(cmd *cobra.Command, args []string) error {
 
 func newSnapshotDeleteCommand() *cobra.Command {
 	deleteCmd := &cobra.Command{
-		Use:               "delete INSTANCE",
-		Aliases:           []string{"del"},
-		Short:             "Delete (del) a snapshot",
+		Use:     "delete INSTANCE",
+		Aliases: []string{"del"},
+		Short:   "Delete (del) a snapshot",
+		Example: `  Delete a snapshot:
+  $ limactl snapshot delete default --tag snap1
+`,
 		Args:              cobra.MinimumNArgs(1),
 		RunE:              snapshotDeleteAction,
 		ValidArgsFunction: snapshotBashComplete,
@@ -104,9 +122,12 @@ func snapshotDeleteAction(cmd *cobra.Command, args []string) error {
 
 func newSnapshotApplyCommand() *cobra.Command {
 	applyCmd := &cobra.Command{
-		Use:               "apply INSTANCE",
-		Aliases:           []string{"load"},
-		Short:             "Apply (load) a snapshot",
+		Use:     "apply INSTANCE",
+		Aliases: []string{"load"},
+		Short:   "Apply (load) a snapshot",
+		Example: `  Apply (restore) a snapshot:
+  $ limactl snapshot apply default --tag snap1
+`,
 		Args:              cobra.MinimumNArgs(1),
 		RunE:              snapshotApplyAction,
 		ValidArgsFunction: snapshotBashComplete,
@@ -139,9 +160,15 @@ func snapshotApplyAction(cmd *cobra.Command, args []string) error {
 
 func newSnapshotListCommand() *cobra.Command {
 	listCmd := &cobra.Command{
-		Use:               "list INSTANCE",
-		Aliases:           []string{"ls"},
-		Short:             "List existing snapshots",
+		Use:     "list INSTANCE",
+		Aliases: []string{"ls"},
+		Short:   "List existing snapshots",
+		Example: `  List all snapshots of an instance:
+  $ limactl snapshot list default
+
+  List only snapshot tags:
+  $ limactl snapshot list default --quiet
+`,
 		Args:              cobra.MinimumNArgs(1),
 		RunE:              snapshotListAction,
 		ValidArgsFunction: snapshotBashComplete,


### PR DESCRIPTION
Fixes #4180

## Changes
- Add `Example` field to `limactl network` command and subcommands (list, delete)
- Add `Example` field to `limactl snapshot` command and subcommands (list, create, apply, delete)

Note: `limactl disk` commands already have examples in place.