### PR TITLE
Add parameters for Kubernetes installation

### DIFF
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -54,10 +54,14 @@ provision:
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
     apt-get install -y apt-transport-https ca-certificates curl
-    VERSION=1.36
-    # VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt | sed -e 's/v//' | cut -d'.' -f1-2)
-    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${VERSION}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-    curl -fsSL https://pkgs.k8s.io/core:/stable:/v${VERSION}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    STABILITY="{{.Param.stability}}"
+    {{if eq .Param.release "stable" }}
+    RELEASE=$(curl -L -s https://dl.k8s.io/release/stable.txt | cut -d'.' -f1-2)
+    {{else}}
+    RELEASE="{{.Param.release}}"
+    {{end}}
+    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/${STABILITY}:/${RELEASE}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+    curl -fsSL https://pkgs.k8s.io/core:/${STABILITY}:/${RELEASE}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     apt-get update
     apt-get install -y kubelet kubeadm kubectl && apt-mark hold kubelet kubeadm kubectl
     systemctl enable --now kubelet
@@ -94,8 +98,9 @@ provision:
     export KUBECONFIG=/etc/kubernetes/admin.conf
     {{if not ( and .Param.url .Param.token )}}
     systemctl stop kubelet
-    kubeadm config images list
-    kubeadm config images pull --cri-socket=unix:///run/containerd/containerd.sock
+    VERSION="{{.Param.version}}"
+    kubeadm config images list --kubernetes-version="${VERSION}"
+    kubeadm config images pull --kubernetes-version="${VERSION}" --cri-socket=unix:///run/containerd/containerd.sock
     systemctl start kubelet
     # Initializing your control-plane node
     cat <<EOF >/etc/kubeadm-config.yaml
@@ -106,6 +111,7 @@ provision:
     ---
     kind: ClusterConfiguration
     apiVersion: kubeadm.k8s.io/v1beta4
+    kubernetesVersion: "${VERSION}"
     apiServer:
       certSANs: # --apiserver-cert-extra-sans
       - "127.0.0.1"
@@ -135,7 +141,11 @@ provision:
 
     {{if not ( and .Param.url .Param.token )}}
     # Installing a Pod network add-on
-    kubectl apply -f https://github.com/flannel-io/flannel/releases/download/v0.28.5/kube-flannel.yml
+    {{if eq .Param.flannelVersion "latest" }}
+    kubectl apply -f https://github.com/flannel-io/flannel/releases/latest/download/kube-flannel.yml
+    {{else}}
+    kubectl apply -f https://github.com/flannel-io/flannel/releases/download/{{.Param.flannelVersion}}/kube-flannel.yml
+    {{end}}
     # Control plane node isolation
     kubectl taint nodes --all node-role.kubernetes.io/control-plane-
     # Symlink the kubeconfig file to the default location for kubectl
@@ -219,6 +229,16 @@ message: |
   ------
   {{end -}}
 param:
+  # The stability can be either "stable" or "prerelease"
+  # <https://build.opensuse.org/project/subprojects/isv:kubernetes:core>
+  stability: "stable"
+  # The release can be either "stable" or "v1.xx" (branch)
+  # (stable version is found at: <https://dl.k8s.io/release/stable.txt>)
+  release: "v1.36"
+  # The k8s version can be either "stable" or "v1.xx.y"
+  version: "stable"
+  # The flannel version is either "latest" or "v0.xx.y"
+  flannelVersion: "v0.28.5"
   url: ""
   token: ""
   discoveryTokenCaCertHash: ""


### PR DESCRIPTION
We added a variable for the hardcoded k8s version:

`https://pkgs.k8s.io/core:/stable:/v1.36/deb/`

Previously the stability was hardcoded to "stable":

`https://pkgs.k8s.io/core:/stable:/v${VERSION}/deb/`

There was also no way to select the version to install.

It would always use https://dl.k8s.io/release/stable.txt

So rename "VERSION" to "RELEASE".

And add a new "STABILITY" variable.

Make "VERSION" be the k8s version...

`https://pkgs.k8s.io/core:/${STABILITY}:/${RELEASE}/deb/`

Issue #4844

```yaml
param:
  stability: "stable" 
  release: "stable"
  version: "stable"
```

```yaml
param:
  stability: "prerelease"
  release: "v1.37"
  version: "v1.37.0-alpha.1"
```

See https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/ for the different params.

And https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/

Closes #4844
Closes #4871 

----

Example, for installing an older version:

```
limactl start ./templates/k8s.yaml --set '.param.release="v1.35"' --set '.param.version="stable-1.35"'
```

EDIT: With the new syntactic sugar:

```
limactl start template:k8s --param "release=v1.35" --param "version=stable-1.35"
```

Note: the second parameter is optional, kubeadm will detect the version skew and do a fallback:

`remote version is much newer: v1.36.2; falling back to: stable-1.35`

Note: older versions of Kubernetes _might_ not be compatible with the Lima version of containerd.

You would have to check the version matrix: https://containerd.io/releases/