### PR TITLE
bats: fix second-boundary race in "shell --instance resolves instance name"

### DIFF
--- a/hack/bats/tests/shell.bats
+++ b/hack/bats/tests/shell.bats
@@ -33,12 +33,15 @@ INSTANCE=bats-dummy
 }
 
 @test 'limactl shell --instance resolves instance name' {
-    # --instance should resolve the instance name the same way as the positional arg
+    # --instance should resolve the instance name the same way as the positional arg.
+    # Normalize the logrus timestamp because the two invocations may land in different seconds.
     run_e -1 limactl shell --tty=false --instance nonexistent
-    inst_output=$stderr
+    inst_output=$(sed 's/^time="[^"]*"/time="TIMESTAMP"/' <<<"$stderr")
 
     run_e -1 limactl shell --tty=false nonexistent
-    assert_stderr "$inst_output"
+    pos_output=$(sed 's/^time="[^"]*"/time="TIMESTAMP"/' <<<"$stderr")
+
+    assert_equal "$pos_output" "$inst_output"
 }
 
 @test 'limactl shell --instance with unknown flag errors' {


### PR DESCRIPTION
The test ran `limactl shell` twice and asserted that the two stderr outputs were byte-identical, but logrus prefixes each line with a `time="..."` timestamp at second granularity. When the two invocations straddled a second boundary the test failed with only the timestamp differing, as seen on the BATS job for PR #4873.

Normalize the timestamp to a fixed placeholder before comparing, so the test continues to verify that `--instance` and the positional form resolve identically without depending on wall-clock alignment.