### PR TITLE
makefile: raise error when VERSION cannot be determined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,12 @@ endif
 
 PACKAGE := github.com/lima-vm/lima/v2
 
-VERSION := $(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
+VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags 2>/dev/null)
 VERSION_TRIMMED := $(VERSION:v%=%)
+
+ifeq ($(VERSION),)
+$(error VERSION could not be determined. Build from a git repo or run: make VERSION=vX.Y.Z)
+endif
 
 # `DEBUG` flag to build binaries with debug information for use by `dlv exec`.
 # This implies KEEP_DWARF=1 and KEEP_SYMBOLS=1.


### PR DESCRIPTION
Makefile: raise error when VERSION cannot be determined

When building from a GitHub release tarball, the source tree does not
contain git metadata, so `git describe` may fail and leave VERSION unset.

Add a validation check to stop the build if VERSION cannot be determined,
preventing binaries from being built with missing version metadata.

NOTE: This change only ensures VERSION is not empty and preserves the existing
behavior using `git describe --always`, so development builds can still
fall back to commit hashes.

Fixes #4654 