### PR TITLE
fix: make port forwarding defaults protocol-aware for IPv6

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -937,14 +937,26 @@ func FillPortForwardDefaults(rule *limatype.PortForward, instDir string, user li
 		rule.Proto = limatype.ProtoAny
 	}
 	if rule.GuestIP == nil {
+		// Determine if the host agent should default to IPv6 based on the HostIP
+		isHostIPv6 := rule.HostIP != nil && rule.HostIP.To4() == nil
 		if rule.GuestIPMustBeZero != nil && *rule.GuestIPMustBeZero {
-			rule.GuestIP = net.IPv4zero
+			if isHostIPv6 {
+				rule.GuestIP = net.IPv6unspecified // "::"
+			} else {
+				rule.GuestIP = net.IPv4zero        
+			}
 		} else {
-			rule.GuestIP = IPv4loopback1
+			if isHostIPv6 {
+				rule.GuestIP = net.IPv6loopback    // "::1"
+			} else {
+				rule.GuestIP = IPv4loopback1       
+			}
 		}
 	}
 	if rule.GuestIPMustBeZero == nil {
-		rule.GuestIPMustBeZero = ptr.Of(rule.GuestIP.Equal(net.IPv4zero))
+		// Recognize both IPv4 and IPv6 unspecified addresses as "Zero" 
+		isZero := rule.GuestIP.Equal(net.IPv4zero) || rule.GuestIP.Equal(net.IPv6unspecified)
+		rule.GuestIPMustBeZero = ptr.Of(isZero)
 	}
 	if rule.HostIP == nil {
 		rule.HostIP = IPv4loopback1


### PR DESCRIPTION
Fixes: #4979

# Description

This PR addresses a protocol mismatch in the port forwarding defaulting logic that causes silent connection hangs and incorrect wildcard assignments when using IPv6.

Previously, Lima's defaults were protocol-blind, hardcoding IPv4 values even when an IPv6 HostIP was explicitly defined. This resulted in the HostAgent attempting to dial an IPv4 GuestIP for an incoming IPv6 request, leading to dropped packets.

## Changes:
Protocol-Aware GuestIP Defaulting: Updated FillPortForwardDefaults in pkg/limayaml/defaults.go to inspect the HostIP. If the HostIP is IPv6 (determined via To4() == nil), the GuestIP now correctly defaults to the IPv6 loopback (::1) instead of the hardcoded IPv4 loopback (127.0.0.1).

Updated GuestIPMustBeZero Logic: Modified the wildcard detection logic to recognize net.IPv6unspecified (::). Previously, Lima failed to set the GuestIPMustBeZero flag for IPv6 unspecified addresses because it only checked against net.IPv4zero.

## Impact:
Fixes Connection Hangs: Prevents the HostAgent dialer from attempting an IPv4 dial for an IPv6 host request, which previously resulted in a silent hang.

Enables Wildcard Binding: Ensures that GuestIPMustBeZero is correctly assigned when the user intends to bind to all interfaces via IPv6 (::).