### PR TITLE
fix(shell-sync): show file contents in new directories by using `-N` flag

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -459,7 +459,7 @@ func askUserForRsyncBack(ctx context.Context, cmd *cobra.Command, inst *limatype
 				}
 				rsyncToTempDir = true
 			}
-			diffCmd := exec.CommandContext(ctx, "diff", "-ru", "--color=always", hostCurrentDir, filepath.Join(hostTmpDest, filepath.Base(hostCurrentDir)))
+			diffCmd := exec.CommandContext(ctx, "diff", "-ruN", "--color=always", hostCurrentDir, filepath.Join(hostTmpDest, filepath.Base(hostCurrentDir)))
 			pager := os.Getenv("PAGER")
 			pager = strings.TrimSpace(pager)
 			if pager == "" {


### PR DESCRIPTION
This PR fixes when a new directory was added, the diff command would only report the directory itself and hiding the actual files(and content) inside it.