### PR TITLE
fix: `limactl create <image URL>` honors `--name` flag

### DIFF
--- a/pkg/limatmpl/locator.go
+++ b/pkg/limatmpl/locator.go
@@ -200,7 +200,9 @@ images:
   arch: %q
 `
 	tmpl.Bytes = fmt.Appendf(nil, template, imageArch, locator, imageArch)
-	tmpl.Name = InstNameFromImageURL(locator, imageArch)
+	if tmpl.Name == "" {
+		tmpl.Name = InstNameFromImageURL(locator, imageArch)
+	}
 	return true
 }
 

--- a/pkg/limatmpl/locator_test.go
+++ b/pkg/limatmpl/locator_test.go
@@ -63,6 +63,21 @@ func TestInstNameFromImageURL(t *testing.T) {
 	})
 }
 
+func TestReadImageURLRespectsName(t *testing.T) {
+	imageURL := "https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/aarch64/Latest/FreeBSD-15.0-RELEASE-arm64-aarch64-BASIC-CLOUDINIT-zfs.raw.xz"
+	t.Run("--name flag overrides image-derived name", func(t *testing.T) {
+		tmpl, err := limatmpl.Read(t.Context(), "freebsd", imageURL)
+		assert.NilError(t, err)
+		assert.Equal(t, tmpl.Name, "freebsd")
+	})
+	t.Run("name is derived from image URL when --name is empty", func(t *testing.T) {
+		tmpl, err := limatmpl.Read(t.Context(), "", imageURL)
+		assert.NilError(t, err)
+		assert.Assert(t, tmpl.Name != "")
+		assert.Assert(t, tmpl.Name != "freebsd")
+	})
+}
+
 func TestSeemsTemplateURL(t *testing.T) {
 	arg := "template:foo/bar"
 	t.Run(arg, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Fixes** #4626
- `imageTemplate()` in `pkg/limatmpl/locator.go` unconditionally overwrote `tmpl.Name` with the name derived from the image URL, ignoring the `--name` CLI flag. Every other code path in `Read()` already guards the assignment with `if tmpl.Name == ""` — this PR applies the same guard to `imageTemplate()`.

## Reproduction

```
limactl create --name freebsd https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/aarch64/Latest/FreeBSD-15.0-RELEASE-arm64-aarch64-BASIC-CLOUDINIT-zfs.raw.xz
```

**Before**: instance created as `freebsd-15.0-release-arm64-basic-zfs`, ignoring `--name freebsd`
**After**: instance created as `freebsd`

## Changes

- `pkg/limatmpl/locator.go`: Guard `tmpl.Name` assignment in `imageTemplate()` with `if tmpl.Name == ""`
- `pkg/limatmpl/locator_test.go`: Add `TestReadImageURLRespectsName` covering both the `--name` override and the default name derivation paths

## Test plan

- [x] `go test ./pkg/limatmpl/ -run TestReadImageURLRespectsName` — passes
- [x] All existing `TestInstNameFromImageURL` tests — still pass