### PR TITLE
Replace diff with sha256sum in boot scripts

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/06-enable-mdns-on-systemd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/06-enable-mdns-on-systemd.sh
@@ -20,7 +20,7 @@ enable_mdns_conf_content="[Resolve]
 MulticastDNS=yes
 "
 # Create /etc/systemd/resolved.conf.d/00-lima-enable-mdns.conf if its content is different
-if ! diff -q <(echo "${enable_mdns_conf_content}") "${enable_mdns_conf_path}" >/dev/null 2>&1; then
+if [ "$(echo "${enable_mdns_conf_content}" | sha256sum)" != "$(sha256sum <"${enable_mdns_conf_path}" 2>/dev/null)" ]; then
 	mkdir -p "$(dirname "${enable_mdns_conf_path}")"
 	echo "${enable_mdns_conf_content}" >"${enable_mdns_conf_path}"
 	systemctl daemon-reload

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/25-guestagent-base.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/25-guestagent-base.sh
@@ -20,7 +20,7 @@ fi
 # Install or update the guestagent binary
 mkdir -p "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin
 guestagent_updated=false
-if diff -q "${LIMA_CIDATA_MNT}"/lima-guestagent "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/lima-guestagent 2>/dev/null; then
+if [ "$(sha256sum <"${LIMA_CIDATA_MNT}"/lima-guestagent)" = "$(sha256sum <"${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/lima-guestagent 2>/dev/null)" ]; then
 	echo "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}/bin/lima-guestagent is up-to-date"
 else
 	install -m 755 "${LIMA_CIDATA_MNT}"/lima-guestagent "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/lima-guestagent
@@ -57,8 +57,8 @@ if [ -f /sbin/openrc-run ]; then
 		EOF
 	}
 	if [ "${guestagent_updated}" = "false" ] &&
-		diff -q <(print_config) /etc/conf.d/lima-guestagent 2>/dev/null &&
-		diff -q <(print_script) /etc/init.d/lima-guestagent 2>/dev/null; then
+		[ "$(print_config | sha256sum)" = "$(sha256sum </etc/conf.d/lima-guestagent 2>/dev/null)" ] &&
+		[ "$(print_script | sha256sum)" = "$(sha256sum </etc/init.d/lima-guestagent 2>/dev/null)" ]; then
 		echo "lima-guestagent service already up-to-date"
 		exit 0
 	fi


### PR DESCRIPTION
The `diff` command is missing on some distributions like openSUSE Tumbleweed. Use `sha256sum` (available in `coreutils` and `busybox`) to compare files instead.

See #4659