### PR TITLE
Fix YQ test with empty input document

### DIFF
--- a/hack/bats/tests/yq.bats
+++ b/hack/bats/tests/yq.bats
@@ -9,7 +9,7 @@ load "../helpers/load"
 }
 
 @test 'yq can evaluate yq expressions' {
-    run -0 limactl yq .foo=42 <<<""
+    run -0 limactl yq -n .foo=42
     assert_output 'foo: 42'
 }
 


### PR DESCRIPTION
The test is using `<<<""` to specify an empty input document. It is however not really empty, but contains a single newline character.

yq versions before 4.50.1 would filter out this newline, but now it is being preserved. This commit changes the test to use a truly empty input document, as was originally intended.

This PR fixes the BATS failure in #4460. It will still be blocked from merging because of the HCL licensing issue.