### PR TITLE
hostagent: wait for the guest agent before opening the inotify stream

### DIFF
--- a/pkg/hostagent/inotify.go
+++ b/pkg/hostagent/inotify.go
@@ -35,6 +35,14 @@ func (a *HostAgent) startInotify(ctx context.Context) error {
 	// goroutine; without notify.Stop they leak for the lifetime of the process.
 	defer notify.Stop(mountWatchCh)
 
+	// PostInotify returns a usable stream wrapper before the server-side
+	// handler is installed, so Sends issued during the gap fail with EOF.
+	select {
+	case <-a.guestAgentAliveCh:
+	case <-ctx.Done():
+		return nil
+	}
+
 	client, err := a.getOrCreateClient(ctx)
 	if err != nil {
 		return fmt.Errorf("inotify: failed to obtain guest agent client: %w", err)


### PR DESCRIPTION
Small follow-up to #4895, addressing the residual startup-window slice of #4153

## Context

#4895 made startInotify return on Send error and wrapped the spawn site in a 10s reconnect loop. That bounds the spam in #4153 - instead of one warn per fs event, you now get one warn per retry cycle. But on a cold start, the first stream is opened before the guest-agent's PostInotify handler is installed, so the first cycle still races and produces `failed to send inotify  error=EOF` (then waits 10s and retries - typically a couple of cycles before the agent is up)

## Change

Wait on `a.guestAgentAliveCh` (or `ctx.Done`) before calling `client.Inotify(ctx)`. Mirrors the pattern `startTimeSync` already uses for the same reason

```
select {
case <-a.guestAgentAliveCh:
case <-ctx.Done():
    return nil
}
```

## Test plan

- [x] `go test ./pkg/hostagent/...` — passes.
- [x] `go test ./...` — full unit suite green.
- [x] `go build ./...` — clean.