### PR TITLE
Update `template://` URLs in the docs to `template:`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ lima nerdctl run --rm hello-world
 
 To run containers with Docker:
 ```bash
-limactl start template://docker
+limactl start template:docker
 export DOCKER_HOST=$(limactl list docker --format 'unix://{{.Dir}}/sock/docker.sock')
 docker run --rm hello-world
 ```
 
 To run containers with Kubernetes:
 ```bash
-limactl start template://k8s
+limactl start template:k8s
 export KUBECONFIG=$(limactl list k8s --format 'unix://{{.Dir}}/copied-from-guest/kubeconfig.yaml')
 kubectl apply -f ...
 ```

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,4 +1,6 @@
-Run `limactl start template://fedora` to create a Lima instance named "fedora".
+Run `limactl start template:fedora` to create a Lima instance named "fedora".
+
+Note: In Lima 1.x template URLs included leading slashes, e.g. `template://fedora`.
 
 To open a shell, run `limactl shell fedora bash` or `LIMA_INSTANCE=fedora lima bash`.
 
@@ -80,12 +82,12 @@ Lost+found:
 - ~`centos-stream-8`~: Remove in Lima v0.23.0, as CentOS Stream 8 reached [EOL](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/).
 - ~`deprecated/centos-7`~: Remove in Lima v0.23.0, as CentOS 7 reached [EOL](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/).
 - ~`experimental/vz`~: Merged into the default template in Lima v1.0. See also <https://lima-vm.io/docs/config/vmtype/>.
-- ~`experimental/armv7l`~: Merged into the `default` template in Lima v1.0. Use `limactl create --arch=armv7l template://default`.
-- ~`experimental/riscv64`~: Merged into the `default` template in Lima v1.0. Use `limactl create --arch=riscv64 template://default`.
-- ~`vmnet`~: Removed in Lima v1.0. Use `limactl create --network=lima:shared template://default` instead. See also <https://lima-vm.io/docs/config/network/>.
-- ~`experimental/net-user-v2`~: Removed in Lima v1.0. Use `limactl create --network=lima:user-v2 template://default` instead. See also <https://lima-vm.io/docs/config/network/>.
-- ~`experimental/9p`~: Removed in Lima v1.0. Use `limactl create --vm-type=qemu --mount-type=9p template://default` instead. See also <https://lima-vm.io/docs/config/mount/>.
-- ~`experimental/virtiofs-linux`~: Removed in Lima v1.0. Use `limactl create --mount-type=virtiofs-linux template://default` instead. See also <https://lima-vm.io/docs/config/mount/>.
+- ~`experimental/armv7l`~: Merged into the `default` template in Lima v1.0. Use `limactl create --arch=armv7l template:default`.
+- ~`experimental/riscv64`~: Merged into the `default` template in Lima v1.0. Use `limactl create --arch=riscv64 template:default`.
+- ~`vmnet`~: Removed in Lima v1.0. Use `limactl create --network=lima:shared template:default` instead. See also <https://lima-vm.io/docs/config/network/>.
+- ~`experimental/net-user-v2`~: Removed in Lima v1.0. Use `limactl create --network=lima:user-v2 template:default` instead. See also <https://lima-vm.io/docs/config/network/>.
+- ~`experimental/9p`~: Removed in Lima v1.0. Use `limactl create --vm-type=qemu --mount-type=9p template:default` instead. See also <https://lima-vm.io/docs/config/mount/>.
+- ~`experimental/virtiofs-linux`~: Removed in Lima v1.0. Use `limactl create --mount-type=virtiofs-linux template:default` instead. See also <https://lima-vm.io/docs/config/mount/>.
 
 ## Tier
 

--- a/website/content/en/docs/config/environment-variables.md
+++ b/website/content/en/docs/config/environment-variables.md
@@ -39,12 +39,12 @@ This page documents the environment variables used in Lima.
 
 ### `LIMA_TEMPLATES_PATH`
 
-- **Description**: Specifies the directories used to resolve `template://` URLs.
+- **Description**: Specifies the directories used to resolve `template:` URLs.
 - **Default**: `$LIMA_HOME/_templates:/usr/local/share/lima/templates`
 - **Usage**:
   ```sh
   export LIMA_TEMPLATES_PATH="$HOME/.config/lima/templates:/usr/local/share/lima/templates"
-  limactl create --name my-vm template://my-distro
+  limactl create --name my-vm template:my-distro
   ```
 
 ### `LIMA_WORKDIR`

--- a/website/content/en/docs/config/multi-arch.md
+++ b/website/content/en/docs/config/multi-arch.md
@@ -42,7 +42,7 @@ arch: "x86_64"
 plain: true
 
 base:
