### PR TITLE
templates: migrate from cpuType to vmOpts.qemu.cpuType

### DIFF
--- a/templates/_images/almalinux-8.yaml
+++ b/templates/_images/almalinux-8.yaml
@@ -34,7 +34,9 @@ images:
 
 mountTypesUnsupported: [9p]
 
-cpuType:
-  # Workaround for "vmx_write_mem: mmu_gva_to_gpa XXXXXXXXXXXXXXXX failed" on Intel Mac
-  # https://bugs.launchpad.net/qemu/+bug/1838390
-  x86_64: Haswell-v4
+vmOpts:
+  qemu:
+    cpuType:
+      # Workaround for "vmx_write_mem: mmu_gva_to_gpa XXXXXXXXXXXXXXXX failed" on Intel Mac
+      # https://bugs.launchpad.net/qemu/+bug/1838390
+      x86_64: Haswell-v4

--- a/templates/_images/oraclelinux-8.yaml
+++ b/templates/_images/oraclelinux-8.yaml
@@ -16,7 +16,9 @@ firmware:
   # Oracle Linux 8 still requires legacyBIOS, while AlmaLinux 8 and Rocky Linux 8 do not.
   legacyBIOS: true
 
-cpuType:
-  # Workaround for vmx_write_mem: mmu_gva_to_gpa XXXXXXXXXXXXXXXX failed on Intel Mac
-  # https://bugs.launchpad.net/qemu/+bug/1838390
-  x86_64: Haswell-v4
+vmOpts:
+  qemu:
+    cpuType:
+      # Workaround for vmx_write_mem: mmu_gva_to_gpa XXXXXXXXXXXXXXXX failed on Intel Mac
+      # https://bugs.launchpad.net/qemu/+bug/1838390
+      x86_64: Haswell-v4

--- a/templates/_images/rocky-8.yaml
+++ b/templates/_images/rocky-8.yaml
@@ -21,7 +21,9 @@ images:
 
 mountTypesUnsupported: [9p]
 
-cpuType:
-  # Workaround for vmx_write_mem: mmu_gva_to_gpa XXXXXXXXXXXXXXXX failed on Intel Mac
-  # https://bugs.launchpad.net/qemu/+bug/1838390
-  x86_64: Haswell-v4
+vmOpts:
+  qemu:
+    cpuType:
+      # Workaround for vmx_write_mem: mmu_gva_to_gpa XXXXXXXXXXXXXXXX failed on Intel Mac
+      # https://bugs.launchpad.net/qemu/+bug/1838390
+      x86_64: Haswell-v4


### PR DESCRIPTION
Silence the warning:

> The top-level `cpuType` field is deprecated and will be removed in a future release.
> Please migrate to `vmOpts.qemu.cpuType`.