### PR TITLE
shell: improve error message when instance name is missing

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -98,7 +98,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		args = append([]string{instName}, args...)
 	} else {
 		if len(args) == 0 {
-			return errors.New("requires at least 1 arg(s), only received 0")
+			return errors.New("requires instance name as first argument")
 		}
 		// simulate the behavior of double dash
 		newArg := []string{}

--- a/hack/bats/tests/shell.bats
+++ b/hack/bats/tests/shell.bats
@@ -15,9 +15,9 @@ INSTANCE=bats-dummy
     bash -c "yes | limactl shell --tty=true $INSTANCE true"
 }
 
-@test 'limactl shell without --instance requires positional arg' {
+@test 'limactl shell without --instance requires instance name as first argument' {
     run_e -1 limactl shell --tty=false
-    assert_stderr --partial "requires at least 1 arg"
+    assert_stderr --partial "requires instance name as first argument"
 }
 
 @test 'limactl shell nonexistent instance' {


### PR DESCRIPTION
Follow-up to:
- https://github.com/lima-vm/lima/pull/4691#discussion_r2908033074