### PR TITLE
Try to patch inotify

### DIFF
--- a/pkg/guestagent/guestagent_linux.go
+++ b/pkg/guestagent/guestagent_linux.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -48,13 +49,11 @@ func New(ctx context.Context, ticker ticker.Ticker, runtimeDir string) (Agent, e
 var _ Agent = (*agent)(nil)
 
 type agent struct {
-	// Ticker is like time.Ticker.
-	// We can't use inotify for /proc/net/tcp, so we need this ticker to
-	// reload /proc/net/tcp.
 	ticker                   ticker.Ticker
 	socketLister             *sockets.Lister
 	kubernetesServiceWatcher *kubernetesservice.ServiceWatcher
 	runtimeDir               string
+	recentChtimes            map[string]time.Time
 }
 
 type eventState struct {
@@ -211,12 +210,38 @@ func (a *agent) Info(ctx context.Context) (*api.Info, error) {
 
 func (a *agent) HandleInotify(event *api.Inotify) {
 	location := event.MountPath
-	if _, err := os.Stat(location); err == nil {
-		local := event.Time.AsTime().Local()
-		err := os.Chtimes(location, local, local)
-		if err != nil {
-			logrus.Errorf("error in inotify handle. Event: %s, Error: %s", event, err)
+	fi, err := os.Stat(location)
+	if err != nil {
+		return
+	}
+	if fi.IsDir() {
+		return
+	}
+
+	now := time.Now()
+
+	// If we called Chtimes on this path recently, this is an echo:
+	// our Chtimes → virtiofs → macOS FSEvents → host agent → back here.
+	// Skip to prevent reload loops and reduce virtiofs traffic.
+	if lastTouch, ok := a.recentChtimes[location]; ok {
+		if now.Sub(lastTouch) < time.Second {
+			return
 		}
+	}
+
+	local := event.Time.AsTime().Local()
+	if err := os.Chtimes(location, local, local); err != nil {
+		logrus.Errorf("error in inotify handle. Event: %s, Error: %s", event, err)
+	}
+
+	if a.recentChtimes == nil {
+		a.recentChtimes = make(map[string]time.Time)
+	}
+	a.recentChtimes[location] = now
+
+	// Prevent unbounded growth during bulk operations
+	if len(a.recentChtimes) > 10000 {
+		a.recentChtimes = make(map[string]time.Time)
 	}
 }
 

--- a/pkg/hostagent/inotify.go
+++ b/pkg/hostagent/inotify.go
@@ -41,20 +41,14 @@ func (a *HostAgent) startInotify(ctx context.Context) error {
 		return err
 	}
 
-	const cooldown = 100 * time.Millisecond
-	timer := time.NewTimer(cooldown)
+	// Trailing-edge debounce: accumulate events and only flush after
+	// a quiet period. During bulk operations (yarn install, nuxt build)
+	// the timer keeps resetting so no events are forwarded until the
+	// burst settles — preventing virtiofs virtqueue contention.
+	const quietPeriod = 200 * time.Millisecond
+	timer := time.NewTimer(quietPeriod)
 	timer.Stop()
 	pending := make(map[string]os.FileInfo)
-	idle := true
-
-	sendEvent := func(watchPath string, stat os.FileInfo) {
-		guestPath := translateToGuestPath(watchPath, mountSymlinks, mountLocations)
-		utcTimestamp := timestamppb.New(stat.ModTime().UTC())
-		event := &guestagentapi.Inotify{MountPath: guestPath, Time: utcTimestamp}
-		if err := inotifyClient.Send(event); err != nil {
-			logrus.WithError(err).Warn("failed to send inotify")
-		}
-	}
 
 	for {
 		select {
@@ -72,22 +66,19 @@ func (a *HostAgent) startInotify(ctx context.Context) error {
 			if filterEvents(watchEvent, stat) {
 				continue
 			}
-
-			if idle {
-				sendEvent(watchPath, stat)
-				idle = false
-				timer.Reset(cooldown)
-			} else {
-				pending[watchPath] = stat
-				timer.Reset(cooldown)
-			}
+			pending[watchPath] = stat
+			timer.Reset(quietPeriod)
 
 		case <-timer.C:
 			for wp, st := range pending {
-				sendEvent(wp, st)
+				guestPath := translateToGuestPath(wp, mountSymlinks, mountLocations)
+				utcTimestamp := timestamppb.New(st.ModTime().UTC())
+				event := &guestagentapi.Inotify{MountPath: guestPath, Time: utcTimestamp}
+				if err := inotifyClient.Send(event); err != nil {
+					logrus.WithError(err).Warn("failed to send inotify")
+				}
 			}
 			pending = make(map[string]os.FileInfo)
-			idle = true
 		}
 	}
 }

--- a/pkg/hostagent/inotify.go
+++ b/pkg/hostagent/inotify.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/rjeczalik/notify"
 	"github.com/sirupsen/logrus"
@@ -40,6 +41,21 @@ func (a *HostAgent) startInotify(ctx context.Context) error {
 		return err
 	}
 
+	const cooldown = 100 * time.Millisecond
+	timer := time.NewTimer(cooldown)
+	timer.Stop()
+	pending := make(map[string]os.FileInfo)
+	idle := true
+
+	sendEvent := func(watchPath string, stat os.FileInfo) {
+		guestPath := translateToGuestPath(watchPath, mountSymlinks, mountLocations)
+		utcTimestamp := timestamppb.New(stat.ModTime().UTC())
+		event := &guestagentapi.Inotify{MountPath: guestPath, Time: utcTimestamp}
+		if err := inotifyClient.Send(event); err != nil {
+			logrus.WithError(err).Warn("failed to send inotify")
+		}
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -50,19 +66,28 @@ func (a *HostAgent) startInotify(ctx context.Context) error {
 			if err != nil {
 				continue
 			}
-
+			if stat.IsDir() {
+				continue
+			}
 			if filterEvents(watchEvent, stat) {
 				continue
 			}
 
-			watchPath = translateToGuestPath(watchPath, mountSymlinks, mountLocations)
-
-			utcTimestamp := timestamppb.New(stat.ModTime().UTC())
-			event := &guestagentapi.Inotify{MountPath: watchPath, Time: utcTimestamp}
-			err = inotifyClient.Send(event)
-			if err != nil {
-				logrus.WithError(err).Warn("failed to send inotify")
+			if idle {
+				sendEvent(watchPath, stat)
+				idle = false
+				timer.Reset(cooldown)
+			} else {
+				pending[watchPath] = stat
+				timer.Reset(cooldown)
 			}
+
+		case <-timer.C:
+			for wp, st := range pending {
+				sendEvent(wp, st)
+			}
+			pending = make(map[string]os.FileInfo)
+			idle = true
 		}
 	}
 }


### PR DESCRIPTION
### Description

When using virtiofs and inotify it seems that you can intermittently hit permission denied errors for example when running yarn install in a decently sized repository. These errors don't actually seem to be a problem with virtiofs.

virtiofs = works fine but no hot reload inside containers
virtiofs + mount inotify = hot reload inside container works but yarn install will crash with a permission denied issue

With this change hopefully we see the following;

virtiofs + mount inotify = yarn install works + hot reload works

This PR seemingly achieves this aim, but I haven't worked on Go in a long time so I'm not an expert this fix is only me debugging with strace and trying to patch what I see.

### Testing Done

1. yarn install inside a Docker container with a virtiofs-mounted volume completes without EACCES errors
2. Editing a source file on the host triggers a single hot-reload cycle (no loops) <- this was a side-effect of an earlier revision of this change, I included it to try to show how the testing was conducted.