### PR TITLE
shell: suppress "READY. Run..." message when launching shell

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -132,7 +132,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		err = instance.Start(ctx, inst, false, false)
+		err = instance.Start(instance.WithLaunchingShell(ctx), inst, false, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When `lima` or `limactl shell` starts a stopped instance, it prints "READY. Run `lima` to open the shell" before immediately opening the shell. This message is confusing because:

1. The shell opens automatically, making the instruction redundant
2. The `lima` command doesn't exist inside the VM

Suppress the message when the shell is about to launch by passing a marked context through the Start function.

Fixes #3452