### PR TITLE
Multi node k8s test updates and related fixes

### DIFF
--- a/hack/bats/extras/k8s.bats
+++ b/hack/bats/extras/k8s.bats
@@ -46,7 +46,7 @@ local_setup() {
                 # kubeadm join ADDRESS --token TOKEN --discovery-token-ca-cert-hash DISCOVERY_TOKEN_CA_CERT_HASH
                 read -ra words <<< "$join_command"
                 assert_equal "${words[1]} ${words[3]} ${words[5]}" "join --token --discovery-token-ca-cert-hash"
-                params=".param.url=\"https://${words[2]}\"|.param.token=\"${words[4]}\"|.param.discoveryTokenCaCertHash=\"${words[6]}\""
+                params=".param.url=\"${words[2]}\"|.param.token=\"${words[4]}\"|.param.discoveryTokenCaCertHash=\"${words[6]}\""
             elif [[ $i -eq 0 && "${TEMPLATE}" == "k3s" ]]; then
                 url=$(printf "https://lima-%s.internal:6443\n" "${NAME}-0")
                 token=$(limactl shell "${NAME}-0" sudo cat /var/lib/rancher/k3s/server/node-token)
@@ -113,6 +113,7 @@ k() {
 
 # bats test_tags=nodes:3
 @test 'Multi-node' {
+    [ $(k get nodes -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' | grep -c True) -eq 3 ]
     # Based on https://github.com/rootless-containers/usernetes/blob/gen2-v20250828.0/hack/test-smoke.sh
     k apply -f - <<EOF
 apiVersion: v1
@@ -147,6 +148,13 @@ spec:
       labels:
         run: dnstest
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                run: dnstest
+            topologyKey: kubernetes.io/hostname
       containers:
       - name: dnstest
         image: ${TEST_CONTAINER_IMAGES[nginx]}

--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -18,7 +18,7 @@
 # (The parameters for the start command printed here)
 #
 # $ limactl start --name k8s-1 --network lima:user-v2 template:k8s \
-#                 --set '.param.url="https://<ADDRESS_FROM_ABOVE>" | .param.token="<TOKEN_FROM_ABOVE>" | \
+#                 --set '.param.url="<ADDRESS_FROM_ABOVE>" | .param.token="<TOKEN_FROM_ABOVE>" | \
 #                        .param.discoveryTokenCaCertHash="<DISCOVERY_TOKEN_CA_CERT_HASH_FROM_ABOVE>"'
 
 minimumLimaVersion: 2.0.0


### PR DESCRIPTION
Joining worker nodes to `k8s-0` was failing for two reasons:
1. `error: can not mix '--config' with arguments [discovery-token-ca-cert-hash token]` was fixed in https://github.com/lima-vm/lima/pull/4829

2. `error: discovery.bootstrapToken.apiServerEndpoint: Invalid value: "https://192.168.104.1:6443": address https://192.168.104.1:6443: too many colons in address`

Additionally, there was no failing test to detect this issue.

This MR address `2` and updates the test to detect the issue.