### PR TITLE
limactl: replace SSH column with IP, drop the local SSH port

### DIFF
--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -31,6 +31,11 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/version/versionutil"
 )
 
+// defaultSSHAddress is the loopback address assigned to an instance's SSHAddress
+// when no other host-reachable IP is known. It is also used by the table printer
+// to decide when the IP column can be hidden on narrow screens.
+const defaultSSHAddress = "127.0.0.1"
+
 // Inspect returns err only when the instance does not exist (os.ErrNotExist).
 // Other errors are returned as *Instance.Errors.
 func Inspect(ctx context.Context, instName string) (*limatype.Instance, error) {
@@ -59,7 +64,7 @@ func Inspect(ctx context.Context, instName string) (*limatype.Instance, error) {
 	inst.Config = y
 	inst.Arch = *y.Arch
 	inst.VMType = *y.VMType
-	inst.SSHAddress = "127.0.0.1"
+	inst.SSHAddress = defaultSSHAddress
 	inst.SSHLocalPort = *y.SSH.LocalPort // maybe 0
 	inst.SSHConfigFile = filepath.Join(instDir, filenames.SSHConfig)
 	inst.HostAgentPID, err = ReadPIDFile(filepath.Join(instDir, filenames.HostAgentPID))
@@ -302,9 +307,11 @@ func PrintInstances(w io.Writer, instances []*limatype.Instance, format string, 
 	case "table":
 		types := map[string]int{}
 		archs := map[string]int{}
+		ips := map[string]int{}
 		for _, instance := range instances {
 			types[instance.VMType]++
 			archs[instance.Arch]++
+			ips[instance.SSHAddress]++
 		}
 		all := options != nil && options.AllFields
 		width := 0
@@ -314,13 +321,21 @@ func PrintInstances(w io.Writer, instances []*limatype.Instance, format string, 
 		columnWidth := 8
 		hideType := false
 		hideArch := false
+		hideIP := false
 		hideDir := false
 
 		// width == 0 means the terminal width is unknown (e.g. stdout is not a TTY),
 		// in which case we treat it as unlimited and never hide any column.
 		columns := 1 // NAME
 		columns += 2 // STATUS
-		columns += 2 // SSH
+		// can we still fit the remaining columns (7) when IP is shown
+		if width != 0 && (columns+2+7)*columnWidth > width && !all {
+			// only hide IP if all instances share the default loopback address
+			hideIP = len(ips) == 1 && instances[0].SSHAddress == defaultSSHAddress
+		}
+		if !hideIP {
+			columns += 2 // IP
+		}
 		// can we still fit the remaining columns (7)
 		if width != 0 && (columns+7)*columnWidth > width && !all {
 			hideType = len(types) == 1
@@ -350,7 +365,10 @@ func PrintInstances(w io.Writer, instances []*limatype.Instance, format string, 
 		_ = columns
 
 		w := tabwriter.NewWriter(w, 4, 8, 4, ' ', 0)
-		fmt.Fprint(w, "NAME\tSTATUS\tSSH")
+		fmt.Fprint(w, "NAME\tSTATUS")
+		if !hideIP {
+			fmt.Fprint(w, "\tIP")
+		}
 		if !hideType {
 			fmt.Fprint(w, "\tVMTYPE")
 		}
@@ -373,11 +391,15 @@ func PrintInstances(w io.Writer, instances []*limatype.Instance, format string, 
 			if strings.HasPrefix(dir, homeDir) {
 				dir = strings.Replace(dir, homeDir, "~", 1)
 			}
-			fmt.Fprintf(w, "%s\t%s\t%s",
+			fmt.Fprintf(w, "%s\t%s",
 				instance.Name,
 				instance.Status,
-				fmt.Sprintf("%s:%d", instance.SSHAddress, instance.SSHLocalPort),
 			)
+			if !hideIP {
+				fmt.Fprintf(w, "\t%s",
+					instance.SSHAddress,
+				)
+			}
 			if !hideType {
 				fmt.Fprintf(w, "\t%s",
 					instance.VMType,

--- a/pkg/store/instance_test.go
+++ b/pkg/store/instance_test.go
@@ -34,38 +34,42 @@ var instance = limatype.Instance{
 }
 
 // width 0 means the terminal width is unknown (stdout is not a TTY), so all columns are shown.
-var table = "NAME    STATUS     SSH            VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
+var table = "NAME    STATUS     IP           VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    127.0.0.1    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
 
-var tableEmu = "NAME    STATUS     SSH            VMTYPE    ARCH       CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    " + vmtype + "      unknown    0       0B        0B      dir\n"
+var tableEmu = "NAME    STATUS     IP           VMTYPE    ARCH       CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    127.0.0.1    " + vmtype + "      unknown    0       0B        0B      dir\n"
 
-var tableHome = "NAME    STATUS     SSH            VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    " + vmtype + "      " + goarch + "    0       0B        0B      ~" + separator + "dir\n"
+var tableHome = "NAME    STATUS     IP           VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    127.0.0.1    " + vmtype + "      " + goarch + "    0       0B        0B      ~" + separator + "dir\n"
 
-var tableAll = "NAME    STATUS     SSH            VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
+var tableAll = "NAME    STATUS     IP           VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    127.0.0.1    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
 
-// for width 60, everything is hidden
-var table60 = "NAME    STATUS     SSH            CPUS    MEMORY    DISK\n" +
-	"foo     Stopped    127.0.0.1:0    0       0B        0B\n"
+// for width 60, IP is hidden (all loopback) along with everything else
+var table60 = "NAME    STATUS     CPUS    MEMORY    DISK\n" +
+	"foo     Stopped    0       0B        0B\n"
 
-// for width 80, identical is hidden (type/arch)
-var table80i = "NAME    STATUS     SSH            CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    0       0B        0B      dir\n"
+// for width 80, IP is hidden (all loopback); type/arch can fit so they show
+var table80i = "NAME    STATUS     VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
 
-// for width 80, different arch is still shown (not dir)
-var table80d = "NAME    STATUS     SSH            ARCH       CPUS    MEMORY    DISK\n" +
-	"foo     Stopped    127.0.0.1:0    unknown    0       0B        0B\n"
+// for width 80, IP is hidden (all loopback); type/arch and dir all fit
+var table80d = "NAME    STATUS     VMTYPE    ARCH       CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    " + vmtype + "      unknown    0       0B        0B      dir\n"
 
 // for width 100, nothing is hidden
-var table100 = "NAME    STATUS     SSH            VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
+var table100 = "NAME    STATUS     IP           VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    127.0.0.1    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
 
-// for width 80, directory is hidden (if not identical)
-var tableTwo = "NAME    STATUS     SSH            VMTYPE    ARCH       CPUS    MEMORY    DISK\n" +
-	"foo     Stopped    127.0.0.1:0    qemu      x86_64     0       0B        0B\n" +
-	"bar     Stopped    127.0.0.1:0    vz        aarch64    0       0B        0B\n"
+// for width 80, IP hidden (all loopback), directory shown as everything fits
+var tableTwo = "NAME    STATUS     VMTYPE    ARCH       CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    qemu      x86_64     0       0B        0B      dir\n" +
+	"bar     Stopped    vz        aarch64    0       0B        0B      dir\n"
+
+// for width 80, with non-loopback IP the IP column stays, hiding others to fit
+var table80nonloop = "NAME    STATUS     IP              CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    192.168.64.2    0       0B        0B      dir\n"
 
 func TestSSHPortFromConfig(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
@@ -190,6 +194,17 @@ func TestPrintInstanceTableNonTTY(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, tableAll, buf.String())
 	})
+}
+
+func TestPrintInstanceTable80NonLoopback(t *testing.T) {
+	var buf bytes.Buffer
+	instance1 := instance
+	instance1.SSHAddress = "192.168.64.2"
+	instances := []*limatype.Instance{&instance1}
+	options := PrintOptions{TerminalWidth: 80}
+	err := PrintInstances(&buf, instances, "table", &options)
+	assert.NilError(t, err)
+	assert.Equal(t, table80nonloop, buf.String())
 }
 
 func TestPrintInstanceTableTwo(t *testing.T) {


### PR DESCRIPTION
Closes #4181.

Implements the column design that @jandubois sketched in #4181 (with @afbjorklund's nod): rename the column from `SSH` to `IP`, drop the `:port` suffix, and treat the new column the same way the `ARCH` column is treated — hide it when every instance is on the default `127.0.0.1` loopback and the screen is too narrow to fit everything else.

## Why drop the port

`SSH` showed `127.0.0.1:<port>` (or the misleading `127.0.0.1:0` for stopped instances). The port on its own is not actionable: it has to be paired with the generated identity file and config, so users go through `ssh -F ~/.lima/<name>/ssh.config lima-<name>` — which keys off the instance name, not the port.

## What changes

- `SSH` column → `IP` column, showing only `instance.SSHAddress`.
- `SSHAddress` is preserved on the struct, so the IP work in #4175 (and any consumer of `instance.SSHAddress` like `cmd/limactl/show-ssh.go` / `tunnel.go`) is unaffected.
- The IP column is hidden when **(a)** every instance has the default loopback address **and** **(b)** the terminal is too narrow to fit everything else. If any instance has a non-default address (the case that motivated #4175), the column stays visible regardless of width — because that IP is the only place the information is surfaced.
- The `"127.0.0.1"` literal that was duplicated between `Inspect` (which seeds `SSHAddress`) and the table printer is consolidated into a `defaultSSHAddress` const, so the seeding and the visibility check can't drift apart.

## Sample output

Wide enough (`width >= 100`):
```
NAME       STATUS     IP              VMTYPE    ARCH       CPUS    MEMORY    DISK      DIR
default    Running    192.168.64.2    vz        aarch64    4       4GiB      100GiB    ~/.lima/default
alpine     Running    127.0.0.1       vz        aarch64    4       4GiB      100GiB    ~/.lima/alpine
```

Narrow + all-loopback (column auto-hidden, mirroring the existing `ARCH` rule):
```
NAME       STATUS     CPUS    MEMORY    DISK
debug      Stopped    4       4GiB      100GiB
docker     Stopped    4       16GiB     100GiB
```

Narrow + non-loopback (column kept, since the IP is the only place this information shows):
```
NAME       STATUS     IP              CPUS    MEMORY    DISK    DIR
default    Running    192.168.64.2    4       4GiB      100GiB  ~/.lima/default
```

## Tests

- All existing `TestPrintInstanceTable*` cases were updated to the new column layout. The hide-on-narrow rule means width=60/80 with all-loopback now produces a tighter table than before — that's the intended change.
- Added `TestPrintInstanceTable80NonLoopback` covering the "keep IP visible when at least one instance has a non-default address" branch.
- `go test ./pkg/store/... -run TestPrintInstance` is green locally.
- `go vet ./...` clean.

Open question for reviewers: I kept the IP column under a 2-`columnWidth` budget (matching how `SSH` was budgeted before, since `192.168.x.x` ≈ 13 chars). Happy to drop it to 1 if you'd rather optimize for short addresses.