### PR TITLE
qemu: pass `-vga none` for headless guests

### DIFF
--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -872,6 +872,11 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 		args = append(args, "-device", "virtio-keyboard-pci")
 		args = append(args, "-device", "virtio-"+input+"-pci")
 		args = append(args, "-device", "qemu-xhci,id=usb-bus")
+	} else {
+		// Suppress any machine-default VGA adapter so the guest needs no VGA
+		// ROM. Only x86_64's q35/pc attach one (a std-vga needing
+		// vgabios-stdvga.bin); on other architectures this is a no-op.
+		args = append(args, "-vga", "none")
 	}
 
 	// Parallel


### PR DESCRIPTION
Commit af5ea86 stopped emitting `-device virtio-vga` when `video.display` is "none". On x86_64 the q35/pc machines then fall back to their built-in std-vga, which requires `vgabios-stdvga.bin`. Distributions that ship a stripped QEMU (only the ROMs lima itself needs) now fail to start with: `failed to find romfile "vgabios-stdvga.bin"`.

Pass `-vga none` in the headless case so QEMU attaches no VGA device and needs no VGA ROM.