### PR TITLE
Bump k8s flannel version from 0.27.4 to 0.28.4

### DIFF
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -134,7 +134,7 @@ provision:
 
     {{if not ( and .Param.url .Param.token )}}
     # Installing a Pod network add-on
-    kubectl apply -f https://github.com/flannel-io/flannel/releases/download/v0.27.4/kube-flannel.yml
+    kubectl apply -f https://github.com/flannel-io/flannel/releases/download/v0.28.2/kube-flannel.yml
     # Control plane node isolation
     kubectl taint nodes --all node-role.kubernetes.io/control-plane-
     # Symlink the kubeconfig file to the default location for kubectl

--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -134,7 +134,7 @@ provision:
 
     {{if not ( and .Param.url .Param.token )}}
     # Installing a Pod network add-on
-    kubectl apply -f https://github.com/flannel-io/flannel/releases/download/v0.27.4/kube-flannel.yml
+    kubectl apply -f https://github.com/flannel-io/flannel/releases/download/v0.28.4/kube-flannel.yml
     # Control plane node isolation
     kubectl taint nodes --all node-role.kubernetes.io/control-plane-
     # Symlink the kubeconfig file to the default location for kubectl


### PR DESCRIPTION
Upgrades the flannel plugin from 1.8.0 to 1.9.1

It gets installed in the `/opt/cni/bin` directory


```diff
@@ -145,7 +145,7 @@
           value: "5000"
         - name: CONT_WHEN_CACHE_NOT_READY
           value: "false"
-        image: ghcr.io/flannel-io/flannel:v0.27.4
+        image: ghcr.io/flannel-io/flannel:v0.28.4
         name: kube-flannel
         resources:
           requests:
@@ -172,7 +172,7 @@
         - /opt/cni/bin/flannel
         command:
         - cp
-        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.8.0-flannel1
+        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.9.1-flannel1
         name: install-cni-plugin
         volumeMounts:
         - mountPath: /opt/cni/bin
@@ -183,7 +183,7 @@
         - /etc/cni/net.d/10-flannel.conflist
         command:
         - cp
-        image: ghcr.io/flannel-io/flannel:v0.27.4
+        image: ghcr.io/flannel-io/flannel:v0.28.4
         name: install-cni
         volumeMounts:
         - mountPath: /etc/cni/net.d
```