### PR TITLE
fix: remove additional tags from image URL names

### DIFF
--- a/pkg/limatmpl/export_test.go
+++ b/pkg/limatmpl/export_test.go
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package limatmpl
+
+var ArchKeywords = archKeywords

--- a/pkg/limatmpl/locator.go
+++ b/pkg/limatmpl/locator.go
@@ -253,10 +253,14 @@ func InstNameFromImageURL(locator, imageArch string) string {
 	// ARM64 FreeBSD images have both "arm64" and "aarch64" in their names.
 	// "FreeBSD-16.0-CURRENT-arm64-aarch64-BASIC-CLOUDINIT-ufs.qcow2.xz"
 	name = strings.Replace(name, "arm64-aarch64", "arm64", 1)
-	// Remove imageArch as well if it is the native arch.
+	// Remove imageArch and all its aliases if it is the native arch.
 	if limatype.IsNativeArch(imageArch) {
-		re := regexp.MustCompile(fmt.Sprintf(`[-_.]%s\b`, imageArch))
-		name = re.ReplaceAllString(name, "")
+		for keyword, arch := range archKeywords {
+			if arch == imageArch {
+				re := regexp.MustCompile(fmt.Sprintf(`[-_.]%s\b`, keyword))
+				name = re.ReplaceAllString(name, "")
+			}
+		}
 	}
 	// Remove timestamps from name: 8 digit date, optionally followed by
 	// a delimiter and one or more digits before a word boundary.

--- a/pkg/limatmpl/locator_test.go
+++ b/pkg/limatmpl/locator_test.go
@@ -53,6 +53,21 @@ func TestInstNameFromImageURL(t *testing.T) {
 		name := limatmpl.InstNameFromImageURL(image, arch)
 		assert.Equal(t, name, "linux")
 	})
+	t.Run("removes native arch aliases", func(t *testing.T) {
+		var alias string
+		for keyword, arch := range limatmpl.ArchKeywords {
+			if limatype.IsNativeArch(arch) && arch != keyword {
+				alias = keyword
+				break
+			}
+		}
+		if alias == "" {
+			t.Skip("no alias for native arch")
+		}
+		image := fmt.Sprintf("linux-%s-basic.raw", alias)
+		name := limatmpl.InstNameFromImageURL(image, limatype.NewArch(runtime.GOARCH))
+		assert.Equal(t, name, "linux")
+	})
 	t.Run("removes redundant major version", func(t *testing.T) {
 		name := limatmpl.InstNameFromImageURL("rocky-8-8.10.raw", "unknown")
 		assert.Equal(t, name, "rocky-8.10")


### PR DESCRIPTION
### Description
When deriving an instance name from an image URL, arch aliases (e.g. arm64 for aarch64, amd64 for x86_64) were not being removed even when the image arch matched the native host arch. Only the canonical arch name was stripped.

### Changes

- `pkg/limatmpl/locator.go`: When the image arch is native, iterate over all archKeywords entries and remove any keyword that maps to the same arch, not just the canonical name.
- `pkg/limatmpl/locator_test.go`: Added test for arch alias deduplication, added the FreeBSD 15.0 aarch64 URL from the issue to TestRead, and made arch-dependent tests use a nativeName field so they pass on any host architecture.

#### Fixes: #4629 

