### PR TITLE
hostagent: add host-to-guest time synchronization

### DIFF
--- a/pkg/guestagent/api/client/client.go
+++ b/pkg/guestagent/api/client/client.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"math"
 	"net"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/lima-vm/lima/v2/pkg/guestagent/api"
 )
@@ -79,4 +81,11 @@ func (c *GuestAgentClient) Tunnel(ctx context.Context) (api.GuestService_TunnelC
 		return nil, err
 	}
 	return stream, nil
+}
+
+func (c *GuestAgentClient) SyncTime(ctx context.Context, hostTime time.Time) (*api.TimeSyncResponse, error) {
+	req := &api.TimeSyncRequest{
+		HostTime: timestamppb.New(hostTime),
+	}
+	return c.cli.SyncTime(ctx, req)
 }

--- a/pkg/guestagent/api/guestservice.pb.desc
+++ b/pkg/guestagent/api/guestservice.pb.desc
@@ -1,5 +1,5 @@
 
-…
+ã
 guestservice.protogoogle/protobuf/empty.protogoogle/protobuf/timestamp.proto"0
 Info(
 local_ports (2.IPPortR
@@ -23,9 +23,16 @@ mount_path (	R	mountPath.
 data (Rdata
 
 guest_addr (	R	guestAddr&
-udp_target_addr (	RudpTargetAddr2È
+udp_target_addr (	RudpTargetAddr"J
+TimeSyncRequest7
+	host_time (2.google.protobuf.TimestampRhostTime"_
+TimeSyncResponse
+adjusted (Radjusted
+drift_ms (RdriftMs
+error (	Rerror2ù
 GuestService(
 GetInfo.google.protobuf.Empty.Info-
 	GetEvents.google.protobuf.Empty.Event01
 PostInotify.Inotify.google.protobuf.Empty(,
-Tunnel.TunnelMessage.TunnelMessage(0B/Z-github.com/lima-vm/lima/v2/pkg/guestagent/apibproto3
+Tunnel.TunnelMessage.TunnelMessage(0/
+SyncTime.TimeSyncRequest.TimeSyncResponseB/Z-github.com/lima-vm/lima/v2/pkg/guestagent/apibproto3

--- a/pkg/guestagent/api/guestservice.pb.go
+++ b/pkg/guestagent/api/guestservice.pb.go
@@ -323,6 +323,110 @@ func (x *TunnelMessage) GetUdpTargetAddr() string {
 	return ""
 }
 
+type TimeSyncRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	HostTime      *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=host_time,json=hostTime,proto3" json:"host_time,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TimeSyncRequest) Reset() {
+	*x = TimeSyncRequest{}
+	mi := &file_guestservice_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TimeSyncRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TimeSyncRequest) ProtoMessage() {}
+
+func (x *TimeSyncRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_guestservice_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TimeSyncRequest.ProtoReflect.Descriptor instead.
+func (*TimeSyncRequest) Descriptor() ([]byte, []int) {
+	return file_guestservice_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *TimeSyncRequest) GetHostTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.HostTime
+	}
+	return nil
+}
+
+type TimeSyncResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Adjusted      bool                   `protobuf:"varint,1,opt,name=adjusted,proto3" json:"adjusted,omitempty"`
+	DriftMs       int64                  `protobuf:"varint,2,opt,name=drift_ms,json=driftMs,proto3" json:"drift_ms,omitempty"`
+	Error         string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TimeSyncResponse) Reset() {
+	*x = TimeSyncResponse{}
+	mi := &file_guestservice_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TimeSyncResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TimeSyncResponse) ProtoMessage() {}
+
+func (x *TimeSyncResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_guestservice_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TimeSyncResponse.ProtoReflect.Descriptor instead.
+func (*TimeSyncResponse) Descriptor() ([]byte, []int) {
+	return file_guestservice_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *TimeSyncResponse) GetAdjusted() bool {
+	if x != nil {
+		return x.Adjusted
+	}
+	return false
+}
+
+func (x *TimeSyncResponse) GetDriftMs() int64 {
+	if x != nil {
+		return x.DriftMs
+	}
+	return 0
+}
+
+func (x *TimeSyncResponse) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
 var File_guestservice_proto protoreflect.FileDescriptor
 
 const file_guestservice_proto_rawDesc = "" +
@@ -350,12 +454,19 @@ const file_guestservice_proto_rawDesc = "" +
 	"\x04data\x18\x03 \x01(\fR\x04data\x12\x1d\n" +
 	"\n" +
 	"guest_addr\x18\x04 \x01(\tR\tguestAddr\x12&\n" +
-	"\x0fudp_target_addr\x18\x05 \x01(\tR\rudpTargetAddr2\xc8\x01\n" +
+	"\x0fudp_target_addr\x18\x05 \x01(\tR\rudpTargetAddr\"J\n" +
+	"\x0fTimeSyncRequest\x127\n" +
+	"\thost_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\bhostTime\"_\n" +
+	"\x10TimeSyncResponse\x12\x1a\n" +
+	"\badjusted\x18\x01 \x01(\bR\badjusted\x12\x19\n" +
+	"\bdrift_ms\x18\x02 \x01(\x03R\adriftMs\x12\x14\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error2\xf9\x01\n" +
 	"\fGuestService\x12(\n" +
 	"\aGetInfo\x12\x16.google.protobuf.Empty\x1a\x05.Info\x12-\n" +
 	"\tGetEvents\x12\x16.google.protobuf.Empty\x1a\x06.Event0\x01\x121\n" +
 	"\vPostInotify\x12\b.Inotify\x1a\x16.google.protobuf.Empty(\x01\x12,\n" +
-	"\x06Tunnel\x12\x0e.TunnelMessage\x1a\x0e.TunnelMessage(\x010\x01B/Z-github.com/lima-vm/lima/v2/pkg/guestagent/apib\x06proto3"
+	"\x06Tunnel\x12\x0e.TunnelMessage\x1a\x0e.TunnelMessage(\x010\x01\x12/\n" +
+	"\bSyncTime\x12\x10.TimeSyncRequest\x1a\x11.TimeSyncResponseB/Z-github.com/lima-vm/lima/v2/pkg/guestagent/apib\x06proto3"
 
 var (
 	file_guestservice_proto_rawDescOnce sync.Once
@@ -369,35 +480,40 @@ func file_guestservice_proto_rawDescGZIP() []byte {
 	return file_guestservice_proto_rawDescData
 }
 
-var file_guestservice_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_guestservice_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_guestservice_proto_goTypes = []any{
 	(*Info)(nil),                  // 0: Info
 	(*Event)(nil),                 // 1: Event
 	(*IPPort)(nil),                // 2: IPPort
 	(*Inotify)(nil),               // 3: Inotify
 	(*TunnelMessage)(nil),         // 4: TunnelMessage
-	(*timestamppb.Timestamp)(nil), // 5: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),         // 6: google.protobuf.Empty
+	(*TimeSyncRequest)(nil),       // 5: TimeSyncRequest
+	(*TimeSyncResponse)(nil),      // 6: TimeSyncResponse
+	(*timestamppb.Timestamp)(nil), // 7: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),         // 8: google.protobuf.Empty
 }
 var file_guestservice_proto_depIdxs = []int32{
-	2, // 0: Info.local_ports:type_name -> IPPort
-	5, // 1: Event.time:type_name -> google.protobuf.Timestamp
-	2, // 2: Event.added_local_ports:type_name -> IPPort
-	2, // 3: Event.removed_local_ports:type_name -> IPPort
-	5, // 4: Inotify.time:type_name -> google.protobuf.Timestamp
-	6, // 5: GuestService.GetInfo:input_type -> google.protobuf.Empty
-	6, // 6: GuestService.GetEvents:input_type -> google.protobuf.Empty
-	3, // 7: GuestService.PostInotify:input_type -> Inotify
-	4, // 8: GuestService.Tunnel:input_type -> TunnelMessage
-	0, // 9: GuestService.GetInfo:output_type -> Info
-	1, // 10: GuestService.GetEvents:output_type -> Event
-	6, // 11: GuestService.PostInotify:output_type -> google.protobuf.Empty
-	4, // 12: GuestService.Tunnel:output_type -> TunnelMessage
-	9, // [9:13] is the sub-list for method output_type
-	5, // [5:9] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	2,  // 0: Info.local_ports:type_name -> IPPort
+	7,  // 1: Event.time:type_name -> google.protobuf.Timestamp
+	2,  // 2: Event.added_local_ports:type_name -> IPPort
+	2,  // 3: Event.removed_local_ports:type_name -> IPPort
+	7,  // 4: Inotify.time:type_name -> google.protobuf.Timestamp
+	7,  // 5: TimeSyncRequest.host_time:type_name -> google.protobuf.Timestamp
+	8,  // 6: GuestService.GetInfo:input_type -> google.protobuf.Empty
+	8,  // 7: GuestService.GetEvents:input_type -> google.protobuf.Empty
+	3,  // 8: GuestService.PostInotify:input_type -> Inotify
+	4,  // 9: GuestService.Tunnel:input_type -> TunnelMessage
+	5,  // 10: GuestService.SyncTime:input_type -> TimeSyncRequest
+	0,  // 11: GuestService.GetInfo:output_type -> Info
+	1,  // 12: GuestService.GetEvents:output_type -> Event
+	8,  // 13: GuestService.PostInotify:output_type -> google.protobuf.Empty
+	4,  // 14: GuestService.Tunnel:output_type -> TunnelMessage
+	6,  // 15: GuestService.SyncTime:output_type -> TimeSyncResponse
+	11, // [11:16] is the sub-list for method output_type
+	6,  // [6:11] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_guestservice_proto_init() }
@@ -411,7 +527,7 @@ func file_guestservice_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_guestservice_proto_rawDesc), len(file_guestservice_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/guestagent/api/guestservice.proto
+++ b/pkg/guestagent/api/guestservice.proto
@@ -11,6 +11,7 @@ service GuestService {
   rpc PostInotify(stream Inotify) returns (google.protobuf.Empty);
 
   rpc Tunnel(stream TunnelMessage) returns (stream TunnelMessage);
+  rpc SyncTime(TimeSyncRequest) returns (TimeSyncResponse);
 }
 
 message Info {
@@ -41,4 +42,14 @@ message TunnelMessage {
   bytes data = 3;
   string guest_addr = 4;
   string udp_target_addr = 5;
+}
+
+message TimeSyncRequest {
+  google.protobuf.Timestamp host_time = 1;
+}
+
+message TimeSyncResponse {
+  bool adjusted = 1;
+  int64 drift_ms = 2;
+  string error = 3;
 }

--- a/pkg/guestagent/api/guestservice_grpc.pb.go
+++ b/pkg/guestagent/api/guestservice_grpc.pb.go
@@ -24,6 +24,7 @@ const (
 	GuestService_GetEvents_FullMethodName   = "/GuestService/GetEvents"
 	GuestService_PostInotify_FullMethodName = "/GuestService/PostInotify"
 	GuestService_Tunnel_FullMethodName      = "/GuestService/Tunnel"
+	GuestService_SyncTime_FullMethodName    = "/GuestService/SyncTime"
 )
 
 // GuestServiceClient is the client API for GuestService service.
@@ -34,6 +35,7 @@ type GuestServiceClient interface {
 	GetEvents(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[Event], error)
 	PostInotify(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[Inotify, emptypb.Empty], error)
 	Tunnel(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[TunnelMessage, TunnelMessage], error)
+	SyncTime(ctx context.Context, in *TimeSyncRequest, opts ...grpc.CallOption) (*TimeSyncResponse, error)
 }
 
 type guestServiceClient struct {
@@ -99,6 +101,16 @@ func (c *guestServiceClient) Tunnel(ctx context.Context, opts ...grpc.CallOption
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type GuestService_TunnelClient = grpc.BidiStreamingClient[TunnelMessage, TunnelMessage]
 
+func (c *guestServiceClient) SyncTime(ctx context.Context, in *TimeSyncRequest, opts ...grpc.CallOption) (*TimeSyncResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(TimeSyncResponse)
+	err := c.cc.Invoke(ctx, GuestService_SyncTime_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // GuestServiceServer is the server API for GuestService service.
 // All implementations must embed UnimplementedGuestServiceServer
 // for forward compatibility.
@@ -107,6 +119,7 @@ type GuestServiceServer interface {
 	GetEvents(*emptypb.Empty, grpc.ServerStreamingServer[Event]) error
 	PostInotify(grpc.ClientStreamingServer[Inotify, emptypb.Empty]) error
 	Tunnel(grpc.BidiStreamingServer[TunnelMessage, TunnelMessage]) error
+	SyncTime(context.Context, *TimeSyncRequest) (*TimeSyncResponse, error)
 	mustEmbedUnimplementedGuestServiceServer()
 }
 
@@ -128,6 +141,9 @@ func (UnimplementedGuestServiceServer) PostInotify(grpc.ClientStreamingServer[In
 }
 func (UnimplementedGuestServiceServer) Tunnel(grpc.BidiStreamingServer[TunnelMessage, TunnelMessage]) error {
 	return status.Errorf(codes.Unimplemented, "method Tunnel not implemented")
+}
+func (UnimplementedGuestServiceServer) SyncTime(context.Context, *TimeSyncRequest) (*TimeSyncResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SyncTime not implemented")
 }
 func (UnimplementedGuestServiceServer) mustEmbedUnimplementedGuestServiceServer() {}
 func (UnimplementedGuestServiceServer) testEmbeddedByValue()                      {}
@@ -193,6 +209,24 @@ func _GuestService_Tunnel_Handler(srv interface{}, stream grpc.ServerStream) err
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type GuestService_TunnelServer = grpc.BidiStreamingServer[TunnelMessage, TunnelMessage]
 
+func _GuestService_SyncTime_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(TimeSyncRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GuestServiceServer).SyncTime(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GuestService_SyncTime_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GuestServiceServer).SyncTime(ctx, req.(*TimeSyncRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // GuestService_ServiceDesc is the grpc.ServiceDesc for GuestService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -203,6 +237,10 @@ var GuestService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetInfo",
 			Handler:    _GuestService_GetInfo_Handler,
+		},
+		{
+			MethodName: "SyncTime",
+			Handler:    _GuestService_SyncTime_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/pkg/guestagent/timesync/timesync_linux.go
+++ b/pkg/guestagent/timesync/timesync_linux.go
@@ -4,32 +4,10 @@
 package timesync
 
 import (
-	"errors"
-	"os"
 	"time"
 
 	"golang.org/x/sys/unix"
 )
-
-const rtc = "/dev/rtc"
-
-func HasRTC() (bool, error) {
-	_, err := os.Stat(rtc)
-	return !errors.Is(err, os.ErrNotExist), err
-}
-
-func GetRTCTime() (time.Time, error) {
-	f, err := os.Open(rtc)
-	if err != nil {
-		return time.Time{}, err
-	}
-	defer f.Close()
-	obj, err := unix.IoctlGetRTCTime(int(f.Fd()))
-	if err != nil {
-		return time.Time{}, err
-	}
-	return time.Date(int(obj.Year+1900), time.Month(obj.Mon+1), int(obj.Mday), int(obj.Hour), int(obj.Min), int(obj.Sec), 0, time.UTC), nil
-}
 
 func SetSystemTime(t time.Time) error {
 	v := unix.NsecToTimeval(t.UnixNano())

--- a/pkg/guestagent/timesync/timesync_others.go
+++ b/pkg/guestagent/timesync/timesync_others.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package timesync
+
+import (
+	"errors"
+	"time"
+)
+
+var errNotSupported = errors.New("timesync: not supported on this platform")
+
+func SetSystemTime(_ time.Time) error {
+	return errNotSupported
+}

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -573,6 +573,7 @@ sudo chown -R "${USER}" /run/host-services`
 
 	if !*a.instConfig.Plain {
 		go a.watchGuestAgentEvents(ctx)
+		go a.startTimeSync(ctx)
 		if a.showProgress {
 			cloudInitDone := make(chan struct{})
 			go func() {

--- a/pkg/hostagent/timesync.go
+++ b/pkg/hostagent/timesync.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hostagent
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	timeSyncInterval     = 10 * time.Second
+	timeSyncStartupDelay = 5 * time.Second
+)
+
+func (a *HostAgent) startTimeSync(ctx context.Context) {
+	select {
+	case <-a.guestAgentAliveCh:
+		logrus.Info("Time sync: guest agent is alive, starting time synchronization")
+	case <-ctx.Done():
+		return
+	}
+
+	select {
+	case <-time.After(timeSyncStartupDelay):
+	case <-ctx.Done():
+		return
+	}
+
+	ticker := time.NewTicker(timeSyncInterval)
+	defer ticker.Stop()
+
+	a.syncTimeOnce(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			logrus.Debug("Time sync: context cancelled, stopping")
+			return
+		case <-ticker.C:
+			a.syncTimeOnce(ctx)
+		}
+	}
+}
+
+func (a *HostAgent) syncTimeOnce(ctx context.Context) {
+	client, err := a.getOrCreateClient(ctx)
+	if err != nil {
+		logrus.WithError(err).Debug("Time sync: failed to get client")
+		return
+	}
+
+	hostTime := time.Now()
+	resp, err := client.SyncTime(ctx, hostTime)
+	if err != nil {
+		logrus.WithError(err).Debug("Time sync: RPC failed")
+		return
+	}
+
+	if resp.Error != "" {
+		logrus.Warnf("Time sync: guest failed to set time: %s (drift was %dms)", resp.Error, resp.DriftMs)
+		return
+	}
+
+	if resp.Adjusted {
+		logrus.Infof("Time sync: guest clock adjusted (was %dms off)", resp.DriftMs)
+	} else {
+		logrus.Debugf("Time sync: drift %dms within threshold", resp.DriftMs)
+	}
+}


### PR DESCRIPTION
The VZ virtualization framework's virtual RTC drifts from host time,
causing timestamp issues with workloads like TestContainers.

This adds a gRPC-based time sync where the host agent periodically
pushes current time to the guest agent, which adjusts the system
clock if drift exceeds 100ms.

Addresses #850, #1307