### PR TITLE
Use idiomatic bats code in copy.bats

### DIFF
--- a/hack/bats/tests/copy.bats
+++ b/hack/bats/tests/copy.bats
@@ -18,42 +18,27 @@ test_copy_dir_from_host_to_instance() {
     mkdir -p "$BATS_TEST_TMPDIR/foo/bar"
 
     # SRC DST
-    run limactl copy --backend="$backend" -r "$BATS_TEST_TMPDIR/foo" "$INSTANCE":/tmp/test_limactl_copy/foo
-    [[ $status == 0 ]]
-    run limactl shell "$INSTANCE" -- test -d /tmp/test_limactl_copy/foo/bar
-    [[ $status == 0 ]]
-    run limactl shell "$INSTANCE" -- rm -rf /tmp/test_limactl_copy/foo
-    [[ $status == 0 ]]
+    limactl copy --backend="$backend" -r "$BATS_TEST_TMPDIR/foo" "$INSTANCE":/tmp/test_limactl_copy/foo
+    limactl shell "$INSTANCE" -- test -d /tmp/test_limactl_copy/foo/bar
+    limactl shell "$INSTANCE" -- rm -rf /tmp/test_limactl_copy/foo
 
     # SRC/ DST
-    run limactl shell "$INSTANCE" -- mkdir -p /tmp/test_limactl_copy/foo_src_with_slash/
-    [[ $status == 0 ]]
-    run limactl copy --backend="$backend" -r "$BATS_TEST_TMPDIR/foo/" "$INSTANCE":/tmp/test_limactl_copy/foo_src_with_slash
-    [[ $status == 0 ]]
-    run limactl shell "$INSTANCE" -- test -d /tmp/test_limactl_copy/foo_src_with_slash/foo
-    [[ $status == 0 ]]
-    run limactl shell "$INSTANCE" -- rm -rf /tmp/test_limactl_copy/foo_src_with_slash
-    [[ $status == 0 ]]
+    limactl shell "$INSTANCE" -- mkdir -p /tmp/test_limactl_copy/foo_src_with_slash/
+    limactl copy --backend="$backend" -r "$BATS_TEST_TMPDIR/foo/" "$INSTANCE":/tmp/test_limactl_copy/foo_src_with_slash
+    limactl shell "$INSTANCE" -- test -d /tmp/test_limactl_copy/foo_src_with_slash/foo
+    limactl shell "$INSTANCE" -- rm -rf /tmp/test_limactl_copy/foo_src_with_slash
 
     # SRC DST/
-    run limactl shell "$INSTANCE" -- mkdir -p /tmp/test_limactl_copy/foo_dst_with_slash/
-    [[ $status == 0 ]]
-    run limactl copy --backend="$backend" -r "$BATS_TEST_TMPDIR/foo" "$INSTANCE":/tmp/test_limactl_copy/foo_dst_with_slash/
-    [[ $status == 0 ]]
-    run limactl shell "$INSTANCE" -- test -d /tmp/test_limactl_copy/foo_dst_with_slash/foo
-    [[ $status == 0 ]]
-    run limactl shell "$INSTANCE" -- rm -rf /tmp/test_limactl_copy/foo_dst_with_slash
-    [[ $status == 0 ]]
+    limactl shell "$INSTANCE" -- mkdir -p /tmp/test_limactl_copy/foo_dst_with_slash/
+    limactl copy --backend="$backend" -r "$BATS_TEST_TMPDIR/foo" "$INSTANCE":/tmp/test_limactl_copy/foo_dst_with_slash/
+    limactl shell "$INSTANCE" -- test -d /tmp/test_limactl_copy/foo_dst_with_slash/foo
+    limactl shell "$INSTANCE" -- rm -rf /tmp/test_limactl_copy/foo_dst_with_slash
 
     # SRC/ DST/
-    run limactl shell "$INSTANCE" -- mkdir -p /tmp/test_limactl_copy/foo_src_dst_with_slash/
-    [[ $status == 0 ]]
-    run limactl copy --backend="$backend" -r "$BATS_TEST_TMPDIR/foo/" "$INSTANCE":/tmp/test_limactl_copy/foo_src_dst_with_slash/
-    [[ $status == 0 ]]
-    run limactl shell "$INSTANCE" -- test -d /tmp/test_limactl_copy/foo_src_dst_with_slash/foo
-    [[ $status == 0 ]]
-    run limactl shell "$INSTANCE" -- rm -rf /tmp/test_limactl_copy/foo_src_dst_with_slash
-    [[ $status == 0 ]]
+    limactl shell "$INSTANCE" -- mkdir -p /tmp/test_limactl_copy/foo_src_dst_with_slash/
+    limactl copy --backend="$backend" -r "$BATS_TEST_TMPDIR/foo/" "$INSTANCE":/tmp/test_limactl_copy/foo_src_dst_with_slash/
+    limactl shell "$INSTANCE" -- test -d /tmp/test_limactl_copy/foo_src_dst_with_slash/foo
+    limactl shell "$INSTANCE" -- rm -rf /tmp/test_limactl_copy/foo_src_dst_with_slash
 }
 
 @test "copy directory from host to Lima instance (scp)" {
@@ -68,28 +53,23 @@ test_copy_dir_from_host_to_instance() {
 test_copy_dir_from_instance_to_host() {
     backend="$1"
 
-    run limactl shell "$INSTANCE" -- mkdir -p /tmp/test_limactl_copy/foo/bar
-    [[ $status == 0 ]]
+    limactl shell "$INSTANCE" -- mkdir -p /tmp/test_limactl_copy/foo/bar
 
     # SRC DST
-    run limactl copy --backend="$backend" -r "$INSTANCE":/tmp/test_limactl_copy/foo "$BATS_TEST_TMPDIR/foo"
-    [[ $status == 0 ]]
-    [[ -d "$BATS_TEST_TMPDIR/foo/bar" ]]
+    limactl copy --backend="$backend" -r "$INSTANCE":/tmp/test_limactl_copy/foo "$BATS_TEST_TMPDIR/foo"
+    assert_dir_exists "$BATS_TEST_TMPDIR/foo/bar"
 
     # SRC/ DST
-    run limactl copy --backend="$backend" -r "$INSTANCE":/tmp/test_limactl_copy/foo/ "$BATS_TEST_TMPDIR/foo_src_with_slash"
-    [[ $status == 0 ]]
-    [[ -d "$BATS_TEST_TMPDIR/foo_src_with_slash/bar" ]]
+    limactl copy --backend="$backend" -r "$INSTANCE":/tmp/test_limactl_copy/foo/ "$BATS_TEST_TMPDIR/foo_src_with_slash"
+    assert_dir_exists "$BATS_TEST_TMPDIR/foo_src_with_slash/bar"
 
     # SRC DST/
-    run limactl copy --backend="$backend" -r "$INSTANCE":/tmp/test_limactl_copy/foo "$BATS_TEST_TMPDIR/foo_dst_with_slash/"
-    [[ $status == 0 ]]
-    [[ -d "$BATS_TEST_TMPDIR/foo_dst_with_slash/bar" ]]
+    limactl copy --backend="$backend" -r "$INSTANCE":/tmp/test_limactl_copy/foo "$BATS_TEST_TMPDIR/foo_dst_with_slash/"
+    assert_dir_exists "$BATS_TEST_TMPDIR/foo_dst_with_slash/bar"
 
     # SRC/ DST/
-    run limactl copy --backend="$backend" -r "$INSTANCE":/tmp/test_limactl_copy/foo/ "$BATS_TEST_TMPDIR/foo_src_dst_with_slash/"
-    [[ $status == 0 ]]
-    [[ -d "$BATS_TEST_TMPDIR/foo_src_dst_with_slash/bar" ]]
+    limactl copy --backend="$backend" -r "$INSTANCE":/tmp/test_limactl_copy/foo/ "$BATS_TEST_TMPDIR/foo_src_dst_with_slash/"
+    assert_dir_exists "$BATS_TEST_TMPDIR/foo_src_dst_with_slash/bar"
 }
 
 @test "copy directory from Lima instance to host (scp)" {
@@ -104,15 +84,12 @@ test_copy_file_from_host_to_instance() {
     backend="$1"
     echo "hello" > "$BATS_TEST_TMPDIR/hello.txt"
 
-    run limactl copy --backend="$backend" "$BATS_TEST_TMPDIR/hello.txt" "$INSTANCE":/tmp/test_limactl_copy/hello.txt
-    [[ $status == 0 ]]
+    limactl copy --backend="$backend" "$BATS_TEST_TMPDIR/hello.txt" "$INSTANCE":/tmp/test_limactl_copy/hello.txt
 
-    run limactl shell "$INSTANCE" -- cat /tmp/test_limactl_copy/hello.txt
-    [[ $status == 0 ]]
-    [[ $output == "hello" ]]
+    run -0 limactl shell "$INSTANCE" -- cat /tmp/test_limactl_copy/hello.txt
+    assert_output "hello"
 
-    run limactl shell "$INSTANCE" -- rm -f /tmp/test_limactl_copy/hello.txt
-    [[ $status == 0 ]]
+    limactl shell "$INSTANCE" -- rm -f /tmp/test_limactl_copy/hello.txt
 }
 
 @test "copy file from host to Lima instance (scp)" {
@@ -125,18 +102,14 @@ test_copy_file_from_host_to_instance() {
 
 test_copy_file_from_instance_to_host() {
     backend="$1"
-    run limactl shell "$INSTANCE" -- bash -c 'echo "hello" > /tmp/test_limactl_copy/hello.txt'
-    [[ $status == 0 ]]
+    limactl shell "$INSTANCE" -- bash -c 'echo "hello" > /tmp/test_limactl_copy/hello.txt'
 
-    run limactl copy --backend="$backend" "$INSTANCE":/tmp/test_limactl_copy/hello.txt "$BATS_TEST_TMPDIR/hello.txt"
-    [[ $status == 0 ]]
+    limactl copy --backend="$backend" "$INSTANCE":/tmp/test_limactl_copy/hello.txt "$BATS_TEST_TMPDIR/hello.txt"
 
-    run cat "$BATS_TEST_TMPDIR/hello.txt"
-    [[ $status == 0 ]]
-    [[ $output == "hello" ]]
+    run -0 cat "$BATS_TEST_TMPDIR/hello.txt"
+    assert_output "hello"
 
-    run limactl shell "$INSTANCE" -- rm -f /tmp/hello.txt
-    [[ $status == 0 ]]
+    limactl shell "$INSTANCE" -- rm -f /tmp/hello.txt
 }
 
 @test "copy file from Lima instance to host (scp)" {


### PR DESCRIPTION
- Don't use `run` unless you want to capture the output
- Use `run -0` if you want to assert the command succeeds and also capture the output
- Use `assert_output` to verify the output
- Use `assert_dir_exists` to verify a directory exists