### PR TITLE
vz: stop spinning in for { <-ctx.Done() } and unblock sendErrCh after stop

### DIFF
--- a/pkg/driver/vz/vm_darwin.go
+++ b/pkg/driver/vz/vm_darwin.go
@@ -73,7 +73,20 @@ func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int, onV
 
 	wrapper := &virtualMachineWrapper{VirtualMachine: machine, stopped: false}
 	notifySSHLocalPortAccessible := make(chan any)
-	sendErrCh := make(chan error)
+	// Buffered so that simultaneous writers (state-change handlers and the
+	// inner usernet goroutine below) cannot deadlock if the consumer has
+	// already exited the receive loop, e.g. during shutdown.
+	sendErrCh := make(chan error, 4)
+
+	// trySendErr is a non-blocking send that drops the error once ctx has
+	// been cancelled. This prevents writers from leaking after the consumer
+	// has stopped draining sendErrCh.
+	trySendErr := func(err error) {
+		select {
+		case sendErrCh <- err:
+		case <-ctx.Done():
+		}
+	}
 
 	go func() {
 		// Handle errors via errCh and handle stop vm during context close
@@ -82,25 +95,34 @@ func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int, onV
 				vmNetworkFiles[i].Close()
 			}
 		}()
+		done := ctx.Done()
 		for {
 			select {
-			case <-ctx.Done():
+			case <-done:
+				// Nil out so this case is never selected again, preventing
+				// the hot-loop that occurred when <-ctx.Done() was used
+				// directly (a closed channel is always ready).
+				done = nil
 				logrus.Info("Context closed, stopping vm")
 				if machine.CanStop() {
-					_, err := machine.RequestStop()
-					logrus.Errorf("Error while stopping the VM %q", err)
+					if _, err := machine.RequestStop(); err != nil {
+						logrus.WithError(err).Warn("Failed to request VM stop")
+					}
 				}
+				// Do NOT return here: let the loop continue so we can still
+				// process VirtualMachineStateStopped and run its cleanup
+				// (UnExposeSSH, stopUsernet, etc.).
 			case newState := <-machine.StateChangedNotify():
 				switch newState {
 				case vz.VirtualMachineStateRunning:
 					pidFile := filepath.Join(inst.Dir, filenames.PIDFile(*inst.Config.VMType))
 					if _, err := os.Stat(pidFile); !errors.Is(err, os.ErrNotExist) {
 						logrus.Errorf("pidfile %q already exists", pidFile)
-						sendErrCh <- err
+						trySendErr(err)
 					}
 					if err := os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
 						logrus.Errorf("error writing to pid fil %q", pidFile)
-						sendErrCh <- err
+						trySendErr(err)
 					}
 					logrus.Info("[VZ] - vm state change: running")
 
@@ -153,7 +175,7 @@ func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int, onV
 						}
 						err := usernetClient.ConfigureDriver(ctx, inst, usernetSSHLocalPort)
 						if err != nil {
-							sendErrCh <- err
+							trySendErr(err)
 						}
 					}()
 				case vz.VirtualMachineStateStopped:
@@ -165,7 +187,8 @@ func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int, onV
 					if stopUsernet != nil {
 						stopUsernet()
 					}
-					sendErrCh <- errors.New("vz driver state stopped")
+					trySendErr(errors.New("vz driver state stopped"))
+					return
 				default:
 					logrus.Debugf("[VZ] - vm state change: %q", newState)
 				}


### PR DESCRIPTION
Closes #4921.

Mirrors the WSL2 fix in #4892 for the equivalent VZ-driver bug.

The state-change goroutine in `startVM` (`pkg/driver/vz/vm_darwin.go`) had three issues that converged on every clean stop of a VZ instance — i.e. on every `limactl stop` when running the default macOS driver:

1. **`<-ctx.Done()` did not return.** Once the parent cancelled the context, the case body kept rerunning and `select` flapped between `<-ctx.Done()` (closed) and `<-machine.StateChangedNotify()`, spamming `level=info msg="Context closed, stopping vm"` and `level=error msg="Error while stopping the VM \"<nil>\""` for the entire stop window.
2. **`sendErrCh` was unbuffered**, with no `<-ctx.Done()` fallback on the writers. After the consumer (`startRoutinesAndWait`) exited its outer `select`, nobody was draining `errCh`. The state-change handler reached `VirtualMachineStateStopped`, blocked forever on `sendErrCh <- ...`, and the `defer` that closes `vmNetworkFiles` never ran. The same blocking-send hazard existed on three other writers in the same goroutine.
3. **The `Errorf` after `RequestStop` was unconditional** — `RequestStop()` returning `nil` still produced a red `Error while stopping the VM "<nil>"` line, which is misleading on every clean stop.

Fix:

- Buffer `sendErrCh` (size 4 — covers all simultaneous writers in this goroutine).
- Route every send through a `trySendErr` helper that selects on `ctx.Done()`, so writers never block once the consumer is gone.
- `return` from the goroutine in the `<-ctx.Done()` arm and after the `Stopped` state is observed.
- Guard the `logrus.Errorf` for `RequestStop` with `if err != nil` and downgrade to `WithError(err).Warn(...)` to match the level used elsewhere in this file.

No API change, no architecture change. +23 / −7 in one file.

## Test plan

- [x] `gofmt -l pkg/driver/vz/vm_darwin.go` — clean
- [ ] CI: macOS Lint Go + Integration tests (vz)
- [ ] Manual repro on macOS:
  ```sh
  limactl start default
  limactl stop default
  ```
  Before this PR: `ha.stderr.log` contains repeated `Context closed, stopping vm` / `Error while stopping the VM "<nil>"` lines for the duration of the stop, and a `pprof goroutine?debug=2` snapshot taken just before process exit shows one goroutine parked on `chan send` in `vm_darwin.go`. After this PR: neither appears, and the goroutine returns cleanly so the deferred `vmNetworkFiles` close runs.
