### PR TITLE
Fix DNS not propagated from base template

### DIFF
--- a/pkg/limatmpl/embed.go
+++ b/pkg/limatmpl/embed.go
@@ -225,7 +225,8 @@ const mergeDocuments = `
 | $b | select((.base | tag == "!!str") and ($a.base | tag == "!!seq")) | .base = [ "" + .base ]
 
 # Delete base DNS entries if the template list is not empty.
-| $a | select(.dns) | del($b.dns, $c.dns)
+| $b | select($a.dns | length > 0) | del(.dns)
+| $c | select($a.dns | length > 0) | del(.dns)
 
 # Mark all new list fields with a custom tag. This is needed to avoid appending
 # newly copied lists to themselves again when we merge lists.

--- a/pkg/limatmpl/embed_test.go
+++ b/pkg/limatmpl/embed_test.go
@@ -101,6 +101,18 @@ minimumLimaVersion: 1.0.2  # or later
 		"dns: [1.1.1.1]",
 	},
 	{
+		"dns is copied from base when template has no dns",
+		"",
+		"dns: [1.1.1.1, 8.8.8.8]",
+		"dns: [1.1.1.1, 8.8.8.8]",
+	},
+	{
+		"dns is copied from base when template has empty list",
+		"dns: []",
+		"dns: [1.1.1.1, 8.8.8.8]",
+		"dns: [1.1.1.1, 8.8.8.8]",
+	},
+	{
 		"Update comments on existing maps and lists that don't have comments yet",
 		`#
 additionalDisks:


### PR DESCRIPTION
 ## Summary

  `del($b.dns, $c.dns)` uses absolute variable paths, which are evaluated
  independently of the pipeline state in yqlib.  So even when
  `$a | select(.dns)` produces an empty pipeline (main template has no DNS),
  the del still executes and removes DNS from $b and $c.

  Fixed by using `$b | select($a.dns | length > 0) | del(.dns)` so the
  deletion only runs when the main template actually has DNS entries.

  Fixes #4760 