### PR TITLE
lint: add nobin to detect binary files and invisible Unicode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,15 @@ jobs:
         make install-protoc-tools
     - name: Verify generated files
       run: make generate check-generated
+    - name: Run nobin
+      run: >-
+        go tool -modfile=./hack/tools/go.mod nobin
+        --allow-emoji
+        --allow-escape
+        --gitignore
+        --skip-ext pb.desc
+        --skip 'website/static/images/**/*.{gif,png}'
+        --skip 'docs/reports/**/*.pdf'
     - name: Run editorconfig-checker
       run: go tool -modfile=./hack/tools/go.mod editorconfig-checker
     - name: Run yamllint

--- a/Makefile
+++ b/Makefile
@@ -605,6 +605,7 @@ bats: native limactl-plugins
 
 .PHONY: lint
 lint: check-generated
+	nobin --allow-emoji --allow-escape --gitignore --skip-ext pb.desc --skip 'website/static/images/**/*.{gif,png}' --skip 'docs/reports/**/*.pdf'
 	editorconfig-checker
 	golangci-lint run ./...
 	yamllint .

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -7,6 +7,7 @@ tool (
 	github.com/containerd/ltag
 	github.com/editorconfig-checker/editorconfig-checker/v3/cmd/editorconfig-checker
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+	github.com/jandubois/nobin
 	github.com/yoheimuta/protolint/cmd/protolint
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc
 	google.golang.org/protobuf/cmd/protoc-gen-go
@@ -16,6 +17,7 @@ tool (
 require (
 	github.com/containerd/ltag v0.3.0
 	github.com/golangci/golangci-lint/v2 v2.11.3
+	github.com/jandubois/nobin v0.8.0
 	github.com/yoheimuta/protolint v0.56.4
 	google.golang.org/grpc v1.79.2
 	google.golang.org/protobuf v1.36.11
@@ -54,6 +56,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bkielbasa/cyclop v1.2.3 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/bombsimon/wsl/v4 v4.7.0 // indirect
 	github.com/bombsimon/wsl/v5 v5.6.0 // indirect
 	github.com/breml/bidichk v0.3.3 // indirect

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -106,6 +106,8 @@ github.com/bkielbasa/cyclop v1.2.3 h1:faIVMIGDIANuGPWH031CZJTi2ymOQBULs9H21HSMa5
 github.com/bkielbasa/cyclop v1.2.3/go.mod h1:kHTwA9Q0uZqOADdupvcFJQtp/ksSnytRMe8ztxG8Fuo=
 github.com/blizzy78/varnamelen v0.8.0 h1:oqSblyuQvFsW1hbBHh1zfwrKe3kcSj0rnXkKzsQ089M=
 github.com/blizzy78/varnamelen v0.8.0/go.mod h1:V9TzQZ4fLJ1DSrjVDfl89H7aMnTvKkApdHeyESmyR7k=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bombsimon/wsl/v4 v4.7.0 h1:1Ilm9JBPRczjyUs6hvOPKvd7VL1Q++PL8M0SXBDf+jQ=
 github.com/bombsimon/wsl/v4 v4.7.0/go.mod h1:uV/+6BkffuzSAVYD+yGyld1AChO7/EuLrCF/8xTiapg=
 github.com/bombsimon/wsl/v5 v5.6.0 h1:4z+/sBqC5vUmSp1O0mS+czxwH9+LKXtCWtHH9rZGQL8=
@@ -376,6 +378,8 @@ github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSo
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jandubois/nobin v0.8.0 h1:nJ4UDkh14goFC19EqayuH5DtdqjWI0QugZss262HXus=
+github.com/jandubois/nobin v0.8.0/go.mod h1:qRcr5FDrIKDLCS6TFd7LzH6j+SDRjElpmmhVQeZLTWM=
 github.com/jgautheron/goconst v1.8.2 h1:y0XF7X8CikZ93fSNT6WBTb/NElBu9IjaY7CCYQrCMX4=
 github.com/jgautheron/goconst v1.8.2/go.mod h1:A0oxgBCHy55NQn6sYpO7UdnA9p+h7cPtoOZUmvNIako=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=

--- a/hack/tools/pinversion.go
+++ b/hack/tools/pinversion.go
@@ -10,6 +10,7 @@ package tools
 import (
 	_ "github.com/containerd/ltag"
 	_ "github.com/golangci/golangci-lint/v2/pkg/exitcodes"
+	_ "github.com/jandubois/nobin/version"
 	_ "github.com/yoheimuta/protolint/lib"
 	_ "google.golang.org/grpc"
 	_ "google.golang.org/protobuf/proto"


### PR DESCRIPTION
Source files should contain only printable UTF-8 text. Binary files committed without proper extensions, zero-width Unicode smuggled into source (Glassworm/Trojan Source attacks), and encoding errors all evade normal code review. nobin catches these at lint time.

```console
❯ nobin --allow-emoji --allow-escape --gitignore --skip-ext pb.desc --skip 'website/static/images/**/*.{gif,png}' --skip 'docs/reports/**/*.pdf'
Scanning . (1188 files) ...

Skipped:
  docs/reports/Ada-Logics-Lima-fuzzing-audit-2024.pdf         --skip docs/reports/**/*.pdf
  pkg/driver/external/driver.pb.desc                          --skip-ext pb.desc
  pkg/guestagent/api/guestservice.pb.desc                     --skip-ext pb.desc
  website/static/images/demo.gif                              --skip website/static/images/**/*.{gif,png}
  website/static/images/internals/lima-sequence-diagram.png   --skip website/static/images/**/*.{gif,png}
  website/static/images/vscode-remote-explorer.png            --skip website/static/images/**/*.{gif,png}
---
Scanned 1188 files, found 0 with issues.
```