### PR TITLE
docs(stargz): drop Rosetta/amd64 workaround now arm64 images exist (fixes #4859)

### DIFF
--- a/website/content/en/docs/examples/containers/containerd/advanced/stargz.md
+++ b/website/content/en/docs/examples/containers/containerd/advanced/stargz.md
@@ -9,16 +9,10 @@ that reduces start-up latency using lazy-pulling technique.
 
 The support for eStargz is available by default in Lima.
 
-{{% alert title="Hint" color=success %}}
-ARM Mac users need to run `limactl start` with `--rosetta` to allow [running AMD64 binaries](../../../../config/multi-arch.md).
-This is not an architectural limitation of eStargz, however, Rosetta is needed because the example Python image below
-is currently [only available for AMD64](https://github.com/containerd/stargz-snapshotter/issues/2143).
-{{% /alert %}}
-
 Without eStargz:
 
 ```console
-$ time lima nerdctl run --platform=amd64 ghcr.io/stargz-containers/python:3.13-org python3 -c 'print("hi")'
+$ time lima nerdctl run ghcr.io/stargz-containers/python:3.13-org python3 -c 'print("hi")'
 [...]
 hi
 
@@ -30,7 +24,7 @@ sys	0m0.020s
 With eStargz:
 
 ```console
-$ time lima nerdctl --snapshotter=stargz run --platform=amd64 ghcr.io/stargz-containers/python:3.13-esgz python3 -c 'print("hi")'
+$ time lima nerdctl --snapshotter=stargz run ghcr.io/stargz-containers/python:3.13-esgz python3 -c 'print("hi")'
 [...]
 hi
 


### PR DESCRIPTION
Fixes #4859.

## What changed

On the [eStargz docs page](https://lima-vm.io/docs/examples/containers/containerd/advanced/stargz/), three things are out of date now that `ghcr.io/stargz-containers/*` ships `linux/arm64` images:

1. The "Hint" callout telling ARM Mac users to start Lima with `--rosetta` is no longer needed.
2. The `--platform=amd64` flag on both `nerdctl run` examples is no longer needed.
3. The benchmark numbers (23.7s vs 13.4s) were captured on an AMD64 host.

## Why now

The image-availability reason for the AMD64 workaround is gone:

- `containerd/stargz-snapshotter#2143` ("Any multi-arch image? (especially for arm64)") was closed on 2026-04-21.
- The fix PR is [`stargz-containers/image-ci#11`](https://github.com/stargz-containers/image-ci/pull/11) (merged): the CI pipeline now builds `ghcr.io/stargz-containers/*` for `linux/arm64`.

So running the example on an ARM Mac no longer requires Rosetta or a `--platform` override.

## This PR

- Removes the "ARM Mac users need `--rosetta`" Hint block.
- Drops `--platform=amd64` from both `nerdctl` invocations.
- Leaves the existing 23.7s / 13.4s numbers in place but adds a short blockquote underneath saying they were measured on AMD64 and that wall-clock will vary by host/arch, with a pointer to re-run locally.

I intentionally did **not** resample the benchmark on arm64 — I don't have an M-series Mac available, and the speed-up illustration (roughly 2x via lazy pulling) is still meaningful at AMD64 numbers. Happy to open a follow-up with fresh arm64 numbers if someone can run it, or if you'd prefer I simply strip the numbers to `[...]` placeholders, I can do that too.

## Test plan

- [x] `rg "rosetta" website/content/en/docs/examples/containers/containerd/advanced/stargz.md` returns no hits after the change.
- [x] `rg "\-\-platform=amd64" website/content/en/docs/examples/containers/containerd/advanced/stargz.md` returns no hits after the change.
- [x] Commit is DCO-signed (`Signed-off-by:`) as required by the project.
