### PR TITLE
krunkit: enable support for nested virtualization

### DIFF
--- a/pkg/driver/krunkit/krunkit_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_darwin_arm64.go
@@ -94,6 +94,11 @@ func Cmdline(inst *limatype.Instance) (*exec.Cmd, error) {
 	}
 
 	args = append(args, networkArgs...)
+
+	if inst.Config.NestedVirtualization != nil && *inst.Config.NestedVirtualization {
+		args = append(args, "--nested")
+	}
+
 	cmd := exec.CommandContext(context.Background(), vmType, args...)
 
 	return cmd, nil

--- a/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
@@ -179,6 +179,12 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 		return fmt.Errorf("field `mountType` must be %q or %q for krunkit driver, got %q", limatype.VIRTIOFS, limatype.REVSSHFS, *cfg.MountType)
 	}
 
+	if cfg.NestedVirtualization != nil && *cfg.NestedVirtualization {
+		if macOSProductVersion.LessThan(*semver.New("15.0.0")) {
+			return errors.New("nested virtualization requires macOS 15 or newer")
+		}
+	}
+
 	return nil
 }
 

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -615,7 +615,7 @@ plain: null
 #   qemu-system-aarch64 -accel kvm -cpu host -M virt
 # - Without specifying `-cpu host`, nested virtualization may fail with the error:
 #   qemu-system-aarch64: kvm_init_vcpu: kvm_arch_init_vcpu failed (0): Invalid argument
-# - Only supported on Apple M3 or later with `vmType: vz`.
+# - Only supported on Apple M3 or later with `vmType: vz` or `vmType: krunkit`.
 # 🟢 Builtin default: false
 nestedVirtualization: null
 


### PR DESCRIPTION
This pull request adds support for nested virtualization to the `krunkit` driver.

Support for nested virtualization in `krunkit` driver:

* Updated `Cmdline` function in `krunkit_darwin_arm64.go` to append the `--nested` argument when `NestedVirtualization` is enabled in the configuration.

Configuration validation:

* Enhanced `validateConfig` in `krunkit_driver_darwin_arm64.go` to check that nested virtualization is only enabled on macOS 15 or newer, returning an error otherwise.

Documentation update:

* Updated comments in `templates/default.yaml` to clarify that nested virtualization is supported on Apple M3 or later with either `vmType: vz` or `vmType: krunkit`.