### PR TITLE
wsl2: stop spinning in for { <-ctx.Done() } after instance stop

### DIFF
--- a/pkg/driver/wsl2/vm_windows.go
+++ b/pkg/driver/wsl2/vm_windows.go
@@ -132,13 +132,11 @@ func provisionVM(ctx context.Context, instanceDir, instanceName, distroName stri
 					"check /var/log/lima-init.log for more details (out=%q)", cmd.Args, err, string(out))
 		}
 
-		for {
-			<-ctx.Done()
-			logrus.Info("Context closed, stopping vm")
-			if status, err := getWslStatus(ctx, instanceName); err == nil &&
-				status == limatype.StatusRunning {
-				_ = stopVM(ctx, distroName)
-			}
+		<-ctx.Done()
+		logrus.Info("Context closed, stopping vm")
+		if status, err := getWslStatus(ctx, instanceName); err == nil &&
+			status == limatype.StatusRunning {
+			_ = stopVM(ctx, distroName)
 		}
 	}()
 


### PR DESCRIPTION
Fixes #4891.

The boot-script goroutine in `provisionVM` wraps a single context-cancellation wait in `for {}`. Once `ctx` is canceled (every `limactl stop` / shutdown), `<-ctx.Done()` returns immediately on every iteration, so the goroutine hot-loops calling `getWslStatus` and `stopVM` forever — pinning a CPU core and flooding `wslservice.exe` with `wsl.exe` subprocesses.

Drop the `for {`/`}` wrapper so the goroutine waits once and exits.

## Test plan

- `GOOS=windows go build ./pkg/driver/wsl2/...`
- `GOOS=windows go vet ./pkg/driver/wsl2/...`
