### PR TITLE
CI: temporarily disable release check for PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,6 @@ on:
     - "docs/**"
     - "website/**"
     - "**.md"
-  pull_request:
-    branches:
-    - 'master'
-    paths-ignore:
-    - "docs/**"
-    - "website/**"
-    - "**.md"
 env:
   GO111MODULE: on
   GOTOOLCHAIN: local


### PR DESCRIPTION
Not likely compromised so far, but temporarily disable the check during investigation.