### PR TITLE
pkg/store: treat unknown terminal width as unlimited in `limactl ls`

### DIFF
--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -316,11 +316,13 @@ func PrintInstances(w io.Writer, instances []*limatype.Instance, format string, 
 		hideArch := false
 		hideDir := false
 
+		// width == 0 means the terminal width is unknown (e.g. stdout is not a TTY),
+		// in which case we treat it as unlimited and never hide any column.
 		columns := 1 // NAME
 		columns += 2 // STATUS
 		columns += 2 // SSH
 		// can we still fit the remaining columns (7)
-		if width == 0 || (columns+7)*columnWidth > width && !all {
+		if width != 0 && (columns+7)*columnWidth > width && !all {
 			hideType = len(types) == 1
 		}
 		if !hideType {
@@ -329,7 +331,7 @@ func PrintInstances(w io.Writer, instances []*limatype.Instance, format string, 
 		// only hide arch if it is the same as the host arch
 		goarch := limatype.NewArch(runtime.GOARCH)
 		// can we still fit the remaining columns (6)
-		if width == 0 || (columns+6)*columnWidth > width && !all {
+		if width != 0 && (columns+6)*columnWidth > width && !all {
 			hideArch = len(archs) == 1 && instances[0].Arch == goarch
 		}
 		if !hideArch {

--- a/pkg/store/instance_test.go
+++ b/pkg/store/instance_test.go
@@ -33,14 +33,15 @@ var instance = limatype.Instance{
 	SSHAddress: "127.0.0.1",
 }
 
-var table = "NAME    STATUS     SSH            CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    0       0B        0B      dir\n"
+// width 0 means the terminal width is unknown (stdout is not a TTY), so all columns are shown.
+var table = "NAME    STATUS     SSH            VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    127.0.0.1:0    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
 
-var tableEmu = "NAME    STATUS     SSH            ARCH       CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    unknown    0       0B        0B      dir\n"
+var tableEmu = "NAME    STATUS     SSH            VMTYPE    ARCH       CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    127.0.0.1:0    " + vmtype + "      unknown    0       0B        0B      dir\n"
 
-var tableHome = "NAME    STATUS     SSH            CPUS    MEMORY    DISK    DIR\n" +
-	"foo     Stopped    127.0.0.1:0    0       0B        0B      ~" + separator + "dir\n"
+var tableHome = "NAME    STATUS     SSH            VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
+	"foo     Stopped    127.0.0.1:0    " + vmtype + "      " + goarch + "    0       0B        0B      ~" + separator + "dir\n"
 
 var tableAll = "NAME    STATUS     SSH            VMTYPE    ARCH" + space + "    CPUS    MEMORY    DISK    DIR\n" +
 	"foo     Stopped    127.0.0.1:0    " + vmtype + "      " + goarch + "    0       0B        0B      dir\n"
@@ -168,6 +169,27 @@ func TestPrintInstanceTableAll(t *testing.T) {
 	err := PrintInstances(&buf, instances, "table", &options)
 	assert.NilError(t, err)
 	assert.Equal(t, tableAll, buf.String())
+}
+
+// Regression test for https://github.com/lima-vm/lima/issues/3986:
+// when stdout is not a TTY (TerminalWidth == 0), all columns must be shown,
+// regardless of whether --all-fields was passed.
+func TestPrintInstanceTableNonTTY(t *testing.T) {
+	instances := []*limatype.Instance{&instance}
+	t.Run("AllFields", func(t *testing.T) {
+		var buf bytes.Buffer
+		options := PrintOptions{AllFields: true}
+		err := PrintInstances(&buf, instances, "table", &options)
+		assert.NilError(t, err)
+		assert.Equal(t, tableAll, buf.String())
+	})
+	t.Run("Default", func(t *testing.T) {
+		var buf bytes.Buffer
+		options := PrintOptions{}
+		err := PrintInstances(&buf, instances, "table", &options)
+		assert.NilError(t, err)
+		assert.Equal(t, tableAll, buf.String())
+	})
 }
 
 func TestPrintInstanceTableTwo(t *testing.T) {


### PR DESCRIPTION
Fixes #3986.

When stdout is not a TTY, `termutil.TerminalWidth()` is not consulted and `PrintOptions.TerminalWidth` stays at `0`. The table printer was reading that `0` as "very narrow" and hiding the VMTYPE and ARCH columns even when `--all-fields` was passed, so `limactl ls --all-fields | cat` produced different output from the same command in a terminal - which is also why integration tests for `--all-fields` weren't possible.

Per the discussion on the issue, this aligns the VMTYPE and ARCH conditions with the existing DIR condition, treating an unknown width as unlimited and showing every column.

## Changes

- `pkg/store/instance.go`: change `width == 0 || ...` to `width != 0 && ...` for the VMTYPE and ARCH hide-checks.
- `pkg/store/instance_test.go`: update the three tests that exercised the zero-width path (they had encoded the old buggy expectation) and add `TestPrintInstanceTableNonTTY` as an explicit regression test covering both `--all-fields` and the default case.

## Test plan

- [x] `go test ./pkg/store/...` - all `TestPrintInstance*` subtests pass, including the new `TestPrintInstanceTableNonTTY/{AllFields,Default}`.
- [x] `go test ./...` - full unit-test suite passes.
- [x] `go build ./...` - clean.
- [x] Manually built `limactl` and confirmed `limactl ls --all-fields | cat` no longer drops columns.