### PR TITLE
macOS guest: support graceful shutdown via `limactl stop`

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -35,8 +35,13 @@ users:
 {{- end }}
     homedir: "{{.Home}}"
     shell: {{.Shell}}
-{{- if ne .OS "Darwin" }}
-{{/* On macOS, the password is not locked so as to allow GUI login */}}
+{{- if eq .OS "Darwin" }}
+    {{/* On macOS, the password is not locked so as to allow GUI login. */}}
+    {{/* Since the user can run sudo with their own password, basically we don't need to set up passwordless sudo. */}}
+    {{/* However, it is still configured to allow `/sbin/shutdown -h now` without password, as it is invoked by `limactl stop` for graceful shutdown. */}}
+    {{/* (Why doesn't macOS VM support graceful shutdown?) */}}
+    sudo: ALL=(ALL) NOPASSWD:/sbin/shutdown -h now
+{{- else }}
     sudo: ALL=(ALL) NOPASSWD:ALL
     lock_passwd: true
 {{- end }}

--- a/pkg/cidata/cloudinittypes/userdata.go
+++ b/pkg/cidata/cloudinittypes/userdata.go
@@ -37,7 +37,7 @@ type User struct {
 	UID               string   `yaml:"uid,omitempty"` // TODO: check if int is allowed too
 	Homedir           string   `yaml:"homedir,omitempty"`
 	Shell             string   `yaml:"shell,omitempty"`
-	Sudo              string   `yaml:"sudo,omitempty"`
+	Sudo              string   `yaml:"sudo,omitempty"` // TODO: allow []string as well
 	LockPasswd        string   `yaml:"lock_passwd,omitempty"`
 	SSHAuthorizedKeys []string `yaml:"ssh-authorized-keys,omitempty"`
 }

--- a/website/content/en/docs/usage/guests/macos.md
+++ b/website/content/en/docs/usage/guests/macos.md
@@ -21,12 +21,10 @@ limactl shell macos cat /Users/${USER}.guest/password
 
 ## Difference from Linux guests
 - Password login is enabled
-- Password-less sudo is disabled
+- Password-less sudo is disabled, except for `/sbin/shutdown -h now`
 - Several features are not implemented yet. See [Caveats](#caveats) below.
 
 ## Caveats
-- No support for graceful `limactl stop`.
-  Shutdown the VM from the GUI, or use `limactl stop -f` with caution.
 - No support for turning off the video display.
 - No support for mounting host directories.
   Use `limactl cp` or `limactl shell --sync` to share files with the host.


### PR DESCRIPTION
`limactl stop` invokes `sudo /sbin/shutdown -h now` via SSH

Fix #4610