### PR TITLE
Change %q in logs and errors to %#q [Part1]

### DIFF
--- a/cmd/limactl/clone.go
+++ b/cmd/limactl/clone.go
@@ -67,7 +67,7 @@ func cloneOrRenameAction(cmd *cobra.Command, args []string) error {
 	oldInst, err := store.Inspect(ctx, oldInstName)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("instance %q not found", oldInstName)
+			return fmt.Errorf("instance %#q not found", oldInstName)
 		}
 		return err
 	}
@@ -98,7 +98,7 @@ func cloneOrRenameAction(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if err := driverutil.ResolveVMType(ctx, y, filePath); err != nil {
-			return fmt.Errorf("failed to resolve vm for %q: %w", filePath, err)
+			return fmt.Errorf("failed to resolve vm for %#q: %w", filePath, err)
 		}
 		if err := limayaml.Validate(y, true); err != nil {
 			return saveRejectedYAML(yBytes, err)

--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -91,7 +91,7 @@ func copyAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	logrus.Debugf("using copy tool %q", cpTool.Name())
+	logrus.Debugf("using copy tool %#q", cpTool.Name())
 
 	copyCmd, err := cpTool.Command(ctx, args, nil)
 	if err != nil {

--- a/cmd/limactl/delete.go
+++ b/cmd/limactl/delete.go
@@ -41,24 +41,24 @@ func deleteAction(cmd *cobra.Command, args []string) error {
 		inst, err := store.Inspect(ctx, instName)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				logrus.Warnf("Ignoring non-existent instance %q", instName)
+				logrus.Warnf("Ignoring non-existent instance %#q", instName)
 				continue
 			}
 			return err
 		}
 		if err := instance.Delete(cmd.Context(), inst, force); err != nil {
-			return fmt.Errorf("failed to delete instance %q: %w", instName, err)
+			return fmt.Errorf("failed to delete instance %#q: %w", instName, err)
 		}
 		if registered, err := autostart.IsRegistered(ctx, inst); err != nil && !errors.Is(err, autostart.ErrNotSupported) {
-			logrus.WithError(err).Warnf("Failed to check if the autostart entry for instance %q is registered", instName)
+			logrus.WithError(err).Warnf("Failed to check if the autostart entry for instance %#q is registered", instName)
 		} else if registered {
 			if err := autostart.UnregisterFromStartAtLogin(ctx, inst); err != nil {
-				logrus.WithError(err).Warnf("Failed to unregister the autostart entry for instance %q", instName)
+				logrus.WithError(err).Warnf("Failed to unregister the autostart entry for instance %#q", instName)
 			} else {
-				logrus.Infof("The autostart entry for instance %q has been unregistered", instName)
+				logrus.Infof("The autostart entry for instance %#q has been unregistered", instName)
 			}
 		}
-		logrus.Infof("Deleted %q (%q)", instName, inst.Dir)
+		logrus.Infof("Deleted %#q (%#q)", instName, inst.Dir)
 	}
 	return reconcile.Reconcile(cmd.Context(), "")
 }

