### PR TITLE
external/server: close driver.stderr.log on Stop so Windows can delete it

### DIFF
--- a/pkg/driver/external/server/server.go
+++ b/pkg/driver/external/server/server.go
@@ -237,6 +237,14 @@ func Start(extDriver *registry.ExternalDriver, instName string) error {
 		cancel()
 		return fmt.Errorf("failed to open external driver log file: %w", err)
 	}
+	// Close logFile on any failure path. Ownership is transferred to
+	// extDriver on the success path below; setting logFile to nil disarms
+	// the defer.
+	defer func() {
+		if logFile != nil {
+			_ = logFile.Close()
+		}
+	}()
 
 	cmd.Stderr = logFile
 
@@ -281,6 +289,8 @@ func Start(extDriver *registry.ExternalDriver, instName string) error {
 	extDriver.Client = driverClient
 	extDriver.Ctx = ctx
 	extDriver.CancelFunc = cancel
+	extDriver.LogFile = logFile
+	logFile = nil // ownership transferred to extDriver; disarm the defer
 
 	driverLogger.Debugf("External driver %s started successfully", extDriver.Name)
 	return nil
@@ -298,6 +308,20 @@ func Stop(extDriver *registry.ExternalDriver) error {
 	if err := extDriver.Command.Process.Signal(syscall.SIGTERM); err != nil {
 		extDriver.Logger.Errorf("Failed to kill external driver process: %v", err)
 	}
+	// Reap the subprocess before releasing any resources it inherits from us
+	// (notably the stderr log file). Without this Wait the child can survive
+	// briefly past Stop and on Windows the parent's handle on
+	// driver.stderr.log keeps `limactl rm --force` from deleting the file
+	// with "The process cannot access the file because it is being used by
+	// another process" (lima-vm/lima#3736).
+	if err := extDriver.Command.Wait(); err != nil {
+		extDriver.Logger.Debugf("External driver %s exited with error: %v", extDriver.Name, err)
+	}
+	if extDriver.LogFile != nil {
+		if err := extDriver.LogFile.Close(); err != nil {
+			extDriver.Logger.Warnf("Failed to close driver stderr log file: %v", err)
+		}
+	}
 	if err := os.Remove(extDriver.SocketPath); err != nil && !os.IsNotExist(err) {
 		extDriver.Logger.Warnf("Failed to remove socket file: %v", err)
 	}
@@ -306,6 +330,7 @@ func Stop(extDriver *registry.ExternalDriver) error {
 	extDriver.Client = nil
 	extDriver.Ctx = nil
 	extDriver.CancelFunc = nil
+	extDriver.LogFile = nil
 
 	extDriver.Logger.Debugf("External driver %s stopped successfully", extDriver.Name)
 	return nil

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -34,6 +34,13 @@ type ExternalDriver struct {
 	Ctx          context.Context
 	Logger       *logrus.Logger
 	CancelFunc   context.CancelFunc
+	// LogFile is the *os.File the external-driver subprocess inherits as
+	// stderr. The parent (limactl) opens it in server.Start and must close
+	// it in server.Stop, otherwise on Windows the file handle stays open
+	// in the parent and `limactl rm --force` fails with "The process
+	// cannot access the file because it is being used by another process"
+	// when trying to delete driver.stderr.log. See lima-vm/lima#3736.
+	LogFile *os.File
 }
 
 var (


### PR DESCRIPTION
Closes #3736.

### Symptom (from the issue)

On Windows, after stopping a WSL2 instance, `limactl rm --force <inst>` fails with:

```
failed to remove "C:\Users\…\.lima\<inst>": remove
C:\Users\…\.lima\<inst>\driver.stderr.log:
The process cannot access the file because it is being used by another process.
```

### Root cause

`server.Start` in `pkg/driver/external/server/server.go` opens `driver.stderr.log` via `os.OpenFile` and hands the `*os.File` to the external-driver subprocess as `cmd.Stderr`:

```go
logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
...
cmd.Stderr = logFile
```

The handle is **never closed** in the parent (limactl). On POSIX, `unlink` is fine while an FD is held open; on Windows, any open HANDLE blocks `DeleteFile`. `server.Stop` sent `SIGTERM` but never `Wait`-ed the subprocess and never closed the inherited log file, so by the time the cleanup code in `limactl rm --force` tried to delete the instance directory, the parent process still held the file open and Windows refused to delete it.

Affects every external driver on Windows (wsl2, qemu, vz, krunkit), but the user-visible damage is worst on wsl2 because that's the Windows default.

### Fix

1. Add `LogFile *os.File` to `registry.ExternalDriver` so `Stop` can find the handle.
2. In `Stop`, after sending `SIGTERM`, call `cmd.Wait()` (so the kernel reaps the child and detaches its end of the inherited handle), then explicitly `Close()` the parent's handle.
3. In `Start`, add a `defer` that closes `logFile` on every failure path between `OpenFile` and the success-path assignment to `extDriver.LogFile`; the defer is disarmed (`logFile = nil`) once ownership is transferred. Without this, every failed `Start` was leaking the FD.

+32 / 0, two files. No API change, no architecture change.

### Test plan

- [x] `gofmt -l pkg/driver/external/server/server.go pkg/registry/registry.go` — clean
- [x] `go vet ./pkg/driver/external/... ./pkg/registry/...` — clean
- [x] `go build ./pkg/driver/external/... ./pkg/registry/... ./cmd/limactl/...` — clean
- [x] `GOOS=windows GOARCH=amd64 go build ./pkg/driver/external/... ./pkg/registry/...` — clean
- [x] `go test ./pkg/registry/...` — pass
- [ ] CI: Windows tests (WSL2, QEMU)
- [ ] Manual on a Windows host:
  ```powershell
  limactl start --vm-type=wsl2 --name=demo template://default-windows
  limactl stop demo
  limactl rm --force demo
  # Before: fails with "The process cannot access the file because it is being used by another process"
  # After: succeeds and the instance directory is fully removed.
  ```
