### PR TITLE
Missing image and checksum for debian-13 riscv64

### DIFF
--- a/hack/update-template-debian.sh
+++ b/hack/update-template-debian.sh
@@ -112,7 +112,7 @@ function debian_digest_from_upload_entry() {
 	debian_digest=$(jq -e -r '.metadata.annotations."cloud.debian.org/digest"' <<<"${upload_entry}") ||
 		error_exit "Failed to get the digest from ${upload_entry}"
 	case "${debian_digest%:*}" in
-	sha512) digest=$(echo "${debian_digest#*:}==" | base64 -d | xxd -p -c -) ||
+	sha512) digest=$(echo "${debian_digest#*:}==" | base64 -d | xxd -p -c 128) ||
 		error_exit "Failed to decode the digest from ${debian_digest}" ;;
 	*) error_exit "Unsupported digest type: ${debian_digest%:*}" ;;
 	esac

--- a/hack/update-template-debian.sh
+++ b/hack/update-template-debian.sh
@@ -57,7 +57,17 @@ HELP
 
 readonly debian_base_url=https://cloud.debian.org/images/cloud/
 
-readonly debian_target_vendor=genericcloud
+function debian_target_vendor_from_arch() {
+	local arch=$1
+	case "$arch" in
+	amd64 | arm64)
+		echo "genericcloud"
+		;;
+	*)
+		echo "generic"
+		;;
+	esac
+}
 
 readonly -A debian_version_to_codename=(
 	[10]=buster
@@ -270,8 +280,9 @@ function debian_location_from_url_spec() {
 	timestamp=$(jq -r 'if .timestamp then .timestamp else empty end' <<<"${url_spec}")
 	base_url+=${timestamp:-latest}/
 	arch=$(jq -e -r '.arch' <<<"${url_spec}")
+	target_vendor=$(debian_target_vendor_from_arch "${arch}")
 	file_extension=$(jq -e -r '.file_extension' <<<"${url_spec}")
-	base_url+=debian-${version}${backports}-${debian_target_vendor}-${arch}${daily:+-${daily}}${timestamp:+-${timestamp}}.${file_extension}
+	base_url+=debian-${version}${backports}-${target_vendor}-${arch}${daily:+-${daily}}${timestamp:+-${timestamp}}.${file_extension}
 	echo "${base_url}"
 }
 
@@ -294,10 +305,11 @@ function debian_cache_key_for_image_kernel_overriding() {
 	version=$(jq -r '.version|if . then "-\(.)" else empty end' <<<"${url_spec}")
 	backports=$(jq -r 'if .backports then "-backports" else empty end' <<<"${url_spec}")
 	arch=$(jq -e -r '.arch' <<<"${url_spec}")
+	target_vendor=$(debian_target_vendor_from_arch "${arch}")
 	daily=$(jq -r 'if .daily then "-daily" else empty end' <<<"${url_spec}")
 	timestamped=$(jq -r 'if .timestamp then "-timestamped" else empty end' <<<"${url_spec}")
 	file_extension=$(jq -e -r '.file_extension' <<<"${url_spec}")
-	echo "debian${with_kernel}${version}${backports}-${debian_target_vendor}-${arch}${daily}${timestamped}.${file_extension}"
+	echo "debian${with_kernel}${version}${backports}-${target_vendor}-${arch}${daily}${timestamped}.${file_extension}"
 }
 
 function debian_image_entry_for_image_kernel_overriding() {

--- a/templates/_images/debian-11.yaml
+++ b/templates/_images/debian-11.yaml
@@ -20,7 +20,7 @@ images:
 - location: https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-genericcloud-arm64.qcow2
   arch: aarch64
 
-- location: https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-genericcloud-ppc64el.qcow2
+- location: https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-generic-ppc64el.qcow2
   arch: ppc64le
 
 mountTypesUnsupported: [9p]

--- a/templates/_images/debian-12.yaml
+++ b/templates/_images/debian-12.yaml
@@ -19,7 +19,7 @@ images:
 - location: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-arm64.qcow2
   arch: aarch64
 
-- location: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-ppc64el.qcow2
+- location: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-generic-ppc64el.qcow2
   arch: ppc64le
 
 mountTypesUnsupported: [9p]

--- a/templates/_images/debian-13.yaml
+++ b/templates/_images/debian-13.yaml
@@ -7,6 +7,12 @@ images:
 - location: "https://cloud.debian.org/images/cloud/trixie/20260413-2447/debian-13-genericcloud-arm64-20260413-2447.qcow2"
   arch: "aarch64"
   digest: "sha512:9de87e5e9739ec07fe61d40e5a6796e6e97e557ddb7d1eee5cf28619e80c21c0da76fc54713161e52c2719a38b5376e7b3bcfcd468e0b82ab9d33f702a09d601"
+- location: "https://cloud.debian.org/images/cloud/trixie/20260413-2447/debian-13-generic-ppc64el-20260413-2447.qcow2"
+  arch: "ppc64le"
+  digest: "sha512:d8d9345bfa563f95f42788218b2c18e1c7e1bbcb3c2c8a0724c2b98337280abcf9158e9e2483c40a893455669f36a20c7ea149cf1dcc6afbd9d138e96119ca8d"
+- location: "https://cloud.debian.org/images/cloud/trixie/20260413-2447/debian-13-generic-riscv64-20260413-2447.qcow2"
+  arch: "riscv64"
+  digest: "sha512:5e725cd9e1daf39c6d97ab2edd06301c566e1d0d317014ac1c3603f094dfe4ce0267370c4dc2a657eb2090cddae518e97d12e0784639cf1e417126d6cc866db2"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 
@@ -16,7 +22,10 @@ images:
 - location: https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-genericcloud-arm64-daily.qcow2
   arch: aarch64
 
-- location: https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-genericcloud-ppc64el-daily.qcow2
+- location: https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-ppc64el-daily.qcow2
   arch: ppc64le
+
+- location: https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-riscv64-daily.qcow2
+  arch: riscv64
 
 mountTypesUnsupported: [9p]

--- a/templates/experimental/debian-sid.yaml
+++ b/templates/experimental/debian-sid.yaml
@@ -15,4 +15,7 @@ images:
 - location: https://cloud.debian.org/images/cloud/sid/daily/latest/debian-sid-generic-ppc64el-daily.qcow2
   arch: ppc64le
 
+- location: https://cloud.debian.org/images/cloud/sid/daily/latest/debian-sid-generic-s390x-daily.qcow2
+  arch: s390x
+
 mountTypesUnsupported: [9p]

--- a/templates/experimental/debian-sid.yaml
+++ b/templates/experimental/debian-sid.yaml
@@ -9,10 +9,10 @@ images:
 - location: https://cloud.debian.org/images/cloud/sid/daily/latest/debian-sid-genericcloud-arm64-daily.qcow2
   arch: aarch64
 
-- location: https://cloud.debian.org/images/cloud/sid/daily/latest/debian-sid-genericcloud-riscv64-daily.qcow2
+- location: https://cloud.debian.org/images/cloud/sid/daily/latest/debian-sid-generic-riscv64-daily.qcow2
   arch: riscv64
 
-- location: https://cloud.debian.org/images/cloud/sid/daily/latest/debian-sid-genericcloud-ppc64el-daily.qcow2
+- location: https://cloud.debian.org/images/cloud/sid/daily/latest/debian-sid-generic-ppc64el-daily.qcow2
   arch: ppc64le
 
 mountTypesUnsupported: [9p]


### PR DESCRIPTION
Tested manually that "latest" is working (in QEMU)

```yaml
- location: https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-riscv64-daily.qcow2
  arch: riscv64
```