### PR TITLE
templates: add macos-15

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -44,6 +44,7 @@ Linux distributions:
 - [`experimental/debian-sid`](./experimental/debian-sid.yaml): [experimental] Debian Sid
 
 Non-Linux:
+- [`macos-15`](./macos-15.yaml): macOS 15 (Sequoia)
 - [`macos-26`](./macos-26.yaml), `macos.yaml`: macOS 26 (Tahoe)
 - [`freebsd-15`](./freebsd-15.yaml), `freebsd.yaml`: FreeBSD 15
 - [`experimental/freebsd-current`](./experimental/freebsd-current.yaml): [experimental] FreeBSD CURRENT

--- a/templates/_images/macos-15.yaml
+++ b/templates/_images/macos-15.yaml
@@ -1,0 +1,13 @@
+# Apple Software License Agreements: https://www.apple.com/legal/sla/
+# (macOS users should have already accepted the agreements on their host machines)
+
+images:
+- location: "https://updates.cdn-apple.com/2025SummerFCS/fullrestores/093-10809/CFD6DD38-DAF0-40DA-854F-31AAD1294C6F/UniversalMac_15.6.1_24G90_Restore.ipsw"
+  arch: "aarch64"
+  digest: "sha256:3d87686b691ac765eb6a6b3082b2334e2af9710096a00432dd519af89ff2ea78"
+os: Darwin
+arch: aarch64
+# vz is the only supported VM type for macOS guests
+vmType: vz
+ssh:
+  overVsock: false

--- a/templates/macos-15.yaml
+++ b/templates/macos-15.yaml
@@ -1,0 +1,13 @@
+minimumLimaVersion: 2.1.0
+
+base:
+- template:_images/macos-15
+- template:_default/mounts
+
+# The installer seems to require the display device to be present.
+video:
+  display: "default"
+
+message: |
+  The user password for GUI session is stored in the `~/password` file in the guest.
+  Consider changing it after the first login.


### PR DESCRIPTION
Tried to add macos-13 and macos-14 as well, but no success
```
INFO[0000] Patching macOS disk "/Users/suda/.lima/macos-14/disk"
DEBU[0000] Executing command: [mount -t apfs -o noowners /dev/disk8s5 /Users/suda/.lima/_mnt/0]
FATA[0000] failed to mount "/dev/disk8s5" on "/Users/suda/.lima/_mnt/0": exit status 65
(output="mount_apfs: volume could not be mounted: Illegal byte sequence\nmount: /Users/suda/.lima/_mnt/0 failed with 65\n"
```
- https://github.com/lima-vm/lima/issues/4665