### PR TITLE
refactor: modularize lint targets with pinned go.mod tools (refs #4606)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,18 +42,11 @@ jobs:
     - name: Verify generated files
       run: make generate check-generated
     - name: Run nobin
-      run: >-
-        go tool -modfile=./hack/tools/go.mod nobin
-        --allow-emoji
-        --allow-escape
-        --gitignore
-        --skip-ext pb.desc
-        --skip 'website/static/images/**/*.{gif,png}'
-        --skip 'docs/reports/**/*.pdf'
+      run: make nobin
     - name: Run editorconfig-checker
-      run: go tool -modfile=./hack/tools/go.mod editorconfig-checker
+      run: make editorconfig-checker
     - name: Run yamllint
-      run: yamllint .
+      run: make yamllint
     - name: Install shellcheck
       run: |
         sudo apt-get update
@@ -61,9 +54,9 @@ jobs:
     - name: Run file and directory name linter
       uses: ls-lint/action@02e380fe8733d499cbfc9e22276de5085508a5bd  # v2.3.1
     - name: Run shellcheck
-      run: find . -name '*.sh' | xargs shellcheck
+      run: make shellcheck
     - name: Run shfmt
-      run: find . -name '*.sh' | xargs go tool -modfile=./hack/tools/go.mod shfmt -s -d
+      run: make shfmt
     - name: Check hyperlinks
       uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
       with:
@@ -79,14 +72,11 @@ jobs:
       # TODO: move to `go tool` after upgrading to v2
       run: go install github.com/google/go-licenses@v1.6.0
     - name: Check licenses
-      # the allow list corresponds to https://github.com/cncf/foundation/blob/e5db022a0009f4db52b89d9875640cf3137153fe/allowed-third-party-license-policy.md
-      # hashicorp/hcl/v2 is MPL-2.0; covered by the CNCF license exception for hashicorp/hcl
-      # see also https://github.com/cncf/foundation/issues/1242
-      run: go-licenses check --include_tests --ignore github.com/hashicorp/hcl/v2 ./... --allowed_licenses=$(cat ./hack/allowed-licenses.txt)
+      run: make go-licenses
     - name: Check license boilerplates
-      run: go tool -modfile=./hack/tools/go.mod ltag -t ./hack/ltag --check -v
+      run: make ltag
     - name: Check protobuf files
-      run: go tool -modfile=./hack/tools/go.mod protolint .
+      run: make protolint
     - name: Run zizmor
       uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e  # v0.5.3
       with:

--- a/Makefile
+++ b/Makefile
@@ -607,21 +607,53 @@ check-generated:
 bats: native limactl-plugins
 	PATH=$$PWD/_output/bin:$$PATH ./hack/bats/lib/bats-core/bin/bats --timing ./hack/bats/tests
 
-.PHONY: lint
-lint: check-generated
-	nobin --allow-emoji --allow-escape --gitignore --skip-ext pb.desc --skip 'website/static/images/**/*.{gif,png}' --skip 'docs/reports/**/*.pdf'
-	editorconfig-checker
-	golangci-lint run ./...
+# Linting targets - individual stages
+.PHONY: nobin
+nobin:
+	$(GO) run -modfile=./hack/tools/go.mod github.com/jandubois/nobin --allow-emoji --allow-escape --gitignore --skip-ext pb.desc --skip 'website/static/images/**/*.{gif,png}' --skip 'docs/reports/**/*.pdf'
+
+.PHONY: editorconfig-checker
+editorconfig-checker:
+	$(GO) run -modfile=./hack/tools/go.mod github.com/editorconfig-checker/editorconfig-checker/v3/cmd/editorconfig-checker
+
+.PHONY: golangci-lint
+golangci-lint:
+	$(GO) run -modfile=./hack/tools/go.mod github.com/golangci/golangci-lint/v2/cmd/golangci-lint run ./...
+
+.PHONY: yamllint
+yamllint:
 	yamllint .
+
+.PHONY: ls-lint
+ls-lint:
 	ls-lint
+
+.PHONY: shellcheck
+shellcheck:
 	find . -name '*.sh' ! -path "./.git/*" | xargs shellcheck
-	find . -name '*.sh' ! -path "./.git/*" | xargs shfmt -s -d
+
+.PHONY: shfmt
+shfmt:
+	find . -name '*.sh' ! -path "./.git/*" | xargs $(GO) run -modfile=./hack/tools/go.mod mvdan.cc/sh/v3/cmd/shfmt -s -d
+
+.PHONY: go-licenses
+go-licenses:
 	# the allow list corresponds to https://github.com/cncf/foundation/blob/e5db022a0009f4db52b89d9875640cf3137153fe/allowed-third-party-license-policy.md
 	# hashicorp/hcl/v2 is MPL-2.0; covered by the CNCF license exception for hashicorp/hcl
 	# see also https://github.com/cncf/foundation/issues/1242
 	go-licenses check --include_tests --ignore github.com/hashicorp/hcl/v2 ./... --allowed_licenses=$$(cat ./hack/allowed-licenses.txt)
-	ltag -t ./hack/ltag --check -v
-	protolint .
+
+.PHONY: ltag
+ltag:
+	$(GO) run -modfile=./hack/tools/go.mod github.com/containerd/ltag -t ./hack/ltag --check -v
+
+.PHONY: protolint
+protolint:
+	$(GO) run -modfile=./hack/tools/go.mod github.com/yoheimuta/protolint/cmd/protolint .
+
+# Main lint target - runs all linting stages
+.PHONY: lint
+lint: check-generated nobin editorconfig-checker golangci-lint yamllint ls-lint shellcheck shfmt go-licenses ltag protolint
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Break lint target into independent stages (nobin, editorconfig, golangci, yaml, ls, shellcheck, shfmt, licenses, ltag, protolint) using pinned versions from hack/tools/go.mod via `go run`. Update CI to call make targets instead of hardcoding commands, ensuring single source of truth.
refs #4606