### PR TITLE
Auto-enable nestedVirtualization on Apple M4 hosts

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/docker/go-units"
 	"github.com/goccy/go-yaml"
 	"github.com/pbnjay/memory"
@@ -822,6 +823,13 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 	}
 	if o.NestedVirtualization != nil {
 		y.NestedVirtualization = o.NestedVirtualization
+	}
+	if y.NestedVirtualization == nil {
+		if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" && osutil.IsAppleSiliconM4OrNewer() {
+			if v, err := osutil.ProductVersion(); err == nil && !v.LessThan(*semver.New("15.0.0")) {
+				y.NestedVirtualization = ptr.Of(true)
+			}
+		}
 	}
 	if y.NestedVirtualization == nil {
 		y.NestedVirtualization = ptr.Of(false)

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
@@ -297,6 +298,11 @@ func TestFillDefault(t *testing.T) {
 	}
 
 	expect.NestedVirtualization = ptr.Of(false)
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" && osutil.IsAppleSiliconM4OrNewer() {
+		if v, err := osutil.ProductVersion(); err == nil && !v.LessThan(*semver.New("15.0.0")) {
+			expect.NestedVirtualization = ptr.Of(true)
+		}
+	}
 
 	FillDefault(t.Context(), &y, &limatype.LimaYAML{}, &limatype.LimaYAML{}, filePath, false)
 	assert.DeepEqual(t, &y, &expect, opts...)

--- a/pkg/osutil/mac_cpu_darwin.go
+++ b/pkg/osutil/mac_cpu_darwin.go
@@ -1,0 +1,30 @@
+//go:build darwin
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package osutil
+
+import (
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+var isAppleSiliconM4OrNewer = sync.OnceValue(func() bool {
+	cmd := exec.Command("sysctl", "-n", "machdep.cpu.brand_string")
+	b, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	brand := strings.TrimSpace(string(b))
+	if strings.Contains(brand, "Apple M4") || strings.Contains(brand, "Apple M5") || strings.Contains(brand, "Apple M6") || strings.Contains(brand, "Apple M7") || strings.Contains(brand, "Apple M8") || strings.Contains(brand, "Apple M9") {
+		return true
+	}
+	return false
+})
+
+// IsAppleSiliconM4OrNewer returns true if the host CPU is Apple M4 or newer.
+func IsAppleSiliconM4OrNewer() bool {
+	return isAppleSiliconM4OrNewer()
+}

--- a/pkg/osutil/mac_cpu_others.go
+++ b/pkg/osutil/mac_cpu_others.go
@@ -1,0 +1,11 @@
+//go:build !darwin
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package osutil
+
+// IsAppleSiliconM4OrNewer returns true if the host CPU is Apple M4 or newer.
+func IsAppleSiliconM4OrNewer() bool {
+	return false
+}


### PR DESCRIPTION
Fixes #4912 Automatically enables nestedVirtualization on Apple M4 hosts (macOS 15+) when using the VZ driver. This resolves the issue where GDB fails to fetch the SVE/SSVE vector length on M4 processors.