### PR TITLE
Remove POSIX path conversion for ssh-keygen on Windows

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -106,15 +106,11 @@ func DefaultPubKeys(ctx context.Context, loadDotSSH bool) ([]PubKey, error) {
 		if err := os.MkdirAll(configDir, 0o700); err != nil {
 			return nil, fmt.Errorf("could not create %q directory: %w", configDir, err)
 		}
+
 		if err := lockutil.WithDirLock(configDir, func() error {
 			// no passphrase, no user@host comment
 			privPath := filepath.Join(configDir, filenames.UserPrivateKey)
-			if runtime.GOOS == "windows" {
-				privPath, err = ioutilx.WindowsSubsystemPath(ctx, privPath)
-				if err != nil {
-					return err
-				}
-			}
+
 			keygenCmd := exec.CommandContext(ctx, "ssh-keygen", "-t", "ed25519", "-q", "-N", "",
 				"-C", "lima", "-f", privPath)
 			logrus.Debugf("executing %v", keygenCmd.Args)
@@ -125,7 +121,8 @@ func DefaultPubKeys(ctx context.Context, loadDotSSH bool) ([]PubKey, error) {
 		}); err != nil {
 			return nil, err
 		}
-	}
+        }
+
 	entry, err := readPublicKey(filepath.Join(configDir, filenames.UserPublicKey))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What the Issue Was

On fresh Windows installations (specifically using QEMU), `limactl start` fails during the initial setup phase with a fatal error: `failed to run [ssh-keygen ...]: "No such file or directory"`. This occurs because the host-native `ssh-keygen.exe` is unable to locate the `.lima/_config` directory to write the user's private key — even though the directory was successfully created by the preceding logic.

---

## Why It Was There

In `pkg/sshutil/sshutil.go`, the `configDir` (a valid native Windows path) was being passed through `ioutilx.WindowsSubsystemPath` whenever `runtime.GOOS == "windows"` was detected. This converted the path into an MSYS2-style POSIX path (e.g., `/c/Users/lts/.lima/_config`).

While this POSIX format is useful for some WSL/Cygwin-based utilities, the host-native `ssh-keygen.exe` has no awareness of this convention and cannot resolve these paths, leading to the `"No such file or directory"` failure.

---

## Solution

Removed the conditional path conversion block in `pkg/sshutil/sshutil.go`. By bypassing `ioutilx.WindowsSubsystemPath`, the native Windows path is preserved and passed directly to the `ssh-keygen` command. Since `os.MkdirAll` already ensures the directory exists using the native path, `ssh-keygen` can now successfully resolve the location and generate the required keypair.

An audit of related startup paths (`pkg/store`, `pkg/networks`) confirmed that other references to `_config` are either read operations or simple string resolutions that do not suffer from this path-mangling issue.

---

## Changes

- **`pkg/sshutil/sshutil.go`** — Deleted the `runtime.GOOS == "windows"` block that performed the POSIX path conversion, ensuring the native path is used for all `ssh-keygen` invocations.

---

## Result

The host-native `ssh-keygen` now correctly resolves the configuration directory on Windows. This restores the ability to perform fresh installs of Lima on Windows/QEMU without manual directory creation workarounds. Verification included:

- Successful cross-compilation and execution of the native Windows `.exe`
- Confirmed no-op regression in Linux/WSL environments
- Passing result for existing `sshutil` unit tests

---

## Test Conducted 

<img width="1790" height="759" alt="image" src="https://github.com/user-attachments/assets/b82ea67a-8387-491e-9634-89ad5523b808" />

---

<img width="1484" height="394" alt="image" src="https://github.com/user-attachments/assets/4d2f9982-b461-45df-8d91-fe14354fd619" />


---


Fixes #4900

