### PR TITLE
Rename /home/${USER}.linux to /home/${USER}.guest

### DIFF
--- a/hack/bats/tests/path.bats
+++ b/hack/bats/tests/path.bats
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load "../helpers/load"
+
+NAME=bats
+
+# TODO The reusable Lima instance setup is copied from preserve-env.bats
+# TODO and should be factored out into helper functions.
+local_setup_file() {
+    if [[ -n "${LIMA_BATS_REUSE_INSTANCE:-}" ]]; then
+        run limactl list --format '{{.Status}}' "$NAME"
+        [[ $status == 0 ]] && [[ $output == "Running" ]] && return
+    fi
+    limactl unprotect "$NAME" || :
+    limactl delete --force "$NAME" || :
+    # Make sure that the host agent doesn't inherit file handles 3 or 4.
+    # Otherwise bats will not finish until the host agent exits.
+    limactl start --yes --name "$NAME" template:default 3>&- 4>&-
+}
+
+local_teardown_file() {
+    if [[ -z "${LIMA_BATS_REUSE_INSTANCE:-}" ]]; then
+        limactl delete --force "$NAME"
+    fi
+}
+
+@test "The guest home is accessible via both .guest and .linux paths" {
+    run limactl shell "$NAME" -- ls -ld /home/"${USER}.guest/.ssh"
+    assert_success
+
+    run limactl shell "$NAME" -- ls -ld /home/"${USER}.linux/.ssh"
+    assert_success
+}

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/00-guest-home.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/00-guest-home.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+# The default guest home directory is "/home/${LIMA_CIDATA_USER}.guest" since Lima 2.1.0.
+# The path was previously "/home/${LIMA_CIDATA_USER}.linux".
+if [ -d "/home/${LIMA_CIDATA_USER}.guest" ] && [ ! -e "/home/${LIMA_CIDATA_USER}.linux" ]; then
+	ln -s "${LIMA_CIDATA_USER}.guest" "/home/${LIMA_CIDATA_USER}.linux"
+fi
+if [ -d "/home/${LIMA_CIDATA_USER}.linux" ] && [ ! -e "/home/${LIMA_CIDATA_USER}.guest" ]; then
+	ln -s "${LIMA_CIDATA_USER}.linux" "/home/${LIMA_CIDATA_USER}.guest"
+fi

