### PR TITLE
[Lima 2.2.0] Set minimal QEMU version to 11.0.0 on Windows

### DIFF
--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -73,6 +72,8 @@ func minimumQemuVersion() (hardMin, softMin semver.Version) {
 			// was removed in https://github.com/lima-vm/lima/pull/3491
 			h, s = "7.0.0", "8.2.1"
 		}
+	case "windows":
+		h, s = "11.0.0", "11.0.0"
 	default:
 		// hardMin: Untested and maybe does not even work.
 		// softMin: Ubuntu 22.04's QEMU. The oldest version that can be easily tested on GitHub Actions.
@@ -563,14 +564,6 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 			// This will disable CPU S3/S4 state.
 			args = append(args, "-global", "ICH9-LPC.disable_s3=1")
 			args = append(args, "-global", "ICH9-LPC.disable_s4=1")
-		case "whpx":
-			if version.LessThan(*semver.New("11.0.0")) {
-				// Older versions of QEMU required disabling `kernel-irqchip` explicitly.
-				// It is not recommended to keep using this with QEMU 11.0.0 and newer.
-				args = appendArgsIfNoConflict(args, "-machine", "q35,accel="+accel+",kernel-irqchip=off")
-			} else {
-				args = appendArgsIfNoConflict(args, "-machine", "q35,accel="+accel)
-			}
 		default:
 			args = appendArgsIfNoConflict(args, "-machine", "q35,accel="+accel)
 		}
