### PR TITLE
wsl2: detach cleanup from canceled ctx and surface terminate errors

### DIFF
--- a/pkg/driver/wsl2/vm_windows.go
+++ b/pkg/driver/wsl2/vm_windows.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -134,9 +135,22 @@ func provisionVM(ctx context.Context, instanceDir, instanceName, distroName stri
 
 		<-ctx.Done()
 		logrus.Info("Context closed, stopping vm")
-		if status, err := getWslStatus(ctx, instanceName); err == nil &&
-			status == limatype.StatusRunning {
-			_ = stopVM(ctx, distroName)
+		// ctx is already canceled at this point, so passing it to wsl.exe
+		// would make the cleanup commands fail with "context canceled"
+		// before they even run. Detach from the cancellation but keep a
+		// short timeout so we don't block forever on a wedged wsl.exe.
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		status, err := getWslStatus(cleanupCtx, instanceName)
+		if err != nil {
+			logrus.WithError(err).Warn("Failed to query WSL status during shutdown; skipping terminate")
+			return
+		}
+		if status != limatype.StatusRunning {
+			return
+		}
+		if err := stopVM(cleanupCtx, distroName); err != nil {
+			logrus.WithError(err).Warn("Failed to terminate WSL distro during shutdown")
 		}
 	}()
 


### PR DESCRIPTION
Closes #4923. Follow-up to the review feedback on #4892.

After we kept the goroutine alive to actually run the terminate, I went back to look at what it does and realised the cleanup itself was broken in two related ways:

1. We pass `ctx` into `getWslStatus` and `stopVM`, but the only reason we're at this code path is because `ctx` is already cancelled. So `wsl.exe --list --verbose` and `wsl.exe --terminate` get killed by `CommandContext` more or less immediately and return `context canceled`. The whole "stop the VM on shutdown" path was effectively a no-op.

2. The `err == nil && status == StatusRunning` guard meant that whenever `getWslStatus` failed (which, per #1, was basically every shutdown), we silently skipped the terminate. And `_ = stopVM(...)` threw away the only signal that the terminate itself failed. So when this stopped working, nothing in the logs would tell you.

The fix is small:

- `context.WithoutCancel(ctx)` for the cleanup commands so they're not pre-cancelled, with a 30s timeout so we don't hang forever on a wedged `wsl.exe`.
- `logrus.WithError(err).Warn(...)` on both error paths instead of swallowing.

Diff is +17/-3, single file. Behaviour on the happy path (VM is `Running`, terminate succeeds) is unchanged.

## Test plan

- [x] `gofmt -l pkg/driver/wsl2/vm_windows.go` — clean
- [x] `GOOS=windows GOARCH=amd64 go vet ./pkg/driver/wsl2/...` — clean
- [ ] CI: Windows tests (WSL2)
- [ ] Manual on a Windows host:
  ```powershell
  limactl start --vm-type=wsl2 --name=demo template://default
  limactl stop demo
  Get-Process wsl  # distro should not show up
  ```
  Before: terminate silently fails on cancelled ctx; if you look at `wsl --list --verbose` after stop, the lima distro often still shows `Running`. After: distro is reliably terminated, and if anything goes wrong you see a clear `Failed to terminate WSL distro during shutdown` warning instead of nothing.
