### PR TITLE
fix: Merge VMOpts from configurations

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -777,6 +777,12 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 	maps.Copy(param, o.Param)
 	y.Param = param
 
+	vmOpts := make(limatype.VMOpts)
+	maps.Copy(vmOpts, d.VMOpts)
+	maps.Copy(vmOpts, y.VMOpts)
+	maps.Copy(vmOpts, o.VMOpts)
+	y.VMOpts = vmOpts
+
 	if y.CACertificates.RemoveDefaults == nil {
 		y.CACertificates.RemoveDefaults = d.CACertificates.RemoveDefaults
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -419,6 +419,11 @@ func TestFillDefault(t *testing.T) {
 			Shell:   ptr.Of("/bin/tcsh"),
 			UID:     ptr.Of(uint32(8080)),
 		},
+		VMOpts: limatype.VMOpts{
+			"qemu": map[string]any{
+				"minimumVersion": "9.1.0",
+			},
+		},
 	}
 
 	expect = d
@@ -469,6 +474,11 @@ func TestFillDefault(t *testing.T) {
 	y.DNS = []net.IP{net.ParseIP("8.8.8.8")}
 	y.AdditionalDisks = []limatype.Disk{{Name: "overridden"}}
 	y.User.Home = ptr.Of("/root")
+	y.VMOpts = limatype.VMOpts{
+		"vz": map[string]any{
+			"diskImageFormat": "raw",
+		},
+	}
 
 	expect = y
 
@@ -493,6 +503,11 @@ func TestFillDefault(t *testing.T) {
 	expect.Env["TWO"] = dExpected.Env["TWO"]
 
 	expect.Param["TWO"] = dExpected.Param["TWO"]
+
+	expect.VMOpts = limatype.VMOpts{
+		"qemu": dExpected.VMOpts["qemu"],
+		"vz":   y.VMOpts["vz"],
+	}
 
 	t.Logf("d.vmType=%v, y.vmType=%v, expect.vmType=%v", d.VMType, y.VMType, expect.VMType)
 
@@ -630,6 +645,14 @@ func TestFillDefault(t *testing.T) {
 			Shell:   ptr.Of("/bin/sh"),
 			UID:     ptr.Of(uint32(1122)),
 		},
+		VMOpts: limatype.VMOpts{
+			"vz": map[string]any{
+				"rosetta": map[string]any{
+					"enabled": true,
+					"binfmt":  true,
+				},
+			},
+		},
 	}
 
 	y = filledDefaults
@@ -683,6 +706,16 @@ func TestFillDefault(t *testing.T) {
 	expect.Plain = ptr.Of(false)
 
 	expect.NestedVirtualization = ptr.Of(false)
+
+	expect.VMOpts = limatype.VMOpts{
+		"qemu": dExpected.VMOpts["qemu"],
+		"vz": map[string]any{
+			"rosetta": map[string]any{
+				"enabled": true,
+				"binfmt":  true,
+			},
+		},
+	}
 
 	FillDefault(t.Context(), &y, &d, &o, filePath, false)
 	assert.DeepEqual(t, &y, &expect, opts...)


### PR DESCRIPTION
This commit fixes an issue where VMOpts configurations were not being merged from default.yaml, lima.yaml, and override.yaml. The entire VMOpts field was being ignored during the configuration merging process.

Fixes #4427