### PR TITLE
refactor: Use slices.Sort instead of sort.Strings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,6 +49,8 @@ linters:
         msg: Do not use fmt.Print statements.
       - pattern: ^testing.T.Fatal.*$
         msg: Use assert functions from the gotest.tools/v3/assert package instead.
+      - pattern: ^sort.*$
+        msg: Use sorting functions from the slices package instead.
       analyze-types: true
     gocritic:
       disabled-checks:

--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/cheggaaa/pb/v3/termutil"
@@ -145,7 +145,7 @@ func listAction(cmd *cobra.Command, args []string) error {
 
 	if listFields {
 		names := fieldNames()
-		sort.Strings(names)
+		slices.Sort(names)
 		fmt.Fprintln(cmd.OutOrStdout(), strings.Join(names, "\n"))
 		return nil
 	}

--- a/pkg/networks/sudoers.go
+++ b/pkg/networks/sudoers.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -32,7 +32,7 @@ func Sudoers() (string, error) {
 		}
 		names = append(names, name)
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 
 	for _, name := range names {
 		sb.WriteRune('\n')

--- a/pkg/windows/registry_windows.go
+++ b/pkg/windows/registry_windows.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -162,7 +161,7 @@ func GetRandomFreeVSockPort(minPort, maxPort int) (int, error) {
 	tree := make([]pair, 1, len(used)+1)
 	tree[0] = pair{0, minPort}
 
-	sort.Ints(used)
+	slices.Sort(used)
 	for i, v := range used {
 		if tree[len(tree)-1].v+tree[len(tree)-1].offset == v {
 			tree[len(tree)-1].offset++


### PR DESCRIPTION
The PR replaces `sort.Strings` and `sort.Ints` with `slices.Sort`. This change is made because the `slices` functions are slightly faster and easier to use.

See https://go-review.googlesource.com/c/go/+/626038.