### PR TITLE
docs: add deprecated LimaYAML fields

### DIFF
--- a/website/content/en/docs/releases/deprecated.md
+++ b/website/content/en/docs/releases/deprecated.md
@@ -9,6 +9,8 @@ The following features are deprecated:
 - Ansible provisioning mode: deprecated in Lima v1.1.0 (Use `ansible-playbook playbook.yaml` after the start instead)
 - `limactl --yes` flag: deprecated in Lima v2.0.0 (Use `limactl (clone|rename|edit|shell) --start` instead)
 - Environment variable `LIMA_SSH_OVER_VSOCK`: deprecated in Lima v2.0.2 (Use the YAML property `.ssh.overVsock`)
+- YAML property `cpuType`: deprecated in Lima v2.0.0 (Use `vmOpts.qemu.cpuType` instead)
+- YAML property `rosetta`: deprecated in Lima v2.0.0 (Use `vmOpts.vz.rosetta` instead)
 
 ## Removed features
 - YAML property `network`: deprecated in [Lima v0.7.0](https://github.com/lima-vm/lima/commit/07e68230e70b21108d2db3ca5e0efd0e43842fbd)


### PR DESCRIPTION
This PR updates the deprecated features list to include `cpuType` and `rosetta`, synchronizing the documentation with the `LimaYAML` struct.

Fixes #4731