### PR TITLE
test: add tests for pkg/must

### DIFF
--- a/pkg/must/must_test.go
+++ b/pkg/must/must_test.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package must
+
+import (
+	"errors"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestMustSuccess(t *testing.T) {
+	str := Must("string", nil)
+	assert.Equal(t, str, "string")
+}
+
+func TestMustPanic(t *testing.T) {
+	defer func() {
+		r := recover()
+		assert.Assert(t, r != nil, "Must should have panicked")
+	}()
+
+	Must("string", errors.New("test error"))
+}


### PR DESCRIPTION
This PR adds unit tests for pkg/must to improve test coverage and verify the expected behaviour of Must() in both success and failure scenarios.

The tests cover:

returning the provided object when the error is nil
panicking when a non-nil error is passed

This ensures the helper behaves correctly across both normal execution and error paths.

**Verification**

Tested locally with:

"go test ./pkg/must"

All tests pass successfully.