### PR TITLE
Support attaching `/dev/diskN` block devices on macOS VZ hosts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -582,6 +582,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         persist-credentials: false
+        submodules: true
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       with:
         go-version: stable
@@ -600,6 +601,8 @@ jobs:
       run: brew uninstall --ignore-dependencies --force qemu
     - name: Test
       run: ./hack/test-templates.sh templates/${{ matrix.template }}
+    - name: Run BATS VZ block-device tests
+      run: ./hack/bats/lib/bats-core/bin/bats --timing ./hack/bats/extras/vz-block-device.bats
     - if: failure()
       uses: ./.github/actions/upload_failure_logs_if_exists
       with:

--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -67,6 +67,7 @@ func RegisterEdit(cmd *cobra.Command, commentPrefix string) {
 	flags.Bool("nested-virt", false, commentPrefix+"Enable nested virtualization")
 
 	flags.Bool("rosetta", false, commentPrefix+"Enable Rosetta (for vz instances)")
+	flags.StringSlice("block-device", nil, commentPrefix+"Host block devices to attach on supported backends, e.g. /dev/disk4")
 
 	flags.StringArray("set", []string{}, commentPrefix+"Modify the template inplace, using yq syntax. Can be passed multiple times. See 'limactl help yq-restrictions' for limitations.")
 	flags.StringArray("param", []string{}, commentPrefix+"Set a template parameter, e.g. name=value. Can be passed multiple times.")
@@ -344,6 +345,25 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool, params map[string]stri
 					return nil, err
 				}
 				return []string{fmt.Sprintf(".vmOpts.vz.rosetta.enabled = %v | .vmOpts.vz.rosetta.binfmt = %v", b, b)}, nil
