### PR TITLE
templates: add experimental/fedora-rawhide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,11 +314,14 @@ endif
 
 LIBEXEC_LIMA := _output/libexec/lima
 
-limactl-plugins: $(LIBEXEC_LIMA)/limactl-mcp$(exe)
+limactl-plugins: $(LIBEXEC_LIMA)/limactl-mcp$(exe) $(LIBEXEC_LIMA)/limactl-url-fedora-rawhide
 
 $(LIBEXEC_LIMA)/limactl-mcp$(exe): $(call dependencies_for_cmd,limactl-mcp) $$(call force_build,$$@)
 	@mkdir -p $(LIBEXEC_LIMA)
 	$(ENVS_$@) $(GO_BUILD) -o $@ ./cmd/limactl-mcp
+
+$(LIBEXEC_LIMA)/limactl-url-fedora-rawhide: cmd/limactl-url-fedora-rawhide
+	cp -aL $< $@
 
 .PHONY: additional-drivers
 additional-drivers:
@@ -587,6 +590,7 @@ uninstall:
 		"$(DEST)/share/lima" \
 		"$(DEST)/share/doc/lima" \
 		"$(DEST)/libexec/lima/limactl-mcp$(exe)" \
+		"$(DEST)/libexec/lima/limactl-url-fedora-rawhide" \
 		"$(DEST)/libexec/lima/lima-driver-qemu$(exe)" \
 		"$(DEST)/libexec/lima/lima-driver-vz$(exe)" \
 		"$(DEST)/libexec/lima/lima-driver-wsl2$(exe)" \

--- a/cmd/limactl-url-fedora-rawhide
+++ b/cmd/limactl-url-fedora-rawhide
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+	echo >&2 "Usage: $0 _images/fedora-rawhide"
+	exit 1
+fi
+if [ "$1" != "_images/fedora-rawhide" ]; then
+	echo >&2 "Expected argument to be '_images/fedora-rawhide', but got '$1'"
+	exit 1
+fi
+
+CACHE_HOME_DEFAULT="${HOME}/.cache"
+if [ "$(uname -s)" = "Darwin" ]; then
+	CACHE_HOME_DEFAULT="${HOME}/Library/Caches"
+fi
+: "${XDG_CACHE_HOME:=${CACHE_HOME_DEFAULT}}"
+CACHE_DIR="${XDG_CACHE_HOME}/lima/limactl-url-fedora-rawhide"
+
+# COMPOSE_ID is like "Fedora-Rawhide-20260316.n.0"
+COMPOSE_ID="$(curl -fsSL https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/COMPOSE_ID)"
+# COMPOSE_ID_TRIMMED is like "20260316.n.0"
+COMPOSE_ID_TRIMMED="${COMPOSE_ID#Fedora-Rawhide-}"
+
+mkdir -p "${CACHE_DIR}"
+FILE="${CACHE_DIR}/fedora-rawhide.yaml"
+
+cat <<EOF >"${FILE}"
+images:
+- location: "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-Rawhide-${COMPOSE_ID_TRIMMED}.x86_64.qcow2"
+  arch: "x86_64"
+- location: "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-Rawhide-${COMPOSE_ID_TRIMMED}.aarch64.qcow2"
+  arch: "aarch64"
+EOF
+
+echo "$FILE"

--- a/templates/README.md
+++ b/templates/README.md
@@ -68,6 +68,7 @@ lima
 - [`experimental/gentoo`](./experimental/gentoo.yaml): Gentoo
 - [`experimental/opensuse-tumbleweed`](./experimental/opensuse-tumbleweed.yaml): openSUSE Tumbleweed
 - [`experimental/debian-sid`](./experimental/debian-sid.yaml): Debian Sid
+- [`experimental/fedora-rawhide`](./experimental/fedora-rawhide.yaml): Fedora Rawhide
 
 ### Non-Linux
 

--- a/templates/experimental/fedora-rawhide.yaml
+++ b/templates/experimental/fedora-rawhide.yaml
@@ -1,0 +1,5 @@
+minimumLimaVersion: 2.0.0
+
+base:
+- fedora-rawhide:_images/fedora-rawhide
+- template:_default/mounts


### PR DESCRIPTION
Internally uses `limactl-url-fedora-rawhide` plugin as the image URL has to be generated dynamically.