### PR TITLE
Fix `limactl shell` to return error for stopped instances

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -145,7 +145,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		}
 
 		if !startNow {
-			return nil
+			return fmt.Errorf("instance %q is stopped, run `limactl start %s` to start the instance", instName, instName)
 		}
 
 		// Network reconciliation will be performed by the process launched by the autostart manager

--- a/hack/bats/tests/shell.bats
+++ b/hack/bats/tests/shell.bats
@@ -7,12 +7,14 @@ INSTANCE=bats-dummy
 
 @test 'lima stopped lima instance' {
     # check that the "tty" flag is used, also for stdin
-    limactl shell --tty=false "$INSTANCE" true </dev/null
+    run_e -1 limactl shell --tty=false "$INSTANCE" true </dev/null
+    assert_stderr --partial "instance \\\"$INSTANCE\\\" is stopped"
 }
 
 @test 'yes | stopped lima instance' {
     # check that stdin is verified and not just crashing
-    bash -c "yes | limactl shell --tty=true $INSTANCE true"
+    run_e -1 bash -c "yes | limactl shell --tty=true $INSTANCE true"
+    assert_stderr --partial "instance \\\"$INSTANCE\\\" is stopped"
 }
 
 @test 'limactl shell without --instance requires positional arg' {


### PR DESCRIPTION
`limactl shell --tty=false STOPPED_INSTANCE` was silently exiting with status 0 instead of returning an error. Now it returns a descriptive error message when the instance is stopped and won't be started.

Fixes #4690

NOTE: used Claude Code