### PR TITLE
Introduce stable disk/iso filenames with symlink-based migration

### DIFF
--- a/pkg/driver/krunkit/krunkit_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_darwin_arm64.go
@@ -45,7 +45,7 @@ func Cmdline(inst *limatype.Instance) (*exec.Cmd, error) {
 		"--restful-uri", "none://",
 
 		// First virtio-blk device is the boot disk
-		"--device", fmt.Sprintf("virtio-blk,path=%s,format=raw", filepath.Join(inst.Dir, filenames.DiffDisk)),
+		"--device", fmt.Sprintf("virtio-blk,path=%s,format=raw", filepath.Join(inst.Dir, filenames.Disk)),
 		"--device", fmt.Sprintf("virtio-blk,path=%s", filepath.Join(inst.Dir, filenames.CIDataISO)),
 	}
 

--- a/pkg/driver/wsl2/fs.go
+++ b/pkg/driver/wsl2/fs.go
@@ -18,7 +18,7 @@ import (
 
 // EnsureFs downloads the root fs.
 func EnsureFs(ctx context.Context, inst *limatype.Instance) error {
-	baseDisk := filepath.Join(inst.Dir, filenames.BaseDisk)
+	baseDisk := filepath.Join(inst.Dir, filenames.BaseDiskLegacy)
 	if _, err := os.Stat(baseDisk); errors.Is(err, os.ErrNotExist) {
 		var ensuredBaseDisk bool
 		errs := make([]error, len(inst.Config.Images))

--- a/pkg/driver/wsl2/vm_windows.go
+++ b/pkg/driver/wsl2/vm_windows.go
@@ -39,7 +39,7 @@ func startVM(ctx context.Context, distroName string) error {
 
 // initVM calls WSL to import a new VM specifically for Lima.
 func initVM(ctx context.Context, instanceDir, distroName string) error {
-	baseDisk := filepath.Join(instanceDir, filenames.BaseDisk)
+	baseDisk := filepath.Join(instanceDir, filenames.BaseDiskLegacy)
 	logrus.Infof("Importing distro from %q to %q", baseDisk, instanceDir)
 	out, err := executil.RunUTF16leCommand([]string{
 		"wsl.exe",

--- a/pkg/driverutil/disk.go
+++ b/pkg/driverutil/disk.go
@@ -12,50 +12,93 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/lima-vm/go-qcow2reader/image"
+	"github.com/sirupsen/logrus"
 
 	"github.com/lima-vm/lima/v2/pkg/imgutil/proxyimgutil"
 	"github.com/lima-vm/lima/v2/pkg/iso9660util"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/osutil"
 )
 
-// EnsureDisk ensures that the diff disk exists with the specified size and format.
-func EnsureDisk(ctx context.Context, instDir, diskSize string, diskImageFormat image.Type) error {
-	diffDisk := filepath.Join(instDir, filenames.DiffDisk)
-	if _, err := os.Stat(diffDisk); err == nil || !errors.Is(err, os.ErrNotExist) {
-		// disk is already ensured
-		return err
+// MigrateDiskLayout creates symlinks from the current filenames (disk, iso) to
+// the legacy filenames (diffdisk, basedisk) used by older Lima versions.
+// The original files are left in place so older Lima versions can still use them.
+func MigrateDiskLayout(instDir string) error {
+	diskPath := filepath.Join(instDir, filenames.Disk)
+	if osutil.FileExists(diskPath) {
+		return nil // already migrated or new instance
 	}
 
-	diskUtil := proxyimgutil.NewDiskUtil(ctx)
-
-	baseDisk := filepath.Join(instDir, filenames.BaseDisk)
-
-	diskSizeInBytes, _ := units.RAMInBytes(diskSize)
-	if diskSizeInBytes == 0 {
-		return nil
+	diffDiskPath := filepath.Join(instDir, filenames.DiffDiskLegacy)
+	if osutil.FileExists(diffDiskPath) {
+		logrus.Infof("Creating symlink %q -> %q", filenames.Disk, filenames.DiffDiskLegacy)
+		if err := os.Symlink(filenames.DiffDiskLegacy, diskPath); err != nil {
+			return fmt.Errorf("failed to symlink %q to %q: %w", filenames.Disk, filenames.DiffDiskLegacy, err)
+		}
 	}
-	isBaseDiskISO, err := iso9660util.IsISO9660(baseDisk)
-	if err != nil {
-		return err
-	}
-	srcDisk := baseDisk
-	if isBaseDiskISO {
-		srcDisk = diffDisk
 
-		// Create an empty data volume for the diff disk
-		diffDiskF, err := os.Create(diffDisk)
+	baseDiskPath := filepath.Join(instDir, filenames.BaseDiskLegacy)
+	isoPath := filepath.Join(instDir, filenames.ISO)
+	if osutil.FileExists(baseDiskPath) && !osutil.FileExists(isoPath) {
+		isISO, err := iso9660util.IsISO9660(baseDiskPath)
 		if err != nil {
 			return err
 		}
+		if isISO {
+			logrus.Infof("Creating symlink %q -> %q", filenames.ISO, filenames.BaseDiskLegacy)
+			if err := os.Symlink(filenames.BaseDiskLegacy, isoPath); err != nil {
+				return fmt.Errorf("failed to symlink %q to %q: %w", filenames.ISO, filenames.BaseDiskLegacy, err)
+			}
+		}
+		// Non-ISO basedisk is a legacy qcow2 backing file; leave it for QEMU to resolve.
+	}
 
-		if err = diffDiskF.Close(); err != nil {
+	return nil
+}
+
+// EnsureDisk creates the VM disk from the downloaded image.
+// For ISO images, it renames the image to "iso" and creates an empty disk.
+// For non-ISO images, it converts the image to "disk" and removes the original.
+func EnsureDisk(ctx context.Context, instDir, diskSize string, diskImageFormat image.Type) error {
+	diskPath := filepath.Join(instDir, filenames.Disk)
+	if _, err := os.Stat(diskPath); err == nil || !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	imagePath := filepath.Join(instDir, filenames.Image)
+	isISO, err := iso9660util.IsISO9660(imagePath)
+	if err != nil {
+		return err
+	}
+
+	diskSizeInBytes, _ := units.RAMInBytes(diskSize)
+	diskUtil := proxyimgutil.NewDiskUtil(ctx)
+
+	if isISO {
+		isoPath := filepath.Join(instDir, filenames.ISO)
+		if err := os.Rename(imagePath, isoPath); err != nil {
 			return err
 		}
+		f, err := os.Create(diskPath)
+		if err != nil {
+			_ = os.Rename(isoPath, imagePath)
+			return err
+		}
+		if err := f.Close(); err != nil {
+			os.Remove(diskPath)
+			_ = os.Rename(isoPath, imagePath)
+			return err
+		}
+		if err := diskUtil.Convert(ctx, diskImageFormat, diskPath, diskPath, &diskSizeInBytes, false); err != nil {
+			os.Remove(diskPath)
+			_ = os.Rename(isoPath, imagePath)
+			return fmt.Errorf("failed to create disk %q: %w", diskPath, err)
+		}
+	} else {
+		if err := diskUtil.Convert(ctx, diskImageFormat, imagePath, diskPath, &diskSizeInBytes, false); err != nil {
+			return fmt.Errorf("failed to convert %q to %q: %w", imagePath, diskPath, err)
+		}
+		os.Remove(imagePath)
 	}
-	// Check whether to use ASIF format
-
-	if err = diskUtil.Convert(ctx, diskImageFormat, srcDisk, diffDisk, &diskSizeInBytes, false); err != nil {
-		return fmt.Errorf("failed to convert %q to a disk %q: %w", srcDisk, diffDisk, err)
-	}
-	return err
+	return nil
 }

--- a/pkg/driverutil/disk_test.go
+++ b/pkg/driverutil/disk_test.go
@@ -60,12 +60,19 @@ func detectImageType(t *testing.T, path string) image.Type {
 	return img.Type()
 }
 
-func checkDisk(t *testing.T, diff string, expectedType image.Type) {
+func checkDisk(t *testing.T, diskPath string, expectedType image.Type) {
 	t.Helper()
-	fi, err := os.Stat(diff)
+	fi, err := os.Stat(diskPath)
 	assert.NilError(t, err)
 	assert.Assert(t, fi.Size() > 0)
-	assert.Equal(t, detectImageType(t, diff), expectedType)
+	assert.Equal(t, detectImageType(t, diskPath), expectedType)
+}
+
+func assertSymlink(t *testing.T, path, expectedTarget string) {
+	t.Helper()
+	target, err := os.Readlink(path)
+	assert.NilError(t, err)
+	assert.Equal(t, target, expectedTarget)
 }
 
 func isMacOS26OrHigher() bool {
@@ -79,16 +86,11 @@ func isMacOS26OrHigher() bool {
 	return version.Major >= 26
 }
 
-func TestEnsureDisk_WithISOBaseImage(t *testing.T) {
+func TestEnsureDisk_WithISOImage(t *testing.T) {
 	instDir := t.TempDir()
-	base := filepath.Join(instDir, filenames.BaseDisk)
-	diff := filepath.Join(instDir, filenames.DiffDisk)
-
-	writeMinimalISO(t, base)
-	isISO, err := iso9660util.IsISO9660(base)
-	assert.NilError(t, err)
-	assert.Assert(t, isISO)
-	baseHashBefore := sha256File(t, base)
+	imagePath := filepath.Join(instDir, filenames.Image)
+	diskPath := filepath.Join(instDir, filenames.Disk)
+	isoPath := filepath.Join(instDir, filenames.ISO)
 
 	formats := []image.Type{typeRAW}
 	if isMacOS26OrHigher() {
@@ -96,25 +98,30 @@ func TestEnsureDisk_WithISOBaseImage(t *testing.T) {
 	}
 
 	for _, format := range formats {
+		writeMinimalISO(t, imagePath)
+		imageHashBefore := sha256File(t, imagePath)
+
 		assert.NilError(t, EnsureDisk(t.Context(), instDir, "2MiB", format))
-		isISO, err = iso9660util.IsISO9660(base)
+
+		// image should have been renamed to iso
+		assert.Assert(t, !osutil.FileExists(imagePath))
+		assert.Equal(t, imageHashBefore, sha256File(t, isoPath))
+		isISO, err := iso9660util.IsISO9660(isoPath)
 		assert.NilError(t, err)
 		assert.Assert(t, isISO)
-		assert.Equal(t, baseHashBefore, sha256File(t, base))
-		checkDisk(t, diff, format)
-		assert.NilError(t, os.Remove(diff))
+
+		// disk should be a real file (empty data disk)
+		checkDisk(t, diskPath, format)
+
+		assert.NilError(t, os.Remove(diskPath))
+		assert.NilError(t, os.Remove(isoPath))
 	}
 }
 
-func TestEnsureDisk_WithNonISOBaseImage(t *testing.T) {
+func TestEnsureDisk_WithNonISOImage(t *testing.T) {
 	instDir := t.TempDir()
-	base := filepath.Join(instDir, filenames.BaseDisk)
-	diff := filepath.Join(instDir, filenames.DiffDisk)
-
-	writeNonISO(t, base)
-	isISO, err := iso9660util.IsISO9660(base)
-	assert.NilError(t, err)
-	assert.Assert(t, !isISO)
+	imagePath := filepath.Join(instDir, filenames.Image)
+	diskPath := filepath.Join(instDir, filenames.Disk)
 
 	formats := []image.Type{typeRAW}
 	if isMacOS26OrHigher() {
@@ -122,18 +129,26 @@ func TestEnsureDisk_WithNonISOBaseImage(t *testing.T) {
 	}
 
 	for _, format := range formats {
+		writeNonISO(t, imagePath)
+
 		assert.NilError(t, EnsureDisk(t.Context(), instDir, "2MiB", format))
-		checkDisk(t, diff, format)
-		assert.NilError(t, os.Remove(diff))
+
+		// image should have been consumed
+		assert.Assert(t, !osutil.FileExists(imagePath))
+
+		// disk should be the converted image
+		checkDisk(t, diskPath, format)
+
+		assert.NilError(t, os.Remove(diskPath))
 	}
 }
 
-func TestEnsureDisk_ExistingDiffDisk(t *testing.T) {
+func TestEnsureDisk_ExistingDisk(t *testing.T) {
 	instDir := t.TempDir()
-	base := filepath.Join(instDir, filenames.BaseDisk)
-	diff := filepath.Join(instDir, filenames.DiffDisk)
+	imagePath := filepath.Join(instDir, filenames.Image)
+	diskPath := filepath.Join(instDir, filenames.Disk)
 
-	writeNonISO(t, base)
+	writeNonISO(t, imagePath)
 
 	formats := []image.Type{typeRAW}
 	if isMacOS26OrHigher() {
@@ -141,10 +156,92 @@ func TestEnsureDisk_ExistingDiffDisk(t *testing.T) {
 	}
 
 	for _, format := range formats {
-		assert.NilError(t, os.WriteFile(diff, []byte("preexisting"), 0o644))
-		origHash := sha256File(t, diff)
+		assert.NilError(t, os.WriteFile(diskPath, []byte("preexisting"), 0o644))
+		origHash := sha256File(t, diskPath)
 		assert.NilError(t, EnsureDisk(t.Context(), instDir, "2MiB", format))
-		assert.Equal(t, sha256File(t, diff), origHash)
-		assert.NilError(t, os.Remove(diff))
+		assert.Equal(t, sha256File(t, diskPath), origHash)
+		assert.NilError(t, os.Remove(diskPath))
 	}
+}
+
+func TestMigrateDiskLayout_LegacyDiffDisk(t *testing.T) {
+	instDir := t.TempDir()
+	diffDiskPath := filepath.Join(instDir, filenames.DiffDiskLegacy)
+
+	assert.NilError(t, os.WriteFile(diffDiskPath, []byte("legacy-disk"), 0o644))
+	origHash := sha256File(t, diffDiskPath)
+
+	assert.NilError(t, MigrateDiskLayout(instDir))
+
+	// disk should be a symlink to diffdisk
+	diskPath := filepath.Join(instDir, filenames.Disk)
+	assertSymlink(t, diskPath, filenames.DiffDiskLegacy)
+	assert.Equal(t, sha256File(t, diskPath), origHash)
+
+	// diffdisk should still exist (untouched)
+	assert.Assert(t, osutil.FileExists(diffDiskPath))
+}
+
+func TestMigrateDiskLayout_LegacyISOBaseDisk(t *testing.T) {
+	instDir := t.TempDir()
+	baseDiskPath := filepath.Join(instDir, filenames.BaseDiskLegacy)
+	diffDiskPath := filepath.Join(instDir, filenames.DiffDiskLegacy)
+
+	writeMinimalISO(t, baseDiskPath)
+	baseHash := sha256File(t, baseDiskPath)
+	assert.NilError(t, os.WriteFile(diffDiskPath, []byte("legacy-disk"), 0o644))
+	diffHash := sha256File(t, diffDiskPath)
+
+	assert.NilError(t, MigrateDiskLayout(instDir))
+
+	// disk should be a symlink to diffdisk
+	diskPath := filepath.Join(instDir, filenames.Disk)
+	assertSymlink(t, diskPath, filenames.DiffDiskLegacy)
+	assert.Equal(t, sha256File(t, diskPath), diffHash)
+
+	// iso should be a symlink to basedisk
+	isoPath := filepath.Join(instDir, filenames.ISO)
+	assertSymlink(t, isoPath, filenames.BaseDiskLegacy)
+	assert.Equal(t, sha256File(t, isoPath), baseHash)
+
+	// original files should still exist
+	assert.Assert(t, osutil.FileExists(diffDiskPath))
+	assert.Assert(t, osutil.FileExists(baseDiskPath))
+}
+
+func TestMigrateDiskLayout_LegacyNonISOBaseDisk(t *testing.T) {
+	instDir := t.TempDir()
+	baseDiskPath := filepath.Join(instDir, filenames.BaseDiskLegacy)
+	diffDiskPath := filepath.Join(instDir, filenames.DiffDiskLegacy)
+
+	writeNonISO(t, baseDiskPath)
+	baseHash := sha256File(t, baseDiskPath)
+	assert.NilError(t, os.WriteFile(diffDiskPath, []byte("legacy-disk"), 0o644))
+
+	assert.NilError(t, MigrateDiskLayout(instDir))
+
+	// disk should be a symlink to diffdisk
+	diskPath := filepath.Join(instDir, filenames.Disk)
+	assertSymlink(t, diskPath, filenames.DiffDiskLegacy)
+
+	// non-ISO basedisk should remain unchanged (qcow2 backing file)
+	assert.Equal(t, sha256File(t, baseDiskPath), baseHash)
+
+	// no iso symlink should be created
+	isoPath := filepath.Join(instDir, filenames.ISO)
+	_, err := os.Lstat(isoPath)
+	assert.Assert(t, os.IsNotExist(err))
+}
+
+func TestMigrateDiskLayout_AlreadyMigrated(t *testing.T) {
+	instDir := t.TempDir()
+	diskPath := filepath.Join(instDir, filenames.Disk)
+
+	assert.NilError(t, os.WriteFile(diskPath, []byte("current-disk"), 0o644))
+	origHash := sha256File(t, diskPath)
+
+	assert.NilError(t, MigrateDiskLayout(instDir))
+
+	// disk should be unchanged
+	assert.Equal(t, sha256File(t, diskPath), origHash)
 }

--- a/pkg/limatype/filenames/filenames.go
+++ b/pkg/limatype/filenames/filenames.go
@@ -36,8 +36,11 @@ const (
 	CIDataISO               = "cidata.iso"
 	CIDataISODir            = "cidata"
 	CloudConfig             = "cloud-config.yaml"
-	BaseDisk                = "basedisk"
-	DiffDisk                = "diffdisk"
+	Image                   = "image"    // downloaded VM image; renamed to Disk or ISO during setup
+	Disk                    = "disk"     // VM disk (or symlink to DiffDiskLegacy for migrated instances)
+	ISO                     = "iso"      // optional CDROM image (or symlink to BaseDiskLegacy for migrated instances)
+	BaseDiskLegacy          = "basedisk" // legacy name for Image; may remain as qcow2 backing file
+	DiffDiskLegacy          = "diffdisk" // legacy name for Disk
 	Kernel                  = "kernel"
 	KernelCmdline           = "kernel.cmdline"
 	Initrd                  = "initrd"

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -992,7 +992,7 @@ func IsExistingInstanceDir(dir string) bool {
 	// because the file is created during the initialization of the instance.
 	for _, f := range []string{
 		filenames.HostAgentStdoutLog, filenames.HostAgentStderrLog,
-		filenames.VzIdentifier, filenames.BaseDisk, filenames.DiffDisk, filenames.CIDataISO,
+		filenames.VzIdentifier, filenames.Image, filenames.Disk, filenames.BaseDiskLegacy, filenames.DiffDiskLegacy, filenames.CIDataISO,
 	} {
 		file := filepath.Join(dir, f)
 		if _, err := os.Lstat(file); !errors.Is(err, os.ErrNotExist) {

--- a/pkg/osutil/file.go
+++ b/pkg/osutil/file.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package osutil
+
+import (
+	"errors"
+	"os"
+)
+
+// FileExists reports whether path exists and is accessible.
+// It returns true for any non-ErrNotExist stat result, including permission errors.
+func FileExists(path string) bool {
+	_, err := os.Stat(path)
+	return !errors.Is(err, os.ErrNotExist)
+}

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -44,8 +44,11 @@ Ansible:
 - `ansible-inventory.yaml`: the Ansible node inventory. See [ansible](#ansible).
 
 disk:
-- `basedisk`: the base image
-- `diffdisk`: the diff image (QCOW2)
+- `image`: the downloaded VM image; renamed to `disk` or `iso` during setup
+- `disk`: the VM disk (can be a symlink to legacy `diffdisk`)
+- `iso`: optional CDROM image for ISO-based installations (can be a symlink to legacy `basedisk`)
+- `basedisk`: legacy name for the downloaded image (pre-v2.1 instances; may remain as a qcow2 backing file)
+- `diffdisk`: legacy name for `disk` (pre-v2.1 instances)
 
 kernel:
 - `kernel`: the kernel


### PR DESCRIPTION
Alternative to #4206.

Replace the legacy basedisk/diffdisk naming with self-documenting filenames: "image" (downloaded VM image), "disk" (VM disk), and "iso" (optional CDROM).

New instances download to "image" and create symlinks: non-ISO images get disk→image; ISO images get iso→image plus a real empty disk. QEMU no longer creates a qcow2 overlay backed by basedisk; it symlinks disk→image directly.

Existing instances are migrated by `MigrateDiskLayout`, which creates disk→diffdisk and (for ISO basedisks) iso→basedisk symlinks. The original files remain so older Lima versions can still use them.

Boot paths now check for the "iso" symlink via `osutil.FileExists` instead of calling `iso9660util.IsISO9660` at startup.

---

### Comparing existing instance vs. one created with this PR

#### Using ISO image

```console
❯ ls -lh ~/.lima/alpine-iso/{image,*disk,iso}
ls: /Users/jan/.lima/alpine-iso/image: No such file or directory
-rw-r--r--@ 1 jan  staff    91M Oct 12 20:22 /Users/jan/.lima/alpine-iso/basedisk
-rw-r--r--@ 1 jan  staff   100G Feb 15 16:43 /Users/jan/.lima/alpine-iso/diffdisk
lrwxr-xr-x@ 1 jan  staff     8B Feb 15 16:42 /Users/jan/.lima/alpine-iso/disk -> diffdisk
lrwxr-xr-x@ 1 jan  staff     8B Feb 15 16:42 /Users/jan/.lima/alpine-iso/iso -> basedisk

❯ ls -lh ~/.lima/alpine-new/{image,*disk,iso}
-rw-r--r--@ 1 jan  staff   100G Feb 15 16:43 /Users/jan/.lima/alpine-new/disk
-rw-r--r--@ 1 jan  staff   103M Jan  7 15:01 /Users/jan/.lima/alpine-new/image
lrwxr-xr-x@ 1 jan  staff     5B Feb 15 16:43 /Users/jan/.lima/alpine-new/iso -> image
```

#### Regular non-ISO image

```console
❯ ls -lh ~/.lima/default/{image,*disk}
ls: /Users/jan/.lima/default/image: No such file or directory
-rw-r--r--@ 1 jan  staff   838M Nov 24 20:38 /Users/jan/.lima/default/basedisk
-rw-r--r--@ 1 jan  staff   100G Feb 15 16:51 /Users/jan/.lima/default/diffdisk
lrwxr-xr-x@ 1 jan  staff     8B Feb 15 16:48 /Users/jan/.lima/default/disk -> diffdisk

❯ ls -lh ~/.lima/default-new/{image,*disk}
lrwxr-xr-x@ 1 jan  staff     5B Feb 15 16:49 /Users/jan/.lima/default-new/disk -> image
-rw-r--r--@ 1 jan  staff   100G Feb 15 16:51 /Users/jan/.lima/default-new/image
```
