### PR TITLE
feat: make limactl respect $LIMA_INSTANCE env var

### DIFF
--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -54,7 +54,7 @@ func editAction(cmd *cobra.Command, args []string) error {
 	var inst *limatype.Instance
 
 	if arg == "" {
-		arg = DefaultInstanceName
+		arg = defaultInstanceName()
 	}
 	if err := dirnames.ValidateInstName(arg); err == nil {
 		inst, err = store.Inspect(ctx, arg)

--- a/cmd/limactl/factory-reset.go
+++ b/cmd/limactl/factory-reset.go
@@ -32,7 +32,7 @@ func newFactoryResetCommand() *cobra.Command {
 
 func factoryResetAction(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	instName := DefaultInstanceName
+	instName := defaultInstanceName()
 	if len(args) > 0 {
 		instName = args[0]
 	}

--- a/cmd/limactl/guest-install.go
+++ b/cmd/limactl/guest-install.go
@@ -55,7 +55,7 @@ func shell(ctx context.Context, name string, flags []string, args ...string) (st
 }
 
 func guestInstallAction(cmd *cobra.Command, args []string) error {
-	instName := DefaultInstanceName
+	instName := defaultInstanceName()
 	if len(args) > 0 {
 		instName = args[0]
 	}

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -26,10 +26,18 @@ import (
 )
 
 const (
-	DefaultInstanceName = "default"
-	basicCommand        = "basic"
-	advancedCommand     = "advanced"
+	defaultInstanceNameConst = "default"
+	basicCommand             = "basic"
+	advancedCommand          = "advanced"
 )
+
+func defaultInstanceName() string {
+	if v := os.Getenv("LIMA_INSTANCE"); v != "" {
+		logrus.Debugf("Using instance name %q from $LIMA_INSTANCE", v)
+		return v
+	}
+	return defaultInstanceNameConst
+}
 
 func main() {
 	if os.Geteuid() == 0 && (len(os.Args) < 2 || os.Args[1] != "generate-doc") {

--- a/cmd/limactl/main_test.go
+++ b/cmd/limactl/main_test.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestDefaultInstanceName(t *testing.T) {
+	t.Run("returns default when LIMA_INSTANCE is unset", func(t *testing.T) {
+		t.Setenv("LIMA_INSTANCE", "")
+		assert.Equal(t, defaultInstanceName(), "default")
+	})
+	t.Run("respects LIMA_INSTANCE", func(t *testing.T) {
+		t.Setenv("LIMA_INSTANCE", "myvm")
+		assert.Equal(t, defaultInstanceName(), "myvm")
+	})
+}

--- a/cmd/limactl/restart.go
+++ b/cmd/limactl/restart.go
@@ -27,7 +27,7 @@ func newRestartCommand() *cobra.Command {
 
 func restartAction(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	instName := DefaultInstanceName
+	instName := defaultInstanceName()
 	if len(args) > 0 {
 		instName = args[0]
 	}

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -37,7 +37,7 @@ import (
 
 const shellHelp = `Execute shell in Lima
 
-lima command is provided as an alias for limactl shell $LIMA_INSTANCE. $LIMA_INSTANCE defaults to "` + DefaultInstanceName + `".
+lima command is provided as an alias for limactl shell $LIMA_INSTANCE. $LIMA_INSTANCE defaults to "` + defaultInstanceNameConst + `".
 
 By default, the first 'ssh' executable found in the host's PATH is used to connect to the Lima instance.
 A custom ssh alias can be used instead by setting the $` + sshutil.EnvShellSSH + ` environment variable.

--- a/cmd/limactl/start-at-login_unix.go
+++ b/cmd/limactl/start-at-login_unix.go
@@ -19,7 +19,7 @@ import (
 
 func startAtLoginAction(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	instName := DefaultInstanceName
+	instName := defaultInstanceName()
 	if len(args) > 0 {
 		instName = args[0]
 	}

--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -270,7 +270,7 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 		tmpl = &limatmpl.Template{Name: name}
 		if arg == "" {
 			if name == "" {
-				tmpl.Name = DefaultInstanceName
+				tmpl.Name = defaultInstanceName()
 			}
 		} else {
 			logrus.Debugf("interpreting argument %q as an instance name", arg)
@@ -302,7 +302,7 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 		if !errors.Is(err, os.ErrNotExist) {
 			return nil, err
 		}
-		if arg != "" && arg != DefaultInstanceName {
+		if arg != "" && arg != defaultInstanceNameConst {
 			logrus.Infof("Creating an instance %q from template:default (Not from template:%s)", tmpl.Name, tmpl.Name)
 			logrus.Warnf("This form is deprecated. Use `limactl create --name=%s template:default` instead", tmpl.Name)
 		}
@@ -442,7 +442,7 @@ func chooseNextCreatorState(ctx context.Context, tmpl *limatmpl.Template, yq str
 			return tmpl, nil
 		case 1: // "Open an editor ..."
 			hdr := fmt.Sprintf("# Review and modify the following configuration for Lima instance %q.\n", tmpl.Name)
-			if tmpl.Name == DefaultInstanceName {
+			if tmpl.Name == defaultInstanceNameConst {
 				hdr += "# - In most cases, you do not need to modify this file.\n"
 			}
 			hdr += "# - To cancel starting Lima, just save this file as an empty file.\n"

--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -27,7 +27,7 @@ func newStopCommand() *cobra.Command {
 
 func stopAction(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	instName := DefaultInstanceName
+	instName := defaultInstanceName()
 	if len(args) > 0 {
 		instName = args[0]
 	}

--- a/website/content/en/docs/config/environment-variables.md
+++ b/website/content/en/docs/config/environment-variables.md
@@ -19,12 +19,14 @@ This page documents the environment variables used in Lima.
 
 ### `LIMA_INSTANCE`
 
-- **Description**: Specifies the name of the Lima instance to use.
+- **Description**: Specifies the name of the Lima instance to use. Both the `lima` wrapper and `limactl` subcommands
+  (e.g. `start`, `stop`, `restart`, `edit`) respect this variable when no instance name is given explicitly.
 - **Default**: `default`
 - **Usage**:
   ```sh
   export LIMA_INSTANCE=my-instance
   lima uname -a
+  limactl start
   ```
 
 ### `LIMA_SHELL`


### PR DESCRIPTION
### Summary

The `lima` wrapper script respects `$LIMA_INSTANCE` to override the default instance name, but `limactl` subcommands always fell back to the hardcoded `"default"`. This PR makes `limactl` subcommands check `$LIMA_INSTANCE` when no instance name is given explicitly.

#### Fixes: #4764 

### Changes

- Replaced the exported `DefaultInstanceName` const with an unexported `defaultInstanceName()` function that reads `$LIMA_INSTANCE` and falls back to `"default"`
- Updated the following subcommands to use `defaultInstanceName()` as the fallback:
  `start`, `stop`, `restart`, `edit`, `factory-reset`, `start-at-login`, `guest-install`
- Updated `$LIMA_INSTANCE` documentation to reflect the expanded scope

### Tests

- Added `TestDefaultInstanceName` covering both the env-set and env-unset cases
- All existing tests pass

### Note

`limactl shell` is intentionally excluded from this PR, it has different arg parsing (instance name is a required positional arg) and needs separate UX consideration. A follow-up PR will address making `limactl shell` (with no args) also fall back to `$LIMA_INSTANCE`.
