### PR TITLE
fix: remove kubernetes cli call when there is no config

### DIFF
--- a/pkg/guestagent/kubernetesservice/kubernetesservice.go
+++ b/pkg/guestagent/kubernetesservice/kubernetesservice.go
@@ -73,6 +73,10 @@ func (s *ServiceWatcher) attemptToStartKubectl(ctx context.Context) {
 		return
 	}
 	kubeconfig := chooseKubeconfig()
+	if kubeconfig == "" {
+		logrus.Debug("No kubeconfig found; skipping kubernetes service watcher")
+		return
+	}
 	// TODO: ensure that kubeconfig points to a local cluster
 	if err := canGetServices(ctx, kubectl, kubeconfig); err != nil {
 		logrus.WithError(err).Debugf("kubectl auth can-i ... failed; will retry")

--- a/pkg/guestagent/kubernetesservice/kubernetesservice_test.go
+++ b/pkg/guestagent/kubernetesservice/kubernetesservice_test.go
@@ -116,6 +116,21 @@ func TestGetPorts(t *testing.T) {
 	}
 }
 
+func TestChooseKubeconfig(t *testing.T) {
+	t.Run("returns KUBECONFIG env var when set", func(t *testing.T) {
+		t.Setenv("KUBECONFIG", "/tmp/my-kubeconfig.yaml")
+		got := chooseKubeconfig()
+		assert.Equal(t, got, "/tmp/my-kubeconfig.yaml")
+	})
+
+	t.Run("returns empty string when KUBECONFIG unset and no files exist", func(t *testing.T) {
+		t.Setenv("KUBECONFIG", "")
+		// Candidate paths don't exist in test environment
+		got := chooseKubeconfig()
+		assert.Equal(t, got, "")
+	})
+}
+
 func TestReadKubectlStream(t *testing.T) {
 	stream := `{"type":"ADDED","object":{"apiVersion":"v1","kind":"Service","metadata":{"creationTimestamp":"2025-09-30T13:39:19Z","labels":{"component":"apiserver","provider":"kubernetes"},"managedFields":[{"apiVersion":"v1","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{".":{},"f:component":{},"f:provider":{}}},"f:spec":{"f:clusterIP":{},"f:internalTrafficPolicy":{},"f:ipFamilyPolicy":{},"f:ports":{".":{},"k:{\"port\":443,\"protocol\":\"TCP\"}":{".":{},"f:name":{},"f:port":{},"f:protocol":{},"f:targetPort":{}}},"f:sessionAffinity":{},"f:type":{}}},"manager":"kube-apiserver","operation":"Update","time":"2025-09-30T13:39:19Z"}],"name":"kubernetes","namespace":"default","resourceVersion":"201","uid":"de36e2fb-3883-47f2-860a-c28dfd896bac"},"spec":{"clusterIP":"10.96.0.1","clusterIPs":["10.96.0.1"],"internalTrafficPolicy":"Cluster","ipFamilies":["IPv4"],"ipFamilyPolicy":"SingleStack","ports":[{"name":"https","port":443,"protocol":"TCP","targetPort":6443}],"sessionAffinity":"None","type":"ClusterIP"},"status":{"loadBalancer":{}}}}
 {"type":"ADDED","object":{"apiVersion":"v1","kind":"Service","metadata":{"annotations":{"prometheus.io/port":"9153","prometheus.io/scrape":"true"},"creationTimestamp":"2025-09-30T13:39:19Z","labels":{"k8s-app":"kube-dns","kubernetes.io/cluster-service":"true","kubernetes.io/name":"CoreDNS"},"managedFields":[{"apiVersion":"v1","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:prometheus.io/port":{},"f:prometheus.io/scrape":{}},"f:labels":{".":{},"f:k8s-app":{},"f:kubernetes.io/cluster-service":{},"f:kubernetes.io/name":{}}},"f:spec":{"f:clusterIP":{},"f:internalTrafficPolicy":{},"f:ports":{".":{},"k:{\"port\":53,\"protocol\":\"TCP\"}":{".":{},"f:name":{},"f:port":{},"f:protocol":{},"f:targetPort":{}},"k:{\"port\":53,\"protocol\":\"UDP\"}":{".":{},"f:name":{},"f:port":{},"f:protocol":{},"f:targetPort":{}},"k:{\"port\":9153,\"protocol\":\"TCP\"}":{".":{},"f:name":{},"f:port":{},"f:protocol":{},"f:targetPort":{}}},"f:selector":{},"f:sessionAffinity":{},"f:type":{}}},"manager":"kubeadm","operation":"Update","time":"2025-09-30T13:39:19Z"}],"name":"kube-dns","namespace":"kube-system","resourceVersion":"240","uid":"73817952-5f95-4a15-a6f9-64ba220a6933"},"spec":{"clusterIP":"10.96.0.10","clusterIPs":["10.96.0.10"],"internalTrafficPolicy":"Cluster","ipFamilies":["IPv4"],"ipFamilyPolicy":"SingleStack","ports":[{"name":"dns","port":53,"protocol":"UDP","targetPort":53},{"name":"dns-tcp","port":53,"protocol":"TCP","targetPort":53},{"name":"metrics","port":9153,"protocol":"TCP","targetPort":9153}],"selector":{"k8s-app":"kube-dns"},"sessionAffinity":"None","type":"ClusterIP"},"status":{"loadBalancer":{}}}}


### PR DESCRIPTION
## Overview

Fixes https://github.com/lima-vm/lima/issues/4791

When the guest agent starts up the kubernetes service watcher, it is incorrectly calling `kubectl` when no kube config exists, falling back to the default kubernetes endpoint of `127.0.0.1:8080`. This PR adds a condition where if no kubernetes config is found, the function exits early without calling `kubectl`. The loop to check for if an kubernetes config exists remains unchanged. 