### PR TITLE
CI: pin Windows QEMU to 10.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,7 +245,10 @@ jobs:
       run: make
     - name: Install QEMU
       run: |
-        winget install --silent --accept-source-agreements --accept-package-agreements --disable-interactivity SoftwareFreedomConservancy.QEMU
+        # Pin to 10.2.0: QEMU 11.0.0 TCG breaks systemd boot on the Windows
+        # runner with "Failed to fork off sandboxing environment: Protocol
+        # error", blocking SSH.
+        winget install --silent --accept-source-agreements --accept-package-agreements --disable-interactivity SoftwareFreedomConservancy.QEMU --version 10.2.0
     - name: Integration tests (QEMU, Windows host)
       run: |
         $env:PATH = "$pwd\_output\bin;" + 'C:\msys64\usr\bin;' + 'C:\Program Files\QEMU;' + $env:PATH


### PR DESCRIPTION
QEMU 11.0.0 (installed via winget) breaks systemd boot on the Windows runner under TCG emulation. systemd fails to fork its sandboxing environment with "Failed to fork off sandboxing environment for executing generators: Protocol error", so SSH never starts and the hostagent times out.

The last green `Windows tests (QEMU)` run on master used QEMU 10.2.0 on 2026-04-22; every push since has picked up QEMU 11.0.0 and failed the same way.