### PR TITLE
Deprecate `_LIMA_QEMU_UEFI_IN_BIOS` flag

### DIFF
--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -604,8 +604,9 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	noFirmware := *y.Arch == limatype.PPC64LE || *y.Arch == limatype.S390X || legacyBIOS
 	if !noFirmware {
 		var firmware string
-		firmwareInBios := runtime.GOOS == "windows"
+		firmwareInBios := runtime.GOOS == "windows" && version.LessThan(*semver.New("11.0.0"))
 		if envVar := os.Getenv("_LIMA_QEMU_UEFI_IN_BIOS"); envVar != "" {
+			logrus.Warn("use of deprecated _LIMA_QEMU_UEFI_IN_BIOS")
 			b, err := strconv.ParseBool(envVar)
 			if err != nil {
 				logrus.WithError(err).Warnf("invalid _LIMA_QEMU_UEFI_IN_BIOS value %q", envVar)
@@ -683,6 +684,7 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 		}
 		if firmware != "" {
 			if firmwareInBios {
+				logrus.Warn("firmware in `-bios` is deprecated, consider upgrading to QEMU supporting `-drive if=pflash`")
 				args = append(args, "-bios", firmware)
 			} else {
 				args = append(args, "-drive", fmt.Sprintf("if=pflash,format=raw,readonly=on,file=%s", firmware))

--- a/website/content/en/docs/config/environment-variables.md
+++ b/website/content/en/docs/config/environment-variables.md
@@ -150,13 +150,13 @@ This page documents the environment variables used in Lima.
 ### `_LIMA_QEMU_UEFI_IN_BIOS`
 
 - **Description**: Commands QEMU to load x86_64 UEFI images using `-bios` instead of `pflash` drives.
-- **Default**: `false` on Unix like hosts and `true` on Windows hosts
+- **Default**: `false` on Unix like hosts and `true` on Windows hosts (if QEMU is older than 11.0.0)
 - **Usage**:
   ```sh
   export _LIMA_QEMU_UEFI_IN_BIOS=true
   ```
-- **Note**: It is expected that this variable will be set to `false` by default in future
-  when QEMU supports `pflash` UEFI for accelerated guests on Windows.
+- **Note**: This variable is deprecated and is expected to be removed, when minimal supported QEMU version
+  on Windows is adjusted.
 
 ### `_LIMA_WINDOWS_EXTRA_PATH`
 


### PR DESCRIPTION
Fixes #4607

Changes default behavior on Windows based on QEMU version. Additionally logs deprecation warnings if the setting is used or if a fallback is triggered.

I manually tested it with QEMU 11.0.0 and 10.2.0.