### PR TITLE
Extract LIMA_BATS_REUSE_INSTANCE logic into helper functions

### DIFF
--- a/hack/bats/helpers/limactl.bash
+++ b/hack/bats/helpers/limactl.bash
@@ -5,7 +5,7 @@
 # This function intentionally doesn't use create/editflags, but modifies the template with yq instead.
 create_dummy_instance() {
     local name=$1
-    local expr=$2
+    local expr=${2:-}
 
     # Template does not validate without an image, and the image must point to a file that exists (for clonefile).
     local template="{images: [location: /etc/profile]}"
@@ -13,4 +13,36 @@ create_dummy_instance() {
         template="$(limactl yq "$expr" <<<"$template")"
     fi
     limactl create --name "$name" - <<<"$template"
+}
+
+# Ensure a Lima instance exists. When LIMA_BATS_REUSE_INSTANCE is set, reuse an
+# existing running instance. Otherwise delete and recreate it.
+# The instance configuration is determined by its name; add a case below for new names.
+# Close file handles 3 and 4 so the host agent doesn't block BATS from exiting.
+ensure_instance() {
+    local instance=$1
+    if [[ -n "${LIMA_BATS_REUSE_INSTANCE:-}" ]]; then
+        run limactl list --format '{{.Status}}' "$instance"
+        [[ $status == 0 ]] && [[ $output == "Running" ]] && return
+    fi
+    limactl unprotect "$instance" || :
+    limactl delete --force "$instance" || :
+    case "$instance" in
+        bats)          limactl start --yes --name "$instance" template:default 3>&- 4>&- ;;
+        bats-nomount)  limactl start --yes --name "$instance" --mount-none template:default 3>&- 4>&- ;;
+        bats-dummy)    create_dummy_instance "$instance" '.disk = "1M"' ;;
+        *)
+            echo "ensure_instance: unknown instance name '$instance'" >&2
+            return 1
+            ;;
+    esac
+}
+
+# Delete the given Lima instance unless LIMA_BATS_REUSE_INSTANCE is set.
+delete_instance() {
+    local instance=$1
+    if [[ -z "${LIMA_BATS_REUSE_INSTANCE:-}" ]]; then
+        limactl unprotect "$instance" || :
+        limactl delete --force "$instance" || :
+    fi
 }

