### PR TITLE
fix: LIMA_SHELLENV_ALLOW doesn't remove variables

### DIFF
--- a/pkg/envutil/envutil.go
+++ b/pkg/envutil/envutil.go
@@ -141,6 +141,12 @@ func FilterEnvironment() []string {
 
 func filterEnvironmentWithLists(env, allowList, blockList []string) []string {
 	var filtered []string
+	allowed := func(name string) bool {
+		if len(allowList) > 0 {
+			return matchesAnyPattern(name, allowList)
+		}
+		return !matchesAnyPattern(name, blockList)
+	}
 
 	for _, envVar := range env {
 		parts := strings.SplitN(envVar, "=", 2)
@@ -150,17 +156,11 @@ func filterEnvironmentWithLists(env, allowList, blockList []string) []string {
 
 		name := parts[0]
 
-		if len(allowList) > 0 && matchesAnyPattern(name, allowList) {
+		if allowed(name) {
 			filtered = append(filtered, envVar)
-			continue
-		}
-
-		if matchesAnyPattern(name, blockList) {
+		} else {
 			logrus.Debugf("Blocked env variable %q", name)
-			continue
 		}
-
-		filtered = append(filtered, envVar)
 	}
 
 	return filtered

--- a/pkg/envutil/envutil_test.go
+++ b/pkg/envutil/envutil_test.go
@@ -170,9 +170,8 @@ func TestFilterEnvironment(t *testing.T) {
 		result := filterEnvironmentWithLists(testEnv, []string{"FOO", "USER"}, nil)
 		expected := []string{"FOO=bar", "USER=testuser"}
 
-		// since FOO and USER are included in testEnv, the filtered result should not differ
-		// from what is in the testEnv
-		assert.Equal(t, len(result), len(testEnv))
+		// Only FOO and USER should be allowed through
+		assert.Equal(t, len(result), len(expected))
 		assert.Assert(t, containsAll(result, expected))
 	})
 


### PR DESCRIPTION
When `LIMA_SHELLENV_ALLOW` was set, `limactl shell --preserve-env` didn't remove environment variables that were not on the list specified by `LIMA_SHELLENV_ALLOW`. This didn't match the documented behavior.

This commit updates the code to filter out all variables not on the allowlist, if the allowlist is configured.

Fix the associated test to match the expected behavior.

Fixes https://github.com/lima-vm/lima/issues/4826.