### PR TITLE
fix:track driver PID to prevent zombie processes

### DIFF
--- a/pkg/driver/external/server/server.go
+++ b/pkg/driver/external/server/server.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -207,6 +208,10 @@ func handlePreConfiguredDriverAction(ctx context.Context, driver driver.Driver) 
 	}
 }
 
+func driverPIDFilePath(instanceDir, driverName, pidFileOwner string) string {
+	return filepath.Join(instanceDir, fmt.Sprintf("lima-driver-%s-%s.pid", driverName, pidFileOwner))
+}
+
 // Start begins the driver startup process. It sends an initial response to unblock
 // the client and then streams subsequent errors(if any), as the driver initializes.
 // A final success message is streamed upon successful completion.
@@ -245,6 +250,15 @@ func Start(extDriver *registry.ExternalDriver, instName string) error {
 		return fmt.Errorf("failed to start external driver: %w", err)
 	}
 
+	pid := cmd.Process.Pid
+	pidFilePath := driverPIDFilePath(instanceDir, extDriver.Name, extDriver.PIDFileOwner)
+	// If the driver crashes immediately, the cleanup paths below will remove this file.
+	if err := os.WriteFile(pidFilePath, []byte(strconv.Itoa(pid)), 0o644); err != nil {
+		cancel()
+		_ = cmd.Process.Kill()
+		return fmt.Errorf("failed to write driver PID file: %w", err)
+	}
+
 	driverLogger := extDriver.Logger.WithField("driver", extDriver.Name)
 
 	scanner := bufio.NewScanner(stdout)
@@ -256,6 +270,8 @@ func Start(extDriver *registry.ExternalDriver, instName string) error {
 			if err := cmd.Process.Kill(); err != nil {
 				driverLogger.Errorf("Failed to kill external driver process: %v", err)
 			}
+			// TODO: reap process (e.g. cmd.Wait()) to avoid temporary zombies
+			_ = os.Remove(pidFilePath)
 			return fmt.Errorf("failed to parse socket path JSON: %w", err)
 		}
 		socketPath = output["socketPath"]
@@ -264,6 +280,7 @@ func Start(extDriver *registry.ExternalDriver, instName string) error {
 		if err := cmd.Process.Kill(); err != nil {
 			driverLogger.Errorf("Failed to kill external driver process: %v", err)
 		}
+		_ = os.Remove(pidFilePath)
 		return errors.New("failed to read socket path from driver")
 	}
 	extDriver.SocketPath = socketPath
@@ -274,6 +291,7 @@ func Start(extDriver *registry.ExternalDriver, instName string) error {
 		if err := cmd.Process.Kill(); err != nil {
 			driverLogger.Errorf("Failed to kill external driver process after client creation failure: %v", err)
 		}
+		_ = os.Remove(pidFilePath)
 		return fmt.Errorf("failed to create driver client: %w", err)
 	}
 
@@ -292,14 +310,52 @@ func Stop(extDriver *registry.ExternalDriver) error {
 	}
 
 	extDriver.Logger.Debugf("Stopping external driver %s", extDriver.Name)
-	if extDriver.CancelFunc != nil {
-		extDriver.CancelFunc()
-	}
-	if err := extDriver.Command.Process.Signal(syscall.SIGTERM); err != nil {
-		extDriver.Logger.Errorf("Failed to kill external driver process: %v", err)
+
+	if extDriver.Command.Process != nil {
+		err := extDriver.Command.Process.Signal(syscall.SIGTERM)
+		if err != nil && !errors.Is(err, os.ErrProcessDone) {
+			extDriver.Logger.Errorf("Failed to send SIGTERM to external driver process: %v", err)
+		}
+
+		done := make(chan error, 1)
+		const stopTimeout = 10 * time.Second
+		cmd := extDriver.Command
+		go func() {
+			done <- cmd.Wait()
+		}()
+
+		select {
+		case waitErr := <-done:
+			if waitErr != nil {
+				extDriver.Logger.Debugf("External driver %s exited with: %v", extDriver.Name, waitErr)
+			} else {
+				extDriver.Logger.Debugf("External driver %s exited gracefully", extDriver.Name)
+			}
+		case <-time.After(stopTimeout):
+			extDriver.Logger.Warnf("External driver %s did not exit in time, forcing cancellation (SIGKILL)", extDriver.Name)
+
+			if extDriver.CancelFunc != nil {
+				extDriver.CancelFunc()
+			}
+
+			// Protect against processes stuck in uninterruptible sleep (D-state)
+			select {
+			case <-done: // reaped successfully after CancelFunc
+			case <-time.After(2 * time.Second):
+				extDriver.Logger.Errorf("External driver %s is stuck in D-state; giving up on reaping", extDriver.Name)
+			}
+		}
 	}
 	if err := os.Remove(extDriver.SocketPath); err != nil && !os.IsNotExist(err) {
 		extDriver.Logger.Warnf("Failed to remove socket file: %v", err)
+	}
+	if instanceDir, err := dirnames.InstanceDir(extDriver.InstanceName); err == nil {
+		pidFilePath := driverPIDFilePath(instanceDir, extDriver.Name, extDriver.PIDFileOwner)
+		if err := os.Remove(pidFilePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			extDriver.Logger.Errorf("Failed to remove driver PID file: %v", err)
+		}
+	} else {
+		extDriver.Logger.Errorf("Failed to determine instance dir for PID cleanup: %v", err)
 	}
 
 	extDriver.Command = nil

--- a/pkg/driverutil/instance.go
+++ b/pkg/driverutil/instance.go
@@ -14,15 +14,24 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/registry"
 )
 
