### PR TITLE
feat(templates): add Fedora 44 template; remove Fedora 41 template

### DIFF
--- a/hack/update-template-fedora.sh
+++ b/hack/update-template-fedora.sh
@@ -36,8 +36,8 @@ Examples:
   Update the Fedora Linux image location in templates/**.yaml:
   $ $(basename "${BASH_SOURCE[0]}") templates/**.yaml
 
-  Update the Fedora Linux image location to version 41 in ~/.lima/fedora/lima.yaml:
-  $ $(basename "${BASH_SOURCE[0]}") --version 41 ~/.lima/fedora/lima.yaml
+  Update the Fedora Linux image location to version 44 in ~/.lima/fedora/lima.yaml:
+  $ $(basename "${BASH_SOURCE[0]}") --version 44 ~/.lima/fedora/lima.yaml
   $ limactl factory-reset fedora
 
 Flags:

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/40-install-containerd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/40-install-containerd.sh
@@ -120,20 +120,20 @@ EOF
 			setenforce 0
 		fi
 		if [ "$(sudo -iu "${LIMA_CIDATA_USER}" sh -ec 'systemctl --user show --property=RefuseManualStart --value dbus')" != "yes" ]; then
-			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" systemctl --user enable --now dbus
+			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" systemctl --user enable --now dbus.socket
 		fi
-		sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" containerd-rootless-setuptool.sh install
-		sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" \
+		sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" "TERM=${TERM}" containerd-rootless-setuptool.sh install
+		sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" "TERM=${TERM}" \
 			"CONTAINERD_NAMESPACE=${CONTAINERD_NAMESPACE}" "CONTAINERD_SNAPSHOTTER=${CONTAINERD_SNAPSHOTTER}" \
 			containerd-rootless-setuptool.sh install-buildkit-containerd
 
 		# $CONTAINERD_SNAPSHOTTER is configured in 20-rootless-base.sh, when the guest kernel is < 5.13, or the instance was created with Lima < 0.9.0.
 		if [ "$(sudo -iu "${LIMA_CIDATA_USER}" sh -ec 'echo $CONTAINERD_SNAPSHOTTER')" = "fuse-overlayfs" ]; then
-			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" containerd-rootless-setuptool.sh install-fuse-overlayfs
+			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" "TERM=${TERM}" containerd-rootless-setuptool.sh install-fuse-overlayfs
 		fi
 
 		if compare_version.sh "$(uname -r)" -ge "5.13"; then
-			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" containerd-rootless-setuptool.sh install-stargz
+			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" "TERM=${TERM}" containerd-rootless-setuptool.sh install-stargz
 		else
 			echo >&2 "WARNING: the guest kernel seems older than 5.13. Skipping installing rootless stargz."
 		fi

--- a/templates/README.md
+++ b/templates/README.md
@@ -48,7 +48,8 @@ lima
 - [`debian-13`](./debian-13.yaml), `debian`: ⭐Debian GNU/Linux 13 (Trixie)
 - [`fedora-41`](./fedora-41.yaml): Fedora 41
 - [`fedora-42`](./fedora-42.yaml): Fedora 42
-- [`fedora-43`](./fedora-43.yaml), `fedora`: ⭐Fedora 43
+- [`fedora-43`](./fedora-43.yaml), Fedora 43
+- [`fedora-44`](./fedora-44.yaml), `fedora`: ⭐Fedora 44
 - [`opensuse-leap-15`](./opensuse-leap-15.yaml): openSUSE Leap 15
 - [`opensuse-leap-16`](./opensuse-leap-16.yaml), `opensuse-leap`, `opensuse`: ⭐openSUSE Leap 16
 - [`oraclelinux-8`](./oraclelinux-8.yaml): Oracle Linux 8

--- a/templates/_images/fedora-44.yaml
+++ b/templates/_images/fedora-44.yaml
@@ -1,0 +1,14 @@
+images:
+- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
+  arch: "x86_64"
+  digest: "sha256:28680fe5b371a5a82ebf43a31926e086a168e59949d03969c5093e7071f90b7f"
+
+- location: "https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-44-1.7.aarch64.qcow2"
+  arch: aarch64
+  digest: "sha256:55c60a3b80d3616a08705afd0459e75fe9f03c54aba7a46e4002a41a72fa0d5b"
+
+# No RISC-V release yet for Fedora 44: https://download.fedoraproject.org/pub/alt/risc-v/release/
+
+# # NOTE: Intel Mac with macOS prior to 15.5 requires setting vmType to qemu
+# # https://github.com/lima-vm/lima/issues/3334
+# vmType: qemu

--- a/templates/_images/fedora.yaml
+++ b/templates/_images/fedora.yaml
@@ -1,1 +1,1 @@
-fedora-43.yaml
+fedora-44.yaml

--- a/templates/fedora-44.yaml
+++ b/templates/fedora-44.yaml
@@ -1,0 +1,5 @@
+minimumLimaVersion: 2.0.0
+
+base:
+- template:_images/fedora-44
+- template:_default/mounts

--- a/templates/fedora.yaml
+++ b/templates/fedora.yaml
@@ -1,1 +1,1 @@
-fedora-43.yaml
+fedora-44.yaml


### PR DESCRIPTION
Hello,

Fedora 44 VM is usable but there is an error with cloud-init-main.service:
```
$ sudo cloud-init status --long
status: error
extended_status: error - done
boot_status_code: enabled-by-generator
last_update: Thu, 01 Jan 1970 00:00:55 +0000
detail: DataSourceNoCloud [seed=/dev/sr0]
errors:
        - ('scripts_per_boot', RuntimeError('Runparts: 1 failures (00-lima.boot.sh) in 1 attempted commands'))
recoverable_errors:
DEPRECATED:
        - Deprecated cloud-config provided: users.0.ssh-authorized-keys:  Deprecated in version 18.3. Use **ssh_authorized_keys** instead., users.0.uid:  Changed in version 22.3. The use of ``string`` type is deprecated. Use an ``integer`` instead.
        - Deprecated cloud-config provided: users.0.ssh-authorized-keys:  Deprecated in version 18.3. Use **ssh_authorized_keys** instead., users.0.uid:  Changed in version 22.3. The use of ``string`` type is deprecated. Use an ``integer`` instead.
WARNING:
        - Failed to set the hostname to lima-testvm (lima-testvm)
        - Failed to set the hostname to lima-testvm (lima-testvm)
        - Failed to set the hostname to lima-testvm (lima-testvm)
        - Failed to run module scripts_per_boot (per-boot in /var/lib/cloud/scripts/per-boot)
        - Running module scripts_per_boot (<module 'cloudinit.config.cc_scripts_per_boot' from '/usr/lib/python3.14/site-packages/cloudinit/config/cc_scripts_per_boot.py'>) failed
```

I think this problem can be resolved later, I will try to fix it.

Regards