### PR TITLE
fix: honor audio.device=none in VZ driver

### DIFF
--- a/pkg/driver/vz/vm_darwin.go
+++ b/pkg/driver/vz/vm_darwin.go
@@ -812,35 +812,6 @@ func attachOtherDevices(inst *limatype.Instance, vmConfig *vz.VirtualMachineConf
 		return err
 	}
 
-	// Set audio device
-	inputAudioDeviceConfig, err := vz.NewVirtioSoundDeviceConfiguration()
-	if err != nil {
-		return err
-	}
-	inputStream, err := vz.NewVirtioSoundDeviceHostInputStreamConfiguration()
-	if err != nil {
-		return err
-	}
-	inputAudioDeviceConfig.SetStreams(
-		inputStream,
-	)
-
-	outputAudioDeviceConfig, err := vz.NewVirtioSoundDeviceConfiguration()
-	if err != nil {
-		return err
-	}
-	outputStream, err := vz.NewVirtioSoundDeviceHostOutputStreamConfiguration()
-	if err != nil {
-		return err
-	}
-	outputAudioDeviceConfig.SetStreams(
-		outputStream,
-	)
-	vmConfig.SetAudioDevicesVirtualMachineConfiguration([]vz.AudioDeviceConfiguration{
-		inputAudioDeviceConfig,
-		outputAudioDeviceConfig,
-	})
-
 	// Set pointing device
 	var pointingDeviceConfig vz.PointingDeviceConfiguration
 	if *inst.Config.OS == limatype.DARWIN {


### PR DESCRIPTION
## Summary
- Remove unconditional virtio sound device attachment in `attachOtherDevices()` that was overriding the `attachAudio()` configuration
- `audio.device: none` now correctly results in no audio devices being attached to the guest VM

## Problem
When using `vmType: vz` with `audio.device: none`, the `attachAudio()` function correctly returned early without attaching audio devices. However, `attachOtherDevices()` — called immediately after — unconditionally added virtio sound input/output devices via `SetAudioDevicesVirtualMachineConfiguration`, overwriting the empty audio configuration.

This meant the guest kernel could still enumerate the virtual sound device even when the user explicitly disabled audio, increasing the attack surface unnecessarily.

## Fix
Removed the duplicate audio device setup from `attachOtherDevices()`. Audio device attachment is already fully handled by `attachAudio()`, which respects the `audio.device` setting:
- `"vz"` / `"default"` → attaches virtio sound output device
- `""` / `"none"` → no audio devices attached
fixes: #4761 