@@ -609,45 +602,26 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	noFirmware := *y.Arch == limatype.PPC64LE || *y.Arch == limatype.S390X || legacyBIOS
 	if !noFirmware {
 		var firmware string
-		firmwareInBios := runtime.GOOS == "windows" && version.LessThan(*semver.New("11.0.0"))
-		if envVar := os.Getenv("_LIMA_QEMU_UEFI_IN_BIOS"); envVar != "" {
-			logrus.Warn("use of deprecated _LIMA_QEMU_UEFI_IN_BIOS")
-			b, err := strconv.ParseBool(envVar)
-			if err != nil {
-				logrus.WithError(err).Warnf("invalid _LIMA_QEMU_UEFI_IN_BIOS value %#q", envVar)
-			} else {
-				firmwareInBios = b
-			}
-		}
-		firmwareInBios = firmwareInBios && *y.Arch == limatype.X8664
 		downloadedFirmware := filepath.Join(cfg.InstanceDir, filenames.QemuEfiCodeFD)
-		firmwareWithVars := filepath.Join(cfg.InstanceDir, filenames.QemuEfiFullFD)
-		if firmwareInBios {
-			if _, stErr := os.Stat(firmwareWithVars); stErr == nil {
-				firmware = firmwareWithVars
-				logrus.Infof("Using existing firmware (%#q)", firmware)
-			}
-		} else {
-			if _, stErr := os.Stat(downloadedFirmware); errors.Is(stErr, os.ErrNotExist) {
-			loop:
-				for _, f := range y.Firmware.Images {
-					switch f.VMType {
-					case "", limatype.QEMU:
-						if f.Arch == *y.Arch {
-							if _, err = fileutils.DownloadFile(ctx, downloadedFirmware, f.File, true, "UEFI code "+f.Location, *y.Arch); err != nil {
-								logrus.WithError(err).Warnf("failed to download %#q", f.Location)
-								continue loop
-							}
-							firmware = downloadedFirmware
-							logrus.Infof("Using firmware %#q (downloaded from %#q)", firmware, f.Location)
-							break loop
+		if _, stErr := os.Stat(downloadedFirmware); errors.Is(stErr, os.ErrNotExist) {
+		loop:
+			for _, f := range y.Firmware.Images {
+				switch f.VMType {
+				case "", limatype.QEMU:
+					if f.Arch == *y.Arch {
+						if _, err = fileutils.DownloadFile(ctx, downloadedFirmware, f.File, true, "UEFI code "+f.Location, *y.Arch); err != nil {
+							logrus.WithError(err).Warnf("failed to download %#q", f.Location)
+							continue loop
 						}
+						firmware = downloadedFirmware
+						logrus.Infof("Using firmware %#q (downloaded from %#q)", firmware, f.Location)
+						break loop
 					}
 				}
-			} else {
-				firmware = downloadedFirmware
-				logrus.Infof("Using existing firmware (%#q)", firmware)
 			}
+		} else {
+			firmware = downloadedFirmware
+			logrus.Infof("Using existing firmware (%#q)", firmware)
 		}
 		if firmware == "" {
 			firmware, err = getFirmware(exe, *y.Arch)
@@ -655,45 +629,9 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 				return "", nil, err
 			}
 			logrus.Infof("Using system firmware (%#q)", firmware)
-			if firmwareInBios {
-				firmwareVars, err := getFirmwareVars(exe, *y.Arch)
-				if err != nil {
-					return "", nil, err
-				}
-				logrus.Infof("Using system firmware vars (%#q)", firmwareVars)
-				varsFile, err := os.Open(firmwareVars)
-				if err != nil {
-					return "", nil, err
-				}
-				defer varsFile.Close()
-				codeFile, err := os.Open(firmware)
-				if err != nil {
-					return "", nil, err
-				}
-				defer codeFile.Close()
-				resultFile, err := os.OpenFile(firmwareWithVars, os.O_CREATE|os.O_WRONLY, 0o644)
-				if err != nil {
-					return "", nil, err
-				}
-				defer resultFile.Close()
-				_, err = io.Copy(resultFile, varsFile)
-				if err != nil {
-					return "", nil, err
-				}
-				_, err = io.Copy(resultFile, codeFile)
-				if err != nil {
-					return "", nil, err
-				}
-				firmware = firmwareWithVars
-			}
 		}
 		if firmware != "" {
-			if firmwareInBios {
-				logrus.Warn("firmware in `-bios` is deprecated, consider upgrading to QEMU supporting `-drive if=pflash`")
-				args = append(args, "-bios", firmware)
-			} else {
-				args = append(args, "-drive", fmt.Sprintf("if=pflash,format=raw,readonly=on,file=%s", firmware))
-			}
+			args = append(args, "-drive", fmt.Sprintf("if=pflash,format=raw,readonly=on,file=%s", firmware))
 		}
 	}
 
@@ -1242,43 +1180,6 @@ func getFirmware(qemuExe string, arch limatype.Arch) (string, error) {
 	}
 	qemuArch := strings.TrimPrefix(filepath.Base(qemuExe), "qemu-system-")
 	return "", fmt.Errorf("could not find firmware for %#q (hint: try copying the `edk-%s-code.fd` firmware to $HOME/.local/share/qemu/)", arch, qemuArch)
-}
-
-func getFirmwareVars(qemuExe string, arch limatype.Arch) (string, error) {
-	var targetArch string
-	switch arch {
-	case limatype.X8664:
-		targetArch = "i386" // vars are unified between i386 and x86_64 and normally only former is bundled
-	default:
-		return "", fmt.Errorf("unexpected architecture: %#q", arch)
-	}
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
-	binDir := filepath.Dir(qemuExe)                  // "/usr/local/bin"
-	localDir := filepath.Dir(binDir)                 // "/usr/local"
-	userLocalDir := filepath.Join(homeDir, ".local") // "$HOME/.local"
-
-	relativePath := fmt.Sprintf("share/qemu/edk2-%s-vars.fd", qemuEdk2Arch(targetArch))
-	relativePathWin := fmt.Sprintf("share/edk2-%s-vars.fd", qemuEdk2Arch(targetArch))
-	candidates := []string{
-		filepath.Join(userLocalDir, relativePath), // XDG-like
-		filepath.Join(localDir, relativePath),     // macOS (homebrew)
-		filepath.Join(binDir, relativePathWin),    // Windows installer
-	}
-
-	logrus.Debugf("firmware vars candidates = %v", candidates)
-
-	for _, f := range candidates {
-		if _, err := os.Stat(f); err == nil {
-			return f, nil
-		}
-	}
-
-	return "", fmt.Errorf("could not find firmware vars for %#q", arch)
 }
 
 var hasSMEDarwin = sync.OnceValue(func() bool {

--- a/pkg/limatype/filenames/filenames.go
+++ b/pkg/limatype/filenames/filenames.go
@@ -69,7 +69,6 @@ const (
 	VzAux                   = "vz-aux"           // macOS guests only
 	VzEfi                   = "vz-efi"           // efi variable store
 	QemuEfiCodeFD           = "qemu-efi-code.fd" // efi code; not always created
-	QemuEfiFullFD           = "qemu-efi-full.fd" // concatenated efi vars and code; not always created
 	AnsibleInventoryYAML    = "ansible-inventory.yaml"
 
 	// SocketDir is the default location for forwarded sockets with a relative paths in HostSocket.

--- a/website/content/en/docs/config/environment-variables.md
+++ b/website/content/en/docs/config/environment-variables.md
@@ -147,17 +147,6 @@ This page documents the environment variables used in Lima.
   export LIMA_USERNET_RESOLVE_IP_ADDRESS_TIMEOUT=5
   ```
 
-### `_LIMA_QEMU_UEFI_IN_BIOS`
-
-- **Description**: Commands QEMU to load x86_64 UEFI images using `-bios` instead of `pflash` drives.
-- **Default**: `false` on Unix like hosts and `true` on Windows hosts (if QEMU is older than 11.0.0)
-- **Usage**:
-  ```sh
-  export _LIMA_QEMU_UEFI_IN_BIOS=true
-  ```
-- **Note**: This variable is deprecated and is expected to be removed, when minimal supported QEMU version
-  on Windows is adjusted.
-
 ### `_LIMA_WINDOWS_EXTRA_PATH`
 
 - **Description**: Additional directories which will be added to PATH by `limactl.exe` process to search for tools.


### PR DESCRIPTION
This is for `2.2.0` or later. I need to try it once in the CI to see the reproducer for the root cause of the QEMU pining, because I tried it locally and in a third party GH repo with GHA and can't get the test failure. If CI fails I will try to investigate further w/o hogging CI for the project and postpone patch waiting for later QEMU if needed. There should be a QEMU point release in 2 weeks https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg02947.html, so, it might bring some fixes as well, but it is a bit iffy when/if the release will be built for Windows and when/if `winget` will update the repo.

Potentially fixes #4949
