### PR TITLE
Update nobin config with base64 and confusables checking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,14 +38,7 @@ jobs:
     - name: Verify generated files
       run: make generate check-generated
     - name: Run nobin
-      run: >-
-        go tool -modfile=./hack/tools/go.mod nobin
-        --allow-emoji
-        --allow-escape
-        --gitignore
-        --skip-ext pb.desc
-        --skip 'website/static/images/**/*.{gif,png}'
-        --skip 'docs/reports/**/*.pdf'
+      run: go tool -modfile=./hack/tools/go.mod nobin
     - name: Run editorconfig-checker
       run: go tool -modfile=./hack/tools/go.mod editorconfig-checker
     - name: Run yamllint

--- a/.nobin.yaml
+++ b/.nobin.yaml
@@ -1,0 +1,31 @@
+all: false
+gitignore: true
+skip:
+- docs/reports/**/*.pdf
+- pkg/**/*.pb.desc
+- website/static/images/**/*.{gif,png}
+skip-ext: []
+
+# Allowed characters
+allow: []
+allow-bell: false
+allow-bom: false
+allow-emoji: true
+allow-escape: true
+
+# Additional checks (opt-in)
+block-base64: 32          # 0 = disabled, N = minimum run length
+skip-base64:
+- go.sum
+- package-lock.json
+- hack/bats/lib/**/*.gpg
+- pkg/limatmpl/embed_test.go
+- pkg/sshutil/sshutil_test.go
+
+block-confusables: alphanum   # "" = disabled, "alphanum" / "url" / "strict"
+skip-confusables: []
+
+# Output
+quiet: false
+verbose: false
+hide-skipped: false


### PR DESCRIPTION
* Move config to `.nobin.yaml`
* Check for unexpected base64 data of 32 bytes or more
* check for use of unicode runes that can be confused with Latin runes

Both base64 and confusables rely on heuristics. They will not match every possible candidate to avoid false positives. Known exceptions are skipped in the config file.

See https://github.com/jandubois/nobin for more information.

You can also check dependencies by running:

```
go mod vendor
go tool -modfile=./hack/tools/go.mod nobin
```

It currently finds 62 files with issues. I haven't checked in detail, but they do look reasonable. I don't think we want to add skip rules for them; it would become a maintenance hassle.