-- template://_images/ubuntu
+- template:_images/ubuntu
 ```
 {{% /tab %}}
 {{< /tabpane >}}

--- a/website/content/en/docs/config/vmtype/krunkit.md
+++ b/website/content/en/docs/config/vmtype/krunkit.md
@@ -103,7 +103,7 @@ This path builds and installs dependencies (which can take some time. For faster
 {{< tabpane text=true >}}
 {{% tab header="CLI" %}}
 ```bash
-limactl start --vm-type=krunkit template://fedora
+limactl start --vm-type=krunkit template:fedora
 limactl shell fedora
 ```
 {{% /tab %}}
@@ -112,8 +112,8 @@ limactl shell fedora
 vmType: krunkit
 
 base:
-- template://_images/fedora
-- template://_default/mounts
+- template:_images/fedora
+- template:_default/mounts
 
 mountType: virtiofs
 ```

--- a/website/content/en/docs/config/vmtype/qemu.md
+++ b/website/content/en/docs/config/vmtype/qemu.md
@@ -23,8 +23,8 @@ limactl start --vm-type=qemu
 vmType: "qemu"
 
 base:
-- template://_images/ubuntu
-- template://_default/mounts
+- template:_images/ubuntu
+- template:_default/mounts
 ```
 {{% /tab %}}
 {{< /tabpane >}}

--- a/website/content/en/docs/config/vmtype/vz.md
+++ b/website/content/en/docs/config/vmtype/vz.md
@@ -22,8 +22,8 @@ limactl start --vm-type=vz
 vmType: "vz"
 
 base:
-- template://_images/ubuntu
-- template://_default/mounts
+- template:_images/ubuntu
+- template:_default/mounts
 ```
 {{% /tab %}}
 {{< /tabpane >}}

