### PR TITLE
Replace diff with instance ID check for boot signal files

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/07-etc-environment.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/07-etc-environment.sh
@@ -22,6 +22,6 @@ if command -v loginctl >/dev/null 2>&1 && [ "${orig}" != "$(cat /etc/environment
 	loginctl terminate-user "${LIMA_CIDATA_USER}" || true
 fi
 
-# Signal that provisioning is done. The instance-id in the meta-data file changes on every boot,
-# so any copy from a previous boot cycle will have different content.
-cp "${LIMA_CIDATA_MNT}"/meta-data /run/lima-ssh-ready
+# Signal that provisioning is done. The instance ID changes on every boot,
+# so any value from a previous boot cycle will be different.
+echo "${LIMA_CIDATA_IID}" >/run/lima-ssh-ready

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.sh
@@ -201,9 +201,9 @@ if [ -d "${LIMA_CIDATA_MNT}"/provision.user ]; then
 	done
 fi
 
-# Signal that provisioning is done. The instance-id in the meta-data file changes on every boot,
-# so any copy from a previous boot cycle will have different content.
-cp "${LIMA_CIDATA_MNT}"/meta-data "${RUN}/lima-boot-done"
+# Signal that provisioning is done. The instance ID changes on every boot,
+# so any value from a previous boot cycle will be different.
+echo "${LIMA_CIDATA_IID}" >"${RUN}/lima-boot-done"
 
 INFO "Exiting with code $CODE"
 exit "$CODE"

--- a/pkg/cidata/cidata.TEMPLATE.d/lima.env
+++ b/pkg/cidata/cidata.TEMPLATE.d/lima.env
@@ -1,4 +1,5 @@
 LIMA_CIDATA_DEBUG={{ .Debug }}
+LIMA_CIDATA_IID={{ .IID }}
 LIMA_CIDATA_NAME={{ .Name }}
 LIMA_CIDATA_USER={{ .User }}
 LIMA_CIDATA_UID={{ .UID }}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -381,24 +381,26 @@ func GenerateCloudConfig(ctx context.Context, instDir, name string, instConfig *
 	return os.WriteFile(filepath.Join(instDir, filenames.CloudConfig), config, 0o444)
 }
 
-func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name string, instConfig *limatype.LimaYAML, udpDNSLocalPort, tcpDNSLocalPort int, guestAgentBinary, nerdctlArchive string, vsockPort int, virtioPort string, noCloudInit, rosettaEnabled, rosettaBinFmt bool) error {
+// GenerateISO9660 generates the cidata ISO9660 image (or directory, for noCloudInit)
+// in instDir. It returns the instance ID, which changes on every boot.
+func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name string, instConfig *limatype.LimaYAML, udpDNSLocalPort, tcpDNSLocalPort int, guestAgentBinary, nerdctlArchive string, vsockPort int, virtioPort string, noCloudInit, rosettaEnabled, rosettaBinFmt bool) (string, error) {
 	args, err := templateArgs(ctx, true, instDir, name, instConfig, udpDNSLocalPort, tcpDNSLocalPort, vsockPort, virtioPort, noCloudInit, rosettaEnabled, rosettaBinFmt)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	if err := ValidateTemplateArgs(args); err != nil {
-		return err
+		return "", err
 	}
 
 	layout, err := ExecuteTemplateCIDataISO(args)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	driverScripts, err := drv.BootScripts()
 	if err != nil {
-		return fmt.Errorf("failed to get boot scripts: %w", err)
+		return "", fmt.Errorf("failed to get boot scripts: %w", err)
 	}
 
 	for filename, content := range driverScripts {
@@ -406,7 +408,7 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 		if strings.Contains(filename, "/") {
 			// When the filename contains a slash, it must be in the format of "boot.<OS>/<SCRIPT>"
 			if !strings.HasPrefix(filename, "boot.") || strings.Count(filename, "/") != 1 {
-				return fmt.Errorf("invalid boot script filename %q: must be in format 'boot.<OS>/<SCRIPT>'", filename)
+				return "", fmt.Errorf("invalid boot script filename %q: must be in format 'boot.<OS>/<SCRIPT>'", filename)
 			}
 			layoutPath = filename
 		} else {
@@ -440,7 +442,7 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 		case limatype.ProvisionModeAnsible:
 			continue
 		default:
-			return fmt.Errorf("unknown provision mode %q", f.Mode)
+			return "", fmt.Errorf("unknown provision mode %q", f.Mode)
 		}
 	}
 
@@ -450,17 +452,17 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 			logrus.Debugf("Decompressing %s", guestAgentBinary)
 			guestAgentGz, err := os.Open(guestAgentBinary)
 			if err != nil {
-				return err
+				return "", err
 			}
 			defer guestAgentGz.Close()
 			guestAgent, err = gzip.NewReader(guestAgentGz)
 			if err != nil {
-				return err
+				return "", err
 			}
 		} else {
 			guestAgent, err = os.Open(guestAgentBinary)
 			if err != nil {
-				return err
+				return "", err
 			}
 		}
 
@@ -475,7 +477,7 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 		nftgz := args.Containerd.Archive
 		nftgzR, err := os.Open(nerdctlArchive)
 		if err != nil {
-			return err
+			return "", err
 		}
 		defer nftgzR.Close()
 		layout = append(layout, iso9660util.Entry{
@@ -490,7 +492,7 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 			Path:   "ssh_authorized_keys",
 			Reader: strings.NewReader(strings.Join(args.SSHPubKeys, "\n")),
 		})
-		return writeCIDataDir(filepath.Join(instDir, filenames.CIDataISODir), layout)
+		return args.IID, writeCIDataDir(filepath.Join(instDir, filenames.CIDataISODir), layout)
 	}
 
 	var iso9660Options []iso9660util.WriteOpt