+const (
+	OwnerHostAgent = "ha"
+	OwnerCLI       = "cli"
+)
+
 // CreateConfiguredDriver creates a driver.ConfiguredDriver for the given instance.
-func CreateConfiguredDriver(inst *limatype.Instance, sshLocalPort int) (*driver.ConfiguredDriver, error) {
+// pidFileOwner identifies the caller (e.g. "ha" or "cli") to isolate driver PID files.
+func CreateConfiguredDriver(inst *limatype.Instance, sshLocalPort int, pidFileOwner string) (*driver.ConfiguredDriver, error) {
 	limaDriver := inst.Config.VMType
 	extDriver, intDriver, exists := registry.Get(*limaDriver)
 	if !exists {
 		return nil, fmt.Errorf("unknown or unsupported VM type: %s", *limaDriver)
 	}
-
+	if pidFileOwner == "" {
+		pidFileOwner = OwnerCLI
+	}
 	if extDriver != nil {
+		extDriver.PIDFileOwner = pidFileOwner
 		extDriver.Logger.Debugf("Using external driver %q", extDriver.Name)
 		if extDriver.Client == nil || extDriver.Command == nil {
 			logrus.Debugf("Starting new instance of external driver %q", extDriver.Name)

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -157,7 +157,7 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 		}
 	}
 
-	limaDriver, err := driverutil.CreateConfiguredDriver(inst, sshLocalPort)
+	limaDriver, err := driverutil.CreateConfiguredDriver(inst, sshLocalPort, driverutil.OwnerHostAgent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create driver instance: %w", err)
 	}

--- a/pkg/instance/create.go
+++ b/pkg/instance/create.go
@@ -80,7 +80,7 @@ func Create(ctx context.Context, instName string, instConfig []byte, saveBrokenY
 		return nil, err
 	}
 
-	limaDriver, err := driverutil.CreateConfiguredDriver(inst, 0)
+	limaDriver, err := driverutil.CreateConfiguredDriver(inst, 0, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create driver instance: %w", err)
 	}

--- a/pkg/instance/delete.go
+++ b/pkg/instance/delete.go
@@ -36,7 +36,7 @@ func Delete(ctx context.Context, inst *limatype.Instance, force bool) error {
 }
 
 func unregister(ctx context.Context, inst *limatype.Instance) error {
-	limaDriver, err := driverutil.CreateConfiguredDriver(inst, 0)
+	limaDriver, err := driverutil.CreateConfiguredDriver(inst, 0, "")
 	if err != nil {
 		return fmt.Errorf("failed to create driver instance: %w", err)
 	}

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -66,7 +66,7 @@ func Prepare(ctx context.Context, inst *limatype.Instance, guestAgent string) (*
 			return nil, err
 		}
 	}
-	limaDriver, err := driverutil.CreateConfiguredDriver(inst, 0)
+	limaDriver, err := driverutil.CreateConfiguredDriver(inst, 0, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create driver instance: %w", err)
 	}

--- a/pkg/instance/stop.go
+++ b/pkg/instance/stop.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -114,6 +116,20 @@ func StopForcibly(inst *limatype.Instance) {
 		}
 	} else {
 		logrus.Infof("The %s driver process seems already stopped", inst.VMType)
+	}
+
+	driverPIDPattern := filepath.Join(inst.Dir, "lima-driver-*.pid")
+	files, _ := filepath.Glob(driverPIDPattern)
+	for _, pidFile := range files {
+		if b, readErr := os.ReadFile(pidFile); readErr == nil {
+			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(b))); convErr == nil && pid > 0 {
+				logrus.Infof("Sending SIGKILL to external driver process %d (from %s)", pid, filepath.Base(pidFile))
+				if err := osutil.SysKill(pid, osutil.SigKill); err != nil && !errors.Is(err, os.ErrProcessDone) && !errors.Is(err, syscall.ESRCH) {
+					logrus.Warnf("Failed to kill external driver process %d: %v", pid, err)
+				}
+			}
+		}
+		_ = os.Remove(pidFile) // Clean up the orphaned pid file
 	}
 
 	for _, d := range inst.AdditionalDisks {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -34,6 +34,7 @@ type ExternalDriver struct {
 	Ctx          context.Context
 	Logger       *logrus.Logger
 	CancelFunc   context.CancelFunc
+	PIDFileOwner string
 }
 
 var (

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Del(ctx context.Context, inst *limatype.Instance, tag string) error {
-	limaDriver, err := driverutil.CreateConfiguredDriver(inst, 0)
+	limaDriver, err := driverutil.CreateConfiguredDriver(inst, 0, "")
 	if err != nil {
 		return fmt.Errorf("failed to create driver instance: %w", err)
 	}
@@ -21,7 +21,7 @@ func Del(ctx context.Context, inst *limatype.Instance, tag string) error {
 }
 
 func Save(ctx context.Context, inst *limatype.Instance, tag string) error {
-	limaDriver, err := driverutil.CreateConfiguredDriver(inst, 0)
+	limaDriver, err := driverutil.CreateConfiguredDriver(inst, 0, "")
 	if err != nil {
 		return fmt.Errorf("failed to create driver instance: %w", err)
 	}
@@ -29,7 +29,7 @@ func Save(ctx context.Context, inst *limatype.Instance, tag string) error {
 }
 
 func Load(ctx context.Context, inst *limatype.Instance, tag string) error {
-	limaDriver, err := driverutil.CreateConfiguredDriver(inst, 0)
+	limaDriver, err := driverutil.CreateConfiguredDriver(inst, 0, "")
 	if err != nil {
 		return fmt.Errorf("failed to create driver instance: %w", err)
 	}
@@ -37,7 +37,7 @@ func Load(ctx context.Context, inst *limatype.Instance, tag string) error {
 }
 
 func List(ctx context.Context, inst *limatype.Instance) (string, error) {
-	limaDriver, err := driverutil.CreateConfiguredDriver(inst, 0)
+	limaDriver, err := driverutil.CreateConfiguredDriver(inst, 0, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to create driver instance: %w", err)
 	}

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -102,6 +102,9 @@ Host agent:
 - `ha.stdout.log`: hostagent stdout (JSON lines, see `pkg/hostagent/events.Event`)
 - `ha.stderr.log`: hostagent stderr (human-readable messages)
 
+External drivers:
+- `lima-driver-<driver-name>-<owner>.pid`: external driver process PID, where `<owner>` is either `ha` (written by the hostagent) or `cli` (written by the CLI process). Used by `limactl stop --force` and `limactl rm --force` to discover and kill orphaned external driver processes. Each process only removes its own PID file on graceful exit; force stop globs all matching files and kills them.
+
 ## Disk directory (`${LIMA_HOME}/_disk/<DISK>`)
 
 A disk directory contains the following files:

--- a/website/content/en/docs/security/_index.md
+++ b/website/content/en/docs/security/_index.md
@@ -28,7 +28,7 @@ sudo softwareupdate --install "Name of the Update"
 Alternatively , you can set the [`upgradePackages`](https://github.com/lima-vm/lima/blob/a28905cb1bd332cc7178c30f4e42d4c6bf1b2a34/templates/default.yaml#L181) in your template to `true` for most Linux distributions (except `alpine-iso`, for example).
 
 
-> ⚠️ Rapidly updating can reduce exposure to known CVEs, but it can also increase exposure to upstream supply chain compromises (for example, [the XZ backdoor](https://en.wikipedia.org/wiki/XZ_Utils_backdoor)). 
+> ⚠️ Rapidly updating can reduce exposure to known CVEs, but it can also increase exposure to upstream supply chain compromises (for example, [the XZ backdoor](https://en.wikipedia.org/wiki/XZ_Utils_backdoor)).
 
 
 ## Security model


### PR DESCRIPTION
Fix #4363 .
This PR implements PID tracking for external drivers by writing and reading a `driver.pid` file so the core engine can discover them.
It also refactors the `Stop()` function to gracefully terminate these processes (SIGTERM → Wait → SIGKILL fallback) to prevent zombies during `limactl rm -f`.
A follow-up PR will address the remaining edge case of forwarding SIGINT (Ctrl+C) during `limactl start`.