### PR TITLE
Update k8s.yaml for bootstrapToken configuration in kubeadm

### DIFF
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -122,9 +122,14 @@ provision:
     apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       criSocket: unix:///run/containerd/containerd.sock
+    discovery:
+      bootstrapToken:
+        apiServerEndpoint: "{{.Param.url}}"
+        token: "{{.Param.token}}"
+        caCertHashes:
+        - "{{.Param.discoveryTokenCaCertHash}}"
     EOF
-    kubeadm join --config kubeadm-config.yaml {{.Param.url}} --token {{.Param.token}} \
-        --discovery-token-ca-cert-hash {{.Param.discoveryTokenCaCertHash}}
+    kubeadm join --config kubeadm-config.yaml
     {{end}}
 
     {{if not ( and .Param.url .Param.token )}}


### PR DESCRIPTION
Joining an existing cluster currently fails due to an error with the join command:

```
error: can not mix '--config' with arguments [discovery-token-ca-cert-hash token]
```