### PR TITLE
QEMU command line: allow `kernel-irqchip` enabled with WHPX

### DIFF
--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -564,8 +564,13 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 			args = append(args, "-global", "ICH9-LPC.disable_s3=1")
 			args = append(args, "-global", "ICH9-LPC.disable_s4=1")
 		case "whpx":
-			// whpx: injection failed, MSI (0, 0) delivery: 0, dest_mode: 0, trigger mode: 0, vector: 0
-			args = appendArgsIfNoConflict(args, "-machine", "q35,accel="+accel+",kernel-irqchip=off")
+			if version.LessThan(*semver.New("11.0.0")) {
+				// Older versions of QEMU required disabling `kernel-irqchip` explicitly.
+				// It is not recommended to keep using this with QEMU 11.0.0 and newer.
+				args = appendArgsIfNoConflict(args, "-machine", "q35,accel="+accel+",kernel-irqchip=off")
+			} else {
+				args = appendArgsIfNoConflict(args, "-machine", "q35,accel="+accel)
+			}
 		default:
 			args = appendArgsIfNoConflict(args, "-machine", "q35,accel="+accel)
 		}


### PR DESCRIPTION
Fixes #4808

Since QEMU 11.0.0 it is now recommended to keep it enabled with Windows 11 and it has safe default fallback to disabled for Windows 10. More details from the maintainer
https://gitlab.com/qemu-project/qemu/-/work_items/2403#note_3222233440

The conditional branches here should disappear, when the minimal version of QEMU is bumped to at least 11.0.0 on Windows hosts, which is a reasonable thing to do considering vastly improved support and compatibility appeared in 11.0.0 and that there is no part providing LTS pre-built QEMU releases for Windows platform - all binary releases are based on most recent release as soon as it is available.

I manually verified command line running patched Lima version against 11.0.0 and 10.2.0 respectively.