--- a/website/content/en/docs/dev/drivers.md
+++ b/website/content/en/docs/dev/drivers.md
@@ -89,7 +89,7 @@ func main() {
 4. **Use the driver**: Explicitly specify the driver when creating instances:
 
 ```bash
-limactl create myinstance --vm-type=mydriver template://default
+limactl create myinstance --vm-type=mydriver template:default
 ```
 
 ## Examples

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -112,7 +112,7 @@ When using `vmType: vz` (Virtualization.framework), on boot, any qcow2 (default)
 
 ## Templates directory (`${LIMA_HOME}/_templates`)
 
-The templates directory can store additional template files that can be referenced with the `template://` schema.
+The templates directory can store additional template files that can be referenced with the `template:` schema.
 
 If the template directory exists (and `$LIMA_TEMPLATES_PATH` is not set), then this directory will be searched before the `/usr/local/share/lima/templates` default directory that contains all the templates bundled with Lima itself.
 

--- a/website/content/en/docs/examples/_index.md
+++ b/website/content/en/docs/examples/_index.md
@@ -36,7 +36,7 @@ nerdctl.lima run -d --name nginx -p 127.0.0.1:8080:80 nginx:alpine
 
 {{% tab header="Docker" %}}
 ```bash
-limactl start template://docker
+limactl start template:docker
 export DOCKER_HOST=$(limactl list docker --format 'unix://{{.Dir}}/sock/docker.sock')
 docker run -d --name nginx -p 127.0.0.1:8080:80 nginx:alpine
 ```
@@ -44,7 +44,7 @@ docker run -d --name nginx -p 127.0.0.1:8080:80 nginx:alpine
 
 {{% tab header="Podman" %}}
 ```bash
-limactl start template://podman
+limactl start template:podman
 export DOCKER_HOST=$(limactl list podman --format 'unix://{{.Dir}}/sock/podman.sock')
 docker run -d --name nginx -p 127.0.0.1:8080:80 nginx:alpine
 ```
@@ -52,7 +52,7 @@ docker run -d --name nginx -p 127.0.0.1:8080:80 nginx:alpine
 
 {{% tab header="Kubernetes" %}}
 ```bash
-limactl start template://k8s
+limactl start template:k8s
 export KUBECONFIG=$(limactl list k8s --format 'unix://{{.Dir}}/copied-from-guest/kubeconfig.yaml')
 kubectl create deployment nginx --image nginx:alpine
 kubectl create service nodeport nginx --node-port=31080 --tcp=80:80
@@ -76,7 +76,7 @@ limactl start \
   --rosetta \
   --mount-writable \
   --network=vzNAT \
-  template://fedora
+  template:fedora
 ```
 
 - `--name=default`: Set the instance name to "default"
@@ -86,4 +86,4 @@ limactl start \
 - `--rosetta`: Allow running Intel (AMD) binaries on ARM
 - `--mount-writable`: Make the home mount (`/Users/<USERNAME>`) writable
 - `--network=vzNAT`: Make the VM reachable from the host by its IP address
-- `template://fedora`: Use Fedora
+- `template:fedora`: Use Fedora

--- a/website/content/en/docs/examples/ai.md
+++ b/website/content/en/docs/examples/ai.md
@@ -152,7 +152,7 @@ The `--sync` flag for [`limactl shell`](../reference/limactl_shell) enables bidi
 1. Create an isolated instance for AI agents which must be started without host mounts for `--sync` to work:
 
 ```bash
-limactl start --mount-none template://default
+limactl start --mount-none template:default
 ```
 
 2. Navigate to your project

--- a/website/content/en/docs/examples/containers/apptainer/_index.md
+++ b/website/content/en/docs/examples/containers/apptainer/_index.md
@@ -6,13 +6,13 @@ weight: 90
 {{< tabpane text=true >}}
 {{% tab header="Rootless" %}}
 ```bash
-limactl start template://apptainer
+limactl start template:apptainer
 limactl shell apptainer apptainer run -u -B $HOME:$HOME docker://alpine
 ```
 {{% /tab %}}
 {{% tab header="Rootful" %}}
 ```bash
-limactl start template://apptainer-rootful
+limactl start template:apptainer-rootful
 limactl shell apptainer-rootful apptainer run -u -B $HOME:$HOME docker://alpine
 ```
 {{% /tab %}}

--- a/website/content/en/docs/examples/containers/docker/_index.md
+++ b/website/content/en/docs/examples/containers/docker/_index.md
@@ -6,14 +6,14 @@ weight: 2
 {{< tabpane text=true >}}
 {{% tab header="Rootless" %}}
 ```bash
-limactl start template://docker
+limactl start template:docker
 export DOCKER_HOST=$(limactl list docker --format 'unix://{{.Dir}}/sock/docker.sock')
 docker run -d --name nginx -p 127.0.0.1:8080:80 nginx:alpine
 ```
 {{% /tab %}}
 {{% tab header="Rootful" %}}
 ```bash
-limactl start template://docker-rootful
+limactl start template:docker-rootful
 export DOCKER_HOST=$(limactl list docker-rootful --format 'unix://{{.Dir}}/sock/docker.sock')
 docker run -d --name nginx -p 127.0.0.1:8080:80 nginx:alpine
 ```

--- a/website/content/en/docs/examples/containers/kubernetes/_index.md
+++ b/website/content/en/docs/examples/containers/kubernetes/_index.md
@@ -8,7 +8,7 @@ weight: 4
 {{< tabpane text=true >}}
 {{% tab header="kubeadm" %}}
 ```bash
-limactl start template://k8s
+limactl start template:k8s
 export KUBECONFIG=$(limactl list k8s --format 'unix://{{.Dir}}/copied-from-guest/kubeconfig.yaml')
 kubectl create deployment nginx --image nginx:alpine
 kubectl create service nodeport nginx --node-port=31080 --tcp=80:80
@@ -21,7 +21,7 @@ See also <https://kubernetes.io/docs/reference/setup-tools/kubeadm/>.
 {{% /tab %}}
 {{% tab header="k3s" %}}
 ```bash
-limactl start template://k3s
+limactl start template:k3s
 export KUBECONFIG=$(limactl list k3s --format 'unix://{{.Dir}}/copied-from-guest/kubeconfig.yaml')
 kubectl create deployment nginx --image nginx:alpine
 kubectl create service nodeport nginx --node-port=31080 --tcp=80:80
@@ -31,7 +31,7 @@ See also <https://docs.k3s.io>.
 {{% /tab %}}
 {{% tab header="k0s" %}}
 ```bash
-limactl start template://k0s
+limactl start template:k0s
 export KUBECONFIG=$(limactl list k0s --format 'unix://{{.Dir}}/copied-from-guest/kubeconfig.yaml')
 kubectl create deployment nginx --image nginx:alpine
 kubectl create service nodeport nginx --node-port=31080 --tcp=80:80
@@ -41,7 +41,7 @@ See also <https://docs.k0sproject.io/>.
 {{% /tab %}}
 {{% tab header="RKE2" %}}
 ```bash
-limactl start template://experimental/rke2
+limactl start template:experimental/rke2
 export KUBECONFIG=$(limactl list rke2 --format 'unix://{{.Dir}}/copied-from-guest/kubeconfig.yaml')
 kubectl create deployment nginx --image nginx:alpine
 kubectl create service nodeport nginx --node-port=31080 --tcp=80:80
@@ -51,7 +51,7 @@ See also <https://docs.rke2.io/>.
 {{% /tab %}}
 {{% tab header="Usernetes" %}}
 ```bash
-limactl start template://experimental/u7s
+limactl start template:experimental/u7s
 export KUBECONFIG=$(limactl list u7s --format 'unix://{{.Dir}}/copied-from-guest/kubeconfig.yaml')
 kubectl create deployment nginx --image nginx:alpine
 # NodePorts are not available by default in the case of Usernetes

--- a/website/content/en/docs/examples/containers/podman/_index.md
+++ b/website/content/en/docs/examples/containers/podman/_index.md
@@ -7,7 +7,7 @@ weight: 3
 {{% tab header="Rootless" %}}
 To use `podman` command in the VM:
 ```bash
-limactl start template://podman
+limactl start template:podman
 limactl shell podman podman run -d --name nginx -p 127.0.0.1:8080:80 docker.io/library/nginx:alpine
 ```
 
@@ -26,7 +26,7 @@ docker run -d --name nginx -p 127.0.0.1:8080:80 docker.io/library/nginx:alpine
 {{% tab header="Rootful" %}}
 To use `podman` command in the VM:
 ```bash
-limactl start template://podman-rootful
+limactl start template:podman-rootful
 limactl shell podman-rootful sudo podman run -d --name nginx -p 127.0.0.1:8080:80 docker.io/library/nginx:alpine
 ```
 

--- a/website/content/en/docs/examples/gha.md
+++ b/website/content/en/docs/examples/gha.md
@@ -43,14 +43,14 @@ jobs:
     - name: "Start an instance of Fedora"
       run: |
         set -eux
-        limactl start --name=default --cpus=1 --memory=1 --network=lima:user-v2 template://fedora
+        limactl start --name=default --cpus=1 --memory=1 --network=lima:user-v2 template:fedora
         lima sudo dnf install -y httpd
         lima sudo systemctl enable --now httpd
 
     - name: "Start another instance of Fedora"
       run: |
         set -eux
-        limactl start --name=another --cpus=1 --memory=1 --network=lima:user-v2 template://fedora
+        limactl start --name=another --cpus=1 --memory=1 --network=lima:user-v2 template:fedora
         limactl shell another curl http://lima-default.internal
 ```
 
@@ -63,7 +63,7 @@ The `--plain` mode is useful when you want the VM instance to be as close as pos
 ```yaml
     - name: "Start Fedora"
       # --plain is set to disable file sharing, port forwarding, built-in containerd, etc.
-      run: limactl start --plain --name=default --cpus=1 --memory=1 --network=lima:user-v2 template://fedora
+      run: limactl start --plain --name=default --cpus=1 --memory=1 --network=lima:user-v2 template:fedora
 
     - name: "Initialize Fedora"
       # plain old rsync and ssh are used for the initialization of the guest,

--- a/website/content/en/docs/faq/colima.md
+++ b/website/content/en/docs/faq/colima.md
@@ -11,13 +11,13 @@ that wraps Lima to provide an alternative user experience for launching containe
 The key difference is that Colima launches Docker by default,
 while Lima launches containerd by default.
 
-| Container            | Lima                              | Colima                              |
-|----------------------|-----------------------------------|-------------------------------------|
-| containerd           | `limactl start`                   | `colima start --runtime=containerd` |
-| Docker               | `limactl start template://docker` | `colima start`                      |
-| Podman               | `limactl start template://podman` | -                                   |
-| Kubernetes (k3s)     | `limactl start template://k3s`    | `colima start --kubernetes`         |
-| Kubernetes (kubeadm) | `limactl start template://k8s`    | -                                   |
+| Container            | Lima                            | Colima                              |
+|----------------------|---------------------------------|-------------------------------------|
+| containerd           | `limactl start`                 | `colima start --runtime=containerd` |
+| Docker               | `limactl start template:docker` | `colima start`                      |
+| Podman               | `limactl start template:podman` | -                                   |
+| Kubernetes (k3s)     | `limactl start template:k3s`    | `colima start --kubernetes`         |
+| Kubernetes (kubeadm) | `limactl start template:k8s`    | -                                   |
 
 The `colima` CLI is similar to the `limactl` CLI, but there are subtle differences:
 

--- a/website/content/en/docs/usage/_index.md
+++ b/website/content/en/docs/usage/_index.md
@@ -26,7 +26,7 @@ For automation,  `--tty=false` flag can be used for disabling the interactive us
 ### Customization
 To create an instance "default" from a template "docker":
 ```bash
-limactl create --name=default template://docker
+limactl create --name=default template:docker
 limactl start default
 ```
 


### PR DESCRIPTION
```
find . -type f -name '*.md' -exec perl -p -i -e 's|template://|template:|' {} \;
```

Plus aligning table columns in `website/content/en/docs/faq/colima.md`.

Replacement for #4347
Closes #4342