### PR TITLE
docs: add network and disk management guide

### DIFF
--- a/website/content/en/docs/config/disk.md
+++ b/website/content/en/docs/config/disk.md
@@ -2,9 +2,73 @@
 title: Disks
 ---
 
-This guide explains how to increase the disk size of a Lima VM when you've run out of space, as well as how to edit the disk size using the `limactl` CLI.
+This guide explains how to manage Lima disks: standalone raw/qcow2 block devices that persist independently of any instance.
 
-## Resize Disk Using limactl
+## Additional Disks (limactl disk)
+
+Lima disks can be shared across instances and survive instance deletion.
+
+### Listing disks
+
+```sh
+limactl disk list
+# or the short alias:
+limactl disk ls
+```
+
+### Creating a disk
+
+```sh
+limactl disk create NAME --size SIZE [--format qcow2|raw]
+```
+
+The supported formats are `qcow2` (default) and `raw`.
+
+Example – create a 20 GiB disk named `data`:
+
+```sh
+limactl disk create data --size 20GiB
+```
+
+### Attaching a disk to an instance
+
+{{< tabpane text=true >}}
+{{% tab header="YAML" %}}
+Add the disk name under `additionalDisks` before starting the instance:
+
+```yaml
+additionalDisks:
+- name: data
+  format: true     # format the disk on first use
+  fsType: ext4     # filesystem to create when format is true
+```
+{{% /tab %}}
+{{% tab header="CLI" %}}
+Use `limactl edit` to attach while the instance is stopped:
+
+```sh
+limactl edit <instance> --set '.additionalDisks += [{"name":"data"}]'
+```
+{{% /tab %}}
+{{< /tabpane >}}
+
+### Resizing an additional disk
+
+```sh
+limactl disk resize NAME --size NEW-SIZE
+```
+
+### Deleting a disk
+
+```sh
+limactl disk delete NAME [NAME...]
+```
+
+> **Note:** A disk cannot be deleted while attached to a running instance. Stop the instance first or use `--force`.
+
+---
+
+## Resizing the VM's primary disk
 
 Starting with v1.1, Lima supports editing the disk size of an existing instance using the `--disk` flag with the `limactl edit` command.
 This is the recommended and simplest way to resize your VM disk.

--- a/website/content/en/docs/config/network/_index.md
+++ b/website/content/en/docs/config/network/_index.md
@@ -14,3 +14,47 @@ connect_to_vm_via{"Connect to the VM via"} -- "localhost" --> default["Default"]
   connect_from -- "Other VMs" --> userV2["user-v2"]
   connect_from -- "Other hosts" --> bridged["socket_vmnet (bridged)"]
 ```
+
+## Managing named networks (limactl network)
+
+Lima networks defined in `~/.lima/_config/networks.yaml` provide named
+interfaces that can be shared across instances.
+
+### Listing networks
+
+```sh
+limactl network list
+# or the short alias:
+limactl network ls
+# machine-readable output:
+limactl network list --json
+```
+
+### Creating a network
+
+```sh
+limactl network create NAME --gateway CIDR
+```
+
+Example:
+
+```sh
+limactl network create mynet --gateway 192.168.42.1/24
+```
+
+### Attaching a network to an instance
+
+Add the network name under the `networks` key before starting the instance:
+
+```yaml
+networks:
+- lima: mynet
+```
+
+### Deleting a network
+
+```sh
+limactl network delete --force NAME [NAME...]
+```
+
+> **Note:** `--force` is currently required.


### PR DESCRIPTION
Adds a dedicated page to the config docs explaining `limactl network list`, `limactl disk list`, and the related create/delete/resize/attach commands with examples.

Fixes #4180