+			},
+			false,
+			false,
+		},
+		{
+			"block-device",
+			func(_ *flag.Flag) ([]string, error) {
+				paths, err := flags.GetStringSlice("block-device")
+				if err != nil {
+					return nil, err
+				}
+				devices := make([]string, len(paths))
+				for i, path := range paths {
+					if path == "" {
+						return nil, errors.New("block device path must not be empty")
+					}
+					devices[i] = strconv.Quote(path)
+				}
+				return []string{fmt.Sprintf(".blockDevices += [%s] | .blockDevices |= unique", strings.Join(devices, ","))}, nil
 			},
 			false,
 			false,

--- a/cmd/limactl/editflags/editflags_test.go
+++ b/cmd/limactl/editflags/editflags_test.go
@@ -285,6 +285,12 @@ func TestYQExpressions(t *testing.T) {
 			expectError: "template does not define param `missing`",
 		},
 		{
+			name:        "block-device",
+			args:        []string{"--block-device", "/dev/disk4", "--block-device", "/dev/rdisk5"},
+			newInstance: false,
+			expected:    []string{`.blockDevices += ["/dev/disk4","/dev/rdisk5"] | .blockDevices |= unique`},
+		},
+		{
 			name:        "invalid network",
 			args:        []string{"--network", "invalid"},
 			newInstance: true,

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -32,7 +32,7 @@ const (
 )
 
 func main() {
-	if os.Geteuid() == 0 && (len(os.Args) < 2 || os.Args[1] != "generate-doc") {
+	if os.Geteuid() == 0 && (len(os.Args) < 2 || (os.Args[1] != "generate-doc" && !isPrivilegedHelperCommand(os.Args[1]))) {
 		fmt.Fprint(os.Stderr, "limactl: must not run as the root user\n")
 		os.Exit(1)
 	}
@@ -136,6 +136,9 @@ func newApp() *cobra.Command {
 			// allow commands that are used for packaging to run under rosetta to allow cross-architecture builds
 			return errors.New("limactl is running under rosetta, please reinstall lima with native arch")
 		}
+		if isPrivilegedHelperCommand(cmd.Name()) {
+			return nil
+		}
 
 		// Make sure either $HOME or $LIMA_HOME is defined, so we don't need
 		// to check for errors later
@@ -212,6 +215,7 @@ func newApp() *cobra.Command {
 		newWatchCommand(),
 		newYQRestrictionsHelpCommand(),
 	)
+	registerHiddenCommands(rootCmd)
 	addPluginCommands(rootCmd)
 
 	return rootCmd

--- a/cmd/limactl/sudo_open_block_device_command_darwin.go
+++ b/cmd/limactl/sudo_open_block_device_command_darwin.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/v2/pkg/blockdevice"
+)
+
+func isPrivilegedHelperCommand(name string) bool {
+	return name == blockdevice.SudoOpenBlockDeviceCommand
+}
+
+func registerHiddenCommands(rootCmd *cobra.Command) {
+	rootCmd.AddCommand(&cobra.Command{
+		Use:    blockdevice.SudoOpenBlockDeviceCommand,
+		Short:  "Open a host block device via privileged helper",
+		Args:   WrapArgsError(cobra.NoArgs),
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return blockdevice.ServeSudoOpenBlockDevice(cmd.InOrStdin())
+		},
+	})
+}

--- a/cmd/limactl/sudo_open_block_device_command_others.go
+++ b/cmd/limactl/sudo_open_block_device_command_others.go
@@ -1,0 +1,14 @@
+//go:build !darwin
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "github.com/spf13/cobra"
+
+func isPrivilegedHelperCommand(string) bool {
+	return false
+}
+
+func registerHiddenCommands(_ *cobra.Command) {}

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -27,7 +27,8 @@ To validate the existing /etc/sudoers.d/lima file:
 $ limactl sudoers --check /etc/sudoers.d/lima
 `,
 		Short: "Generate the content of the /etc/sudoers.d/lima file",
-		Long: fmt.Sprintf(`Generate the content of the /etc/sudoers.d/lima file for enabling vmnet.framework support (socket_vmnet) on macOS.
+		Long: fmt.Sprintf(`Generate the content of the /etc/sudoers.d/lima file for macOS host helpers that require privilege escalation.
+This includes vmnet.framework support (socket_vmnet) and host block-device attachment with --block-device on supported backends.
 The content is written to stdout, NOT to the file.
 This command must not run as the root user.
 See %s for the usage.`, socketVMNetURL),

--- a/cmd/limactl/sudoers_darwin.go
+++ b/cmd/limactl/sudoers_darwin.go
@@ -8,22 +8,19 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/lima-vm/lima/v2/pkg/blockdevice"
 	"github.com/lima-vm/lima/v2/pkg/networks"
+	"github.com/lima-vm/lima/v2/pkg/sudoers"
 )
 
 func sudoersAction(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	nwCfg, err := networks.LoadConfig()
 	if err != nil {
-		return err
-	}
-	// Make sure the current network configuration is secure
-	if err := nwCfg.Validate(); err != nil {
-		logrus.Infof("Please check %s for more information.", socketVMNetURL)
 		return err
 	}
 	check, err := cmd.Flags().GetBool("check")
@@ -41,11 +38,16 @@ func sudoersAction(cmd *cobra.Command, args []string) error {
 	default:
 		return fmt.Errorf("unexpected arguments %v", args)
 	}
-	sudoers, err := networks.Sudoers()
+	networkSudoers, err := nwCfg.Sudoers()
 	if err != nil {
 		return err
 	}
-	fmt.Fprint(cmd.OutOrStdout(), sudoers)
+	blockDeviceSudoers, err := blockdevice.Sudoers(nwCfg.Group)
+	if err != nil {
+		return err
+	}
+	content := sudoers.AssembleSudoersFragments(networkSudoers, blockDeviceSudoers)
+	fmt.Fprint(cmd.OutOrStdout(), content)
 	return nil
 }
 
@@ -63,9 +65,38 @@ func verifySudoAccess(ctx context.Context, nwCfg networks.Config, args []string,
 	default:
 		return errors.New("can check only a single sudoers file")
 	}
-	if err := nwCfg.VerifySudoAccess(ctx, file); err != nil {
+	if err := verifySudoersFile(ctx, nwCfg, file); err != nil {
 		return err
 	}
 	fmt.Fprintf(stdout, "%#q is up-to-date (or sudo doesn't require a password)\n", file)
+	return nil
+}
+
+func verifySudoersFile(ctx context.Context, nwCfg networks.Config, file string) error {
+	hint := fmt.Sprintf("run `%s sudoers >etc_sudoers.d_lima && sudo install -o root etc_sudoers.d_lima %q`)",
+		os.Args[0], file)
+	b, err := os.ReadFile(file)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if err := nwCfg.VerifySudoAccess(ctx, ""); err == nil {
+				if err := sudoers.Run(ctx, "root", "wheel", nil, nil, nil, "", "true"); err == nil {
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("can't read %q: %w: (Hint: %s)", file, err, hint)
+	}
+	networkSudoers, err := nwCfg.Sudoers()
+	if err != nil {
+		return err
+	}
+	blockDeviceSudoers, err := blockdevice.Sudoers(nwCfg.Group)
+	if err != nil {
+		return err
+	}
+	content := sudoers.AssembleSudoersFragments(networkSudoers, blockDeviceSudoers)
+	if string(b) != content {
+		return fmt.Errorf("sudoers file %q is out of sync and must be regenerated (Hint: %s)", file, hint)
+	}
 	return nil
 }

--- a/hack/bats/extras/vz-block-device.bats
+++ b/hack/bats/extras/vz-block-device.bats
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load "../helpers/load"
+
+# End-to-end flow:
+# 1. Create a tiny host RAM disk and attach it to a VZ VM as either /dev/diskN or /dev/rdiskN.
+# 2. In the guest, partition it as GPT with an msftdata partition, format it as exFAT, and write test data.
+# 3. Stop the VM, mount the same partition on the macOS host, verify the guest write, and append more data.
+# 4. Start the VM again, verify the host write from the guest, append again, stop the VM, and verify the final
+#    contents from the host once more. This exercises the real guest<->host handoff instead of just local helpers.
+
+configured_block_device=""
+host_disk_device=""
+host_partition=""
+instance_name=""
+
+teardown() {
+	if [[ -n ${instance_name} ]]; then
+		limactl unprotect "${instance_name}" || :
+		limactl delete --force "${instance_name}" || :
+	fi
+	if [[ -n ${host_partition} ]]; then
+		sudo diskutil unmount force "${host_partition}" >/dev/null 2>&1 || :
+	fi
+	if [[ -n ${host_disk_device} ]]; then
+		sudo diskutil unmountDisk force "${host_disk_device}" >/dev/null 2>&1 || :
+		sudo hdiutil detach "${host_disk_device}" -force >/dev/null 2>&1 || :
+	fi
+	configured_block_device=""
+	host_disk_device=""
+	host_partition=""
+	instance_name=""
+}
+
+bats::on_failure() {
+	if [[ -n ${instance_name} ]] && [[ -d ${LIMA_HOME}/${instance_name} ]]; then
+		tail -n 100 "${LIMA_HOME}/${instance_name}"/*.log || :
+		limactl shell "${instance_name}" -- sudo cat /var/log/cloud-init-output.log || :
+	fi
+}
+
+create_ramdisk() {
+	host_disk_device=$(sudo hdiutil attach -nomount ram://65536 | awk 'NR==1 {print $1}')
+	[[ -n ${host_disk_device} ]]
+}
+
+configure_block_device_path() {
+	case "$1" in
+	disk)
+		configured_block_device="${host_disk_device}"
+		;;
+	rdisk)
+		configured_block_device="${host_disk_device/\/dev\/disk/\/dev\/rdisk}"
+		;;
+	*)
+		echo "unknown block device kind: $1" >&2
+		return 1
+		;;
+	esac
+}
+
+start_vz_instance_with_cli_flag() {
+	local extra_args=()
+	if [[ -n ${LIMACTL_CREATE_ARGS:-} ]]; then
+		read -r -a extra_args <<<"${LIMACTL_CREATE_ARGS}"
+	fi
+
+	limactl delete --force "${instance_name}" || :
+	limactl start --tty=false \
+		"${extra_args[@]}" \
+		--vm-type=vz \
+		--block-device "${configured_block_device}" \
+		--name "${instance_name}" \
+		template:default \
+		3>&- 4>&-
+}
+
+start_vz_instance_with_yaml() {
+	local config_file="${BATS_TEST_TMPDIR}/${instance_name}.yaml"
+	local extra_args=()
+	if [[ -n ${LIMACTL_CREATE_ARGS:-} ]]; then
+		read -r -a extra_args <<<"${LIMACTL_CREATE_ARGS}"
+	fi
+
+	cat >"${config_file}" <<EOF
+base: template:default
+vmType: vz
+blockDevices:
+  - ${configured_block_device}
+EOF
+
+	limactl delete --force "${instance_name}" || :
+	limactl start --tty=false \
+		"${extra_args[@]}" \
+		--name "${instance_name}" \
+		"${config_file}" \
+		3>&- 4>&-
+}
+
+format_and_write_from_guest() {
+	local guest_block_device=$1
+	local guest_partition_by_id=$2
+	local volume_label=$3
+	local expected_contents=$4
+
+	limactl shell "${instance_name}" bash -eus -- "${guest_block_device}" "${guest_partition_by_id}" "${volume_label}" "${expected_contents}" <<'EOF'
+guest_block_device="$1"
+guest_partition_by_id="$2"
+volume_label="$3"
+expected_contents="$4"
+guest_partition="$guest_partition_by_id"
+
+if ! command -v mkfs.exfat >/dev/null 2>&1 || ! command -v parted >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y exfatprogs parted
+fi
+
+# macOS only auto-recognizes the guest-created exFAT filesystem after shutdown if the GPT partition type is
+# Microsoft Basic Data rather than the generic Linux filesystem type.
+sudo parted -s "${guest_block_device}" -- mklabel gpt mkpart primary 1MiB 100% set 1 msftdata on
+sudo udevadm settle
+if [ ! -e "${guest_partition}" ]; then
+    # /dev/disk/by-id/...-part1 is the stable path we expect, but udev can lag behind partition creation.
+    # Fall back to the first partition discovered directly from lsblk so the test still validates the same disk.
+    guest_partition="$(lsblk -nrpo PATH "${guest_block_device}" | sed -n '2p')"
+fi
+test -n "${guest_partition}"
+sudo mkfs.exfat -n "${volume_label}" "${guest_partition}"
+sudo mkdir -p /mnt/test
+sudo mount "${guest_partition}" /mnt/test
+printf '%s\n' "${expected_contents}" | sudo tee /mnt/test/test.txt >/dev/null
+sudo sync
+if [ "$(cat /mnt/test/test.txt)" != "${expected_contents}" ]; then
+    exit 1
+fi
+sudo umount /mnt/test
+EOF
+}
+
+append_and_verify_from_guest() {
+	local guest_block_device=$1
+	local guest_partition_by_id=$2
+	local append_line=$3
+	local expected_before=$4
+	local expected_after=$5
+
+	limactl shell "${instance_name}" bash -eus -- "${guest_block_device}" "${guest_partition_by_id}" "${append_line}" "${expected_before}" "${expected_after}" <<'EOF'
+guest_block_device="$1"
+guest_partition_by_id="$2"
+append_line="$3"
+expected_before="$4"
+expected_after="$5"
+guest_partition="$guest_partition_by_id"
+
+if [ ! -e "${guest_partition}" ]; then
+    # After the host mount/unmount handoff, the by-id partition symlink may reappear later than the block device.
+    guest_partition="$(lsblk -nrpo PATH "${guest_block_device}" | sed -n '2p')"
+fi
+test -n "${guest_partition}"
+sudo mkdir -p /mnt/test
+sudo mount "${guest_partition}" /mnt/test
+if [ "$(cat /mnt/test/test.txt)" != "${expected_before}" ]; then
+    exit 1
+fi
+printf '%s\n' "${append_line}" | sudo tee -a /mnt/test/test.txt >/dev/null
+sudo sync
+if [ "$(cat /mnt/test/test.txt)" != "${expected_after}" ]; then
+    exit 1
+fi
+sudo umount /mnt/test
+EOF
+}
+
+mount_and_verify_from_host() {
+	local expected_contents=$1
+
+	# Resolve the host-visible partition that backs the same raw RAM disk after the guest has partitioned it.
+	host_partition="$(diskutil list "${host_disk_device}" | awk '$NF ~ /^disk[0-9]+s[0-9]+$/ {print "/dev/" $NF; exit}')"
+	[[ -n ${host_partition} ]]
+
+	sudo diskutil mount "${host_partition}" >/dev/null
+	local host_mount_point
+	host_mount_point=$(diskutil info -plist "${host_partition}" | plutil -extract MountPoint raw -o - -)
+	[[ -n ${host_mount_point} ]]
+
+	run -0 cat "${host_mount_point}/test.txt"
+	assert_output "${expected_contents}"
+}
+
+append_and_verify_from_host() {
+	local append_line=$1
+	local expected_before=$2
+	local expected_after=$3
+
+	mount_and_verify_from_host "${expected_before}"
+
+	local host_mount_point
+	host_mount_point=$(diskutil info -plist "${host_partition}" | plutil -extract MountPoint raw -o - -)
+	[[ -n ${host_mount_point} ]]
+
+	printf '%s\n' "${append_line}" | sudo tee -a "${host_mount_point}/test.txt" >/dev/null
+	run -0 cat "${host_mount_point}/test.txt"
+	assert_output "${expected_after}"
+}
+
+unmount_host_partition() {
+	[[ -n ${host_partition} ]]
+	sudo diskutil unmount force "${host_partition}"
+	host_partition=""
+}
+
+run_roundtrip_test() {
+	local block_device_kind=$1
+	local start_mode=$2
+	local expected_after_guest_1
+	local expected_after_host_1
+	local expected_after_guest_2
+	local block_device_id
+	local guest_block_device
+	local guest_partition_by_id
+	local volume_label
+
+	[[ $(uname) == "Darwin" ]] || skip "requires macOS host"
+	command -v hdiutil >/dev/null
+	command -v diskutil >/dev/null
+	command -v plutil >/dev/null
+
+	instance_name="vz-block-device-${block_device_kind}"
+	create_ramdisk
+	configure_block_device_path "${block_device_kind}"
+
+	block_device_id=$(basename "${configured_block_device}")
+	guest_block_device="/dev/disk/by-id/virtio-${block_device_id}"
+	guest_partition_by_id="/dev/disk/by-id/virtio-${block_device_id}-part1"
+	volume_label="LIMABD${RANDOM}"
+	expected_after_guest_1="$(printf 'guest-1')"
+	expected_after_host_1="$(printf 'guest-1\nhost-1')"
+	expected_after_guest_2="$(printf 'guest-1\nhost-1\nguest-2')"
+
+	# Cover both user-facing entry points: CLI flag wiring and YAML config wiring.
+	case "${start_mode}" in
+	cli)
+		start_vz_instance_with_cli_flag
+		;;
+	yaml)
+		start_vz_instance_with_yaml
+		;;
+	*)
+		echo "unknown start mode: ${start_mode}" >&2
+		return 1
+		;;
+	esac
+	format_and_write_from_guest "${guest_block_device}" "${guest_partition_by_id}" "${volume_label}" "${expected_after_guest_1}"
+	limactl stop "${instance_name}"
+
+	# The host and guest must not mount the filesystem concurrently; this validates the intended stop/remount handoff.
+	append_and_verify_from_host "host-1" "${expected_after_guest_1}" "${expected_after_host_1}"
+	unmount_host_partition
+
+	limactl start --tty=false "${instance_name}" 3>&- 4>&-
+	append_and_verify_from_guest "${guest_block_device}" "${guest_partition_by_id}" "guest-2" "${expected_after_host_1}" "${expected_after_guest_2}"
+	limactl stop "${instance_name}"
+
+	mount_and_verify_from_host "${expected_after_guest_2}"
+}
+
+@test "VZ block device roundtrip via CLI flag and /dev/diskN" {
+	# /dev/diskN is the documented host-facing path users are most likely to provide.
+	run_roundtrip_test disk cli
+}
+
+@test "VZ block device roundtrip via YAML and /dev/rdiskN" {
+	# /dev/rdiskN exercises the raw-device variant and the YAML blockDevices configuration path in one case.
+	run_roundtrip_test rdisk yaml
+}

--- a/hack/bats/tests/shell.bats
+++ b/hack/bats/tests/shell.bats
@@ -5,6 +5,10 @@ load "../helpers/load"
 
 INSTANCE=bats-dummy
 
+normalize_stderr_log() {
+    printf '%s\n' "$1" | sed -E 's/^time="[^"]+" //'
+}
+
 @test 'lima stopped lima instance' {
     # check that the "tty" flag is used, also for stdin
     run_e -1 limactl shell --tty=false "$INSTANCE" true </dev/null
@@ -36,12 +40,10 @@ INSTANCE=bats-dummy
     # --instance should resolve the instance name the same way as the positional arg.
     # Normalize the logrus timestamp because the two invocations may land in different seconds.
     run_e -1 limactl shell --tty=false --instance nonexistent
-    inst_output=$(sed 's/^time="[^"]*"/time="TIMESTAMP"/' <<<"$stderr")
+    inst_output=$(normalize_stderr_log "$stderr")
 
     run_e -1 limactl shell --tty=false nonexistent
-    pos_output=$(sed 's/^time="[^"]*"/time="TIMESTAMP"/' <<<"$stderr")
-
-    assert_equal "$pos_output" "$inst_output"
+    assert_equal "$inst_output" "$(normalize_stderr_log "$stderr")"
 }
 
 @test 'limactl shell --instance with unknown flag errors' {

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -600,7 +600,9 @@ fi
 if [[ -n ${CHECKS["user-v2"]} ]]; then
 	INFO "Testing user-v2 network"
 	secondvm="$NAME-1"
+	limactl delete -f "$secondvm" >/dev/null 2>&1 || true
 	"${LIMACTL_CREATE[@]}" --set ".additionalDisks=null" "$FILE_HOST" --name "$secondvm"
+	defer "limactl delete -f \"$secondvm\" >/dev/null 2>&1 || true"
 	if ! limactl start "$secondvm"; then
 		ERROR "Failed to start \"$secondvm\""
 		diagnose "$secondvm"

--- a/pkg/blockdevice/block_device_darwin.go
+++ b/pkg/blockdevice/block_device_darwin.go
@@ -1,0 +1,213 @@
+//go:build darwin
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package blockdevice
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/balajiv113/fd"
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/sudoers"
+)
+
+// SudoOpenBlockDeviceCommand is the hidden helper that opens a host block
+// device as root and passes the descriptor back to the unprivileged process.
+const SudoOpenBlockDeviceCommand = "sudo-open-block-device"
+
+// ServeSudoOpenBlockDevice runs inside the short-lived privileged helper
+// process launched via sudo. It receives a JSON request on stdin, opens the
+// requested host device node as root, and sends the resulting file descriptor
+// back to the already-running unprivileged process over a private Unix socket.
+func ServeSudoOpenBlockDevice(r io.Reader) error {
+	var req sudoOpenBlockDeviceRequest
+	if err := json.NewDecoder(r).Decode(&req); err != nil {
+		return fmt.Errorf("failed to decode request: %w", err)
+	}
+	if err := req.validate(); err != nil {
+		return err
+	}
+
+	deviceFile, err := os.OpenFile(req.DevicePath, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open %q: %w", req.DevicePath, err)
+	}
+	defer deviceFile.Close()
+
+	fi, err := deviceFile.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat %q: %w", req.DevicePath, err)
+	}
+	if fi.Mode()&os.ModeDevice == 0 {
+		return fmt.Errorf("%q is not a device node", req.DevicePath)
+	}
+
+	socketAddr, err := net.ResolveUnixAddr("unix", req.SocketPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve socket %q: %w", req.SocketPath, err)
+	}
+	conn, err := net.DialUnix("unix", nil, socketAddr)
+	if err != nil {
+		return fmt.Errorf("failed to connect to socket %q: %w", req.SocketPath, err)
+	}
+	defer conn.Close()
+
+	if err := fd.Put(conn, deviceFile); err != nil {
+		return fmt.Errorf("failed to send file descriptor for %q: %w", req.DevicePath, err)
+	}
+	return nil
+}
+
+// sudoOpenBlockDeviceRequest is the JSON payload sent to the privileged helper.
+// SocketPath is the absolute path to the private Unix socket that the helper
+// must connect back to after opening DevicePath, so it can return the opened
+// file descriptor to the unprivileged caller via SCM_RIGHTS.
+type sudoOpenBlockDeviceRequest struct {
+	DevicePath string `json:"devicePath"`
+	SocketPath string `json:"socketPath"`
+}
+
+// Sudoers returns the sudoers fragment needed to run the hidden block-device
+// helper without prompting.
+func Sudoers(group string) (string, error) {
+	helperArgs, err := sudoOpenBlockDeviceHelperArgs()
+	if err != nil {
+		return "", err
+	}
+	return sudoers.NOPASSWD("%"+group, "root", "wheel", strings.Join(helperArgs, " ")), nil
+}
+
+func (r sudoOpenBlockDeviceRequest) validate() error {
+	if r.DevicePath == "" {
+		return errors.New("devicePath must not be empty")
+	}
+	if !filepath.IsAbs(r.DevicePath) {
+		return fmt.Errorf("devicePath %q must be an absolute path", r.DevicePath)
+	}
+	if filepath.Clean(r.DevicePath) != r.DevicePath {
+		return fmt.Errorf("devicePath %q must be normalized", r.DevicePath)
+	}
+	if !strings.HasPrefix(r.DevicePath, "/dev/") {
+		return fmt.Errorf("devicePath %q must be under /dev", r.DevicePath)
+	}
+
+	if r.SocketPath == "" {
+		return errors.New("socketPath must not be empty")
+	}
+	if !filepath.IsAbs(r.SocketPath) {
+		return fmt.Errorf("socketPath %q must be an absolute path", r.SocketPath)
+	}
+	if filepath.Clean(r.SocketPath) != r.SocketPath {
+		return fmt.Errorf("socketPath %q must be normalized", r.SocketPath)
+	}
+	return nil
+}
+
+func sudoOpenBlockDeviceHelperArgs() ([]string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+	if strings.ContainsAny(exe, " \t\r\n") {
+		return nil, fmt.Errorf("limactl executable path %q contains whitespace and cannot be used in sudoers", exe)
+	}
+	return []string{exe, SudoOpenBlockDeviceCommand}, nil
+}
+
+// Open creates a private Unix socket, asks the privileged helper to open the
+// host device and connect back to that socket, then returns a duplicated
+// descriptor that the caller can retain for as long as needed.
+func Open(ctx context.Context, devicePath, socketPath string) (*os.File, error) {
+	helperArgs, err := sudoOpenBlockDeviceHelperArgs()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.RemoveAll(socketPath); err != nil {
+		return nil, err
+	}
+
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on %q: %w", socketPath, err)
+	}
+	listener.SetUnlinkOnClose(true)
+	defer func() {
+		_ = listener.Close()
+		_ = os.RemoveAll(socketPath)
+	}()
+
+	req := sudoOpenBlockDeviceRequest{
+		DevicePath: devicePath,
+		SocketPath: socketPath,
+	}
+	var stdin bytes.Buffer
+	if err := json.NewEncoder(&stdin).Encode(req); err != nil {
+		return nil, err
+	}
+
+	type receivedFD struct {
+		file *os.File
+		err  error
+	}
+	fdCh := make(chan receivedFD, 1)
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			fdCh <- receivedFD{err: err}
+			return
+		}
+		defer conn.Close()
+
+		files, err := fd.Get(conn, 1, []string{filepath.Base(devicePath)})
+		if err != nil {
+			fdCh <- receivedFD{err: err}
+			return
+		}
+		if len(files) != 1 {
+			for _, file := range files {
+				_ = file.Close()
+			}
+			fdCh <- receivedFD{err: fmt.Errorf("expected 1 file descriptor for %q, got %d", devicePath, len(files))}
+			return
+		}
+		fdCh <- receivedFD{file: files[0]}
+	}()
+
+	var stdout, stderr bytes.Buffer
+	cmd := sudoers.NewCommand(ctx, "root", "wheel", &stdin, &stdout, &stderr, "", helperArgs...)
+	logrus.Debugf("Opening block device %q via sudo helper: %v", devicePath, cmd.Args)
+	if err := cmd.Run(); err != nil {
+		_ = listener.Close()
+		received := <-fdCh
+		if received.file != nil {
+			_ = received.file.Close()
+		}
+		return nil, fmt.Errorf("failed to run %v: stdout=%q, stderr=%q: %w", cmd.Args, stdout.String(), stderr.String(), err)
+	}
+
+	received := <-fdCh
+	if received.err != nil {
+		return nil, fmt.Errorf("failed to receive file descriptor for %q: %w", devicePath, received.err)
+	}
+	dupFD, err := syscall.Dup(int(received.file.Fd()))
+	if err != nil {
+		_ = received.file.Close()
+		return nil, fmt.Errorf("failed to duplicate file descriptor for %q: %w", devicePath, err)
+	}
+	_ = received.file.Close()
+
+	return os.NewFile(uintptr(dupFD), filepath.Base(devicePath)), nil
+}

--- a/pkg/blockdevice/block_device_darwin_test.go
+++ b/pkg/blockdevice/block_device_darwin_test.go
@@ -1,0 +1,83 @@
+//go:build darwin
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package blockdevice
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSudoers(t *testing.T) {
+	sudoers, err := Sudoers("everyone")
+	assert.NilError(t, err)
+	exe, err := os.Executable()
+	assert.NilError(t, err)
+	assert.Equal(t, sudoers, "%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: "+filepath.Clean(exe)+" "+SudoOpenBlockDeviceCommand+"\n")
+}
+
+func TestSudoOpenBlockDeviceRequestValidate(t *testing.T) {
+	valid := sudoOpenBlockDeviceRequest{
+		DevicePath: "/dev/disk4",
+		SocketPath: "/tmp/block-device.0.sock",
+	}
+	assert.NilError(t, valid.validate())
+
+	testCases := []struct {
+		name          string
+		request       sudoOpenBlockDeviceRequest
+		errorContains string
+	}{
+		{
+			name: "empty device path",
+			request: sudoOpenBlockDeviceRequest{
+				SocketPath: valid.SocketPath,
+			},
+			errorContains: "devicePath must not be empty",
+		},
+		{
+			name: "relative device path",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: "disk4",
+				SocketPath: valid.SocketPath,
+			},
+			errorContains: "must be an absolute path",
+		},
+		{
+			name: "non dev device path",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: "/tmp/disk4",
+				SocketPath: valid.SocketPath,
+			},
+			errorContains: "must be under /dev",
+		},
+		{
+			name: "unnormalized socket path",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: valid.DevicePath,
+				SocketPath: "/tmp/../tmp/block-device.0.sock",
+			},
+			errorContains: "socketPath",
+		},
+		{
+			name: "relative socket path",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: valid.DevicePath,
+				SocketPath: "block-device.0.sock",
+			},
+			errorContains: "must be an absolute path",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.request.validate()
+			assert.ErrorContains(t, err, tc.errorContains)
+		})
+	}
+}

--- a/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
@@ -230,6 +230,9 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 	if cfg.MountType != nil && (*cfg.MountType != limatype.VIRTIOFS && *cfg.MountType != limatype.REVSSHFS) {
 		return fmt.Errorf("field `mountType` must be %#q or %#q for krunkit driver, got %#q", limatype.VIRTIOFS, limatype.REVSSHFS, *cfg.MountType)
 	}
+	if len(cfg.BlockDevices) > 0 {
+		return fmt.Errorf("field `blockDevices` is not supported for vmType: %s", vmType)
+	}
 
 	if cfg.NestedVirtualization != nil && *cfg.NestedVirtualization {
 		if macOSProductVersion.LessThan(*semver.New("15.0.0")) {

--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -91,6 +91,9 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 	if err := validateMountType(cfg); err != nil {
 		return err
 	}
+	if len(cfg.BlockDevices) > 0 {
+		return fmt.Errorf("field `blockDevices` is not supported for vmType: %s", limatype.QEMU)
+	}
 
 	for i, nw := range cfg.Networks {
 		if unknown := reflectutil.UnknownNonEmptyFields(nw,

--- a/pkg/driver/qemu/qemu_test.go
+++ b/pkg/driver/qemu/qemu_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
 )
 
 func TestArgValue(t *testing.T) {
@@ -88,4 +90,11 @@ func TestParseQemuVersion(t *testing.T) {
 		}
 		assert.Equal(t, tc.expectedValue, v.String())
 	}
+}
+
+func TestValidateConfigRejectsBlockDevices(t *testing.T) {
+	err := validateConfig(&limatype.LimaYAML{
+		BlockDevices: []string{"/dev/disk4"},
+	})
+	assert.ErrorContains(t, err, "field `blockDevices` is not supported for vmType: qemu")
 }

--- a/pkg/driver/vz/block_device_darwin.go
+++ b/pkg/driver/vz/block_device_darwin.go
@@ -1,0 +1,96 @@
+//go:build darwin && !no_vz
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package vz
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	vzapi "github.com/Code-Hex/vz/v3"
+
+	"github.com/lima-vm/lima/v2/pkg/blockdevice"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+)
+
+// attachHostBlockDevices runs while Lima is building the VZ storage device
+// configuration before the VM boots. For each configured host block device, it
+// obtains a retained descriptor from the privileged helper path, wraps that
+// descriptor in a VZ block-device attachment, and appends it to the VM's
+// storage device list alongside the normal disk image attachments.
+func attachHostBlockDevices(ctx context.Context, inst *limatype.Instance, configurations []vzapi.StorageDeviceConfiguration) ([]vzapi.StorageDeviceConfiguration, error) {
+	if len(inst.Config.BlockDevices) == 0 {
+		return configurations, nil
+	}
+
+	for i, devicePath := range inst.Config.BlockDevices {
+		deviceFile, err := openHostBlockDevice(ctx, inst, devicePath, i)
+		if err != nil {
+			return nil, err
+		}
+		attachment, err := vzapi.NewDiskBlockDeviceStorageDeviceAttachment(deviceFile, false, vzapi.DiskSynchronizationModeFull)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create block device attachment for %q: %w", devicePath, err)
+		}
+		device, err := vzapi.NewVirtioBlockDeviceConfiguration(attachment)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create virtio block device for %q: %w", devicePath, err)
+		}
+		if err := device.SetBlockDeviceIdentifier(guestBlockDeviceIdentifier(devicePath)); err != nil {
+			return nil, fmt.Errorf("failed to set block device identifier for %q: %w", devicePath, err)
+		}
+		configurations = append(configurations, device)
+	}
+	return configurations, nil
+}
+
+// openHostBlockDevice bridges the generic host helper into the VZ lifecycle by
+// choosing a VZ-local socket path and retaining the returned descriptor until
+// the VM stops.
+func openHostBlockDevice(ctx context.Context, inst *limatype.Instance, devicePath string, index int) (*os.File, error) {
+	socketPath := filepath.Join(inst.Dir, fmt.Sprintf("vz-block-device.%d.sock", index))
+	deviceFile, err := blockdevice.Open(ctx, devicePath, socketPath)
+	if err != nil {
+		return nil, err
+	}
+	vmRetainedFileDescriptors = append(vmRetainedFileDescriptors, deviceFile)
+	return deviceFile, nil
+}
+
+// guestBlockDeviceIdentifier derives the VZ block device identifier from the
+// host device basename. This does not force the guest kernel to use a specific
+// /dev node like "/dev/vdb", but it does give the guest a stable identifier
+// value that Linux exposes in predictable places such as /dev/disk/by-id and
+// lsblk SERIAL output.
+func guestBlockDeviceIdentifier(devicePath string) string {
+	base := filepath.Base(devicePath)
+	var b strings.Builder
+	b.Grow(len(base))
+	for _, r := range base {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	id := b.String()
+	if id == "" {
+		id = "block-device"
+	}
+	if len(id) > 20 {
+		id = id[:20]
+	}
+	return id
+}

--- a/pkg/driver/vz/block_device_darwin_test.go
+++ b/pkg/driver/vz/block_device_darwin_test.go
@@ -1,0 +1,19 @@
+//go:build darwin && !no_vz
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package vz
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGuestBlockDeviceIdentifier(t *testing.T) {
+	assert.Equal(t, guestBlockDeviceIdentifier("/dev/disk4"), "disk4")
+	assert.Equal(t, guestBlockDeviceIdentifier("/dev/disk@4"), "disk-4")
+	assert.Equal(t, guestBlockDeviceIdentifier("/dev/"+strings.Repeat("a", 64)), strings.Repeat("a", 20))
+}

--- a/pkg/driver/vz/vm_darwin.go
+++ b/pkg/driver/vz/vm_darwin.go
@@ -52,8 +52,10 @@ type virtualMachineWrapper struct {
 	stopped bool
 }
 
-// Hold all *os.File created via socketpair() so that they won't get garbage collected. f.FD() gets invalid if f gets garbage collected.
-var vmNetworkFiles = make([]*os.File, 1)
+// Hold all *os.File retained by VZ for the VM lifetime so they won't get garbage collected.
+// VZ keeps using the underlying descriptors after configuration is created.
+// For example, block device attachments and network device attachments.
+var vmRetainedFileDescriptors []*os.File
 
 func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int, onVsockEvent func(*events.VsockEvent)) (vm *virtualMachineWrapper, waitSSHLocalPortAccessible <-chan any, errCh chan error, err error) {
 	usernetClient, stopUsernet, err := startUsernet(ctx, inst)
@@ -78,8 +80,8 @@ func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int, onV
 	go func() {
 		// Handle errors via errCh and handle stop vm during context close
 		defer func() {
-			for i := range vmNetworkFiles {
-				vmNetworkFiles[i].Close()
+			for i := range vmRetainedFileDescriptors {
+				_ = vmRetainedFileDescriptors[i].Close()
 			}
 		}()
 		for {
@@ -610,6 +612,11 @@ func attachDisks(ctx context.Context, inst *limatype.Instance, vmConfig *vz.Virt
 		configurations = append(configurations, extraDisk)
 	}
 
+	configurations, err := attachHostBlockDevices(ctx, inst, configurations)
+	if err != nil {
+		return err
+	}
+
 	if err := validateDiskFormat(ciDataPath); err != nil {
 		return err
 	}
@@ -945,7 +952,7 @@ func createSockPair() (server, client *os.File, _ error) {
 	runtime.SetFinalizer(client, func(*os.File) {
 		logrus.Debugf("Client network file GC'ed")
 	})
-	vmNetworkFiles = append(vmNetworkFiles, server, client)
+	vmRetainedFileDescriptors = append(vmRetainedFileDescriptors, server, client)
 	return server, client, nil
 }
 

--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -44,6 +44,7 @@ var knownYamlProperties = []string{
 	"AdditionalDisks",
 	"Arch",
 	"Audio",
+	"BlockDevices",
 	"CACertificates",
 	"Containerd",
 	"CopyToHost",
@@ -344,6 +345,9 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 		}
 	default:
 		return fmt.Errorf("field `vmOpts.vz.diskImageFormat` must be %#q or %#q, got %#q", raw.Type, asif.Type, *vzOpts.DiskImageFormat)
+	}
+	if len(cfg.BlockDevices) > 0 && macOSProductVersion.LessThan(*semver.New("14.0.0")) {
+		return fmt.Errorf("field `blockDevices` requires macOS 14 or higher to run, got %q", macOSProductVersion)
 	}
 	return nil
 }

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -25,6 +25,7 @@ import (
 
 var knownYamlProperties = []string{
 	"Arch",
+	"BlockDevices",
 	"Containerd",
 	"CopyToHost",
 	"CPUType",
@@ -99,6 +100,9 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 	}
 	if cfg.MountType != nil && *cfg.MountType != limatype.WSLMount {
 		return fmt.Errorf("field `mountType` must be %#q for WSL2 driver, got %#q", limatype.WSLMount, *cfg.MountType)
+	}
+	if len(cfg.BlockDevices) > 0 {
+		return fmt.Errorf("field `blockDevices` is not supported for vmType: %s", limatype.WSL2)
 	}
 	// TODO: revise this list for WSL2
 	if cfg.VMType != nil {

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -27,6 +27,7 @@ type LimaYAML struct {
 	Memory                *string       `yaml:"memory,omitempty" json:"memory,omitempty" jsonschema:"nullable"` // go-units.RAMInBytes
 	Disk                  *string       `yaml:"disk,omitempty" json:"disk,omitempty" jsonschema:"nullable"`     // go-units.RAMInBytes
 	AdditionalDisks       []Disk        `yaml:"additionalDisks,omitempty" json:"additionalDisks,omitempty" jsonschema:"nullable"`
+	BlockDevices          []string      `yaml:"blockDevices,omitempty" json:"blockDevices,omitempty" jsonschema:"nullable"`
 	Mounts                []Mount       `yaml:"mounts,omitempty" json:"mounts,omitempty"`
 	MountTypesUnsupported []string      `yaml:"mountTypesUnsupported,omitempty" json:"mountTypesUnsupported,omitempty" jsonschema:"nullable"`
 	MountType             *MountType    `yaml:"mountType,omitempty" json:"mountType,omitempty" jsonschema:"nullable"`

--- a/pkg/limayaml/marshal_test.go
+++ b/pkg/limayaml/marshal_test.go
@@ -122,6 +122,18 @@ vmOpts:
 	t.Log(dumpYAML(t, o))
 }
 
+func TestBlockDevices(t *testing.T) {
+	text := `
+blockDevices:
+  - /dev/disk4
+  - /dev/rdisk5
+`
+	var y limatype.LimaYAML
+	err := Unmarshal([]byte(text), &y, "lima.yaml")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, y.BlockDevices, []string{"/dev/disk4", "/dev/rdisk5"})
+}
+
 func TestVMOptsNull(t *testing.T) {
 	text := `
 vmOpts: null

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -57,6 +57,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 	if !slices.Contains(limatype.ArchTypes, *y.Arch) {
 		errs = errors.Join(errs, fmt.Errorf("field `arch` must be one of %v; got %#q", limatype.ArchTypes, *y.Arch))
 	}
+	errs = errors.Join(errs, validateBlockDevices(y.BlockDevices))
 
 	if len(y.Images) == 0 {
 		errs = errors.Join(errs, errors.New("field `images` must be set"))
@@ -414,6 +415,23 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 			if guestRange > portRangeWarnThreshold || hostRange > portRangeWarnThreshold {
 				logrus.Warnf("[plain mode] portForwards[%d] covers a range of more than %d ports (guest: %d, host: %d). All ports will be forwarded unconditionally, which may be inefficient.", i, portRangeWarnThreshold, guestRange, hostRange)
 			}
+		}
+	}
+
+	return errs
+}
+
+func validateBlockDevices(blockDevices []string) error {
+	var errs error
+
+	for i, blockDevice := range blockDevices {
+		field := fmt.Sprintf("blockDevices[%d]", i)
+		if blockDevice == "" {
+			errs = errors.Join(errs, fmt.Errorf("field `%s` must not be empty", field))
+			continue
+		}
+		if !filepath.IsAbs(blockDevice) && !path.IsAbs(blockDevice) {
+			errs = errors.Join(errs, fmt.Errorf("field `%s` must be an absolute path, got %q", field, blockDevice))
 		}
 	}
 

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -234,6 +234,33 @@ additionalDisks:
 	assert.Error(t, err, "field `additionalDisks[0].name is invalid`: identifier must not be empty")
 }
 
+func TestValidateBlockDevices(t *testing.T) {
+	y, err := Load(t.Context(), []byte(`
+images:
+  - location: /
+vmType: qemu
+blockDevices:
+  - /dev/disk4
+`), "lima.yaml")
+	assert.NilError(t, err)
+
+	err = Validate(y, false)
+	assert.NilError(t, err)
+}
+
+func TestValidateBlockDevicesRequiresAbsolutePaths(t *testing.T) {
+	y, err := Load(t.Context(), []byte(`
+images:
+  - location: /
+blockDevices:
+  - disk4
+`), "lima.yaml")
+	assert.NilError(t, err)
+
+	err = Validate(y, false)
+	assert.ErrorContains(t, err, "field `blockDevices[0]` must be an absolute path")
+}
+
 func TestValidateParamName(t *testing.T) {
 	images := `images: [{"location": "/"}]`
 	validProvision := `provision: [{"script": "echo $PARAM_name $PARAM_NAME $PARAM_Name_123"}]`

--- a/pkg/networks/reconcile/reconcile.go
+++ b/pkg/networks/reconcile/reconcile.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"runtime"
 	"strings"
 	"sync"
@@ -22,6 +21,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/networks/usernet"
 	"github.com/lima-vm/lima/v2/pkg/osutil"
 	"github.com/lima-vm/lima/v2/pkg/store"
+	pkgsudoers "github.com/lima-vm/lima/v2/pkg/sudoers"
 )
 
 func Reconcile(ctx context.Context, newInst string) error {
@@ -69,12 +69,8 @@ func Reconcile(ctx context.Context, newInst string) error {
 }
 
 func sudo(ctx context.Context, user, group, command string) error {
-	args := []string{"--user", user, "--group", group, "--non-interactive"}
-	args = append(args, strings.Split(command, " ")...)
 	var stdout, stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, "sudo", args...)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd := pkgsudoers.NewCommand(ctx, user, group, nil, &stdout, &stderr, "", strings.Split(command, " ")...)
 	logrus.Debugf("Running: %v", cmd.Args)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to run %v: stdout=%q, stderr=%q: %w",
@@ -128,9 +124,7 @@ func startDaemon(ctx context.Context, cfg *networks.Config, name, daemon string)
 		return err
 	}
 
-	args := []string{"--user", user.User, "--group", user.Group, "--non-interactive"}
-	args = append(args, strings.Split(cfg.StartCmd(name, daemon), " ")...)
-	cmd := exec.CommandContext(ctx, "sudo", args...)
+	cmd := pkgsudoers.NewCommand(ctx, user.User, user.Group, nil, nil, nil, "", strings.Split(cfg.StartCmd(name, daemon), " ")...)
 	// set directory to a path the daemon user has read access to because vde_switch calls getcwd() which
 	// can fail when called from directories like ~/Downloads, which has 700 permissions
 	cmd.Dir = cfg.Paths.VarRun

--- a/pkg/networks/sudoers.go
+++ b/pkg/networks/sudoers.go
@@ -13,20 +13,17 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/sudoers"
 )
 
-func Sudoers() (string, error) {
-	cfg, err := LoadConfig()
-	if err != nil {
-		return "", err
-	}
-
+func (c Config) Sudoers() (string, error) {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "%%%s ALL=(root:wheel) NOPASSWD:NOSETENV: %s\n", cfg.Group, cfg.MkdirCmd())
+	sb.WriteString(sudoers.NOPASSWD("%"+c.Group, "root", "wheel", c.MkdirCmd()))
 
 	// names must be in stable order to be able to check if sudoers file needs updating
-	names := make([]string, 0, len(cfg.Networks))
-	for name, nw := range cfg.Networks {
+	names := make([]string, 0, len(c.Networks))
+	for name, nw := range c.Networks {
 		if nw.Mode == ModeUserV2 {
 			continue // no sudo needed
 		}
@@ -38,19 +35,17 @@ func Sudoers() (string, error) {
 		sb.WriteRune('\n')
 		fmt.Fprintf(&sb, "# Manage %q network daemons\n", name)
 		for _, daemon := range []string{SocketVMNet} {
-			if ok, err := cfg.IsDaemonInstalled(daemon); err != nil {
+			if ok, err := c.IsDaemonInstalled(daemon); err != nil {
 				return "", err
 			} else if !ok {
 				continue
 			}
-			user, err := cfg.User(daemon)
+			user, err := c.User(daemon)
 			if err != nil {
 				return "", err
 			}
 			sb.WriteRune('\n')
-			fmt.Fprintf(&sb, "%%%s ALL=(%s:%s) NOPASSWD:NOSETENV: \\\n", cfg.Group, user.User, user.Group)
-			fmt.Fprintf(&sb, "    %s, \\\n", cfg.StartCmd(name, daemon))
-			fmt.Fprintf(&sb, "    %s\n", cfg.StopCmd(name, daemon))
+			sb.WriteString(sudoers.NOPASSWD("%"+c.Group, user.User, user.Group, c.StartCmd(name, daemon), c.StopCmd(name, daemon)))
 		}
 	}
 	return sb.String(), nil
@@ -74,9 +69,8 @@ func (c *Config) passwordLessSudo(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		cmd = exec.CommandContext(ctx, "sudo", "--user", user.User, "--group", user.Group, "--non-interactive", "true")
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to run %v: %w", cmd.Args, err)
+		if err := sudoers.Run(ctx, user.User, user.Group, nil, nil, nil, "", "true"); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -107,11 +101,14 @@ func (c *Config) VerifySudoAccess(ctx context.Context, sudoersFile string) error
 		}
 		return fmt.Errorf("can't read %q: %w: (Hint: %s)", sudoersFile, err, hint)
 	}
-	sudoers, err := Sudoers()
+	sudoers, err := c.Sudoers()
 	if err != nil {
 		return err
 	}
-	if string(b) != sudoers {
+	// limactl sudoers writes a single file that may include additional
+	// non-network entries. Network startup only needs its own generated
+	// fragment to be present verbatim.
+	if !strings.Contains(string(b), sudoers) {
 		// Happens on upgrading socket_vmnet with Homebrew
 		return fmt.Errorf("sudoers file %q is out of sync and must be regenerated (Hint: %s)", sudoersFile, hint)
 	}

--- a/pkg/networks/sudoers_test.go
+++ b/pkg/networks/sudoers_test.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package networks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestVerifySudoAccessAllowsAdditionalFragments(t *testing.T) {
+	cfg := Config{
+		Group:    "everyone",
+		Networks: map[string]Network{},
+		Paths: Paths{
+			VarRun: "/private/var/run/lima",
+		},
+	}
+
+	networkSudoers, err := cfg.Sudoers()
+	assert.NilError(t, err)
+
+	composed := networkSudoers
+	if composed != "" && !strings.HasSuffix(composed, "\n") {
+		composed += "\n"
+	}
+	composed += "%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: /usr/local/bin/limactl sudo-open-block-device\n"
+
+	sudoersFile := filepath.Join(t.TempDir(), "lima.sudoers")
+	assert.NilError(t, os.WriteFile(sudoersFile, []byte(composed), 0o600))
+
+	assert.NilError(t, cfg.VerifySudoAccess(t.Context(), sudoersFile))
+}
+
+func TestVerifySudoAccessRejectsOutOfSyncNetworkFragment(t *testing.T) {
+	cfg := Config{
+		Group:    "everyone",
+		Networks: map[string]Network{},
+		Paths: Paths{
+			VarRun: "/private/var/run/lima",
+		},
+	}
+
+	networkSudoers, err := cfg.Sudoers()
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(networkSudoers, "NOPASSWD:NOSETENV"))
+
+	modified := strings.Replace(networkSudoers, "NOPASSWD:NOSETENV", "NOPASSWD", 1)
+	sudoersFile := filepath.Join(t.TempDir(), "lima.sudoers")
+	assert.NilError(t, os.WriteFile(sudoersFile, []byte(modified), 0o600))
+
+	err = cfg.VerifySudoAccess(t.Context(), sudoersFile)
+	assert.ErrorContains(t, err, "out of sync")
+}

--- a/pkg/sudoers/sudoers.go
+++ b/pkg/sudoers/sudoers.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sudoers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Args is the one place that defines Lima's non-interactive sudo invocation
+// shape. Callers own the actual helper command names and sudoers policy; this
+// package only keeps the invocation mechanics consistent.
+func Args(user, group string, args ...string) []string {
+	sudoArgs := []string{"--user", user, "--group", group, "--non-interactive"}
+	return append(sudoArgs, args...)
+}
+
+func NewCommand(ctx context.Context, user, group string, stdin io.Reader, stdout, stderr io.Writer, dir string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "sudo", Args(user, group, args...)...)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.Dir = dir
+	return cmd
+}
+
+func Run(ctx context.Context, user, group string, stdin io.Reader, stdout, stderr io.Writer, dir string, args ...string) error {
+	cmd := NewCommand(ctx, user, group, stdin, stdout, stderr, dir, args...)
+	logrus.Debugf("Running: %v", cmd.Args)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run %v: %w", cmd.Args, err)
+	}
+	return nil
+}
+
+// NOPASSWD renders a sudoers entry for one or more commands.
+func NOPASSWD(subject, runAsUser, runAsGroup string, commands ...string) string {
+	if len(commands) == 1 {
+		return fmt.Sprintf("%s ALL=(%s:%s) NOPASSWD:NOSETENV: %s\n", subject, runAsUser, runAsGroup, commands[0])
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s ALL=(%s:%s) NOPASSWD:NOSETENV: \\\n", subject, runAsUser, runAsGroup)
+	for i, command := range commands {
+		fmt.Fprintf(&sb, "    %s", command)
+		if i < len(commands)-1 {
+			sb.WriteString(", \\\n")
+		} else {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+// AssembleSudoersFragments joins already-rendered sudoers fragments into a
+// single file. The individual fragments stay owned by their domain packages;
+// this helper only handles the generic newline normalization needed to
+// concatenate them.
+func AssembleSudoersFragments(fragments ...string) string {
+	var sb strings.Builder
+	for _, fragment := range fragments {
+		if fragment == "" {
+			continue
+		}
+		if sb.Len() > 0 && !strings.HasSuffix(sb.String(), "\n") {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(fragment)
+	}
+	return sb.String()
+}

--- a/pkg/sudoers/sudoers_test.go
+++ b/pkg/sudoers/sudoers_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sudoers
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestArgs(t *testing.T) {
+	assert.DeepEqual(t, Args("root", "wheel", "true"), []string{
+		"--user", "root",
+		"--group", "wheel",
+		"--non-interactive",
+		"true",
+	})
+}
+
+func TestNewCommand(t *testing.T) {
+	stdin := strings.NewReader("")
+	cmd := NewCommand(t.Context(), "root", "wheel", stdin, io.Discard, io.Discard, "/tmp", "true")
+
+	assert.Equal(t, cmd.Args[0], "sudo")
+	assert.DeepEqual(t, cmd.Args[1:], Args("root", "wheel", "true"))
+	assert.Equal(t, cmd.Stdin, stdin)
+	assert.Equal(t, cmd.Stdout, io.Discard)
+	assert.Equal(t, cmd.Stderr, io.Discard)
+	assert.Equal(t, cmd.Dir, "/tmp")
+}
+
+func TestNOPASSWD(t *testing.T) {
+	assert.Equal(t, NOPASSWD("%everyone", "root", "wheel", "/usr/local/bin/limactl sudo-open-block-device"),
+		"%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: /usr/local/bin/limactl sudo-open-block-device\n")
+
+	assert.Equal(t, NOPASSWD("%everyone", "daemon", "staff", "/bin/start", "/bin/stop"),
+		"%everyone ALL=(daemon:staff) NOPASSWD:NOSETENV: \\\n    /bin/start, \\\n    /bin/stop\n")
+}

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -128,6 +128,13 @@ additionalDisks:
 #   format: true
 #   fsType: "ext4"
 
+# Attach host block devices directly to supported backends.
+# This is currently supported on macOS with `vmType: vz`.
+# Each entry must be an absolute host path, typically under /dev.
+# This requires limactl sudoers to allow the hidden block-device helper.
+# 🟢 Builtin default: []
+blockDevices: []
+
 ssh:
   # A localhost port of the host. Forwarded to port 22 of the guest.
   # 🟢 Builtin default: 0 (automatically assigned to a free port)

--- a/website/content/en/docs/config/disk.md
+++ b/website/content/en/docs/config/disk.md
@@ -86,3 +86,57 @@ limactl edit default --disk 20
 > **Note:**
 > - Increasing disk size is supported, but shrinking disks is not recommended.
 > - The instance may need to be stopped before editing disk size.
+
+## Attach host block devices
+
+| ⚡ Requirement | Lima >= 2.2, macOS >= 14.0, vmType: vz |
+| ------------- | -------------------------------------- |
+
+Lima can attach a host block device directly to the guest.
+
+Example configuration:
+{{< tabpane text=true >}}
+{{% tab header="CLI" %}}
+```bash
+# hdiutil attach -nomount ram://65536   # create a ramdisk to test without a USB key or real drive
+limactl start --vm-type=vz --block-device=/dev/disk4 template:default
+```
+
+`/dev/rdiskN` also works:
+
+```bash
+# hdiutil attach -nomount ram://65536   # create a ramdisk to test without a USB key or real drive
+limactl start --vm-type=vz --block-device=/dev/rdisk4 template:default
+```
+{{% /tab %}}
+{{% tab header="YAML" %}}
+```yaml
+vmType: "vz"
+blockDevices:
+- /dev/disk4
+- /dev/rdisk5
+```
+{{% /tab %}}
+{{< /tabpane >}}
+
+The `--block-device` flag can be specified multiple times to attach multiple host block devices.
+
+### Sudoers setup
+
+Opening a host block device requires a privileged helper on macOS.
+Generate and install the Lima sudoers file before using `--block-device`:
+
+```sh
+limactl sudoers >etc_sudoers.d_lima
+less etc_sudoers.d_lima
+sudo install -o root etc_sudoers.d_lima /etc/sudoers.d/lima
+rm etc_sudoers.d_lima
+```
+
+`limactl sudoers` emits the entries needed for both vmnet helpers and block-device helpers.
+
+### Notes
+
+- The configured path must be an absolute host path under `/dev`, e.g. `/dev/disk4`, `/dev/rdisk4`, `/dev/sdc`, etc.
+- The guest will see a corresponding virtio `/dev/disk/by-id/virtio-disk4` block device attached, you are responsible for partitioning, formatting, and mounting any filesystems on the block devices
+- Avoid mounting filesystems on shared block devices on both host and guest at the same time, it will cause corruption as most filesystems are not designed to be shared by multiple live kernels at once.


### PR DESCRIPTION
> [!IMPORTANT]
> Superseeded by https://github.com/lima-vm/lima/pull/5117

---
---

Fixes https://github.com/lima-vm/lima/discussions/1314 & https://github.com/lima-vm/lima/issues/2224

📖 Wrote a blog post based on my learnings too: https://docs.sweeting.me/s/sockets-101

## Summary

This adds VZ-only support on macOS for attaching host block devices to Lima VMs.

A VM can now be launched with:

```bash
limactl start --block-device=/dev/disk4 ...
```

It can also be configured in YAML with the top-level `blockDevices` field.

The attached device is exposed to the guest as a virtio block device, and Lima sets a deterministic block device identifier from the host basename. For example, `/dev/disk4` appears in the guest under `/dev/disk/by-id/virtio-disk4`.

## Implementation

- added the `--block-device` CLI flag and top-level `blockDevices` config support
- attached host block devices in the VZ driver with [`VZDiskBlockDeviceStorageDeviceAttachment`](https://developer.apple.com/documentation/virtualization/vzdiskblockdevicestoragedeviceattachment)
- kept block-device-specific VZ runtime logic in `pkg/driver/vz/block_device_darwin.go`
- added a hidden `limactl sudo-open-block-device` helper that opens a host block device and passes the file descriptor back to the unprivileged VM process
- kept the helper path backend-neutral in `pkg/blockdevice`
- moved generic sudo execution and sudoers rendering helpers into `pkg/sudoers`
- kept `pkg/networks` network-specific by limiting it to network sudoers entries and network validation
- updated `limactl sudoers` to compose the shared `/etc/sudoers.d/lima` file from network entries plus the block-device helper entry
- documented top-level `blockDevices` in `templates/default.yaml` and the disk docs
- non-VZ backends reject `blockDevices` explicitly for now

## Layout Notes

The ownership boundaries are now:

- `pkg/networks`: network config, validation, and network-specific sudoers fragments
- `pkg/sudoers`: generic sudo invocation and sudoers file helpers
- `pkg/blockdevice`: generic block-device helper, request validation, fd handoff, and sudoers fragment
- `pkg/driver/vz/block_device_darwin.go`: VZ block-device attachment logic
- `cmd/limactl sudoers`: existing CLI command, combines network sudoers entries with blockdevice entries to create the final `/etc/sudoers.d/lima` file
- `cmd/limactl sudo-open-block-device`: small helper that runs as root to get a file descriptor for the block device before passing it to the still-rootless main Lima VM process

That keeps block-device support separate from network behavior while still reusing the same sudo helpers that both need.

## Why

Opening `/dev/disk*` on macOS requires elevated privileges, but Lima generally avoids running its normal VM lifecycle as root. This change keeps that behavior intact by escalating only for the narrow helper that opens the requested block device and passes the file descriptor back to the unprivileged VZ process.

Adding this feature to Lima unlocks many use-cases around testing and using custom filesystem kernel modules, e.g. ZFS-in-lima on macOS hosts that don't have ZFS/macFUSE installed: https://github.com/pirate/zfsbox

## Validation

Automated:

- `go test ./pkg/limayaml ./cmd/limactl/editflags ./pkg/driver/qemu ./pkg/blockdevice ./pkg/sudoers ./pkg/networks`
- `go test -c ./pkg/driver/vz`
- `go test -c ./pkg/driver/krunkit`
- `go test -c ./cmd/limactl`
- `GOOS=windows GOARCH=amd64 go test -c ./pkg/driver/wsl2`
- `./hack/bats/lib/bats-core/bin/bats --count ./hack/bats/extras/vz-block-device.bats`

Live validation on macOS with VZ block-device roundtrip coverage:

- `--block-device /dev/diskN` roundtrip via BATS
- top-level `blockDevices:` YAML using `/dev/rdiskN` roundtrip via BATS
- both cases create a ramdisk, partition it as `GPT`, format it as `exFAT`, write from the guest, stop the VM, mount and read on the host, append on the host, restart, and read back in the guest

Round-trip writes succeed and the block device is usable as a normal drive in both OSs.

---

### Related Links

- https://github.com/lima-vm/lima/discussions/1314
- https://github.com/lima-vm/lima/issues/2224
- https://github.com/lima-vm/lima/pull/1317
- https://www.reddit.com/r/zfs/comments/1sqvqfd/zfsbox_run_zfs_in_a_small_vm_so_you_dont_need_to/oho1ef5/?context=3
- https://github.com/utmapp/UTM/discussions/5921
- https://wiki.openstack.org/wiki/Raw-device-mapping-support
- https://old.reddit.com/r/VFIO/comments/4fjsie/howto_passing_through_an_entire_block_device/
- https://lima-vm.io/docs/config/mount/
- https://developer.apple.com/documentation/virtualization/vzdiskblockdevicestoragedeviceattachment

### Next Steps

There are more VZ APIs we can wire up to forward things like `/dev/tty0-usbmodem.sock`, USB HCI devices, and more.

- https://developer.apple.com/documentation/virtualization/usb-devices
- https://developer.apple.com/documentation/virtualization/vznetworkblockdevicestoragedeviceattachment
- https://developer.apple.com/documentation/virtualization/vzvirtioblockdeviceconfiguration