--- a/cmd/limactl/disk.go
+++ b/cmd/limactl/disk.go
@@ -91,7 +91,7 @@ func diskCreateAction(cmd *cobra.Command, args []string) error {
 	switch format {
 	case "qcow2", "raw":
 	default:
-		return fmt.Errorf(`disk format %#q not supported, use "qcow2" or "raw" instead`, format)
+		return fmt.Errorf("disk format %#q not supported, use `qcow2` or `raw` instead", format)
 	}
 
 	// only exactly one arg is allowed
@@ -470,7 +470,7 @@ func diskImportAction(_ *cobra.Command, args []string) error {
 	switch format {
 	case "qcow2", "raw":
 	default:
-		return fmt.Errorf(`disk format %#q not supported, use "qcow2" or "raw" instead`, format)
+		return fmt.Errorf("disk format %#q not supported, use `qcow2` or `raw` instead", format)
 	}
 
 	if err := os.MkdirAll(diskDir, 0o755); err != nil {

--- a/cmd/limactl/disk.go
+++ b/cmd/limactl/disk.go
@@ -91,7 +91,7 @@ func diskCreateAction(cmd *cobra.Command, args []string) error {
 	switch format {
 	case "qcow2", "raw":
 	default:
-		return fmt.Errorf(`disk format %q not supported, use "qcow2" or "raw" instead`, format)
+		return fmt.Errorf(`disk format %#q not supported, use "qcow2" or "raw" instead`, format)
 	}
 
 	// only exactly one arg is allowed
@@ -103,10 +103,10 @@ func diskCreateAction(cmd *cobra.Command, args []string) error {
 	}
 
 	if _, err := os.Stat(diskDir); !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("disk %q already exists (%q)", name, diskDir)
+		return fmt.Errorf("disk %#q already exists (%#q)", name, diskDir)
 	}
 
-	logrus.Infof("Creating %s disk %q with size %s", format, name, units.BytesSize(float64(diskSize)))
+	logrus.Infof("Creating %s disk %#q with size %s", format, name, units.BytesSize(float64(diskSize)))
 
 	if err := os.MkdirAll(diskDir, 0o700); err != nil {
 		return err
@@ -119,9 +119,9 @@ func diskCreateAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		rerr := os.RemoveAll(diskDir)
 		if rerr != nil {
-			err = errors.Join(err, fmt.Errorf("failed to remove a directory %q: %w", diskDir, rerr))
+			err = errors.Join(err, fmt.Errorf("failed to remove a directory %#q: %w", diskDir, rerr))
 		}
-		return fmt.Errorf("failed to create %s disk in %q: %w", format, diskDir, err)
+		return fmt.Errorf("failed to create %s disk in %#q: %w", format, diskDir, err)
 	}
 
 	return nil
@@ -182,7 +182,7 @@ func diskListAction(cmd *cobra.Command, args []string) error {
 		for _, diskName := range disks {
 			disk, err := store.InspectDisk(diskName, nil)
 			if err != nil {
-				logrus.WithError(err).Errorf("disk %q does not exist?", diskName)
+				logrus.WithError(err).Errorf("disk %#q does not exist?", diskName)
 				continue
 			}
 			j, err := json.Marshal(disk)
@@ -204,7 +204,7 @@ func diskListAction(cmd *cobra.Command, args []string) error {
 	for _, diskName := range disks {
 		disk, err := store.InspectDisk(diskName, nil)
 		if err != nil {
-			logrus.WithError(err).Errorf("disk %q does not exist?", diskName)
+			logrus.WithError(err).Errorf("disk %#q does not exist?", diskName)
 			continue
 		}
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", disk.Name, units.BytesSize(float64(disk.Size)), disk.Format, disk.Dir, disk.Instance)
@@ -257,7 +257,7 @@ func diskDeleteAction(cmd *cobra.Command, args []string) error {
 		disk, err := store.InspectDisk(diskName, nil)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				logrus.Warnf("Ignoring non-existent disk %q", diskName)
+				logrus.Warnf("Ignoring non-existent disk %#q", diskName)
 				continue
 			}
 			return err
@@ -265,7 +265,7 @@ func diskDeleteAction(cmd *cobra.Command, args []string) error {
 
 		if !force {
 			if disk.Instance != "" {
-				return fmt.Errorf("cannot delete disk %q in use by instance %q", disk.Name, disk.Instance)
+				return fmt.Errorf("cannot delete disk %#q in use by instance %#q", disk.Name, disk.Instance)
 			}
 			var refInstances []string
 			for _, inst := range instances {
@@ -276,24 +276,24 @@ func diskDeleteAction(cmd *cobra.Command, args []string) error {
 				}
 			}
 			if len(refInstances) > 0 {
-				logrus.Warnf("Skipping deleting disk %q, disk is referenced by one or more non-running instances: %q",
+				logrus.Warnf("Skipping deleting disk %#q, disk is referenced by one or more non-running instances: %#q",
 					diskName, refInstances)
-				logrus.Warnf("To delete anyway, run %q", forceDeleteCommand(diskName))
+				logrus.Warnf("To delete anyway, run %#q", forceDeleteCommand(diskName))
 				continue
 			}
 		}
 
 		if err := deleteDisk(disk); err != nil {
-			return fmt.Errorf("failed to delete disk %q: %w", diskName, err)
+			return fmt.Errorf("failed to delete disk %#q: %w", diskName, err)
 		}
-		logrus.Infof("Deleted %q (%q)", diskName, disk.Dir)
+		logrus.Infof("Deleted %#q (%#q)", diskName, disk.Dir)
 	}
 	return nil
 }
 
 func deleteDisk(disk *store.Disk) error {
 	if err := os.RemoveAll(disk.Dir); err != nil {
-		return fmt.Errorf("failed to remove %q: %w", disk.Dir, err)
+		return fmt.Errorf("failed to remove %#q: %w", disk.Dir, err)
 	}
 	return nil
 }
@@ -328,32 +328,32 @@ func diskUnlockAction(cmd *cobra.Command, args []string) error {
 		disk, err := store.InspectDisk(diskName, nil)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				logrus.Warnf("Ignoring non-existent disk %q", diskName)
+				logrus.Warnf("Ignoring non-existent disk %#q", diskName)
 				continue
 			}
 			return err
 		}
 		if disk.Instance == "" {
-			logrus.Warnf("Ignoring unlocked disk %q", diskName)
+			logrus.Warnf("Ignoring unlocked disk %#q", diskName)
 			continue
 		}
 		// if store.Inspect throws an error, the instance does not exist, and it is safe to unlock
 		inst, err := store.Inspect(ctx, disk.Instance)
 		if err == nil {
 			if len(inst.Errors) > 0 {
-				logrus.Warnf("Cannot unlock disk %q, attached instance %q has errors: %+v",
+				logrus.Warnf("Cannot unlock disk %#q, attached instance %#q has errors: %+v",
 					diskName, disk.Instance, inst.Errors)
 				continue
 			}
 			if inst.Status == limatype.StatusRunning {
-				logrus.Warnf("Cannot unlock disk %q used by running instance %q", diskName, disk.Instance)
+				logrus.Warnf("Cannot unlock disk %#q used by running instance %#q", diskName, disk.Instance)
 				continue
 			}
 		}
 		if err := disk.Unlock(); err != nil {
-			return fmt.Errorf("failed to unlock disk %q: %w", diskName, err)
+			return fmt.Errorf("failed to unlock disk %#q: %w", diskName, err)
 		}
-		logrus.Infof("Unlocked disk %q (%q)", diskName, disk.Dir)
+		logrus.Infof("Unlocked disk %#q (%#q)", diskName, disk.Dir)
 	}
 	return nil
 }
@@ -390,21 +390,21 @@ func diskResizeAction(cmd *cobra.Command, args []string) error {
 	disk, err := store.InspectDisk(diskName, nil)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("disk %q does not exists", diskName)
+			return fmt.Errorf("disk %#q does not exists", diskName)
 		}
 		return err
 	}
 
 	// Shrinking can cause a disk failure
 	if diskSize < disk.Size {
-		return fmt.Errorf("specified size %q is less than the current disk size %q. Disk shrinking is currently unavailable", units.BytesSize(float64(diskSize)), units.BytesSize(float64(disk.Size)))
+		return fmt.Errorf("specified size %#q is less than the current disk size %#q. Disk shrinking is currently unavailable", units.BytesSize(float64(diskSize)), units.BytesSize(float64(disk.Size)))
 	}
 
 	if disk.Instance != "" {
 		inst, err := store.Inspect(ctx, disk.Instance)
 		if err == nil {
 			if inst.Status == limatype.StatusRunning {
-				return fmt.Errorf("cannot resize disk %q used by running instance %q. Please stop the VM instance", diskName, disk.Instance)
+				return fmt.Errorf("cannot resize disk %#q used by running instance %#q. Please stop the VM instance", diskName, disk.Instance)
 			}
 		}
 	}
@@ -414,10 +414,10 @@ func diskResizeAction(cmd *cobra.Command, args []string) error {
 	diskUtil := proxyimgutil.NewDiskUtil(ctx)
 	err = diskUtil.ResizeDisk(ctx, dataDisk, diskSize)
 	if err != nil {
-		return fmt.Errorf("failed to resize disk %q: %w", diskName, err)
+		return fmt.Errorf("failed to resize disk %#q: %w", diskName, err)
 	}
 
-	logrus.Infof("Resized disk %q (%q)", diskName, disk.Dir)
+	logrus.Infof("Resized disk %#q (%#q)", diskName, disk.Dir)
 	return nil
 }
 
@@ -450,7 +450,7 @@ func diskImportAction(_ *cobra.Command, args []string) error {
 	}
 
 	if _, err := os.Stat(diskDir); !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("disk %q already exists (%q)", diskName, diskDir)
+		return fmt.Errorf("disk %#q already exists (%#q)", diskName, diskDir)
 	}
 
 	f, err := os.Open(fName)
@@ -470,7 +470,7 @@ func diskImportAction(_ *cobra.Command, args []string) error {
 	switch format {
 	case "qcow2", "raw":
 	default:
-		return fmt.Errorf(`disk format %q not supported, use "qcow2" or "raw" instead`, format)
+		return fmt.Errorf(`disk format %#q not supported, use "qcow2" or "raw" instead`, format)
 	}
 
 	if err := os.MkdirAll(diskDir, 0o755); err != nil {

--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -60,7 +60,7 @@ func editAction(cmd *cobra.Command, args []string) error {
 		inst, err = store.Inspect(ctx, arg)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("instance %q not found", arg)
+				return fmt.Errorf("instance %#q not found", arg)
 			}
 			return err
 		}
@@ -107,9 +107,9 @@ func editAction(cmd *cobra.Command, args []string) error {
 	} else if tty {
 		var hdr string
 		if inst != nil {
-			hdr = fmt.Sprintf("# Please edit the following configuration for Lima instance %q\n", inst.Name)
+			hdr = fmt.Sprintf("# Please edit the following configuration for Lima instance %#q\n", inst.Name)
 		} else {
-			hdr = fmt.Sprintf("# Please edit the following configuration %q\n", filePath)
+			hdr = fmt.Sprintf("# Please edit the following configuration %#q\n", filePath)
 		}
 		hdr += "# and an empty file will abort the edit.\n"
 		hdr += "\n"
@@ -132,7 +132,7 @@ func editAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if err := driverutil.ResolveVMType(ctx, y, filePath); err != nil {
-		return fmt.Errorf("failed to resolve vm for %q: %w", filePath, err)
+		return fmt.Errorf("failed to resolve vm for %#q: %w", filePath, err)
 	}
 	if err := limayaml.Validate(y, true); err != nil {
 		return saveRejectedYAML(yBytes, err)
@@ -147,7 +147,7 @@ func editAction(cmd *cobra.Command, args []string) error {
 	}
 
 	if inst != nil {
-		logrus.Infof("Instance %q configuration edited", inst.Name)
+		logrus.Infof("Instance %#q configuration edited", inst.Name)
 	}
 
 	if inst == nil {
@@ -171,7 +171,7 @@ func editAction(cmd *cobra.Command, args []string) error {
 	}
 	// Network reconciliation will be performed by the process launched by the autostart manager
 	if registered, err := autostart.IsRegistered(ctx, inst); err != nil && !errors.Is(err, autostart.ErrNotSupported) {
-		return fmt.Errorf("failed to check if the autostart entry for instance %q is registered: %w", inst.Name, err)
+		return fmt.Errorf("failed to check if the autostart entry for instance %#q is registered: %w", inst.Name, err)
 	} else if !registered {
 		err = reconcile.Reconcile(ctx, inst.Name)
 		if err != nil {
@@ -205,8 +205,8 @@ func editBashComplete(cmd *cobra.Command, _ []string, _ string) ([]string, cobra
 func saveRejectedYAML(y []byte, origErr error) error {
 	rejectedYAML := "lima.REJECTED.yaml"
 	if writeErr := os.WriteFile(rejectedYAML, y, 0o644); writeErr != nil {
-		return fmt.Errorf("the YAML is invalid, attempted to save the buffer as %q but failed: %w", rejectedYAML, errors.Join(writeErr, origErr))
+		return fmt.Errorf("the YAML is invalid, attempted to save the buffer as %#q but failed: %w", rejectedYAML, errors.Join(writeErr, origErr))
 	}
 	// TODO: may need to support editing the rejected YAML
-	return fmt.Errorf("the YAML is invalid, saved the buffer as %q: %w", rejectedYAML, origErr)
+	return fmt.Errorf("the YAML is invalid, saved the buffer as %#q: %w", rejectedYAML, origErr)
 }

--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -392,7 +392,7 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool, params map[string]stri
 				case "none":
 					return []string{`.containerd.user = false | .containerd.system = false`}, nil
 				default:
-					return nil, fmt.Errorf(`expected one of ["user", "system", "user+system", "none"], got %#q`, s)
+					return nil, fmt.Errorf("expected one of [`user`, `system`, `user+system`, `none`], got %#q", s)
 				}
 			},
 			true,

--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -127,12 +127,12 @@ func defaultExprFunc(expr string) func(v *flag.Flag) ([]string, error) {
 func ParsePortForward(spec string) (hostPort, guestPort string, isStatic bool, err error) {
 	parts := strings.Split(spec, ",")
 	if len(parts) > 2 {
-		return "", "", false, fmt.Errorf("invalid port forward format %q, expected HOST:GUEST or HOST:GUEST,static=true", spec)
+		return "", "", false, fmt.Errorf("invalid port forward format %#q, expected HOST:GUEST or HOST:GUEST,static=true", spec)
 	}
 
 	portParts := strings.Split(strings.TrimSpace(parts[0]), ":")
 	if len(portParts) != 2 {
-		return "", "", false, fmt.Errorf("invalid port forward format %q, expected HOST:GUEST", parts[0])
+		return "", "", false, fmt.Errorf("invalid port forward format %#q, expected HOST:GUEST", parts[0])
 	}
 
 	hostPort = strings.TrimSpace(portParts[0])
@@ -143,10 +143,10 @@ func ParsePortForward(spec string) (hostPort, guestPort string, isStatic bool, e
 		if staticValue, ok := strings.CutPrefix(staticPart, "static="); ok {
 			isStatic, err = strconv.ParseBool(staticValue)
 			if err != nil {
-				return "", "", false, fmt.Errorf("invalid value for static parameter: %q", staticValue)
+				return "", "", false, fmt.Errorf("invalid value for static parameter: %#q", staticValue)
 			}
 		} else {
-			return "", "", false, fmt.Errorf("invalid parameter %q, expected 'static=' followed by a boolean value", staticPart)
+			return "", "", false, fmt.Errorf("invalid parameter %#q, expected 'static=' followed by a boolean value", staticPart)
 		}
 	}
 
@@ -175,10 +175,10 @@ func BuildParamExpressions(params []string, allowedParams map[string]string) ([]
 	for i, param := range params {
 		key, value, ok := strings.Cut(param, "=")
 		if !ok {
-			return nil, fmt.Errorf("invalid parameter %q, expected NAME=VALUE", param)
+			return nil, fmt.Errorf("invalid parameter %#q, expected NAME=VALUE", param)
 		}
 		if _, ok := allowedParams[key]; !ok {
-			return nil, fmt.Errorf("template does not define param %q", key)
+			return nil, fmt.Errorf("template does not define param %#q", key)
 		}
 		exprs[i] = fmt.Sprintf(".param[%q] = %q", key, value)
 	}
@@ -325,7 +325,7 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool, params map[string]stri
 						network := strings.TrimPrefix(s, "lima:")
 						networks[i] = fmt.Sprintf(`{"lima": %q}`, network)
 					default:
-						return nil, fmt.Errorf(`network name must be "vzNAT" or "lima:*", got %q`, s)
+						return nil, fmt.Errorf("network name must be `vzNAT` or `lima:*`, got %#q", s)
 					}
 				}
 				expr := fmt.Sprintf(`.networks += [%s] | .networks |= unique_by(.lima)`, strings.Join(networks, ","))
@@ -392,7 +392,7 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool, params map[string]stri
 				case "none":
 					return []string{`.containerd.user = false | .containerd.system = false`}, nil
 				default:
-					return nil, fmt.Errorf(`expected one of ["user", "system", "user+system", "none"], got %q`, s)
+					return nil, fmt.Errorf(`expected one of ["user", "system", "user+system", "none"], got %#q`, s)
 				}
 			},
 			true,
@@ -431,7 +431,7 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool, params map[string]stri
 			}
 			newExprs, err := def.exprFunc(v)
 			if err != nil {
-				return exprs, fmt.Errorf("error while processing flag %q: %w", def.flagName, err)
+				return exprs, fmt.Errorf("error while processing flag %#q: %w", def.flagName, err)
 			}
 			exprs = append(exprs, newExprs...)
 		}

--- a/cmd/limactl/editflags/editflags_test.go
+++ b/cmd/limactl/editflags/editflags_test.go
@@ -186,13 +186,13 @@ func TestBuildParamExpressions(t *testing.T) {
 			name:          "invalid format",
 			params:        []string{"version"},
 			allowedParams: map[string]string{"version": ""},
-			expectError:   `invalid parameter "version", expected NAME=VALUE`,
+			expectError:   "invalid parameter `version`, expected NAME=VALUE",
 		},
 		{
 			name:          "undefined param",
 			params:        []string{"missing=value"},
 			allowedParams: map[string]string{"version": ""},
-			expectError:   `template does not define param "missing"`,
+			expectError:   "template does not define param `missing`",
 		},
 	}
 
@@ -282,13 +282,13 @@ func TestYQExpressions(t *testing.T) {
 			name:        "undefined param",
 			args:        []string{"--param", "missing=value"},
 			newInstance: false,
-			expectError: `template does not define param "missing"`,
+			expectError: "template does not define param `missing`",
 		},
 		{
 			name:        "invalid network",
 			args:        []string{"--network", "invalid"},
 			newInstance: true,
-			expectError: `network name must be "vzNAT" or "lima:*", got "invalid"`,
+			expectError: "network name must be `vzNAT` or `lima:*`, got `invalid`",
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/limactl/factory-reset.go
+++ b/cmd/limactl/factory-reset.go
@@ -40,7 +40,7 @@ func factoryResetAction(cmd *cobra.Command, args []string) error {
 	inst, err := store.Inspect(ctx, instName)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logrus.Infof("Instance %q not found", instName)
+			logrus.Infof("Instance %#q not found", instName)
 			return nil
 		}
 		return err
@@ -63,7 +63,7 @@ func factoryResetAction(cmd *cobra.Command, args []string) error {
 	for _, f := range fi {
 		path := filepath.Join(inst.Dir, f.Name())
 		if _, ok := retain[f.Name()]; !ok && !strings.HasSuffix(path, ".yaml") && !strings.HasSuffix(path, ".yml") {
-			logrus.Infof("Removing %q", path)
+			logrus.Infof("Removing %#q", path)
 			if err := os.Remove(path); err != nil {
 				logrus.Error(err)
 			}
@@ -74,7 +74,7 @@ func factoryResetAction(cmd *cobra.Command, args []string) error {
 		logrus.Error(err)
 	}
 
-	logrus.Infof("Instance %q has been factory reset", instName)
+	logrus.Infof("Instance %#q has been factory reset", instName)
 	return nil
 }
 

--- a/cmd/limactl/gendoc.go
+++ b/cmd/limactl/gendoc.go
@@ -72,7 +72,7 @@ func gendocAction(cmd *cobra.Command, args []string) error {
 }
 
 func genMan(cmd *cobra.Command, dir string) error {
-	logrus.Infof("Generating man %q", dir)
+	logrus.Infof("Generating man %#q", dir)
 	// lima(1)
 	filePath := filepath.Join(dir, "lima.1")
 	md := "LIMA 1\n======" + `
@@ -140,7 +140,7 @@ weight: 3
 
 // replaceAll replaces all occurrences of text with replacement, for all files in dir.
 func replaceAll(dir, text, replacement string) error {
-	logrus.Infof("Replacing %q with %q", text, replacement)
+	logrus.Infof("Replacing %#q with %#q", text, replacement)
 	return filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return err

--- a/cmd/limactl/genschema.go
+++ b/cmd/limactl/genschema.go
@@ -95,9 +95,9 @@ func genschemaAction(cmd *cobra.Command, args []string) error {
 	for _, f := range args {
 		err = jsonschemautil.Validate(file, f)
 		if err != nil {
-			return fmt.Errorf("%q: %w", f, err)
+			return fmt.Errorf("%#q: %w", f, err)
 		}
-		logrus.Infof("%q: OK", f)
+		logrus.Infof("%#q: OK", f)
 	}
 
 	return err

--- a/cmd/limactl/guest-install.go
+++ b/cmd/limactl/guest-install.go
@@ -65,7 +65,7 @@ func guestInstallAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if inst.Status == limatype.StatusStopped {
-		return fmt.Errorf("instance %q is stopped, run `limactl start %s` to start the instance", instName, instName)
+		return fmt.Errorf("instance %#q is stopped, run `limactl start %s` to start the instance", instName, instName)
 	}
 
 	ctx := cmd.Context()
@@ -117,7 +117,7 @@ func guestInstallAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	bin := prefix + "/bin/lima-guestagent"
-	logrus.Infof("Copying %q to %s:%s", guestAgentFilename, inst.Name, tmpname)
+	logrus.Infof("Copying %#q to %s:%s", guestAgentFilename, inst.Name, tmpname)
 	scpArgs := []string{guestAgentBinary, hostname + ":" + tmp}
 	if err := runCmd(ctx, scpExe, scpFlags, scpArgs...); err != nil {
 		return nil
@@ -141,7 +141,7 @@ func guestInstallAction(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		logrus.Infof("Copying %q to %s:%s", nerdctlFilename, inst.Name, tmpname)
+		logrus.Infof("Copying %#q to %s:%s", nerdctlFilename, inst.Name, tmpname)
 		scpArgs := []string{nerdctlArchive, hostname + ":" + tmp}
 		if err := runCmd(ctx, scpExe, scpFlags, scpArgs...); err != nil {
 			return nil

--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -48,7 +48,7 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 	}
 	if pidfile != "" {
 		if existingPID, err := store.ReadPIDFile(pidfile); existingPID != 0 {
-			return fmt.Errorf("another hostagent may already be running with pid %d (pidfile %q)", existingPID, pidfile)
+			return fmt.Errorf("another hostagent may already be running with pid %d (pidfile %#q)", existingPID, pidfile)
 		} else if err != nil {
 			return fmt.Errorf("failed to determine if another hostagent is running: %w", err)
 		}

--- a/cmd/limactl/list.go
+++ b/cmd/limactl/list.go
@@ -172,7 +172,7 @@ func listAction(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := store.Validate(); err != nil {
-		logrus.Warnf("The directory %q does not look like a valid Lima directory: %v", store.Directory(), err)
+		logrus.Warnf("The directory %#q does not look like a valid Lima directory: %v", store.Directory(), err)
 	}
 
 	allInstances, err := store.Instances()
@@ -243,7 +243,7 @@ func listAction(cmd *cobra.Command, args []string) error {
 
 	for _, instance := range instances {
 		if len(instance.Errors) > 0 {
-			logrus.WithField("errors", instance.Errors).Warnf("instance %q has errors", instance.Name)
+			logrus.WithField("errors", instance.Errors).Warnf("instance %#q has errors", instance.Name)
 		}
 	}
 
@@ -377,12 +377,12 @@ func filterInstances(instances []*limatype.Instance, yqExprs []string) ([]*limat
 	for _, instance := range instances {
 		jsonBytes, err := json.Marshal(instance)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal instance %q: %w", instance.Name, err)
+			return nil, fmt.Errorf("failed to marshal instance %#q: %w", instance.Name, err)
 		}
 
 		result, err := yqutil.EvaluateExpression(yqExpr, jsonBytes)
 		if err != nil {
-			return nil, fmt.Errorf("failed to apply filter %q: %w", yqExpr, err)
+			return nil, fmt.Errorf("failed to apply filter %#q: %w", yqExpr, err)
 		}
 
 		if len(bytes.TrimSpace(result)) > 0 {

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -86,7 +86,7 @@ func processGlobalFlags(rootCmd *cobra.Command) error {
 			logrus.StandardLogger().SetFormatter(formatter)
 		}
 	default:
-		return fmt.Errorf("unsupported log-format: %q", logFormat)
+		return fmt.Errorf("unsupported log-format: %#q", logFormat)
 	}
 	return nil
 }
@@ -278,7 +278,7 @@ func WrapArgsError(argFn cobra.PositionalArgs) cobra.PositionalArgs {
 			return nil
 		}
 
-		return fmt.Errorf("%q %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
+		return fmt.Errorf("%#q %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
 			cmd.CommandPath(), err.Error(),
 			cmd.CommandPath(),
 			cmd.UseLine(), cmd.Short,

--- a/cmd/limactl/network.go
+++ b/cmd/limactl/network.go
@@ -111,7 +111,7 @@ func networkListAction(cmd *cobra.Command, args []string) error {
 		for _, name := range networks {
 			nw, ok := config.Networks[name]
 			if !ok {
-				logrus.Errorf("network %q does not exist", nw)
+				logrus.Errorf("network %#q does not exist", nw)
 				continue
 			}
 			j, err := json.Marshal(nw)
@@ -128,7 +128,7 @@ func networkListAction(cmd *cobra.Command, args []string) error {
 	for _, name := range networks {
 		nw, ok := config.Networks[name]
 		if !ok {
-			logrus.Errorf("network %q does not exist", nw)
+			logrus.Errorf("network %#q does not exist", nw)
 			continue
 		}
 		gwStr := "-"
@@ -175,7 +175,7 @@ func networkCreateAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if _, ok := config.Networks[name]; ok {
-		return fmt.Errorf("network %q already exists", name)
+		return fmt.Errorf("network %#q already exists", name)
 	}
 
 	flags := cmd.Flags()
@@ -197,26 +197,26 @@ func networkCreateAction(cmd *cobra.Command, args []string) error {
 	switch mode {
 	case networks.ModeBridged:
 		if gateway != "" {
-			return fmt.Errorf("network mode %q does not support specifying gateway", mode)
+			return fmt.Errorf("network mode %#q does not support specifying gateway", mode)
 		}
 		if intf == "" {
-			return fmt.Errorf("network mode %q requires specifying interface", mode)
+			return fmt.Errorf("network mode %#q requires specifying interface", mode)
 		}
 		yq := fmt.Sprintf(`.networks.%q = {"mode":%q,"interface":%q}`, name, mode, intf)
 		return networkApplyYQ(yq)
 	default:
 		if gateway == "" {
-			return fmt.Errorf("network mode %q requires specifying gateway", mode)
+			return fmt.Errorf("network mode %#q requires specifying gateway", mode)
 		}
 		if intf != "" {
-			return fmt.Errorf("network mode %q does not support specifying interface", mode)
+			return fmt.Errorf("network mode %#q does not support specifying interface", mode)
 		}
 		if !strings.Contains(gateway, "/") {
 			gateway += "/24"
 		}
 		gwIP, gwMask, err := net.ParseCIDR(gateway)
 		if err != nil {
-			return fmt.Errorf("failed to parse CIDR %q: %w", gateway, err)
+			return fmt.Errorf("failed to parse CIDR %#q: %w", gateway, err)
 		}
 		if gwIP.IsUnspecified() || gwIP.IsLoopback() {
 			return fmt.Errorf("invalid IP address: %v", gwIP)

--- a/cmd/limactl/protect.go
+++ b/cmd/limactl/protect.go
@@ -33,18 +33,18 @@ func protectAction(cmd *cobra.Command, args []string) error {
 	for _, instName := range args {
 		inst, err := store.Inspect(ctx, instName)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to inspect instance %q: %w", instName, err))
+			errs = append(errs, fmt.Errorf("failed to inspect instance %#q: %w", instName, err))
 			continue
 		}
 		if inst.Protected {
-			logrus.Warnf("Instance %q is already protected. Skipping.", instName)
+			logrus.Warnf("Instance %#q is already protected. Skipping.", instName)
 			continue
 		}
 		if err := inst.Protect(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to protect instance %q: %w", instName, err))
+			errs = append(errs, fmt.Errorf("failed to protect instance %#q: %w", instName, err))
 			continue
 		}
-		logrus.Infof("Protected %q", instName)
+		logrus.Infof("Protected %#q", instName)
 	}
 	return errors.Join(errs...)
 }

--- a/cmd/limactl/prune.go
+++ b/cmd/limactl/prune.go
@@ -55,11 +55,11 @@ func pruneAction(cmd *cobra.Command, _ []string) error {
 	}
 	for cacheKey, cachePath := range cacheEntries {
 		if file, exists := knownLocations[cacheKey]; exists {
-			logrus.Debugf("Keep %q caching %q", cacheKey, file.Location)
+			logrus.Debugf("Keep %#q caching %#q", cacheKey, file.Location)
 		} else {
 			logrus.Debug("Deleting ", cacheKey)
 			if err := os.RemoveAll(cachePath); err != nil {
-				logrus.Warnf("Failed to delete %q: %v", cacheKey, err)
+				logrus.Warnf("Failed to delete %#q: %v", cacheKey, err)
 				return err
 			}
 		}
@@ -81,7 +81,7 @@ func knownLocations(ctx context.Context) (map[string]limatype.File, error) {
 			return nil, err
 		}
 		if instance.Errors != nil {
-			logrus.Warnf("skipping instance %q because it has errors: %v", instanceName, instance.Errors)
+			logrus.Warnf("skipping instance %#q because it has errors: %v", instanceName, instance.Errors)
 			continue
 		}
 		maps.Copy(locations, locationsFromLimaYAML(instance.Config))
@@ -105,7 +105,7 @@ func knownLocations(ctx context.Context) (map[string]limatype.File, error) {
 			return nil, err
 		}
 		if err := driverutil.ResolveVMType(ctx, y, t.Name); err != nil {
-			logrus.Warnf("failed to resolve vmType for %q: %v", t.Name, err)
+			logrus.Warnf("failed to resolve vmType for %#q: %v", t.Name, err)
 		}
 		maps.Copy(locations, locationsFromLimaYAML(y))
 	}

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -125,15 +125,15 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	inst, err := store.Inspect(ctx, instName)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("instance %q does not exist, run `limactl create %s` to create a new instance", instName, instName)
+			return fmt.Errorf("instance %#q does not exist, run `limactl create %s` to create a new instance", instName, instName)
 		}
 		return err
 	}
 	if len(inst.Errors) > 0 {
-		logrus.WithError(errors.Join(inst.Errors...)).Errorf("Instance %q has configuration errors", instName)
+		logrus.WithError(errors.Join(inst.Errors...)).Errorf("Instance %#q has configuration errors", instName)
 	}
 	if inst.Config == nil {
-		return fmt.Errorf("instance %q has no configuration", instName)
+		return fmt.Errorf("instance %#q has no configuration", instName)
 	}
 	if inst.Status == limatype.StatusStopped {
 		startNow, err := flags.GetBool("start")
@@ -149,12 +149,12 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		}
 
 		if !startNow {
-			return fmt.Errorf("instance %q is stopped, run `limactl start %s` to start the instance", instName, instName)
+			return fmt.Errorf("instance %#q is stopped, run `limactl start %s` to start the instance", instName, instName)
 		}
 
 		// Network reconciliation will be performed by the process launched by the autostart manager
 		if registered, err := autostart.IsRegistered(ctx, inst); err != nil && !errors.Is(err, autostart.ErrNotSupported) {
-			return fmt.Errorf("failed to check if the autostart entry for instance %q is registered: %w", inst.Name, err)
+			return fmt.Errorf("failed to check if the autostart entry for instance %#q is registered: %w", inst.Name, err)
 		} else if !registered {
 			err = reconcile.Reconcile(ctx, inst.Name)
 			if err != nil {
@@ -178,7 +178,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if restart && sshutil.IsControlMasterExisting(inst.Dir) {
-		logrus.Infof("Exiting ssh session for the instance %q", instName)
+		logrus.Infof("Exiting ssh session for the instance %#q", instName)
 
 		sshConfig := &ssh.SSHConfig{
 			ConfigFile:     inst.SSHConfigFile,
@@ -226,7 +226,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 
 		srcWdDepth := len(strings.Split(hostCurrentDir, string(os.PathSeparator)))
 		if srcWdDepth < rsyncMinimumSrcDirDepth {
-			return fmt.Errorf("expected the depth of the host working directory (%q) to be more than %d, only got %d (Hint: %s)",
+			return fmt.Errorf("expected the depth of the host working directory (%#q) to be more than %d, only got %d (Hint: %s)",
 				hostCurrentDir, rsyncMinimumSrcDirDepth, srcWdDepth, "cd to a deeper directory")
 		}
 	}
@@ -270,7 +270,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	if changeDirCmd == "" {
 		changeDirCmd = "false"
 	}
-	logrus.Debugf("changeDirCmd=%q", changeDirCmd)
+	logrus.Debugf("changeDirCmd=%#q", changeDirCmd)
 
 	shell, err := cmd.Flags().GetString("shell")
 	if err != nil {
@@ -390,7 +390,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		logrus.Debugf("using copy tool %q", rsync.Name())
+		logrus.Debugf("using copy tool %#q", rsync.Name())
 
 		if err := rsyncDirectory(ctx, cmd, rsync, paths); err != nil {
 			return fmt.Errorf("failed to rsync to the guest %w", err)

--- a/cmd/limactl/show-ssh.go
+++ b/cmd/limactl/show-ssh.go
@@ -87,7 +87,7 @@ func showSSHAction(cmd *cobra.Command, args []string) error {
 	inst, err := store.Inspect(ctx, instName)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("instance %q does not exist, run `limactl create %s` to create a new instance", instName, instName)
+			return fmt.Errorf("instance %#q does not exist, run `limactl create %s` to create a new instance", instName, instName)
 		}
 		return err
 	}

--- a/cmd/limactl/start-at-login_unix.go
+++ b/cmd/limactl/start-at-login_unix.go
@@ -27,7 +27,7 @@ func startAtLoginAction(cmd *cobra.Command, args []string) error {
 	inst, err := store.Inspect(ctx, instName)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logrus.Infof("Instance %q not found", instName)
+			logrus.Infof("Instance %#q not found", instName)
 			return nil
 		}
 		return err
@@ -39,23 +39,23 @@ func startAtLoginAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if registered, err := autostart.IsRegistered(ctx, inst); err != nil {
-		return fmt.Errorf("failed to check if the autostart entry for instance %q is registered: %w", inst.Name, err)
+		return fmt.Errorf("failed to check if the autostart entry for instance %#q is registered: %w", inst.Name, err)
 	} else if startAtLogin {
 		verb := "create"
 		if registered {
 			verb = "update"
 		}
 		if err := autostart.RegisterToStartAtLogin(ctx, inst); err != nil {
-			return fmt.Errorf("failed to %s the autostart entry for instance %q: %w", verb, inst.Name, err)
+			return fmt.Errorf("failed to %s the autostart entry for instance %#q: %w", verb, inst.Name, err)
 		}
-		logrus.Infof("The autostart entry for instance %q has been %sd", inst.Name, verb)
+		logrus.Infof("The autostart entry for instance %#q has been %sd", inst.Name, verb)
 	} else {
 		if !registered {
-			logrus.Infof("The autostart entry for instance %q is not registered", inst.Name)
+			logrus.Infof("The autostart entry for instance %#q is not registered", inst.Name)
 		} else if err := autostart.UnregisterFromStartAtLogin(ctx, inst); err != nil {
-			return fmt.Errorf("failed to unregister the autostart entry for instance %q: %w", inst.Name, err)
+			return fmt.Errorf("failed to unregister the autostart entry for instance %#q: %w", inst.Name, err)
 		} else {
-			logrus.Infof("The autostart entry for instance %q has been unregistered", inst.Name)
+			logrus.Infof("The autostart entry for instance %#q has been unregistered", inst.Name)
 		}
 	}
 

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -272,9 +272,9 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 				tmpl.Name = DefaultInstanceName
 			}
 		} else {
-			logrus.Debugf("interpreting argument %q as an instance name", arg)
+			logrus.Debugf("interpreting argument %#q as an instance name", arg)
 			if name != "" && name != arg {
-				return nil, fmt.Errorf("instance name %q and CLI flag --name=%q cannot be specified together", arg, tmpl.Name)
+				return nil, fmt.Errorf("instance name %#q and CLI flag --name=%#q cannot be specified together", arg, tmpl.Name)
 			}
 			tmpl.Name = arg
 		}
@@ -282,9 +282,9 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 		inst, err := store.Inspect(ctx, tmpl.Name)
 		if err == nil {
 			if createOnly {
-				return nil, fmt.Errorf("instance %q already exists", tmpl.Name)
+				return nil, fmt.Errorf("instance %#q already exists", tmpl.Name)
 			}
-			logrus.Infof("Using the existing instance %q", tmpl.Name)
+			logrus.Infof("Using the existing instance %#q", tmpl.Name)
 			yqExprs, err := editflags.YQExpressions(flags, false, inst.Config.Param)
 			if err != nil {
 				return nil, err
@@ -293,7 +293,7 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 				yq := yqutil.Join(yqExprs)
 				inst, err = applyYQExpressionToExistingInstance(ctx, inst, yq)
 				if err != nil {
-					return nil, fmt.Errorf("failed to apply yq expression %q to instance %q: %w", yq, tmpl.Name, err)
+					return nil, fmt.Errorf("failed to apply yq expression %#q to instance %#q: %w", yq, tmpl.Name, err)
 				}
 			}
 			return inst, nil
@@ -302,7 +302,7 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 			return nil, err
 		}
 		if arg != "" && arg != DefaultInstanceName {
-			logrus.Infof("Creating an instance %q from template:default (Not from template:%s)", tmpl.Name, tmpl.Name)
+			logrus.Infof("Creating an instance %#q from template:default (Not from template:%s)", tmpl.Name, tmpl.Name)
 			logrus.Warnf("This form is deprecated. Use `limactl create --name=%s template:default` instead", tmpl.Name)
 		}
 		// Read the default template for creating a new instance
@@ -318,7 +318,7 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 		if createOnly {
 			// store.Inspect() will also validate the instance name
 			if _, err := store.Inspect(ctx, tmpl.Name); err == nil {
-				return nil, fmt.Errorf("instance %q already exists", tmpl.Name)
+				return nil, fmt.Errorf("instance %#q already exists", tmpl.Name)
 			}
 		} else if err := dirnames.ValidateInstName(tmpl.Name); err != nil {
 			return nil, err
@@ -364,7 +364,7 @@ func applyYQExpressionToExistingInstance(ctx context.Context, inst *limatype.Ins
 	if err != nil {
 		return nil, err
 	}
-	logrus.Debugf("Applying yq expression %q to an existing instance %q", yq, inst.Name)
+	logrus.Debugf("Applying yq expression %#q to an existing instance %#q", yq, inst.Name)
 	yBytes, err := yqutil.EvaluateExpression(yq, yContent)
 	if err != nil {
 		return nil, err
@@ -374,15 +374,15 @@ func applyYQExpressionToExistingInstance(ctx context.Context, inst *limatype.Ins
 		return nil, err
 	}
 	if err := driverutil.ResolveVMType(ctx, y, filePath); err != nil {
-		return nil, fmt.Errorf("failed to resolve vm for %q: %w", filePath, err)
+		return nil, fmt.Errorf("failed to resolve vm for %#q: %w", filePath, err)
 	}
 	if err := limayaml.Validate(y, true); err != nil {
 		rejectedYAML := "lima.REJECTED.yaml"
 		if writeErr := os.WriteFile(rejectedYAML, yBytes, 0o644); writeErr != nil {
-			return nil, fmt.Errorf("the YAML is invalid, attempted to save the buffer as %q but failed: %w: %w", rejectedYAML, writeErr, err)
+			return nil, fmt.Errorf("the YAML is invalid, attempted to save the buffer as %#q but failed: %w: %w", rejectedYAML, writeErr, err)
 		}
 		// TODO: may need to support editing the rejected YAML
-		return nil, fmt.Errorf("the YAML is invalid, saved the buffer as %q: %w", rejectedYAML, err)
+		return nil, fmt.Errorf("the YAML is invalid, saved the buffer as %#q: %w", rejectedYAML, err)
 	}
 	if err := os.WriteFile(filePath, yBytes, 0o644); err != nil {
 		return nil, err
@@ -421,7 +421,7 @@ func chooseNextCreatorState(ctx context.Context, tmpl *limatmpl.Template, yq str
 			logrus.WithError(err).Warn("Failed to evaluate yq expression")
 			return tmpl, err
 		}
-		message := fmt.Sprintf("Creating an instance %q", tmpl.Name)
+		message := fmt.Sprintf("Creating an instance %#q", tmpl.Name)
 		options := []string{
 			"Proceed with the current configuration",
 			"Open an editor to review or modify the current configuration",
@@ -440,7 +440,7 @@ func chooseNextCreatorState(ctx context.Context, tmpl *limatmpl.Template, yq str
 		case 0: // "Proceed with the current configuration"
 			return tmpl, nil
 		case 1: // "Open an editor ..."
-			hdr := fmt.Sprintf("# Review and modify the following configuration for Lima instance %q.\n", tmpl.Name)
+			hdr := fmt.Sprintf("# Review and modify the following configuration for Lima instance %#q.\n", tmpl.Name)
 			if tmpl.Name == DefaultInstanceName {
 				hdr += "# - In most cases, you do not need to modify this file.\n"
 			}
@@ -499,7 +499,7 @@ func chooseNextCreatorState(ctx context.Context, tmpl *limatmpl.Template, yq str
 		case 3: // "Exit"
 			return nil, exitSuccessError{Msg: "Choosing to exit"}
 		default:
-			return tmpl, fmt.Errorf("unexpected answer %q", ans)
+			return tmpl, fmt.Errorf("unexpected answer %#q", ans)
 		}
 	}
 }
@@ -580,19 +580,19 @@ func startAction(cmd *cobra.Command, args []string) error {
 	}
 	switch inst.Status {
 	case limatype.StatusRunning:
-		logrus.Infof("The instance %q is already running. Run `%s` to open the shell.",
+		logrus.Infof("The instance %#q is already running. Run `%s` to open the shell.",
 			inst.Name, instance.LimactlShellCmd(inst.Name))
 		// Not an error
 		return nil
 	case limatype.StatusStopped:
 		// NOP
 	default:
-		logrus.Warnf("expected status %q, got %q", limatype.StatusStopped, inst.Status)
+		logrus.Warnf("expected status %#q, got %#q", limatype.StatusStopped, inst.Status)
 	}
 	ctx := cmd.Context()
 	// Network reconciliation will be performed by the process launched by the autostart manager
 	if registered, err := autostart.IsRegistered(ctx, inst); err != nil && !errors.Is(err, autostart.ErrNotSupported) {
-		return fmt.Errorf("failed to check if the autostart entry for instance %q is registered: %w", inst.Name, err)
+		return fmt.Errorf("failed to check if the autostart entry for instance %#q is registered: %w", inst.Name, err)
 	} else if (registered && autostart.AutoStartedIdentifier() != "") || !registered {
 		err = reconcile.Reconcile(ctx, inst.Name)
 		if err != nil {

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -37,6 +37,6 @@ See %s for the usage.`, socketVMNetURL),
 	}
 	cfgFile, _ := networks.ConfigFile()
 	sudoersCommand.Flags().Bool("check", false,
-		fmt.Sprintf("check that the sudoers file is up-to-date with %q", cfgFile))
+		fmt.Sprintf("check that the sudoers file is up-to-date with %#q", cfgFile))
 	return sudoersCommand
 }

--- a/cmd/limactl/sudoers_darwin.go
+++ b/cmd/limactl/sudoers_darwin.go
@@ -56,7 +56,7 @@ func verifySudoAccess(ctx context.Context, nwCfg networks.Config, args []string,
 		file = nwCfg.Paths.Sudoers
 		if file == "" {
 			cfgFile, _ := networks.ConfigFile()
-			return fmt.Errorf("no sudoers file defined in %q", cfgFile)
+			return fmt.Errorf("no sudoers file defined in %#q", cfgFile)
 		}
 	case 1:
 		file = args[0]
@@ -66,6 +66,6 @@ func verifySudoAccess(ctx context.Context, nwCfg networks.Config, args []string,
 	if err := nwCfg.VerifySudoAccess(ctx, file); err != nil {
 		return err
 	}
-	fmt.Fprintf(stdout, "%q is up-to-date (or sudo doesn't require a password)\n", file)
+	fmt.Fprintf(stdout, "%#q is up-to-date (or sudo doesn't require a password)\n", file)
 	return nil
 }

--- a/cmd/limactl/template.go
+++ b/cmd/limactl/template.go
@@ -88,7 +88,7 @@ func fillDefaults(ctx context.Context, tmpl *limatmpl.Template) error {
 		tmpl.Bytes, err = limayaml.Marshal(tmpl.Config, false)
 	}
 	if err := driverutil.ResolveVMType(ctx, tmpl.Config, filePath); err != nil {
-		logrus.Warnf("failed to resolve VM type for %q: %v", filePath, err)
+		logrus.Warnf("failed to resolve VM type for %#q: %v", filePath, err)
 		return nil
 	}
 	return err
@@ -131,7 +131,7 @@ func templateCopyAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if len(tmpl.Bytes) == 0 {
-		return fmt.Errorf("don't know how to interpret %q as a template locator", source)
+		return fmt.Errorf("don't know how to interpret %#q as a template locator", source)
 	}
 	if !verbatim {
 		if embed {
@@ -203,7 +203,7 @@ func templateYQAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if len(tmpl.Bytes) == 0 {
-		return fmt.Errorf("don't know how to interpret %q as a template locator", locator)
+		return fmt.Errorf("don't know how to interpret %#q as a template locator", locator)
 	}
 	if err := tmpl.Embed(cmd.Context(), true, true); err != nil {
 		return err
@@ -247,10 +247,10 @@ func templateValidateAction(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if len(tmpl.Bytes) == 0 {
-			return fmt.Errorf("don't know how to interpret %q as a template locator", arg)
+			return fmt.Errorf("don't know how to interpret %#q as a template locator", arg)
 		}
 		if tmpl.Name == "" {
-			return fmt.Errorf("can't determine instance name from template locator %q", arg)
+			return fmt.Errorf("can't determine instance name from template locator %#q", arg)
 		}
 		// Embed default base.yaml only when fill is true.
 		if err := tmpl.Embed(cmd.Context(), true, fill); err != nil {
@@ -264,16 +264,16 @@ func templateValidateAction(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if err := driverutil.ResolveVMType(ctx, y, filePath); err != nil {
-			logrus.Warnf("failed to resolve VM type for %q: %v", filePath, err)
+			logrus.Warnf("failed to resolve VM type for %#q: %v", filePath, err)
 		}
 		if err := limayaml.Validate(y, false); err != nil {
-			return fmt.Errorf("failed to validate YAML file %q: %w", arg, err)
+			return fmt.Errorf("failed to validate YAML file %#q: %w", arg, err)
 		}
-		logrus.Infof("%q: OK", arg)
+		logrus.Infof("%#q: OK", arg)
 		if fill {
 			b, err := limayaml.Marshal(y, len(args) > 1)
 			if err != nil {
-				return fmt.Errorf("failed to marshal template %q again after filling defaults: %w", arg, err)
+				return fmt.Errorf("failed to marshal template %#q again after filling defaults: %w", arg, err)
 			}
 			fmt.Fprint(cmd.OutOrStdout(), string(b))
 		}

--- a/cmd/limactl/tunnel.go
+++ b/cmd/limactl/tunnel.go
@@ -55,7 +55,7 @@ func tunnelAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if tunnelType != "socks" {
-		return fmt.Errorf("unknown tunnel type: %q", tunnelType)
+		return fmt.Errorf("unknown tunnel type: %#q", tunnelType)
 	}
 	port, err := flags.GetInt("socks-port")
 	if err != nil {
@@ -69,12 +69,12 @@ func tunnelAction(cmd *cobra.Command, args []string) error {
 	inst, err := store.Inspect(ctx, instName)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("instance %q does not exist, run `limactl create %s` to create a new instance", instName, instName)
+			return fmt.Errorf("instance %#q does not exist, run `limactl create %s` to create a new instance", instName, instName)
 		}
 		return err
 	}
 	if inst.Status == limatype.StatusStopped {
-		return fmt.Errorf("instance %q is stopped, run `limactl start %s` to start the instance", instName, instName)
+		return fmt.Errorf("instance %#q is stopped, run `limactl start %s` to start the instance", instName, instName)
 	}
 
 	if port == 0 {

--- a/cmd/limactl/unprotect.go
+++ b/cmd/limactl/unprotect.go
@@ -31,18 +31,18 @@ func unprotectAction(cmd *cobra.Command, args []string) error {
 	for _, instName := range args {
 		inst, err := store.Inspect(ctx, instName)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to inspect instance %q: %w", instName, err))
+			errs = append(errs, fmt.Errorf("failed to inspect instance %#q: %w", instName, err))
 			continue
 		}
 		if !inst.Protected {
-			logrus.Warnf("Instance %q isn't protected. Skipping.", instName)
+			logrus.Warnf("Instance %#q isn't protected. Skipping.", instName)
 			continue
 		}
 		if err := inst.Unprotect(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to unprotect instance %q: %w", instName, err))
+			errs = append(errs, fmt.Errorf("failed to unprotect instance %#q: %w", instName, err))
 			continue
 		}
-		logrus.Infof("Unprotected %q", instName)
+		logrus.Infof("Unprotected %#q", instName)
 	}
 	return errors.Join(errs...)
 }

--- a/cmd/limactl/usernet.go
+++ b/cmd/limactl/usernet.go
@@ -41,7 +41,7 @@ func usernetAction(cmd *cobra.Command, _ []string) error {
 	}
 	if pidfile != "" {
 		if _, err := os.Stat(pidfile); !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("pidfile %q already exists", pidfile)
+			return fmt.Errorf("pidfile %#q already exists", pidfile)
 		}
 		if err := os.WriteFile(pidfile, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
 			return err

--- a/cmd/limactl/watch.go
+++ b/cmd/limactl/watch.go
@@ -81,7 +81,7 @@ func (w *eventWatcher) startInstance(instName string) {
 
 	inst, err := store.Inspect(w.ctx, instName)
 	if err != nil {
-		logrus.WithError(err).Warnf("Failed to inspect instance %q", instName)
+		logrus.WithError(err).Warnf("Failed to inspect instance %#q", instName)
 		w.watching.Delete(instName)
 		return
 	}
@@ -102,7 +102,7 @@ func (w *eventWatcher) watchInstance(instName, haStdoutPath, haStderrPath string
 		return false
 	})
 	if err != nil && w.ctx.Err() == nil {
-		logrus.WithError(err).Warnf("Watcher for instance %q stopped", instName)
+		logrus.WithError(err).Warnf("Watcher for instance %#q stopped", instName)
 	}
 }
 

--- a/hack/bats/tests/param.bats
+++ b/hack/bats/tests/param.bats
@@ -37,7 +37,7 @@ EOF
 
 @test 'create rejects undefined --param' {
     run_e -1 limactl create --name param-create-invalid --param missing=value - <<<"$(param_template)"
-    assert_fatal 'error while processing flag "param": template does not define param "missing"'
+    assert_fatal "error while processing flag \`param\`: template does not define param \`missing\`"
 }
 
 @test 'edit accepts --param shortcut' {

--- a/hack/bats/tests/protect.bats
+++ b/hack/bats/tests/protect.bats
@@ -17,7 +17,7 @@ local_setup_file() {
 
 @test 'protecting a non-existing instance fails' {
     run_e -1 limactl protect "${NOTEXIST}"
-    assert_fatal "failed to inspect instance `${NOTEXIST}`…"
+    assert_fatal "failed to inspect instance \`${NOTEXIST}\`…"
 }
 
 @test 'protecting the dummy instance succeeds' {
@@ -41,7 +41,7 @@ local_setup_file() {
 
 @test 'deleting the unprotected clone instance succeeds' {
     run_e -0 limactl delete --force "$CLONE"
-    assert_info "Deleted `${CLONE}`…"
+    assert_info "Deleted \`${CLONE}\`…"
 }
 
 @test 'deleting protected dummy instance fails' {
@@ -64,5 +64,5 @@ local_setup_file() {
 
 @test 'deleting unprotected dummy instance succeeds' {
     run_e -0 limactl delete --force "$INSTANCE"
-    assert_info "Deleted `${INSTANCE}`…"
+    assert_info "Deleted \`${INSTANCE}\`…"
 }

--- a/hack/bats/tests/protect.bats
+++ b/hack/bats/tests/protect.bats
@@ -17,18 +17,18 @@ local_setup_file() {
 
 @test 'protecting a non-existing instance fails' {
     run_e -1 limactl protect "${NOTEXIST}"
-    assert_fatal "failed to inspect instance \"${NOTEXIST}\"…"
+    assert_fatal "failed to inspect instance `${NOTEXIST}`…"
 }
 
 @test 'protecting the dummy instance succeeds' {
     run_e -0 limactl protect "$INSTANCE"
-    assert_info "Protected \"${INSTANCE}\""
+    assert_info "Protected \`${INSTANCE}\`"
     assert_file_exists "${LIMA_HOME}/${INSTANCE}/protected"
 }
 
 @test 'protecting it again shows a warning, but succeeds' {
     run_e -0 limactl protect "$INSTANCE"
-    assert_warning "Instance \"${INSTANCE}\" is already protected. Skipping."
+    assert_warning "Instance \`${INSTANCE}\` is already protected. Skipping."
     assert_file_exists "${LIMA_HOME}/${INSTANCE}/protected"
 }
 
@@ -41,28 +41,28 @@ local_setup_file() {
 
 @test 'deleting the unprotected clone instance succeeds' {
     run_e -0 limactl delete --force "$CLONE"
-    assert_info "Deleted \"${CLONE}\"…"
+    assert_info "Deleted `${CLONE}`…"
 }
 
 @test 'deleting protected dummy instance fails' {
     run_e -1 limactl delete --force "$INSTANCE"
-    assert_fatal "failed to delete instance \"${INSTANCE}\": instance is protected…"
+    assert_fatal "failed to delete instance \`${INSTANCE}\`: instance is protected…"
     assert_file_exists "$LIMA_HOME/$INSTANCE/protected"
 }
 
 @test 'unprotecting the dummy instance succeeds' {
     run_e -0 limactl unprotect "$INSTANCE"
-    assert_info "Unprotected \"${INSTANCE}\""
+    assert_info "Unprotected \`${INSTANCE}\`"
     assert_file_not_exists "$LIMA_HOME/$INSTANCE/protected"
 }
 
 @test 'unprotecting it again shows a warning, but succeeds' {
     run_e -0 limactl unprotect "$INSTANCE"
-    assert_warning "Instance \"${INSTANCE}\" isn't protected. Skipping."
+    assert_warning "Instance \`${INSTANCE}\` isn't protected. Skipping."
     assert_file_not_exists "$LIMA_HOME/$INSTANCE/protected"
 }
 
 @test 'deleting unprotected dummy instance succeeds' {
     run_e -0 limactl delete --force "$INSTANCE"
-    assert_info "Deleted \"${INSTANCE}\"…"
+    assert_info "Deleted `${INSTANCE}`…"
 }

--- a/hack/bats/tests/shell.bats
+++ b/hack/bats/tests/shell.bats
@@ -8,13 +8,13 @@ INSTANCE=bats-dummy
 @test 'lima stopped lima instance' {
     # check that the "tty" flag is used, also for stdin
     run_e -1 limactl shell --tty=false "$INSTANCE" true </dev/null
-    assert_stderr --partial "instance \\\"$INSTANCE\\\" is stopped"
+    assert_stderr --partial "instance \`$INSTANCE\` is stopped"
 }
 
 @test 'yes | stopped lima instance' {
     # check that stdin is verified and not just crashing
     run_e -1 bash -c "yes | limactl shell --tty=true $INSTANCE true"
-    assert_stderr --partial "instance \\\"$INSTANCE\\\" is stopped"
+    assert_stderr --partial "instance \`$INSTANCE\` is stopped"
 }
 
 @test 'limactl shell without --instance requires instance name as first argument' {


### PR DESCRIPTION
Change `%q` in logs and errors to `%#q` (all files in `cmd/limactl`) .

Related issue: #4898 

Question:
I have modified 126 files in total, so I need to push another 98 files.
I am worried that 126 files are too many to be reviewd in one PR.
Can I add them in this PR?
Would it be better to raise another PRs?