### PR TITLE
Revert "CI: temporarily disable release check for PRs"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,13 @@ on:
     - "docs/**"
     - "website/**"
     - "**.md"
+  pull_request:
+    branches:
+    - 'master'
+    paths-ignore:
+    - "docs/**"
+    - "website/**"
+    - "**.md"
 env:
   GO111MODULE: on
   GOTOOLCHAIN: local


### PR DESCRIPTION
Revert:
- #4646 

I was overreacting to https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation .
We were not vulnerable because we had no workflows that permitted triggers from `pull_request_target`, `issue_comment`, or anything similar events.