### PR TITLE
fix(validate): correct misleading mountType error on Windows

### DIFF
--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -134,6 +134,12 @@ func validateArch(ctx context.Context, cfg *limatype.LimaYAML) error {
 // Helper method for mount type validation.
 func validateMountType(cfg *limatype.LimaYAML) error {
 	if cfg.MountType != nil && *cfg.MountType == limatype.VIRTIOFS && runtime.GOOS != "linux" {
+		// Windows explicitly does not support 9p, so we should not suggest it.
+		if runtime.GOOS == "windows" {
+			return fmt.Errorf("field `mountType` must be %q for QEMU driver on Windows, got %q",
+				limatype.REVSSHFS, *cfg.MountType)
+		}
+		// For macOS/Darwin, 9p remains a valid suggestion.
 		return fmt.Errorf("field `mountType` must be %q or %q for QEMU driver on non-Linux, got %q",
 			limatype.REVSSHFS, limatype.NINEP, *cfg.MountType)
 	}


### PR DESCRIPTION
**Closes #4954**

### Description
This PR fixes a minor desync in the `mountType` validation logic specifically for Windows hosts.

Previously, `validateMountType` would suggest `"9p"` as a valid fallback for `"virtiofs"` on all non-Linux systems. However, `"9p"` is explicitly blocked on Windows later in the exact same function. This resulted in users being advised to use a mount type that would immediately crash the boot process.

This PR splits the `runtime.GOOS != "linux"` check:
- **Windows:** Now exclusively suggests `"reverse-sshfs"`.
- **macOS/Darwin:** Retains the original suggestion of `"reverse-sshfs" or "9p"`.

### Testing
- Verified that providing `mountType: "virtiofs"` on a Windows host now correctly outputs: `field 'mountType' must be "reverse-sshfs" for QEMU driver on Windows`.