--- a/pkg/cidata/template_test.go
+++ b/pkg/cidata/template_test.go
@@ -19,7 +19,7 @@ func TestConfig(t *testing.T) {
 		User:    "foo",
 		UID:     501,
 		Comment: "Foo",
-		Home:    "/home/foo.linux",
+		Home:    "/home/foo.guest",
 		Shell:   "/bin/bash",
 		SSHPubKeys: []string{
 			"ssh-rsa dummy foo@example.com",
@@ -39,7 +39,7 @@ func TestConfigCACerts(t *testing.T) {
 		User:    "foo",
 		UID:     501,
 		Comment: "Foo",
-		Home:    "/home/foo.linux",
+		Home:    "/home/foo.guest",
 		Shell:   "/bin/bash",
 		SSHPubKeys: []string{
 			"ssh-rsa dummy foo@example.com",
@@ -56,7 +56,7 @@ func TestConfigCACerts(t *testing.T) {
 }
 
 var defaultMounts = []Mount{
-	{MountPoint: "/home/foo.linux", Tag: "mount0", Type: "virtiofs", Options: "ro"},
+	{MountPoint: "/home/foo.guest", Tag: "mount0", Type: "virtiofs", Options: "ro"},
 	{MountPoint: "/tmp/lima", Tag: "mount1", Type: "virtiofs"},
 }
 
@@ -66,7 +66,7 @@ func TestConfigMounts(t *testing.T) {
 		User:    "foo",
 		UID:     501,
 		Comment: "Foo",
-		Home:    "/home/foo.linux",
+		Home:    "/home/foo.guest",
 		Shell:   "/bin/bash",
 		SSHPubKeys: []string{
 			"ssh-rsa dummy foo@example.com",
@@ -86,7 +86,7 @@ func TestConfigMountsNone(t *testing.T) {
 		User:    "foo",
 		UID:     501,
 		Comment: "Foo",
-		Home:    "/home/foo.linux",
+		Home:    "/home/foo.guest",
 		Shell:   "/bin/bash",
 		SSHPubKeys: []string{
 			"ssh-rsa dummy foo@example.com",
@@ -105,7 +105,7 @@ func TestTemplate(t *testing.T) {
 		Name:  "default",
 		User:  "foo",
 		UID:   501,
-		Home:  "/home/foo.linux",
+		Home:  "/home/foo.guest",
 		Shell: "/bin/bash",
 		SSHPubKeys: []string{
 			"ssh-rsa dummy foo@example.com",
@@ -141,7 +141,7 @@ func TestTemplate9p(t *testing.T) {
 		Name:  "default",
 		User:  "foo",
 		UID:   501,
-		Home:  "/home/foo.linux",
+		Home:  "/home/foo.guest",
 		Shell: "/bin/bash",
 		SSHPubKeys: []string{
 			"ssh-rsa dummy foo@example.com",

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -65,7 +65,7 @@ func TestFillDefault(t *testing.T) {
 	limaHome, err := dirnames.LimaDir()
 	assert.NilError(t, err)
 	user := osutil.LimaUser(t.Context(), "0.0.0", false)
-	user.HomeDir = fmt.Sprintf("/home/%s.linux", user.Username)
+	user.HomeDir = fmt.Sprintf("/home/%s.guest", user.Username)
 	uid, err := strconv.ParseUint(user.Uid, 10, 32)
 	assert.NilError(t, err)
 

--- a/pkg/osutil/user.go
+++ b/pkg/osutil/user.go
@@ -111,7 +111,6 @@ func LimaUser(ctx context.Context, limaVersion string, warn bool) *user.User {
 			warnings = append(warnings, warning)
 			limaUser.Username = fallbackUser
 		}
-		limaUser.HomeDir = "/home/{{.User}}.linux"
 		if runtime.GOOS == "windows" {
 			idu, err := call(ctx, []string{"id", "-u"})
 			if err != nil {
@@ -150,6 +149,14 @@ func LimaUser(ctx context.Context, limaVersion string, warn bool) *user.User {
 	}
 	// Make sure we return a pointer to a COPY of limaUser
 	u := *limaUser
+	limaVersionUnknown := limaVersion == "" || limaVersion == "<unknown>"
+	if limaVersionUnknown || versionutil.GreaterEqual(limaVersion, "2.1.0") {
+		u.HomeDir = "/home/{{.User}}.guest"
+		// boot script symlinks "/home/{{.User}}.linux" to "{{.User}}.guest" for compatibility
+	} else {
+		u.HomeDir = "/home/{{.User}}.linux"
+		// boot script symlinks "/home/{{.User}}.guest" to "{{.User}}.linux" for compatibility
+	}
 	if versionutil.GreaterEqual(limaVersion, "1.0.0") {
 		if u.Username == "admin" {
 			if warn {

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -351,7 +351,7 @@ user:
   uid: null
   # Home directory inside the VM, NOT the mounted home directory of the host.
   # It can use the following template variables: {{.Name}}, {{.Hostname}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
-  # 🟢 Builtin default: "/home/{{.User}}.linux"
+  # 🟢 Builtin default: "/home/{{.User}}.guest" (Also accessible as "/home/{{.User}}.linux")
   home: null
   # Shell. Needs to be an absolute path.
   # 🟢 Builtin default: "/bin/bash"

--- a/website/content/en/docs/examples/ai.md
+++ b/website/content/en/docs/examples/ai.md
@@ -44,6 +44,7 @@ lima aider
 Follow the guide shown in the first session for authentication.
 
 Alternatively, you can set environmental variables via:
+<!-- TODO: change ${USER}.linux to ${USER}.guest after releasing v2.1 GA -->
 ```
 lima vi "/home/${USER}.linux/.bash_profile"
 ```

--- a/website/content/en/docs/usage/_index.md
+++ b/website/content/en/docs/usage/_index.md
@@ -50,6 +50,19 @@ lima uname -a
 ```
 The `lima` command also accepts the instance name as the environment variable `$LIMA_INSTANCE`.
 
+### Home directory
+
+The host home directory is mounted as read-only on the following path by default:
+- `/Users/${USER}` (on macOS hosts)
+- `/home/${USER}`  (on other hosts)
+
+To make the host mount writable, run `limactl start` with `--mount-writable`.
+To disable the mount, `limactl start` with `--mount-none` or `--plain`.
+
+The guest home directory exists independently on the following path:
+- `/home/${USER}.guest` (since Lima v2.1)
+- `/home/${USER}.linux` (prior to Lima v2.1)
+
 ### Shell completion
 - To enable bash completion, add `source <(limactl completion bash)` to `~/.bash_profile`.
 - To enable zsh completion, see `limactl completion zsh --help`


### PR DESCRIPTION
Fix #4577

Newly created instances now use `/home/${USER}.guest` as the home directory. To maintain compatibility,  `/home/${USER}.linux` is created as a symlink to `${USER}.guest`.

For existing instances, the symlink is created in the opposite direction.