### PR TITLE
pkg/networks/usernet: use domain.tld zones

### DIFF
--- a/pkg/networks/usernet/dnshosts/dnshosts.go
+++ b/pkg/networks/usernet/dnshosts/dnshosts.go
@@ -95,7 +95,7 @@ func (z zoneHost) name() string {
 	if i < 0 {
 		return string(z)
 	}
-	return string(z)[i+1:] + "."
+	return string(z)[z.zoneIndex()+1:] + "."
 }
 
 func (z zoneHost) recordName() string {
@@ -103,9 +103,22 @@ func (z zoneHost) recordName() string {
 	if i < 0 {
 		return ""
 	}
-	return string(z)[:i]
+
+	j := z.zoneIndex()
+	if j < 0 {
+		return ""
+	}
+
+	return string(z)[:j]
 }
 
 func (z zoneHost) dotIndex() int {
 	return strings.LastIndex(string(z), ".")
+}
+
+func (z zoneHost) zoneIndex() int {
+	parts := strings.Split(string(z), ".")
+	host := strings.Join(parts[:len(parts)-1], ".")
+
+	return strings.LastIndex(host, ".")
 }

--- a/pkg/networks/usernet/dnshosts/dnshosts_test.go
+++ b/pkg/networks/usernet/dnshosts/dnshosts_test.go
@@ -79,10 +79,10 @@ func Test_zoneHost(t *testing.T) {
 	}{
 		{}, // test for empty value as well
 		{host: "sample", want: val{name: "sample"}},
-		{host: "another.sample", want: val{name: "sample.", recordName: "another"}},
-		{host: "another.sample.com", want: val{name: "com.", recordName: "another.sample"}},
-		{host: "a.c", want: val{name: "c.", recordName: "a"}},
-		{host: "a.b.c.d", want: val{name: "d.", recordName: "a.b.c"}},
+		{host: "another.sample", want: val{name: "another.sample."}},
+		{host: "another.sample.com", want: val{name: "sample.com.", recordName: "another"}},
+		{host: "a.c", want: val{name: "a.c."}},
+		{host: "a.b.c.d", want: val{name: "c.d.", recordName: "a.b"}},
 	}
 	for i, tt := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
@@ -148,23 +148,26 @@ func TestExtractZones(t *testing.T) {
 		{
 			wantZones: []types.Zone{
 				{
-					Name: "ae.",
+					Name:      "google.ae.",
+					DefaultIP: net.ParseIP("8.8.4.4"),
+				},
+				{
+					Name:      "google.com.",
+					DefaultIP: net.ParseIP("8.8.4.4"),
 					Records: []types.Record{
-						{Name: "google", IP: net.ParseIP("8.8.4.4")},
+						{Name: "local", IP: net.ParseIP("8.8.8.8")},
 					},
 				},
 				{
-					Name: "com.",
+					Name: "docker.internal.",
 					Records: []types.Record{
-						{Name: "google", IP: net.ParseIP("8.8.4.4")},
-						{Name: "local.google", IP: net.ParseIP("8.8.8.8")},
+						{Name: "host", IP: net.ParseIP("192.168.5.2")},
 					},
 				},
 				{
-					Name: "internal.",
+					Name: "lima.internal.",
 					Records: []types.Record{
-						{Name: "host.docker", IP: net.ParseIP("192.168.5.2")},
-						{Name: "host.lima", IP: net.ParseIP("192.168.5.2")},
+						{Name: "host", IP: net.ParseIP("192.168.5.2")},
 					},
 				},
 				{


### PR DESCRIPTION
The usernet client stores dns records in tld zones, and as such the default host.lima.internal record breaks resolving .internal domains that may exist on the host network (e.g. compute.internal, dev.internal, etc).

This is a proposal to store dns records in domain.tld zones to be able to use such domains.

It may close #3161 also.