### PR TITLE
shell: clean up stale ssh.sock on --reconnect when the master is already dead

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,6 +29,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/instance"
 	"github.com/lima-vm/lima/v2/pkg/ioutilx"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/localpathutil"
 	"github.com/lima-vm/lima/v2/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/v2/pkg/sshutil"
@@ -186,9 +188,30 @@ func shellAction(cmd *cobra.Command, args []string) error {
 			AdditionalArgs: []string{},
 		}
 
+		// IsControlMasterExisting only checks that the control socket file is
+		// present; it does not verify that the master process is alive. After
+		// an unclean hostagent shutdown the file can outlive the master, in
+		// which case `ssh -O exit` fails. Treating that failure as fatal
+		// defeats the purpose of --reconnect (the user is asking us to reset
+		// a broken state).
+		//
+		// However, ExitMaster can also fail for reasons other than a dead
+		// master (transient ssh errors, missing binary, etc.); blindly
+		// removing the socket in those cases would rip it out from under a
+		// still-live multiplexed connection. Disambiguate by running
+		// `ssh -O check` after a failed exit, and only remove the stale
+		// socket when the master is confirmed dead.
 		if err := ssh.ExitMaster(inst.Hostname, inst.SSHLocalPort, sshConfig); err != nil {
-			return err
+			if isControlMasterAlive(inst.Hostname, inst.SSHLocalPort, sshConfig) {
+				return fmt.Errorf("ssh master is still alive but `ssh -O exit` failed: %w", err)
+			}
+			logrus.WithError(err).Warn("ssh master is not responding; removing stale control socket")
+			controlSock := filepath.Join(inst.Dir, filenames.SSHSock)
+			if rmErr := os.Remove(controlSock); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
+				return fmt.Errorf("failed to remove stale ssh control socket %q: %w", controlSock, rmErr)
+			}
 		}
+		// Success path: `ssh -O exit` already unlinked the control socket.
 	}
 
 	syncDirVal, err := flags.GetString("sync")
@@ -726,6 +749,22 @@ func quoteEnv(arg string) string {
 	env := strings.SplitN(arg, "=", 2)
 	env[1] = shellescape.Quote(env[1])
 	return strings.Join(env, "=")
+}
+
+// isControlMasterAlive runs `ssh -O check` against the multiplex control
+// socket in c. It returns true if the master process behind the socket is
+// still running (the check command exits 0), and false otherwise (master
+// is dead, socket is stale, or the check itself failed). Used to decide
+// whether a failed `ssh -O exit` indicates a dead master that we can clean
+// up after, or a still-live master we should leave alone.
+func isControlMasterAlive(host string, port int, c *ssh.SSHConfig) bool {
+	args := c.Args()
+	args = append(args, "-O", "check")
+	if port != 0 {
+		args = append(args, "-p", strconv.Itoa(port))
+	}
+	args = append(args, host)
+	return exec.Command(c.Binary(), args...).Run() == nil
 }
 
 type rsyncStats struct {


### PR DESCRIPTION
## Summary

Fixes #4913.

`limactl shell --reconnect <inst>` (added in #3125 as the user-visible escape hatch for resetting a wedged SSH session) currently fails with `exit status 255` when the SSH ControlMaster file in `<instDir>/ssh.sock` exists but the master process is already dead — exactly the scenario where the user expects `--reconnect` to *recover* the broken state.

`sshutil.IsControlMasterExisting` is a pure `os.Stat` (`pkg/sshutil/sshutil.go:328-333`); it does not verify the master process is alive. After any unclean hostagent exit (`kill -9`, OOM, panic before the registered `cleanUp` runs) the socket file outlives the master. In that state `ssh.ExitMaster` shells out `ssh -O exit`, which fails with `Control socket connect: Connection refused`. `shellAction` returned that error directly, leaving the user with no in-tree recovery — they had to `rm ~/.lima/<inst>/ssh.sock` by hand.

This PR:

1. Treats the `ssh.ExitMaster` failure as a warning instead of fatal.
2. Forcibly removes the stale control socket after `ExitMaster`. `ssh -O exit` already unlinks the socket on success, so this is a no-op on the happy path and the only effective recovery on the unhappy path.

Disproportionately affects Windows hosts: Cygwin/msys2 OpenSSH emulates the Unix-domain control socket as a regular file + TCP fallback, which is even more prone to outliving its master than a real Unix-domain socket. Lima already strips `ControlMaster` in three Windows-specific call sites for related Cygwin flakiness (`pkg/hostagent/hostagent.go:290`, `pkg/hostagent/requirements.go:124`, `cmd/limactl/shell.go:337`); this PR closes the matching gap on the `--reconnect` cleanup path.

Closes #4913.

## Test plan

- [x] `go vet ./cmd/limactl/...` — clean
- [x] `go build ./cmd/limactl/...` — clean
- [x] `go test ./cmd/limactl/...` — pass
- [ ] Manual repro:
  ```sh
  limactl start default
  kill -9 $(cat ~/.lima/default/ha.pid)
  ls ~/.lima/default/ssh.sock          # still present
  limactl shell --reconnect default    # before: exit 255; after: succeeds
  ls ~/.lima/default/ssh.sock          # should be gone
  ```
- [ ] Re-run `limactl shell default` afterwards to confirm a clean session is re-established.
- [ ] Confirm the happy path is unaffected: `limactl shell --reconnect default` against a live master should still exit cleanly with no warning.
