### PR TITLE
Support import of Kubernetes images from tarball

### DIFF
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -95,6 +95,14 @@ provision:
     {{if not ( and .Param.url .Param.token )}}
     systemctl stop kubelet
     kubeadm config images list
+    # Support adding archives of required images, for an "air-gapped" installation.
+    if [ -d /var/lib/kubernetes/images ]; then
+      for tar in /var/lib/kubernetes/images/*.tar*; do
+        # Also supports other compression formats. Delete the compressed layer copies.
+        zstdcat "$tar" | ctr -n k8s.io images import --local --discard-unpacked-layers -
+      done
+    fi
+    # This will use a pull policy of IfNotPresent, it will not pull existing images.
     kubeadm config images pull --cri-socket=unix:///run/containerd/containerd.sock
     systemctl start kubelet
     # Initializing your control-plane node
@@ -135,7 +143,13 @@ provision:
 
     {{if not ( and .Param.url .Param.token )}}
     # Installing a Pod network add-on
-    kubectl apply -f https://github.com/flannel-io/flannel/releases/download/v0.28.5/kube-flannel.yml
+    mkdir -p /var/lib/kubernetes/manifests
+    cd /var/lib/kubernetes/manifests
+    if [ ! -r kube-flannel.yml ]; then
+      curl -fsSL -O https://github.com/flannel-io/flannel/releases/download/v0.28.5/kube-flannel.yml
+    fi
+    kubectl apply -f kube-flannel.yml
+    cd -
     # Control plane node isolation
     kubectl taint nodes --all node-role.kubernetes.io/control-plane-
     # Symlink the kubeconfig file to the default location for kubectl

--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -94,7 +94,7 @@ provision:
     export KUBECONFIG=/etc/kubernetes/admin.conf
     {{if not ( and .Param.url .Param.token )}}
     systemctl stop kubelet
-    kubeadm config images list
+    kubeadm config images list | tee kube-images.txt
     # Support adding archives of required images, for an "air-gapped" installation.
     if [ -d /var/lib/kubernetes/images ]; then
       for tar in /var/lib/kubernetes/images/*.tar*; do
@@ -147,6 +147,7 @@ provision:
     cd /var/lib/kubernetes/manifests
     if [ ! -r kube-flannel.yml ]; then
       curl -fsSL -O https://github.com/flannel-io/flannel/releases/download/v0.28.5/kube-flannel.yml
+      lima-guestagent yq .spec.template.spec.initContainers.[].image kube-flannel.yml | sort -r | uniq | tee kube-flannel.txt
     fi
     kubectl apply -f kube-flannel.yml
     cd -


### PR DESCRIPTION
Make it possible to save the required images, beforehand. They can be copied in the lima.yaml, or mounted from host.

```diff
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -26,7 +26,9 @@ minimumLimaVersion: 2.0.0
 base: template:_images/ubuntu-lts
 
 # Mounts are disabled in this template, but can be enabled optionally.
-mounts: []
+mounts:
+  - location: "/home/anders/lima/images"
+    mountPoint: /var/lib/kubernetes/images
 containerd:
   system: true
   user: false
```

<details>
<pre>
+ systemctl stop kubelet
+ kubeadm config images list
registry.k8s.io/kube-apiserver:v1.35.4
registry.k8s.io/kube-controller-manager:v1.35.4
registry.k8s.io/kube-scheduler:v1.35.4
registry.k8s.io/kube-proxy:v1.35.4
registry.k8s.io/coredns/coredns:v1.13.1
registry.k8s.io/pause:3.10.1
registry.k8s.io/etcd:3.6.6-0
+ '[' -d /var/lib/kubernetes/images ']'
+ for tar in /var/lib/kubernetes/images/*.tar*
+ ctr -n k8s.io images import --local --discard-unpacked-layers -
+ zstdcat /var/lib/kubernetes/images/flannel-images-0.27.4-amd64.tar.zst
unpacking ghcr.io/flannel-io/flannel:v0.27.4 (sha256:9a14ddaa3e001d29a4ab6064883586706139535aad4644c806acde120dc9a98d)...done
unpacking ghcr.io/flannel-io/flannel-cni-plugin:v1.8.0-flannel1 (sha256:569fa51f939e77f60234adfd737b627f07b72d0de7fab8eff1bcd7882b0cf9ef)...done
+ for tar in /var/lib/kubernetes/images/*.tar*
+ ctr -n k8s.io images import --local --discard-unpacked-layers -
+ zstdcat /var/lib/kubernetes/images/kubernetes-images-1.35.4-amd64.tar.zst
unpacking registry.k8s.io/etcd:3.6.6-0 (sha256:8ff11273b70ad0247cb279d05427e3b327aaebf96e061a5358277dc7cf0c38d0)...done
unpacking registry.k8s.io/kube-apiserver:v1.35.4 (sha256:5b72edd4202a0db192dcedb87a7460c730e7cf14c25a2d119dd6ae47cdf58077)...done
unpacking registry.k8s.io/kube-controller-manager:v1.35.4 (sha256:5c9db9a2f5119a908adb141cab6632be1958e9a96373213b9fc687cb6375f4a7)...done
unpacking registry.k8s.io/kube-scheduler:v1.35.4 (sha256:c3c414bbc301dc23dedb5ffa406a293871771c80891e4347c7bf14f084d988d7)...done
unpacking registry.k8s.io/kube-proxy:v1.35.4 (sha256:13afcf1cfe41d40e9b2bcb2e079fa3ded01d4e4cca168b8401766f12c1341317)...done
unpacking registry.k8s.io/coredns/coredns:v1.13.1 (sha256:c259a14fc408dd1d923c0c977255c14c7271e540cf9bdd5cdd8db8be4a9d1690)...done
unpacking registry.k8s.io/pause:3.10.1 (sha256:68b1f66d545ec1b629dafdc6b6ef48e3156f096f12269034c662f1fad8ad4804)...done
+ kubeadm config images pull --cri-socket=unix:///run/containerd/containerd.sock
[config/images] Pulled registry.k8s.io/kube-apiserver:v1.35.4
[config/images] Pulled registry.k8s.io/kube-controller-manager:v1.35.4
[config/images] Pulled registry.k8s.io/kube-scheduler:v1.35.4
[config/images] Pulled registry.k8s.io/kube-proxy:v1.35.4
[config/images] Pulled registry.k8s.io/coredns/coredns:v1.13.1
[config/images] Pulled registry.k8s.io/pause:3.10.1
[config/images] Pulled registry.k8s.io/etcd:3.6.6-0
+ systemctl start kubelet
</pre>
</details>

Closes #4875 

Save a list of the images used, and of the flannel manifest. It can be useful when preparing the image archives, later.

```
registry.k8s.io/kube-apiserver:v1.35.4
registry.k8s.io/kube-controller-manager:v1.35.4
registry.k8s.io/kube-scheduler:v1.35.4
registry.k8s.io/kube-proxy:v1.35.4
registry.k8s.io/coredns/coredns:v1.13.1
registry.k8s.io/pause:3.10.1
registry.k8s.io/etcd:3.6.6-0
```

```
ghcr.io/flannel-io/flannel:v0.27.4
ghcr.io/flannel-io/flannel-cni-plugin:v1.8.0-flannel1
```