### PR TITLE
vz: disable ssh.overVsock by default for non-Linux guests

### DIFF
--- a/pkg/driver/vz/vm_darwin.go
+++ b/pkg/driver/vz/vm_darwin.go
@@ -107,7 +107,7 @@ func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int, onV
 					go func() {
 						defer close(notifySSHLocalPortAccessible)
 						usernetSSHLocalPort := sshLocalPort
-						useSSHOverVsock := true
+						useSSHOverVsock := *inst.Config.OS == limatype.LINUX
 						if inst.Config.SSH.OverVsock != nil {
 							useSSHOverVsock = *inst.Config.SSH.OverVsock
 						}

--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -168,7 +168,7 @@ func (l *LimaVzDriver) FillConfig(ctx context.Context, cfg *limatype.LimaYAML, _
 	}
 
 	if cfg.SSH.OverVsock == nil {
-		cfg.SSH.OverVsock = ptr.Of(true)
+		cfg.SSH.OverVsock = ptr.Of(*cfg.OS == limatype.LINUX)
 	}
 
 	var vzOpts limatype.VZOpts

--- a/templates/_images/macos-15.yaml
+++ b/templates/_images/macos-15.yaml
@@ -9,5 +9,3 @@ os: Darwin
 arch: aarch64
 # vz is the only supported VM type for macOS guests
 vmType: vz
-ssh:
-  overVsock: false

--- a/templates/_images/macos-26.yaml
+++ b/templates/_images/macos-26.yaml
@@ -9,5 +9,3 @@ os: Darwin
 arch: aarch64
 # vz is the only supported VM type for macOS guests
 vmType: vz
-ssh:
-  overVsock: false

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -139,7 +139,7 @@ ssh:
   # 🟢 Builtin default: false
   forwardX11Trusted: null
   # Enable SSH over vsock.
-  # 🟢 Builtin default: true for vz, false for other vmTypes
+  # 🟢 Builtin default: true for vz with Linux guests, false otherwise
   overVsock: null
 
 caCerts:


### PR DESCRIPTION
The feature is Linux-only as it depends on systemd