### PR TITLE
qemu: support vmOpts.qemu.extraArgs

### DIFF
--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -481,6 +481,14 @@ func resolveCPUType(y *limatype.LimaYAML) string {
 	return cpuType[*y.Arch]
 }
 
+func qemuExtraArgs(y *limatype.LimaYAML) ([]string, error) {
+	var qemuOpts limatype.QEMUOpts
+	if err := limayaml.Convert(y.VMOpts[limatype.QEMU], &qemuOpts, "vmOpts.qemu"); err != nil {
+		return nil, fmt.Errorf("failed to convert `vmOpts.qemu`: %w", err)
+	}
+	return qemuOpts.ExtraArgs, nil
+}
+
 func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err error) {
 	y := cfg.LimaYAML
 	exe, args, err = Exe(*y.Arch)
@@ -1032,6 +1040,11 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	// QEMU process
 	args = append(args, "-name", "lima-"+cfg.Name)
 	args = append(args, "-pidfile", filepath.Join(cfg.InstanceDir, filenames.PIDFile(*y.VMType)))
+	extraArgs, err := qemuExtraArgs(y)
+	if err != nil {
+		return "", nil, err
+	}
+	args = append(args, extraArgs...)
 
 	return exe, args, nil
 }

--- a/pkg/driver/qemu/qemu_test.go
+++ b/pkg/driver/qemu/qemu_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/limayaml"
 )
 
 func TestArgValue(t *testing.T) {
@@ -150,4 +151,73 @@ func TestSwtpmCmdline(t *testing.T) {
 	assert.NilError(t, err)
 	_, err = os.Stat(swtpmSock)
 	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestQemuExtraArgs(t *testing.T) {
+	type testCase struct {
+		name          string
+		inputYAML     string
+		expected      []string
+		expectedError string
+	}
+	testCases := []testCase{
+		{
+			name: "no vmOpts",
+			inputYAML: `
+vmType: "qemu"
+`,
+			expected: nil,
+		},
+		{
+			name: "qemu opts without extra args",
+			inputYAML: `
+vmType: "qemu"
+vmOpts:
+  qemu:
+    minimumVersion: "8.2.1"
+`,
+			expected: nil,
+		},
+		{
+			name: "extra args set",
+			inputYAML: `
+vmType: "qemu"
+vmOpts:
+  qemu:
+    extraArgs:
+    - "-device"
+    - "virtio-balloon"
+    - "-overcommit"
+    - "mem-lock=off"
+`,
+			expected: []string{"-device", "virtio-balloon", "-overcommit", "mem-lock=off"},
+		},
+		{
+			name: "structurally wrong extra args",
+			inputYAML: `
+vmType: "qemu"
+vmOpts:
+  qemu:
+    extraArgs:
+    - "-device"
+    - {bad: "shape"}
+`,
+			expectedError: "failed to convert `vmOpts.qemu`",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var y limatype.LimaYAML
+			err := limayaml.Unmarshal([]byte(tc.inputYAML), &y, "lima.yaml")
+			assert.NilError(t, err)
+
+			got, err := qemuExtraArgs(&y)
+			if tc.expectedError == "" {
+				assert.NilError(t, err)
+				assert.DeepEqual(t, got, tc.expected)
+			} else {
+				assert.ErrorContains(t, err, tc.expectedError)
+			}
+		})
+	}
 }

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -120,8 +120,9 @@ type User struct {
 type VMOpts map[VMType]any
 
 type QEMUOpts struct {
-	MinimumVersion *string `yaml:"minimumVersion,omitempty" json:"minimumVersion,omitempty" jsonschema:"nullable"`
-	CPUType        CPUType `yaml:"cpuType,omitempty" json:"cpuType,omitempty" jsonschema:"nullable"`
+	MinimumVersion *string  `yaml:"minimumVersion,omitempty" json:"minimumVersion,omitempty" jsonschema:"nullable"`
+	CPUType        CPUType  `yaml:"cpuType,omitempty" json:"cpuType,omitempty" jsonschema:"nullable"`
+	ExtraArgs      []string `yaml:"extraArgs,omitempty" json:"extraArgs,omitempty" jsonschema:"nullable"`
 }
 
 type VZOpts struct {

--- a/pkg/limayaml/marshal_test.go
+++ b/pkg/limayaml/marshal_test.go
@@ -93,6 +93,9 @@ vmOpts:
   qemu:
     minimumVersion: null
     cpuType:
+    extraArgs:
+    - "-device"
+    - "virtio-balloon"
 `
 	var y limatype.LimaYAML
 	err := Unmarshal([]byte(text), &y, "lima.yaml")
@@ -100,6 +103,7 @@ vmOpts:
 	var o limatype.QEMUOpts
 	err = Convert(y.VMOpts[limatype.QEMU], &o, "vmOpts.qemu")
 	assert.NilError(t, err)
+	assert.DeepEqual(t, o.ExtraArgs, []string{"-device", "virtio-balloon"})
 	t.Log(dumpYAML(t, o))
 }
 

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -396,6 +396,12 @@ vmOpts:
     #   armv7l:  "max" # (or "host" when running on armv7l host)
     #   riscv64: "max" # (or "host" when running on riscv64 host)
     #   x86_64:  "max" # (or "host" when running on x86_64 host; additional options are appended on Intel Mac)
+
+    # Extra arguments to pass to QEMU.
+    # Each list entry is one CLI token (no shell parsing).
+    # 🟢 Builtin default: []
+    # extraArgs:
+    # - "-usb"
   vz:
     # Specify the disk image format: "raw" or "asif".
     # Currently only applies to the primary disk image.


### PR DESCRIPTION
Add support for passing additional QEMU CLI arguments via template YAML.

- add ExtraArgs to limatype.QEMUOpts
- append extra args to the generated QEMU command line
- document usage in templates/default.yaml