### PR TITLE
Set `TERM` before running `containerd-rootless-setup.sh`

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/40-install-containerd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/40-install-containerd.sh
@@ -122,18 +122,18 @@ EOF
 		if [ "$(sudo -iu "${LIMA_CIDATA_USER}" sh -ec 'systemctl --user show --property=RefuseManualStart --value dbus')" != "yes" ]; then
 			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" systemctl --user enable --now dbus
 		fi
-		sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" containerd-rootless-setuptool.sh install
-		sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" \
+		sudo -iu "${LIMA_CIDATA_USER}" "TERM=${TERM:-xterm}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" containerd-rootless-setuptool.sh install
+		sudo -iu "${LIMA_CIDATA_USER}" "TERM=${TERM:-xterm}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" \
 			"CONTAINERD_NAMESPACE=${CONTAINERD_NAMESPACE}" "CONTAINERD_SNAPSHOTTER=${CONTAINERD_SNAPSHOTTER}" \
 			containerd-rootless-setuptool.sh install-buildkit-containerd
 
 		# $CONTAINERD_SNAPSHOTTER is configured in 20-rootless-base.sh, when the guest kernel is < 5.13, or the instance was created with Lima < 0.9.0.
 		if [ "$(sudo -iu "${LIMA_CIDATA_USER}" sh -ec 'echo $CONTAINERD_SNAPSHOTTER')" = "fuse-overlayfs" ]; then
-			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" containerd-rootless-setuptool.sh install-fuse-overlayfs
+			sudo -iu "${LIMA_CIDATA_USER}" "TERM=${TERM:-xterm}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" containerd-rootless-setuptool.sh install-fuse-overlayfs
 		fi
 
 		if compare_version.sh "$(uname -r)" -ge "5.13"; then
-			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" containerd-rootless-setuptool.sh install-stargz
+			sudo -iu "${LIMA_CIDATA_USER}" "TERM=${TERM:-xterm}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" containerd-rootless-setuptool.sh install-stargz
 		else
 			echo >&2 "WARNING: the guest kernel seems older than 5.13. Skipping installing rootless stargz."
 		fi


### PR DESCRIPTION
Fixes #4744 

The cause of the issue is an updated `less` package (>= 691) in Fedora 44 that now requires `TERM` to be set. When `containerd-rootless-setuptool.sh` runs its [systemd check](https://github.com/containerd/nerdctl/blob/0b388bb31d7877ab9b73155e0fa387843d0954ea/extras/rootless/containerd-rootless-setuptool.sh#L75-L79) without `TERM`, `less` fails and the script incorrectly reports `"Needs systemd"`

Thanks @afbjorklund for identifying the root cause!