### PR TITLE
templates: update WSL2 template

### DIFF
--- a/templates/experimental/wsl2.yaml
+++ b/templates/experimental/wsl2.yaml
@@ -4,9 +4,9 @@ vmType: wsl2
 
 images:
 # Source: https://github.com/runfinch/finch-core/blob/main/rootfs/Dockerfile (image based on fedora)
-- location: "https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1741837119.tar.gz"
+- location: "https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1771357941.tar.gz"
   arch: "x86_64"
-  digest: "sha256:1ebee4c785fc4d31fd514365694a7d4d50a95093526c051f76dc63d8ba9fafe6"
+  digest: "sha256:423d1a0f1cabeaea6801995c90ed896dccc091180068626430f19fd87853fdf3"
 
 mountType: wsl2
 

--- a/website/content/en/docs/config/vmtype/wsl2.md
+++ b/website/content/en/docs/config/vmtype/wsl2.md
@@ -23,10 +23,10 @@ limactl start --vm-type=wsl2 --mount-type=wsl2 --containerd=system
 # Example to run Fedora using vmType: wsl2
 vmType: wsl2
 images:
-# Source: https://github.com/runfinch/finch-core/blob/main/Dockerfile
-- location: "https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1690920103.tar.zst"
+# Source: https://github.com/runfinch/finch-core/blob/main/rootfs/Dockerfile
+- location: "https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1771357941.tar.gz"
   arch: "x86_64"
-  digest: "sha256:53f2e329b8da0f6a25e025d1f6cc262ae228402ba615ad095739b2f0ec6babc9"
+  digest: "sha256:423d1a0f1cabeaea6801995c90ed896dccc091180068626430f19fd87853fdf3"
 mountType: wsl2
 containerd:
   system: true


### PR DESCRIPTION
Latest finch-rootfs is Fedora 42 based, which is significant update over currently used Fedora 40 based one.

Fedora 40 is already EOL, where Fedora 42 should be good for about 2 months (but this is the latest provided by finch right now). I believe it would be a reasonable bump to add to 2.1 release scope.

I also update web site content to reflect the latest changes to template.