### PR TITLE
feat: make limactl shell fall back to default instance when no args given

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -100,10 +100,10 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	if instName != "" {
 		// All args are COMMAND; prepend a placeholder instance name so the rest of the code works unchanged.
 		args = append([]string{instName}, args...)
+	} else if len(args) == 0 {
+		instName = DefaultInstanceName
+		args = append([]string{instName}, args...)
 	} else {
-		if len(args) == 0 {
-			return errors.New("requires instance name as first argument")
-		}
 		// simulate the behavior of double dash
 		newArg := []string{}
 		if len(args) >= 2 && args[1] == "--" {


### PR DESCRIPTION
## Summary

Currently `limactl shell` with no positional args and no `--instance` flag errors out with "requires instance name as first argument". This makes it fall back to the default instance (`"default"`), consistent with other subcommands like `start`, `stop`, and `restart` that already do this.

With zero args there's no ambiguity — the first-arg-is-instance-name convention only applies when args are present.

### Closes #4764 

## Changes

- Modified `shellAction()` to fall back to `DefaultInstanceName` when no args and no `--instance` flag, instead of returning an error

## Note

This is a follow-up to #4945 . Both PRs are independent and can be merged in any order.
