### PR TITLE
Enhance user UID handling in fakecloudinit for macOS

### DIFF
--- a/pkg/guestagent/fakecloudinit/fakecloudinit_darwin.go
+++ b/pkg/guestagent/fakecloudinit/fakecloudinit_darwin.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -261,6 +262,18 @@ func createUser(ctx context.Context, u *cloudinittypes.User) error {
 	logrus.Infof("Executing command: %v", cmd.Args)
 	if err = cmd.Run(); err != nil {
 		return fmt.Errorf("failed to execute command %v: %w", cmd.Args, err)
+	}
+
+	// Look up the actual UID assigned by the system, as it may differ from
+	// the requested UID (e.g., when macOS Setup Assistant already created
+	// the user with a different UID).
+	if sysUser, err := user.Lookup(u.Name); err != nil {
+		logrus.WithError(err).Warnf("Failed to look up user %q, using requested UID %d", u.Name, uid)
+	} else if actualUID, err := strconv.Atoi(sysUser.Uid); err != nil {
+		logrus.WithError(err).Warnf("Failed to parse actual UID %q for user %q, using requested UID %d", sysUser.Uid, u.Name, uid)
+	} else if actualUID != uid {
+		logrus.Warnf("Requested UID %d for user %q, but the system assigned UID %d; using the actual UID", uid, u.Name, actualUID)
+		uid = actualUID
 	}
 
 	// sysadminctl does not create the custom home directory


### PR DESCRIPTION
In my case there were mismatch in userId handled within macos

This fix ensures that proper UID is user for user dir so permission are set correctly

```
IOServiceMatchingfailed for: AppleM2ScalerParavirtDriver
2026-03-24 15:55:24.838 sysadminctl[392:2381] Creating user record…
2026-03-24 15:55:25.796 sysadminctl[392:2381] Assigning UID: 502 GID: 20
2026-03-24 15:55:25.811 sysadminctl[392:2381] ### Error:-14120 File:/AppleInternal/Library/BuildRoots/4~CG5LugAme55yQcvAiCAauirtEM0sbn-MIakZUTY/Library/Caches/com.apple.xbs/Sources/Admin/DSRecord.m Line:418
2026-03-24 15:55:25.848 sysadminctl[392:2381] Home directory is assigned (not created!) at /Users/bavijayakumar.guest
[33mWARN[0m[0003] Requested UID 502 for user "bavijayakumar", but the system assigned UID 501; using the actual UID 
[36mINFO[0m[0003] Executing command: [ditto --noqtn /System/Library/User Template/English.lproj /Users/bavijayakumar.guest] 
[36mINFO[0m[0004] Executing command: [chown -R 501:staff /Users/bavijayakumar.guest] 

```