### PR TITLE
Pin composite action dependencies by SHA

### DIFF
--- a/.github/actions/setup_cache_for_template/action.yml
+++ b/.github/actions/setup_cache_for_template/action.yml
@@ -32,7 +32,7 @@ runs:
   - name: "Cache ${{ steps.cache-params-from-template.outputs.image-path }}"
     if: ${{ steps.cache-params-from-template.outputs.image-key != '' }}
     # avoid using `~` in path that will be expanded to platform specific home directory
-    uses: actions/cache@v4
+    uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
     with:
       path: ${{ steps.cache-params-from-template.outputs.image-path }}
       key: ${{ steps.cache-params-from-template.outputs.image-key }}
@@ -41,7 +41,7 @@ runs:
   - name: "Cache ${{ steps.cache-params-from-template.outputs.kernel-path }}"
     if: ${{ steps.cache-params-from-template.outputs.kernel-key != '' }}
     # avoid using `~` in path that will be expanded to platform specific home directory
-    uses: actions/cache@v4
+    uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
     with:
       path: ${{ steps.cache-params-from-template.outputs.kernel-path }}
       key: ${{ steps.cache-params-from-template.outputs.kernel-key }}
@@ -50,7 +50,7 @@ runs:
   - name: "Cache ${{ steps.cache-params-from-template.outputs.initrd-path }}"
     if: ${{ steps.cache-params-from-template.outputs.initrd-key != '' }}
     # avoid using `~` in path that will be expanded to platform specific home directory
-    uses: actions/cache@v4
+    uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
     with:
       path: ${{ steps.cache-params-from-template.outputs.initrd-path }}
       key: ${{ steps.cache-params-from-template.outputs.initrd-key }}
@@ -58,7 +58,7 @@ runs:
 
   - name: "Cache ${{ steps.cache-params-from-template.outputs.containerd-key }}"
     if: ${{ steps.cache-params-from-template.outputs.containerd-key != '' }}
-    uses: actions/cache@v4
+    uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
     with:
       path: ${{ steps.cache-params-from-template.outputs.containerd-path }}
       key: ${{ steps.cache-params-from-template.outputs.containerd-key }}

--- a/.github/actions/upload_failure_logs_if_exists/action.yml
+++ b/.github/actions/upload_failure_logs_if_exists/action.yml
@@ -24,7 +24,7 @@ runs:
     shell: bash
   - name: "Upload failure-logs"
     if: steps.check-if-failure-logs-exists.outputs.exists == 'true'
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
     with:
       name: failure-logs-${{ github.job }}${{ steps.normalize-suffix.outputs.result }}
       path: failure-logs/


### PR DESCRIPTION
The composite actions in `.github/actions/` referenced `actions/cache` and `actions/upload-artifact` by tag (v4) instead of by SHA. Pin them to match the versions used in the workflow files: `actions/cache` v5.0.4 and `actions/upload-artifact` v7.0.0.