### PR TITLE
Fix details summary and markdown rendering in templates

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -121,6 +121,7 @@ See <https://lima-vm.io/docs/examples/ai/>.
 ### Lost+found
 
 <details>
+<summary>Details</summary>
 <p>
 
 - `centos`: Removed in Lima v0.8.0, as CentOS 8 reached [EOL](https://www.centos.org/centos-linux-eol/).

--- a/website/layouts/shortcodes/readtemplates.html
+++ b/website/layouts/shortcodes/readtemplates.html
@@ -39,7 +39,7 @@ safeHTML ) (.Get "lang") "" -}}
 {{ else }}
 {{ $file_content := ($.Scratch.Get "filepath" | os.ReadFile) }}
 {{ $file_content = replace $file_content "../docs/" $gh_docs }}
-{{- replace $file_content "./" $gh_templates -}}
+{{- replace $file_content "./" $gh_templates | markdownify -}}
 {{ end }}
 {{ else if eq (.Get "draft") "true" }}
 


### PR DESCRIPTION
- Added missing `<summary>Details</summary>` to the Lost+found `<details>` block in templates/README.md for proper collapsible section labeling
- Applied `markdownify` filter to template file content in `readtemplates.html` shortcode to ensure markdown is correctly rendered as HTML on the website

Closes: #4745 