### PR TITLE
docs: stargz: Rosetta/--platform=amd64 no longer required on ARM Macs

### DIFF
--- a/website/content/en/docs/examples/containers/containerd/advanced/stargz.md
+++ b/website/content/en/docs/examples/containers/containerd/advanced/stargz.md
@@ -10,9 +10,10 @@ that reduces start-up latency using lazy-pulling technique.
 The support for eStargz is available by default in Lima.
 
 {{% alert title="Hint" color=success %}}
-ARM Mac users need to run `limactl start` with `--rosetta` to allow [running AMD64 binaries](../../../../config/multi-arch.md).
-This is not an architectural limitation of eStargz, however, Rosetta is needed because the example Python image below
-is currently [only available for AMD64](https://github.com/containerd/stargz-snapshotter/issues/2143).
+The example images used below are available for both `amd64` and `arm64`
+(see [containerd/stargz-snapshotter#2143](https://github.com/containerd/stargz-snapshotter/issues/2143)).
+Rosetta and `--platform=amd64` are not required on ARM Macs; the `--platform=amd64` flag is retained
+in the commands below purely so the benchmark numbers remain comparable to earlier measurements.
 {{% /alert %}}
 
 Without eStargz:


### PR DESCRIPTION
Closes #4859.

Per [containerd/stargz-snapshotter#2143](https://github.com/containerd/stargz-snapshotter/issues/2143), the `ghcr.io/stargz-containers/python:3.13-{org,esgz}` images referenced in this page are now multi-arch, so ARM Mac users no longer need Rosetta or `--platform=amd64` to pull them.

## Change

The alert block now:
- states that the example images are available for both `amd64` and `arm64`, with a link to stargz-snapshotter#2143;
- clarifies that Rosetta and `--platform=amd64` are not required on ARM Macs;
- explains why the commands below still retain `--platform=amd64` (to keep benchmark numbers comparable).

## Benchmark numbers intentionally unchanged

The issue notes that "when updating a benchmark script, the benchmark result has to be updated too". I did not re-run the benchmark, so I left the commands themselves (and the `real`/`user`/`sys` numbers) untouched. A follow-up PR is welcome to switch the examples to the native arm64 path on an ARM Mac and refresh the measurements; I didn't want to silently invalidate existing numbers.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>