### PR TITLE
feat: Add `limactl ssh` as alias to `limactl shell`

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -48,6 +48,7 @@ Hint: try --debug to show the detailed logs, if it seems hanging (mostly due to 
 func newShellCommand() *cobra.Command {
 	shellCmd := &cobra.Command{
 		Use:               "shell [flags] INSTANCE [COMMAND...]",
+		Aliases:           []string{"ssh"},
 		Short:             "Execute shell in Lima",
 		Long:              shellHelp,
 		Args:              WrapArgsError(cobra.MinimumNArgs(1)),


### PR DESCRIPTION
Fixes #3613

## Changes
- Add `ssh` as Cobra alias for the `shell` command

This follows the existing pattern used by other commands (e.g., `rm` for `delete`, `ls` for `list`, `cp` for `copy`).