@@ -500,7 +502,7 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 		// FreeBSD: Without Joliet, the files are not executable
 		iso9660Options = append(iso9660Options, iso9660util.WithJoliet())
 	}
-	return iso9660util.Write(filepath.Join(instDir, filenames.CIDataISO), "cidata", layout, iso9660Options...)
+	return args.IID, iso9660util.Write(filepath.Join(instDir, filenames.CIDataISO), "cidata", layout, iso9660Options...)
 }
 
 func removeControlChars(s string) string {

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -72,6 +72,7 @@ type HostAgent struct {
 
 	vSockPort  int
 	virtioPort string
+	iid        string // instance ID, changes on every boot
 
 	clientMu sync.RWMutex
 	client   *guestagentclient.GuestAgentClient
@@ -176,7 +177,8 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 	if err := cidata.GenerateCloudConfig(ctx, inst.Dir, instName, inst.Config); err != nil {
 		return nil, err
 	}
-	if err := cidata.GenerateISO9660(ctx, limaDriver, inst.Dir, instName, inst.Config, udpDNSLocalPort, tcpDNSLocalPort, o.guestAgentBinary, o.nerdctlArchive, vSockPort, virtioPort, noCloudInit, rosettaEnabled, rosettaBinFmt); err != nil {
+	iid, err := cidata.GenerateISO9660(ctx, limaDriver, inst.Dir, instName, inst.Config, udpDNSLocalPort, tcpDNSLocalPort, o.guestAgentBinary, o.nerdctlArchive, vSockPort, virtioPort, noCloudInit, rosettaEnabled, rosettaBinFmt)
+	if err != nil {
 		return nil, err
 	}
 
@@ -250,6 +252,7 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 		eventEnc:          json.NewEncoder(stdout),
 		vSockPort:         vSockPort,
 		virtioPort:        virtioPort,
+		iid:               iid,
 		guestAgentAliveCh: make(chan struct{}),
 		showProgress:      o.showProgress,
 	}

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -183,13 +183,13 @@ true
 	req = append(req,
 		requirement{
 			description: "user session is ready for ssh",
-			script: `#!/bin/bash
+			script: fmt.Sprintf(`#!/bin/bash
 set -eux -o pipefail
-if ! timeout 30s bash -c "until sudo diff -q /run/lima-ssh-ready /mnt/lima-cidata/meta-data 2>/dev/null; do sleep 3; done"; then
+if ! timeout 30s bash -c "until [ \"\$(cat /run/lima-ssh-ready 2>/dev/null)\" = \"%s\" ]; do sleep 3; done"; then
 	echo >&2 "not ready to start persistent ssh session"
 	exit 1
 fi
-`,
+`, a.iid),
 			debugHint: `The boot sequence will terminate any existing user session after updating
 /etc/environment to make sure the session includes the new values.
 Terminating the session will break the persistent SSH tunnel, so
@@ -288,28 +288,22 @@ func (a *HostAgent) finalRequirements() []requirement {
 	req = append(req,
 		requirement{
 			description: "boot scripts must have finished",
-			script: `#!/bin/sh
+			script: fmt.Sprintf(`#!/bin/sh
 set -eux
 timeout=timeout
-sudo=sudo
-A=/run/lima-boot-done
-B=/mnt/lima-cidata/meta-data
+BOOT_DONE=/run/lima-boot-done
 UNAME="$(uname)"
 if [ "$UNAME" = "Darwin" ]; then
 	timeout=/Volumes/cidata/util/timeout.sh
-	# On macOS, /Volumes/cidata is not mounted as "root access only"
-	# FIXME: The cidata does not need to be root-only on Linux, either?
-	sudo=
-	A=/var/run/lima-boot-done
-	B=/Volumes/cidata/meta-data
+	BOOT_DONE=/var/run/lima-boot-done
 elif [ "$UNAME" = "FreeBSD" ]; then
-	A=/var/run/lima-boot-done
+	BOOT_DONE=/var/run/lima-boot-done
 fi
-if ! "$timeout" 30s sh -c "until $sudo diff -q $A $B 2>/dev/null; do sleep 3; done"; then
+if ! "$timeout" 30s sh -c "until [ \"\$(cat $BOOT_DONE 2>/dev/null)\" = \"%s\" ]; do sleep 3; done"; then
 	echo >&2 "boot scripts have not finished"
 	exit 1
 fi
-`,
+`, a.iid),
 			debugHint: `All boot scripts, provisioning scripts, and readiness probes must
 finish before the instance is considered "ready".
 Check "` + logLocation + `" to see where the process is blocked!

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -169,6 +169,7 @@ The volume label is "cidata", as defined by [cloud-init NoCloud](https://docs.cl
 
 ### Environment variables
 - `LIMA_CIDATA_DEBUG`: the value of the `--debug` flag of the `limactl start` command.
+- `LIMA_CIDATA_IID`: the instance ID, regenerated on every boot.
 - `LIMA_CIDATA_NAME`: the lima instance name
 - `LIMA_CIDATA_MNT`: the mount point of the disk. `/mnt/lima-cidata`.
 - `LIMA_CIDATA_USER`: the username string


### PR DESCRIPTION
The boot-done and ssh-ready signal files previously copied the entire meta-data file and used `diff -q` to verify completion. This failed on distributions like openSUSE Tumbleweed where `diffutils` is not installed.

Write just the instance ID to the signal files and compare it directly using `cat`, which removes the dependency on `diff` and `sudo`.

Fixes #4659

```console
❯ limactl start -y template:experimental/opensuse-tumbleweed
...
INFO[0078] [hostagent] The final requirement 1 of 1 is satisfied
INFO[0079] READY. Run `limactl shell opensuse-tumbleweed` to open the shell.
```