### PR TITLE
mounts: use path-based tags instead of index-based tags

### DIFF
--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -203,8 +203,8 @@ func templateArgs(ctx context.Context, bootScripts bool, instDir, name string, i
 	if err != nil {
 		return nil, err
 	}
-	for i, f := range instConfig.Mounts {
-		tag := fmt.Sprintf("mount%d", i)
+	for _, f := range instConfig.Mounts {
+		tag := limayaml.MountTag(f.Location, *f.MountPoint)
 		options := "defaults"
 		switch fstype {
 		case "9p", "virtiofs":

--- a/pkg/driver/krunkit/krunkit_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_darwin_arm64.go
@@ -81,13 +81,13 @@ func Cmdline(inst *limatype.Instance) (*exec.Cmd, error) {
 
 	// File sharing commands
 	if *inst.Config.MountType == limatype.VIRTIOFS {
-		for i, mount := range inst.Config.Mounts {
+		for _, mount := range inst.Config.Mounts {
 			if _, err := os.Stat(mount.Location); errors.Is(err, os.ErrNotExist) {
 				if err := os.MkdirAll(mount.Location, 0o750); err != nil {
 					return nil, err
 				}
 			}
-			tag := fmt.Sprintf("mount%d", i)
+			tag := limayaml.MountTag(mount.Location, *mount.MountPoint)
 			mountArg := fmt.Sprintf("virtio-fs,sharedDir=%s,mountTag=%s", mount.Location, tag)
 			args = append(args, "--device", mountArg)
 		}

--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -936,7 +936,7 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 
 	if *y.MountType == limatype.NINEP || *y.MountType == limatype.VIRTIOFS {
 		for i, f := range y.Mounts {
-			tag := fmt.Sprintf("mount%d", i)
+			tag := limayaml.MountTag(f.Location, *f.MountPoint)
 			if err := os.MkdirAll(f.Location, 0o755); err != nil {
 				return "", nil, err
 			}

--- a/pkg/driver/vz/vm_darwin.go
+++ b/pkg/driver/vz/vm_darwin.go
@@ -575,7 +575,7 @@ func attachDisplay(inst *limatype.Instance, vmConfig *vz.VirtualMachineConfigura
 func attachFolderMounts(inst *limatype.Instance, vmConfig *vz.VirtualMachineConfiguration) error {
 	var mounts []vz.DirectorySharingDeviceConfiguration
 	if *inst.Config.MountType == limatype.VIRTIOFS {
-		for i, mount := range inst.Config.Mounts {
+		for _, mount := range inst.Config.Mounts {
 			if _, err := os.Stat(mount.Location); errors.Is(err, os.ErrNotExist) {
 				err := os.MkdirAll(mount.Location, 0o750)
 				if err != nil {
@@ -592,7 +592,7 @@ func attachFolderMounts(inst *limatype.Instance, vmConfig *vz.VirtualMachineConf
 				return err
 			}
 
-			tag := fmt.Sprintf("mount%d", i)
+			tag := limayaml.MountTag(mount.Location, *mount.MountPoint)
 			config, err := vz.NewVirtioFileSystemDeviceConfiguration(tag)
 			if err != nil {
 				return err

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -92,6 +92,13 @@ func MACAddress(uniqueID string) string {
 	return hw.String()
 }
 
+// MountTag generates a stable mount tag from location and mountPoint.
+// Both paths are hashed to handle the same location mounted to multiple mount points.
+func MountTag(location, mountPoint string) string {
+	sha := sha256.Sum256([]byte(location + "\x00" + mountPoint))
+	return fmt.Sprintf("lima-%x", sha[0:8])
+}
+
 func defaultCPUs() int {
 	const x = 4
 	if hostCPUs := runtime.NumCPU(); hostCPUs < x {


### PR DESCRIPTION
Previously, mount tags were generated using index-based naming (mount0, mount1, etc.). This caused issues when mount configuration changed: the old mount remained active with its original path while the new fstab entry used the same tag for a different path. Users had to reboot twice to apply configuration changes.

This commit generates stable mount tags by hashing both the host location and guest mountPoint. This ensures:
- Tags remain consistent across VM restarts regardless of mount order
- Configuration changes take effect after a single reboot
- Same host path mounted to multiple guest paths get unique tags

Fixes #3957