### PR TITLE
shell: fix path quoting for rsync 3.0.0 through 3.2.3

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -366,12 +366,13 @@ func shellAction(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to create the synced workdir in guest instance: %w", err)
 		}
 
-		// The macOS release of rsync (the latest being 2.6.9) does not support shell escaping of destination path but other versions do.
+		// Quote the destination path for rsync versions before 3.2.4, where --protect-args is not the default
+		// and the remote shell would split paths containing spaces.
 		rsyncVer, err := rsyncVersion(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to get rsync version: %w", err)
 		}
-		if rsyncVer.LessThan(*semver.New("3.0.0")) {
+		if rsyncVer.LessThan(*semver.New("3.2.4")) {
 			destRsyncDir = shellescape.Quote(destRsyncDir)
 		}
 


### PR DESCRIPTION
### Problem
`destRsyncDir` is only shell-quoted for rsync < 3.0.0, but `--protect-args`
didn't become the default until rsync 3.2.4. For versions 3.0.0–3.2.3
(e.g. rsync 3.1.3 on Ubuntu 20.04), paths with spaces get split by the
remote shell, breaking `limactl shell --sync`.

### Fix
Changed the version threshold from `3.0.0` to `3.2.4` so the destination
path is properly quoted for all rsync versions that don't default to
`--protect-args`.

Fixes #4720 
