### PR TITLE
vz,qemu: auto-unlock disk locked to the same instance on startup

### DIFF
--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -702,21 +702,9 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 			return "", nil, err
 		}
 
-		if disk.Instance != "" {
-			if disk.InstanceDir != cfg.InstanceDir {
-				logrus.Errorf("could not attach disk %q, in use by instance %q", diskName, disk.Instance)
-				return "", nil, err
-			}
-			err = disk.Unlock()
-			if err != nil {
-				logrus.Errorf("could not unlock disk %q to reuse in the same instance %q", diskName, cfg.Name)
-				return "", nil, err
-			}
-		}
 		logrus.Infof("Mounting disk %q on %q", diskName, disk.MountPoint)
-		err = disk.Lock(cfg.InstanceDir)
-		if err != nil {
-			logrus.Errorf("could not lock disk %q: %q", diskName, err)
+		if err = disk.LockForInstance(cfg.InstanceDir); err != nil {
+			logrus.Errorf("could not attach disk %q: %s", diskName, err)
 			return "", nil, err
 		}
 		dataDisk := filepath.Join(disk.Dir, filenames.DataDisk)

--- a/pkg/driver/vz/vm_darwin.go
+++ b/pkg/driver/vz/vm_darwin.go
@@ -588,13 +588,9 @@ func attachDisks(ctx context.Context, inst *limatype.Instance, vmConfig *vz.Virt
 			return fmt.Errorf("failed to run load disk %q: %w", diskName, err)
 		}
 
-		if disk.Instance != "" {
-			return fmt.Errorf("failed to run attach disk %q, in use by instance %q", diskName, disk.Instance)
-		}
 		logrus.Infof("Mounting disk %q on %q", diskName, disk.MountPoint)
-		err = disk.Lock(inst.Dir)
-		if err != nil {
-			return fmt.Errorf("failed to run lock disk %q: %w", diskName, err)
+		if err = disk.LockForInstance(inst.Dir); err != nil {
+			return fmt.Errorf("failed to attach disk %q: %w", diskName, err)
 		}
 		extraDiskPath := filepath.Join(disk.Dir, filenames.DataDisk)
 		// ConvertToRaw is a NOP if no conversion is needed

--- a/pkg/store/disk.go
+++ b/pkg/store/disk.go
@@ -97,3 +97,15 @@ func (d *Disk) Unlock() error {
 	inUseBy := filepath.Join(d.Dir, filenames.InUseBy)
 	return os.Remove(inUseBy)
 }
+
+func (d *Disk) LockForInstance(instanceDir string) error {
+	if d.Instance != "" {
+		if d.InstanceDir != instanceDir {
+			return fmt.Errorf("in use by instance %q", d.Instance)
+		}
+		if err := d.Unlock(); err != nil {
+			return fmt.Errorf("failed to unlock for reuse in the same instance: %w", err)
+		}
+	}
+	return d.Lock(instanceDir)
+}

--- a/pkg/store/disk_test.go
+++ b/pkg/store/disk_test.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+)
+
+func TestDiskLockForInstance(t *testing.T) {
+	t.Run("unlocked disk", func(t *testing.T) {
+		diskDir := t.TempDir()
+		instanceDir := t.TempDir()
+		disk := &Disk{Name: "testdisk", Dir: diskDir}
+
+		assert.NilError(t, disk.LockForInstance(instanceDir))
+		target, err := os.Readlink(filepath.Join(diskDir, filenames.InUseBy))
+		assert.NilError(t, err)
+		assert.Equal(t, target, instanceDir)
+	})
+
+	t.Run("locked by same instance (stale lock)", func(t *testing.T) {
+		diskDir := t.TempDir()
+		instanceDir := t.TempDir()
+		disk := &Disk{
+			Name:        "testdisk",
+			Dir:         diskDir,
+			Instance:    filepath.Base(instanceDir),
+			InstanceDir: instanceDir,
+		}
+		// Simulate stale lock from previous run
+		assert.NilError(t, os.Symlink(instanceDir, filepath.Join(diskDir, filenames.InUseBy)))
+
+		// LockForInstance should auto-unlock and re-lock
+		assert.NilError(t, disk.LockForInstance(instanceDir))
+		target, err := os.Readlink(filepath.Join(diskDir, filenames.InUseBy))
+		assert.NilError(t, err)
+		assert.Equal(t, target, instanceDir)
+	})
+
+	t.Run("locked by different instance", func(t *testing.T) {
+		diskDir := t.TempDir()
+		otherDir := t.TempDir()
+		disk := &Disk{
+			Name:        "testdisk",
+			Dir:         diskDir,
+			Instance:    filepath.Base(otherDir),
+			InstanceDir: otherDir,
+		}
+		assert.NilError(t, os.Symlink(otherDir, filepath.Join(diskDir, filenames.InUseBy)))
+
+		newInstanceDir := t.TempDir()
+		err := disk.LockForInstance(newInstanceDir)
+		assert.ErrorContains(t, err, "in use by instance")
+	})
+}


### PR DESCRIPTION
After an unclean shutdown (crash, macOS reboot, `pkill -9`), the `in_use_by` symlink for additional disks persists. The QEMU driver already handled this by checking if the disk was locked to the same instance and auto-unlocking it (added in #2092 for #1683), but the VZ driver did not, causing startup failures with:

```
failed to run attach disk "X", in use by instance "X"
```

This PR extracts the check-unlock-lock logic into `Disk.LockForInstance()` and uses it from both drivers.

Fixes https://github.com/lima-vm/lima/issues/4755.