### PR TITLE
wsl2: unblock keepAlive / provisionVM errCh sends after instance stop

### DIFF
--- a/pkg/driver/wsl2/vm_windows.go
+++ b/pkg/driver/wsl2/vm_windows.go
@@ -127,9 +127,9 @@ func provisionVM(ctx context.Context, instanceDir, instanceName, distroName stri
 		os.RemoveAll(limaBootFileWinPath)
 		logrus.Debugf("%v: %q", cmd.Args, string(out))
 		if err != nil {
-			errCh <- fmt.Errorf(
+			trySendErr(ctx, errCh, fmt.Errorf(
 				"error running wslCommand that executes boot.sh (%v): %w, "+
-					"check /var/log/lima-init.log for more details (out=%q)", cmd.Args, err, string(out))
+					"check /var/log/lima-init.log for more details (out=%q)", cmd.Args, err, string(out)))
 		}
 
 		for {
@@ -159,10 +159,23 @@ func keepAlive(ctx context.Context, distroName string, errCh chan<- error) {
 
 	go func() {
 		if err := keepAliveCmd.Run(); err != nil {
-			errCh <- fmt.Errorf(
-				"error running wsl keepAlive command: %w", err)
+			trySendErr(ctx, errCh, fmt.Errorf(
+				"error running wsl keepAlive command: %w", err))
 		}
 	}()
+}
+
+// trySendErr is a non-blocking send that drops the error once ctx has been
+// cancelled. Without this guard, writers spawned from Start() block forever
+// when the hostagent abandons errCh during shutdown (after the signal
+// handler in startRoutinesAndWait exits its outer select), leaving a
+// non-terminating goroutine parked on `chan send` for the rest of the
+// process lifetime. Same shape of fix as #4922 for the VZ driver.
+func trySendErr(ctx context.Context, errCh chan<- error, err error) {
+	select {
+	case errCh <- err:
+	case <-ctx.Done():
+	}
 }
 
 // unregisterVM calls WSL to unregister a VM.

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -242,7 +242,11 @@ func (l *LimaWslDriver) Start(ctx context.Context) (chan error, error) {
 		}
 	}
 
-	errCh := make(chan error)
+	// Buffered so that the first shutdown-time error from provisionVM /
+	// keepAlive does not block the writer if the hostagent has already
+	// stopped draining errCh (the trySendErr helper guards subsequent
+	// sends).
+	errCh := make(chan error, 2)
 
 	if err := startVM(ctx, distroName); err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #4957.

Same shape of fix as #4922 (VZ) and #4892 (WSL2 hot-loop), but for the keepAlive / provisionVM writers in `pkg/driver/wsl2/vm_windows.go`, which the earlier PRs did not touch.

### What was broken

Two goroutines in this file write to the driver's `errCh`:

1. `keepAlive`'s supervisor goroutine, when `wsl.exe ... sleep 2147483647d` is killed by ctx cancellation.
2. `provisionVM`'s boot.sh supervisor, on the error path after `cmd.CombinedOutput()`.

`errCh` is allocated unbuffered in `(*LimaWslDriver).Start` (`wsl_driver_windows.go:245`) and has exactly one consumer — the outer `select` in `(*HostAgent).startRoutinesAndWait`. The moment SIGTERM picks the `signalCh` arm, nobody reads `errCh` again. Both writers then sit on an unbuffered send with no `<-ctx.Done()` fallback and block for the rest of the hostagent's lifetime, parked at `chan send`.

### What this PR does

- Adds a small `trySendErr(ctx, errCh, err)` helper in `vm_windows.go` that selects on `ctx.Done()`.
- Routes both writers (`keepAlive` and `provisionVM`) through it.
- Buffers `errCh` to size 2 in `(*LimaWslDriver).Start` so the first shutdown-time error from either writer is captured even before `trySendErr` is reached.

+22 / −5, two files. No API or architecture change.

### Test plan

- [x] `gofmt -l pkg/driver/wsl2/...` — clean
- [x] `GOOS=windows GOARCH=amd64 go build ./pkg/driver/wsl2/...` — clean
- [x] `GOOS=windows GOARCH=amd64 go vet ./pkg/driver/wsl2/...` — clean
- [ ] CI: Windows tests (WSL2)
- [ ] Manual on a Windows host:
  ```powershell
  limactl start --vm-type=wsl2 --name=demo template://default-windows
  limactl stop demo
  ```
  Before: a goroutine snapshot taken just before hostagent exit shows one goroutine parked at `chan send` in `vm_windows.go:keepAlive.func1`. After: that goroutine returns cleanly when the consumer is gone.
