### PR TITLE
fix(limactl): allow $EDITOR with flags

### DIFF
--- a/pkg/editutil/editorcmd/editorcmd.go
+++ b/pkg/editutil/editorcmd/editorcmd.go
@@ -23,7 +23,18 @@ package editorcmd
 import (
 	"os"
 	"os/exec"
+	"strings"
 )
+
+// ShellMetaChars is the set of characters that, when present in an editor
+// command string, require it to be executed via a shell rather than as a
+// direct argv. The list matches git's prepare_shell_cmd in run-command.c.
+const ShellMetaChars = "|&;<>()$`\\\"' \t\n*?[#~=%"
+
+// HasShellMeta reports whether s contains any character from ShellMetaChars.
+func HasShellMeta(s string) bool {
+	return strings.ContainsAny(s, ShellMetaChars)
+}
 
 // Detect detects a text editor command.
 // Returns an empty string when no editor is found.
@@ -39,6 +50,9 @@ func Detect() string {
 	for _, f := range candidates {
 		if f == "" {
 			continue
+		}
+		if HasShellMeta(f) {
+			return f
 		}
 		x, err := exec.LookPath(f)
 		if err == nil {

--- a/pkg/editutil/editutil.go
+++ b/pkg/editutil/editutil.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -76,7 +77,12 @@ func OpenEditor(ctx context.Context, content []byte, hdr string) ([]byte, error)
 		return nil, err
 	}
 
-	editorCmd := exec.CommandContext(ctx, editor, tmpYAMLPath)
+	var editorCmd *exec.Cmd
+	if editorcmd.HasShellMeta(editor) && runtime.GOOS != "windows" {
+		editorCmd = exec.CommandContext(ctx, "sh", "-c", editor+` "$@"`, editor, tmpYAMLPath)
+	} else {
+		editorCmd = exec.CommandContext(ctx, editor, tmpYAMLPath)
+	}
 	editorCmd.Env = os.Environ()
 	editorCmd.Stdin = os.Stdin
 	editorCmd.Stdout = os.Stdout


### PR DESCRIPTION
Allows $VISUAL/$EDITOR to have flags in it, eg for `code -w`, or for some emacs setups