### PR TITLE
docs: add blogs section with curated CNCF and nttlabs posts

### DIFF
--- a/website/content/en/docs/blogs/_index.md
+++ b/website/content/en/docs/blogs/_index.md
@@ -3,7 +3,15 @@ title: Blogs
 weight: 451
 ---
 
-Curated blog articles about Lima. Suggestions welcome via [GitHub issues](https://github.com/lima-vm/lima/issues).
+Curated blog articles about Lima. Community-contributed additions are collected in the [Show and tell](https://github.com/lima-vm/lima/discussions/categories/show-and-tell) discussion category, in particular the [Community blogs and write-ups about Lima](https://github.com/lima-vm/lima/discussions/4864) thread -- please add new finds there and the best-known ones will be folded into this page over time.
+
+## 2021
+
+### containerd & Lima: Open source alternative to Docker for Mac
+
+[Akihiro Suda](https://github.com/AkihiroSuda) on Lima as a free, libre, and open source alternative to Docker for Mac, paired with containerd and nerdctl.
+
+Read the [post on nttlabs / Medium](https://medium.com/nttlabs/containerd-and-lima-39e0b64d2a59).
 
 ## 2022
 
@@ -13,7 +21,41 @@ Curated blog articles about Lima. Suggestions welcome via [GitHub issues](https:
 
 Read the [post on nttlabs / Medium](https://medium.com/nttlabs/lima-is-now-a-cncf-project-a7affde4f03c).
 
+## 2023
+
+### Lima: a nice way to run Linux VMs on Mac
+
+[Julia Evans](https://jvns.ca/) walks through using Lima day-to-day to run Linux VMs on macOS.
+
+Read the [post on jvns.ca](https://jvns.ca/blog/2023/07/10/lima--a-nice-way-to-run-linux-vms-on-mac/).
+
+## 2024
+
+### Accelerating Llama on Lima, with WASI-NN RPC
+
+[Akihiro Suda](https://github.com/AkihiroSuda) on exposing host GPUs to Lima VMs through WASI-NN over gRPC, taking Llama 2 on Apple M2 Pro from 0.66 to 14.73 tokens/s.
+
+Read the [post on nttlabs / Medium](https://medium.com/nttlabs/accelerating-llama-on-lima-with-wasi-nn-rpc-06b84bcbbe5c).
+
+### Lima completes fuzzing audit
+
+CNCF blog post covering the third-party fuzzing audit of Lima and its findings.
+
+Read the [post on the CNCF blog](https://www.cncf.io/blog/2024/10/10/lima-completes-fuzzing-audit/).
+
+### containerd v2.0, nerdctl v2.0, Lima v1.0
+
+[Akihiro Suda](https://github.com/AkihiroSuda) on the coordinated v2.0 / v2.0 / v1.0 releases of containerd, nerdctl, and Lima.
+
+Read the [post on nttlabs / Medium](https://medium.com/nttlabs/containerd-v2-0-nerdctl-v2-0-lima-v1-0-93026b5839f8).
+
 ## 2025
+
+### containerd v2.1, nerdctl v2.1, and Lima v1.1
+
+[Akihiro Suda](https://github.com/AkihiroSuda) on the next coordinated release wave across containerd, nerdctl, and Lima.
+
+Read the [post on nttlabs / Medium](https://medium.com/nttlabs/containerd-v2-1-nerdctl-v2-1-and-lima-v1-1-74400ee87c2c).
 
 ### Lima becomes a CNCF incubating project
 
@@ -34,3 +76,13 @@ Read the [post on the CNCF blog](https://www.cncf.io/blog/2025/12/11/lima-v2-0-n
 Highlights of the Lima 2.1 release, covering experimental macOS and FreeBSD guest support, `limactl shell --sync` for safer AI-agent sandboxing, a smaller guestagent footprint, and the new `limactl watch` command.
 
 Read the [post on the CNCF blog](https://www.cncf.io/blog/2026/03/25/lima-v2-1-macos-guests-and-enhanced-ai-agent-safety/).
+
+## More community posts
+
+Additional community write-ups collected so far -- add to or comment on the [Show and tell discussion](https://github.com/lima-vm/lima/discussions/4864) to have yours folded in:
+
+- [Exposing LoadBalancer services running on kind in Lima VMs](https://medium.com/@lizrice/exposing-loadbalancer-services-running-on-kind-in-lima-vms-4d58cd4b5e12) -- Liz Rice
+- [Lima, Linux on macOS without the ceremony](https://cloudsecburrito.com/lima-linux-on-macos-without-the-ceremony)
+- [Setup K3s single-node GitOps dengan Flux](https://blog.wayanjim.my.id/en/posts/setup-k3s-single-node-gitops-dengan-flux) -- Wayan Jimmy
+- [Why I chose limactl](https://medium.com/@lysharing/why-i-chose-limactl-461840c476ad)
+- [Lima on Tencent Cloud developer blog](https://cloud.tencent.com.cn/developer/article/2425111)

--- a/website/content/en/docs/blogs/_index.md
+++ b/website/content/en/docs/blogs/_index.md
@@ -1,0 +1,36 @@
+---
+title: Blogs
+weight: 451
+---
+
+Curated blog articles about Lima. Suggestions welcome via [GitHub issues](https://github.com/lima-vm/lima/issues).
+
+## 2022
+
+### Lima is now a CNCF project
+
+[Akihiro Suda](https://github.com/AkihiroSuda) on Lima's acceptance into CNCF at the Sandbox level.
+
+Read the [post on nttlabs / Medium](https://medium.com/nttlabs/lima-is-now-a-cncf-project-a7affde4f03c).
+
+## 2025
+
+### Lima becomes a CNCF incubating project
+
+Announcement covering Lima's promotion from Sandbox to Incubating.
+
+Read the [post on the CNCF blog](https://www.cncf.io/blog/2025/11/11/lima-becomes-a-cncf-incubating-project/).
+
+### Lima v2.0: New features for secure AI workflows
+
+Highlights of the Lima 2.0 release, covering plugin infrastructure (VM driver, CLI, URL-scheme plugins), GPU acceleration via `krunkit`, Model Context Protocol tooling, and expanded networking.
+
+Read the [post on the CNCF blog](https://www.cncf.io/blog/2025/12/11/lima-v2-0-new-features-for-secure-ai-workflows/).
+
+## 2026
+
+### Lima v2.1: macOS guests and enhanced AI agent safety
+
+Highlights of the Lima 2.1 release, covering experimental macOS and FreeBSD guest support, `limactl shell --sync` for safer AI-agent sandboxing, a smaller guestagent footprint, and the new `limactl watch` command.
+
+Read the [post on the CNCF blog](https://www.cncf.io/blog/2026/03/25/lima-v2-1-macos-guests-and-enhanced-ai-agent-safety/).


### PR DESCRIPTION
### Summary

Addresses #4818 -- adds the curated `blogs` section Akihiro suggested when #4817 landed.

Creates `website/content/en/docs/blogs/_index.md`, modelled directly on the `talks/_index.md` structure (year-bucketed `##` headings, `###` per entry, one-line description, "Read the [post on ...]" link). Weight is `451` so the section appears right under Talks (450) in the sidebar.

### Seed content

Four well-known posts to start with; easy to grow from here:

- **2022 -- nttlabs / Medium:** [Lima is now a CNCF project](https://medium.com/nttlabs/lima-is-now-a-cncf-project-a7affde4f03c) (@AkihiroSuda, Sandbox entry)
- **2025 -- CNCF blog:** [Lima becomes a CNCF incubating project](https://www.cncf.io/blog/2025/11/11/lima-becomes-a-cncf-incubating-project/)
- **2025 -- CNCF blog:** [Lima v2.0: New features for secure AI workflows](https://www.cncf.io/blog/2025/12/11/lima-v2-0-new-features-for-secure-ai-workflows/)
- **2026 -- CNCF blog:** [Lima v2.1: macOS guests and enhanced AI agent safety](https://www.cncf.io/blog/2026/03/25/lima-v2-1-macos-guests-and-enhanced-ai-agent-safety/)

If you prefer a different initial set (e.g. include Rancher Desktop / Colima coverage, or a specific author's post) happy to swap.

### Checklist

- [x] DCO signed-off
- [x] Structure mirrors `talks/_index.md`
- [x] No new nav wiring needed -- Hugo picks it up from the `_index.md` weight

Closes #4818.