### PR TITLE
fix: panic when run as root

### DIFF
--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -33,7 +33,8 @@ const (
 
 func main() {
 	if os.Geteuid() == 0 && (len(os.Args) < 2 || os.Args[1] != "generate-doc") {
-		panic("must not run as the root user")
+		fmt.Fprint(os.Stderr, "limactl: must not run as the root user\n")
+		os.Exit(1)
 	}
 
 	yq.MaybeRunYQ()


### PR DESCRIPTION
fix 
limactl list
```
panic: must not run as the root user

goroutine 1 [running]:
main.main()
	/home/runner/work/lima/lima/cmd/limactl/main.go:36 +0x110

```