--- a/hack/bats/helpers/load.bash
+++ b/hack/bats/helpers/load.bash
@@ -60,10 +60,16 @@ setup_file() {
         TEST_FILENAME=${TEST_FILENAME%.bats}
         echo "# ===== ${TEST_FILENAME} =====" >&3
     fi
+    if [[ -n "${INSTANCE:-}" ]]; then
+        ensure_instance "$INSTANCE"
+    fi
     call_local_function
 }
 teardown_file() {
     call_local_function
+    if [[ -n "${INSTANCE:-}" ]]; then
+        delete_instance "$INSTANCE"
+    fi
 }
 setup() {
     call_local_function

--- a/hack/bats/tests/path.bats
+++ b/hack/bats/tests/path.bats
@@ -3,32 +3,12 @@
 
 load "../helpers/load"
 
-NAME=bats
-
-# TODO The reusable Lima instance setup is copied from preserve-env.bats
-# TODO and should be factored out into helper functions.
-local_setup_file() {
-    if [[ -n "${LIMA_BATS_REUSE_INSTANCE:-}" ]]; then
-        run limactl list --format '{{.Status}}' "$NAME"
-        [[ $status == 0 ]] && [[ $output == "Running" ]] && return
-    fi
-    limactl unprotect "$NAME" || :
-    limactl delete --force "$NAME" || :
-    # Make sure that the host agent doesn't inherit file handles 3 or 4.
-    # Otherwise bats will not finish until the host agent exits.
-    limactl start --yes --name "$NAME" template:default 3>&- 4>&-
-}
-
-local_teardown_file() {
-    if [[ -z "${LIMA_BATS_REUSE_INSTANCE:-}" ]]; then
-        limactl delete --force "$NAME"
-    fi
-}
+INSTANCE=bats
 
 @test "The guest home is accessible via both .guest and .linux paths" {
-    run limactl shell "$NAME" -- ls -ld /home/"${USER}.guest/.ssh"
+    run limactl shell "$INSTANCE" -- ls -ld /home/"${USER}.guest/.ssh"
     assert_success
 
-    run limactl shell "$NAME" -- ls -ld /home/"${USER}.linux/.ssh"
+    run limactl shell "$INSTANCE" -- ls -ld /home/"${USER}.linux/.ssh"
     assert_success
 }

--- a/hack/bats/tests/protect.bats
+++ b/hack/bats/tests/protect.bats
@@ -3,19 +3,16 @@
 
 load "../helpers/load"
 
-NAME=dummy
+INSTANCE=bats-dummy
 CLONE=clone
 NOTEXIST=notexist
 
 local_setup_file() {
-    for INSTANCE in "$NAME" "$CLONE" "$NOTEXIST"; do
-        limactl unprotect "$INSTANCE" || :
-        limactl delete --force "$INSTANCE" || :
+    local inst
+    for inst in "$CLONE" "$NOTEXIST"; do
+        limactl unprotect "$inst" || :
+        limactl delete --force "$inst" || :
     done
-}
-
-@test 'create dummy instance' {
-    run -0 create_dummy_instance "$NAME" '.disk = "1M"'
 }
 
 @test 'protecting a non-existing instance fails' {
@@ -24,19 +21,19 @@ local_setup_file() {
 }
 
 @test 'protecting the dummy instance succeeds' {
-    run_e -0 limactl protect "$NAME"
-    assert_info "Protected \"${NAME}\""
-    assert_file_exists "${LIMA_HOME}/${NAME}/protected"
+    run_e -0 limactl protect "$INSTANCE"
+    assert_info "Protected \"${INSTANCE}\""
+    assert_file_exists "${LIMA_HOME}/${INSTANCE}/protected"
 }
 
 @test 'protecting it again shows a warning, but succeeds' {
-    run_e -0 limactl protect "$NAME"
-    assert_warning "Instance \"${NAME}\" is already protected. Skipping."
-    assert_file_exists "${LIMA_HOME}/${NAME}/protected"
+    run_e -0 limactl protect "$INSTANCE"
+    assert_warning "Instance \"${INSTANCE}\" is already protected. Skipping."
+    assert_file_exists "${LIMA_HOME}/${INSTANCE}/protected"
 }
 
 @test 'cloning a protected instance creates an unprotected clone' {
-    run_e -0 limactl clone --yes "$NAME" "$CLONE"
+    run_e -0 limactl clone --yes "$INSTANCE" "$CLONE"
     # TODO there is currently no output from the clone command, which feels wrong
     refute_output
     assert_file_not_exists "${LIMA_HOME}/${CLONE}/protected"
@@ -48,24 +45,24 @@ local_setup_file() {
 }
 
 @test 'deleting protected dummy instance fails' {
-    run_e -1 limactl delete --force "$NAME"
-    assert_fatal "failed to delete instance \"${NAME}\": instance is protected…"
-    assert_file_exists "$LIMA_HOME/$NAME/protected"
+    run_e -1 limactl delete --force "$INSTANCE"
+    assert_fatal "failed to delete instance \"${INSTANCE}\": instance is protected…"
+    assert_file_exists "$LIMA_HOME/$INSTANCE/protected"
 }
 
 @test 'unprotecting the dummy instance succeeds' {
-    run_e -0 limactl unprotect "$NAME"
-    assert_info "Unprotected \"${NAME}\""
-    assert_file_not_exists "$LIMA_HOME/$NAME/protected"
+    run_e -0 limactl unprotect "$INSTANCE"
+    assert_info "Unprotected \"${INSTANCE}\""
+    assert_file_not_exists "$LIMA_HOME/$INSTANCE/protected"
 }
 
 @test 'unprotecting it again shows a warning, but succeeds' {
-    run_e -0 limactl unprotect "$NAME"
-    assert_warning "Instance \"${NAME}\" isn't protected. Skipping."
-    assert_file_not_exists "$LIMA_HOME/$NAME/protected"
+    run_e -0 limactl unprotect "$INSTANCE"
+    assert_warning "Instance \"${INSTANCE}\" isn't protected. Skipping."
+    assert_file_not_exists "$LIMA_HOME/$INSTANCE/protected"
 }
 
 @test 'deleting unprotected dummy instance succeeds' {
-    run_e -0 limactl delete --force "$NAME"
-    assert_info "Deleted \"${NAME}\"…"
+    run_e -0 limactl delete --force "$INSTANCE"
+    assert_info "Deleted \"${INSTANCE}\"…"
 }

--- a/hack/bats/tests/shell.bats
+++ b/hack/bats/tests/shell.bats
@@ -3,29 +3,14 @@
 
 load "../helpers/load"
 
-NAME=dummy
-
-local_setup_file() {
-    for INSTANCE in "$NAME"; do
-        limactl delete --force "$INSTANCE" || :
-    done
-}
-
-@test 'create dummy instance' {
-    run -0 create_dummy_instance "$NAME" '.disk = "1M"'
-}
+INSTANCE=bats-dummy
 
 @test 'lima stopped lima instance' {
     # check that the "tty" flag is used, also for stdin
-    limactl shell --tty=false "$NAME" true </dev/null
+    limactl shell --tty=false "$INSTANCE" true </dev/null
 }
 
 @test 'yes | stopped lima instance' {
     # check that stdin is verified and not just crashing
-    bash -c "yes | limactl shell --tty=true $NAME true"
-}
-
-@test 'delete dummy instance' {
-    run_e -0 limactl delete --force "$NAME"
-    assert_info "Deleted \"${NAME}\"…"
+    bash -c "yes | limactl shell --tty=true $INSTANCE true"
 }


### PR DESCRIPTION
Move the duplicated instance setup/teardown code from five test files into `ensure_lima_instance` and `cleanup_lima_instance` in limactl.bash. The instance configuration is determined by $NAME, preventing tests from sharing a name but using incompatible settings.

Give shell-sync.bats its own instance name (`bats-nomount`) so it no longer contaminates the shared `bats` instance by removing mounts.

Closes #4599