### PR TITLE
Unpin QEMU version in Windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -235,10 +235,7 @@ jobs:
       run: make
     - name: Install QEMU
       run: |
-        # Pin to 10.2.0: QEMU 11.0.0 TCG breaks systemd boot on the Windows
-        # runner with "Failed to fork off sandboxing environment: Protocol
-        # error", blocking SSH.
-        winget install --silent --accept-source-agreements --accept-package-agreements --disable-interactivity SoftwareFreedomConservancy.QEMU --version 10.2.0
+        winget install --silent --accept-source-agreements --accept-package-agreements --disable-interactivity SoftwareFreedomConservancy.QEMU
     - name: Integration tests (QEMU, Windows host)
       run: |
         $env:PATH = "$pwd\_output\bin;" + 'C:\msys64\usr\bin;' + 'C:\Program Files\QEMU;' + $env:PATH


### PR DESCRIPTION
Factored out changes from #4970 related to CI.

I didn't manage to reproduce failure on any setup running QEMU 11.0.0 and the tests passed at least in #4970 where prior version of QEMU are even unsupported. May be it is worth trying to unpin the QEMU version.

Alternatively we can wait for 2-3 weeks for 11.0.1 being released.