### PR TITLE
Suggest shell subcommand when user writes ssh

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -48,6 +48,7 @@ Hint: try --debug to show the detailed logs, if it seems hanging (mostly due to 
 func newShellCommand() *cobra.Command {
 	shellCmd := &cobra.Command{
 		Use:               "shell [flags] INSTANCE [COMMAND...]",
+		SuggestFor:        []string{"ssh"},
 		Short:             "Execute shell in Lima",
 		Long:              shellHelp,
 		Args:              WrapArgsError(cobra.MinimumNArgs(1)),


### PR DESCRIPTION
Fixes #3613

Ref https://github.com/lima-vm/lima/pull/4500#issuecomment-3704248746

```console
❯ l ssh
FATA[0000] unknown command "ssh" for "limactl"

Did you mean this?
	shell
```