### PR TITLE
docs: add limactl network list and disk list examples to config guide

### DIFF
--- a/website/content/en/docs/config/_index.md
+++ b/website/content/en/docs/config/_index.md
@@ -12,3 +12,96 @@ The current default spec:
 - Disk: 100 GiB
 - Mounts: `~` (read-only), `/tmp/lima` (writable; removed in Lima v2.0)
 - SSH: 127.0.0.1:<Random port>
+
+## Listing resources
+
+Lima provides `limactl` subcommands to inspect the networks and disks that
+exist on the host. These are a good starting point before creating new
+instances that share resources.
+
+### Networks
+
+```sh
+limactl network list
+```
+
+Example output:
+
+```
+NAME     GATEWAY         DNS              DHCP-RANGE
+shared   192.168.105.1   192.168.105.1    192.168.105.2-192.168.105.254
+user-v2  192.168.106.1   192.168.106.1    192.168.106.2-192.168.106.254
+foo      192.168.42.1    -                192.168.42.2-192.168.42.254
+```
+
+To use a listed network when creating an instance:
+
+```sh
+limactl create --network lima:shared template:default
+limactl create --network lima:foo    --name dev template:default
+```
+
+To create a new user-defined network and share it between two VMs:
+
+```sh
+limactl network create foo --gateway 192.168.42.1/24
+limactl create --network lima:foo --name vm1 template:default
+limactl create --network lima:foo --name vm2 template:default
+```
+
+To remove a network:
+
+```sh
+limactl network delete foo
+# Force-delete even if instances reference it:
+limactl network delete --force foo
+```
+
+### Disks
+
+Additional data disks can be created and attached to multiple instances.
+
+```sh
+limactl disk list
+```
+
+Example output:
+
+```
+NAME     SIZE    FORMAT   INSTANCE
+mydata   20GiB   qcow2    -
+pgdata   50GiB   qcow2    postgres
+```
+
+The `INSTANCE` column shows which instance a disk is currently locked to.
+A disk that shows `-` is available to mount.
+
+To create a new data disk:
+
+```sh
+limactl disk create mydata --size 20
+```
+
+To resize an existing disk:
+
+```sh
+limactl disk resize mydata --size 40
+```
+
+To attach the disk to an instance at creation time, add a `disk` entry in
+the instance template, or pass it at the command line:
+
+```sh
+limactl create --disk mydata template:default
+```
+
+To delete a disk:
+
+```sh
+limactl disk delete mydata
+# Force-delete even if an instance holds a lock on the disk:
+limactl disk delete --force mydata
+```
+
+See the [Disks](./disk/) page for more information about increasing the size of
+the primary VM disk.


### PR DESCRIPTION
Fixes #4180

## What is added

The configuration guide page (`/docs/config/`) lacked any mention of
`limactl network list`, `limactl disk list`, and related management
subcommands. Users who found the reference docs had no examples to guide
them from 'what networks/disks do I have?' to 'how do I use them?'

This PR adds a **"Listing resources"** section with:

### Networks
- Sample `limactl network list` output showing NAME / GATEWAY / DNS columns
- `--network lima:<name>` usage when creating instances
- End-to-end example of creating a shared network and attaching two VMs
- Delete / force-delete commands

### Disks
- Sample `limactl disk list` output with the INSTANCE lock column explained
- `limactl disk create` / `resize` / attach at creation / delete
- Link to the Disks page for primary disk resizing

All examples are copy-paste ready and mirror the examples already in the
CLI help text, making them easy to discover via the website.

No code changes.

Made with [Cursor](https://cursor.com)