### PR TITLE
POC: add Windows guest support via autounattend.xml

### DIFF
--- a/hack/gen-autounattend-iso.go
+++ b/hack/gen-autounattend-iso.go
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// gen-autounattend-iso generates an autounattend.iso for testing the Windows
+// guest POC with QEMU.
+// Usage: go run hack/gen-autounattend-iso.go [-arch amd64|arm64] [-o autounattend.iso]
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/lima-vm/lima/v2/pkg/cidata"
+	"github.com/lima-vm/lima/v2/pkg/iso9660util"
+)
+
+func main() {
+	outPath := flag.String("o", "autounattend.iso", "output ISO file path")
+	arch := flag.String("arch", "amd64", "target architecture: amd64 or arm64")
+	flag.Parse()
+
+	if *arch != "amd64" && *arch != "arm64" {
+		fmt.Fprintf(os.Stderr, "error: -arch must be amd64 or arm64, got %q\n", *arch)
+		os.Exit(1)
+	}
+
+	args := &cidata.TemplateArgs{
+		Name: "windows-test",
+	}
+
+	xmlBytes, err := cidata.ExecuteTemplateAutounattend(args, *arch)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error rendering template: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Also write the raw XML for inspection
+	xmlPath := *outPath + ".xml"
+	if err := os.WriteFile(xmlPath, xmlBytes, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing XML: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stdout, "Wrote %s (%d bytes)\n", xmlPath, len(xmlBytes))
+
+	layout := []iso9660util.Entry{
+		{
+			Path:   "autounattend.xml",
+			Reader: bytes.NewReader(xmlBytes),
+		},
+	}
+
+	// Only include startup.nsh for amd64 (EFI Shell fallback for OVMF on x86_64)
+	if *arch == "amd64" {
+		layout = append(layout, iso9660util.Entry{
+			Path: "startup.nsh",
+			Reader: bytes.NewReader([]byte("@echo -off\r\n" +
+				"echo Searching for Windows Boot Manager...\r\n" +
+				"FS0:\\EFI\\BOOT\\BOOTX64.EFI\r\n" +
+				"FS1:\\EFI\\BOOT\\BOOTX64.EFI\r\n" +
+				"FS2:\\EFI\\BOOT\\BOOTX64.EFI\r\n" +
+				"FS3:\\EFI\\BOOT\\BOOTX64.EFI\r\n" +
+				"FS4:\\EFI\\BOOT\\BOOTX64.EFI\r\n")),
+		})
+	}
+
+	if err := iso9660util.Write(*outPath, "autounattend", layout, iso9660util.WithJoliet()); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing ISO: %v\n", err)
+		os.Exit(1)
+	}
+
+	fi, _ := os.Stat(*outPath)
+	fmt.Fprintf(os.Stdout, "Wrote %s (%d bytes)\n", *outPath, fi.Size())
+
+	if *arch == "amd64" {
+		printAmd64Usage(*outPath)
+	} else {
+		printArm64Usage(*outPath)
+	}
+}
+
+func printAmd64Usage(outPath string) {
+	fmt.Fprintln(os.Stdout, "\nUsage with QEMU amd64 (UEFI boot required):")
+	fmt.Fprintln(os.Stdout, "  qemu-img create -f qcow2 disk.qcow2 64G")
+	fmt.Fprintln(os.Stdout, "  dd if=/dev/zero of=ovmf_vars.fd bs=1M count=4")
+	fmt.Fprintln(os.Stdout, "  qemu-system-x86_64 -m 4G -smp 2 -machine q35 \\")
+	fmt.Fprintln(os.Stdout, "    -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.fd \\")
+	fmt.Fprintln(os.Stdout, "    -drive if=pflash,format=raw,file=ovmf_vars.fd \\")
+	fmt.Fprintln(os.Stdout, "    -cdrom /path/to/windows.iso \\")
+	fmt.Fprintf(os.Stdout, "    -drive file=%s,media=cdrom,index=3 \\\n", outPath)
+	fmt.Fprintln(os.Stdout, "    -drive file=disk.qcow2,index=0,media=disk,format=qcow2 \\")
+	fmt.Fprintln(os.Stdout, "    -nic user,hostfwd=tcp::2222-:22")
+	fmt.Fprintln(os.Stdout, "\n  On macOS (Homebrew): replace OVMF paths with")
+	fmt.Fprintln(os.Stdout, "    /opt/homebrew/share/qemu/edk2-x86_64-code.fd")
+	fmt.Fprintln(os.Stdout, "\n  On Windows (PowerShell, WHPX): add -accel whpx")
+}
+
+func printArm64Usage(outPath string) {
+	fmt.Fprintln(os.Stdout, "\nUsage with QEMU aarch64 on Apple Silicon (HVF):")
+	fmt.Fprintln(os.Stdout, "  qemu-img create -f qcow2 disk.qcow2 64G")
+	fmt.Fprintln(os.Stdout, "  dd if=/dev/zero of=ovmf_vars.fd bs=1M count=64")
+	fmt.Fprintln(os.Stdout, "")
+	fmt.Fprintln(os.Stdout, "  qemu-system-aarch64 \\")
+	fmt.Fprintln(os.Stdout, "    -machine virt,accel=hvf \\")
+	fmt.Fprintln(os.Stdout, "    -cpu host \\")
+	fmt.Fprintln(os.Stdout, "    -m 4G -smp 4 \\")
+	fmt.Fprintln(os.Stdout, "    -drive if=pflash,format=raw,readonly=on,file=/opt/homebrew/share/qemu/edk2-aarch64-code.fd \\")
+	fmt.Fprintln(os.Stdout, "    -drive if=pflash,format=raw,file=ovmf_vars.fd \\")
+	fmt.Fprintln(os.Stdout, "    -drive file=disk.qcow2,if=none,id=hd0,format=qcow2 \\")
+	fmt.Fprintln(os.Stdout, "    -device nvme,serial=lima0,drive=hd0 \\")
+	fmt.Fprintln(os.Stdout, "    -device qemu-xhci \\")
+	fmt.Fprintln(os.Stdout, "    -device usb-kbd \\")
+	fmt.Fprintln(os.Stdout, "    -device usb-tablet \\")
+	fmt.Fprintln(os.Stdout, "    -drive file=/path/to/Win11_ARM64.iso,if=none,id=cdrom0,media=cdrom,readonly=on \\")
+	fmt.Fprintln(os.Stdout, "    -device usb-storage,drive=cdrom0 \\")
+	fmt.Fprintf(os.Stdout, "    -drive file=%s,if=none,id=unattend,media=cdrom,readonly=on \\\n", outPath)
+	fmt.Fprintln(os.Stdout, "    -device usb-storage,drive=unattend \\")
+	fmt.Fprintln(os.Stdout, "    -device ramfb \\")
+	fmt.Fprintln(os.Stdout, "    -nic user,hostfwd=tcp::2222-:22")
+}

--- a/pkg/cidata/cidata.TEMPLATE.d.Windows.amd64/autounattend.xml
+++ b/pkg/cidata/cidata.TEMPLATE.d.Windows.amd64/autounattend.xml
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Windows unattended answer file for Lima guest VMs (amd64).
+     Ref: https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/update-windows-settings-and-scripts-create-your-own-answer-file-sxs -->
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+
+  <!-- windowsPE: locale, disk layout, image selection, hw bypass -->
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral"
+               versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+
+    <component name="Microsoft-Windows-Setup"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral"
+               versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+
+      <!-- Bypass Win11 hardware checks (TPM, SecureBoot, RAM, etc.) — irrelevant in a VM -->
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>3</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>4</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassCPUCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>5</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassStorageCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>6</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\MoSetup" /v AllowUpgradesWithUnsupportedTPMOrCPU /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <FullName>User</FullName>
+        <Organization>Lima</Organization>
+        <ProductKey>
+          <WillShowUI>Never</WillShowUI>
+        </ProductKey>
+      </UserData>
+
+      <!-- GPT partition layout for UEFI boot.
+           NOTE: On amd64, disk is attached via SATA/AHCI so WinPE can see it without extra drivers. -->
+      <DiskConfiguration>
+        <Disk wcm:action="add">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Type>EFI</Type>
+              <Size>100</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>MSR</Type>
+              <Size>16</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>3</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionID>1</PartitionID>
+              <Label>System</Label>
+              <Format>FAT32</Format>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionID>2</PartitionID>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>3</Order>
+              <PartitionID>3</PartitionID>
+              <Label>Windows</Label>
+              <Format>NTFS</Format>
+              <Letter>C</Letter>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+
+      <!-- Index 6 = Pro on Win10/Win11 x86_64 multi-edition ISOs -->
+      <ImageInstall>
+        <OSImage>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>3</PartitionID>
+          </InstallTo>
+          <InstallToAvailablePartition>false</InstallToAvailablePartition>
+          <OSImageIndex>6</OSImageIndex>
+        </OSImage>
+      </ImageInstall>
+
+    </component>
+  </settings>
+
+  <!-- specialize: machine identity (runs after file copy, before first boot) -->
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral"
+               versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <ComputerName>lima-default</ComputerName>
+      <TimeZone>UTC</TimeZone>
+    </component>
+  </settings>
+
+  <!-- oobeSystem: suppress OOBE prompts, create user, install OpenSSH -->
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-Shell-Setup"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral"
+               versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>false</HideLocalAccountScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>3</ProtectYourPC>
+        <SkipMachineOOBE>true</SkipMachineOOBE>
+        <SkipUserOOBE>true</SkipUserOOBE>
+      </OOBE>
+      <UserAccounts>
+        <LocalAccounts>
+          <LocalAccount wcm:action="add">
+            <Name>lima</Name>
+            <DisplayName>lima</DisplayName>
+            <Group>Administrators</Group>
+            <Password>
+              <Value></Value>
+              <PlainText>true</PlainText>
+            </Password>
+          </LocalAccount>
+        </LocalAccounts>
+      </UserAccounts>
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Username>lima</Username>
+        <Password>
+          <Value></Value>
+          <PlainText>true</PlainText>
+        </Password>
+        <LogonCount>3</LogonCount>
+      </AutoLogon>
+
+      <!-- Install and configure OpenSSH server for Lima host-agent connectivity -->
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <CommandLine>powershell.exe -NoProfile -Command "Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0"</CommandLine>
+          <Description>Install OpenSSH Server</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <CommandLine>powershell.exe -NoProfile -Command "Start-Service sshd; Set-Service -Name sshd -StartupType Automatic"</CommandLine>
+          <Description>Start and enable sshd</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>3</Order>
+          <CommandLine>powershell.exe -NoProfile -Command "New-Item -Path 'C:\ProgramData\ssh' -ItemType Directory -Force"</CommandLine>
+          <Description>Create SSH config directory</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>4</Order>
+          <CommandLine>powershell.exe -NoProfile -Command "Set-Content -Path 'C:\ProgramData\ssh\administrators_authorized_keys' -Value 'ssh-rsa PLACEHOLDER'; icacls 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r /grant 'SYSTEM:(F)' /grant 'Administrators:(F)'"</CommandLine>
+          <Description>Write authorized_keys with correct ACLs</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>5</Order>
+          <CommandLine>powershell.exe -NoProfile -Command "$cfg = 'C:\ProgramData\ssh\sshd_config'; (Get-Content $cfg) -replace '#?AuthorizedKeysFile.*', 'AuthorizedKeysFile .ssh/authorized_keys' | Set-Content $cfg; Add-Content $cfg 'Match Group administrators`r`n  AuthorizedKeysFile C:/ProgramData/ssh/administrators_authorized_keys'; Restart-Service sshd"</CommandLine>
+          <Description>Configure sshd for admin key auth</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>6</Order>
+          <CommandLine>reg.exe add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoAdminLogon /t REG_SZ /d 0 /f</CommandLine>
+          <Description>Disable auto-logon after provisioning</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>7</Order>
+          <CommandLine>powershell.exe -NoProfile -Command "New-NetFirewallRule -Name 'OpenSSH-Server' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22"</CommandLine>
+          <Description>Allow SSH through firewall</Description>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+    <component name="Microsoft-Windows-International-Core"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral"
+               versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+  </settings>
+
+</unattend>

--- a/pkg/cidata/cidata.TEMPLATE.d.Windows.arm64/autounattend.xml
+++ b/pkg/cidata/cidata.TEMPLATE.d.Windows.arm64/autounattend.xml
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Windows unattended answer file for Lima guest VMs (ARM64).
+     Ref: https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/update-windows-settings-and-scripts-create-your-own-answer-file-sxs -->
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+
+  <!-- windowsPE: locale, disk layout, image selection, hw bypass, VirtIO drivers -->
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE"
+               processorArchitecture="arm64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral"
+               versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+
+    <component name="Microsoft-Windows-Setup"
+               processorArchitecture="arm64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral"
+               versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+
+      <!-- Bypass Win11 hardware checks (TPM, SecureBoot, RAM, etc.) — irrelevant in a VM -->
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>3</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>4</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassCPUCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>5</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassStorageCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>6</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\MoSetup" /v AllowUpgradesWithUnsupportedTPMOrCPU /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <FullName>User</FullName>
+        <Organization>Lima</Organization>
+        <ProductKey>
+          <WillShowUI>Never</WillShowUI>
+        </ProductKey>
+      </UserData>
+
+      <!-- GPT partition layout for UEFI boot. EFI partition 260MB (Win11 ARM requirement).
+           Disk is attached via NVMe which has built-in WinPE drivers (no virtio-win needed). -->
+      <DiskConfiguration>
+        <Disk wcm:action="add">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Type>EFI</Type>
+              <Size>260</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>MSR</Type>
+              <Size>16</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>3</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionID>1</PartitionID>
+              <Label>System</Label>
+              <Format>FAT32</Format>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionID>2</PartitionID>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>3</Order>
+              <PartitionID>3</PartitionID>
+              <Label>Windows</Label>
+              <Format>NTFS</Format>
+              <Letter>C</Letter>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+
+      <!-- Index 3 = Pro on Win11 ARM64 multi-edition ISOs.
+           Explicit index selects the edition without needing a product key. -->
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/IMAGE/INDEX</Key>
+              <Value>3</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>3</PartitionID>
+          </InstallTo>
+          <InstallToAvailablePartition>false</InstallToAvailablePartition>
+        </OSImage>
+      </ImageInstall>
+
+    </component>
+  </settings>
+
+  <!-- specialize: machine identity (runs after file copy, before first boot) -->
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup"
+               processorArchitecture="arm64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral"
+               versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <ComputerName>lima-default</ComputerName>
+      <TimeZone>UTC</TimeZone>
+    </component>
+  </settings>
+
+  <!-- oobeSystem: suppress OOBE prompts, create user, install OpenSSH -->
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-Shell-Setup"
+               processorArchitecture="arm64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral"
+               versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>false</HideLocalAccountScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>3</ProtectYourPC>
+        <SkipMachineOOBE>true</SkipMachineOOBE>
+        <SkipUserOOBE>true</SkipUserOOBE>
+      </OOBE>
+      <UserAccounts>
+        <LocalAccounts>
+          <LocalAccount wcm:action="add">
+            <Name>lima</Name>
+            <DisplayName>lima</DisplayName>
+            <Group>Administrators</Group>
+            <Password>
+              <Value></Value>
+              <PlainText>true</PlainText>
+            </Password>
+          </LocalAccount>
+        </LocalAccounts>
+      </UserAccounts>
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Username>lima</Username>
+        <Password>
+          <Value></Value>
+          <PlainText>true</PlainText>
+        </Password>
+        <LogonCount>3</LogonCount>
+      </AutoLogon>
+
+      <!-- Install and configure OpenSSH server for Lima host-agent connectivity -->
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <CommandLine>powershell.exe -NoProfile -Command "Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0"</CommandLine>
+          <Description>Install OpenSSH Server</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <CommandLine>powershell.exe -NoProfile -Command "Start-Service sshd; Set-Service -Name sshd -StartupType Automatic"</CommandLine>
+          <Description>Start and enable sshd</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>3</Order>
+          <CommandLine>powershell.exe -NoProfile -Command "New-Item -Path 'C:\ProgramData\ssh' -ItemType Directory -Force"</CommandLine>
+          <Description>Create SSH config directory</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>4</Order>
+          <CommandLine>powershell.exe -NoProfile -Command "Set-Content -Path 'C:\ProgramData\ssh\administrators_authorized_keys' -Value 'ssh-rsa PLACEHOLDER'; icacls 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r /grant 'SYSTEM:(F)' /grant 'Administrators:(F)'"</CommandLine>
+          <Description>Write authorized_keys with correct ACLs</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>5</Order>
+          <CommandLine>powershell.exe -NoProfile -Command "$cfg = 'C:\ProgramData\ssh\sshd_config'; (Get-Content $cfg) -replace '#?AuthorizedKeysFile.*', 'AuthorizedKeysFile .ssh/authorized_keys' | Set-Content $cfg; Add-Content $cfg 'Match Group administrators`r`n  AuthorizedKeysFile C:/ProgramData/ssh/administrators_authorized_keys'; Restart-Service sshd"</CommandLine>
+          <Description>Configure sshd for admin key auth</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>6</Order>
+          <CommandLine>reg.exe add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoAdminLogon /t REG_SZ /d 0 /f</CommandLine>
+          <Description>Disable auto-logon after provisioning</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>7</Order>
+          <CommandLine>powershell.exe -NoProfile -Command "New-NetFirewallRule -Name 'OpenSSH-Server' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22"</CommandLine>
+          <Description>Allow SSH through firewall</Description>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+    <component name="Microsoft-Windows-International-Core"
+               processorArchitecture="arm64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral"
+               versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+  </settings>
+
+</unattend>

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -4,6 +4,7 @@
 package cidata
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
 	"errors"
@@ -389,6 +390,17 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 		return "", err
 	}
 
+	// Windows guests use autounattend.xml instead of cloud-init.
+	if *instConfig.OS == limatype.WINDOWS {
+		var winArch string
+		if instConfig.Arch != nil && *instConfig.Arch == limatype.AARCH64 {
+			winArch = "arm64"
+		} else {
+			winArch = "amd64"
+		}
+		return generateWindowsISO(args, instDir, winArch)
+	}
+
 	if err := ValidateTemplateArgs(args); err != nil {
 		return "", err
 	}
@@ -503,6 +515,26 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 		iso9660Options = append(iso9660Options, iso9660util.WithJoliet())
 	}
 	return args.IID, iso9660util.Write(filepath.Join(instDir, filenames.CIDataISO), "cidata", layout, iso9660Options...)
+}
+
+// generateWindowsISO produces a Joliet ISO containing autounattend.xml.
+// Joliet is required because ISO9660 Level 1 truncates to 8.3 ("AUTOUNAT.XML")
+// which Windows Setup does not recognize.
+func generateWindowsISO(args *TemplateArgs, instDir, arch string) (string, error) {
+	xmlBytes, err := ExecuteTemplateAutounattend(args, arch)
+	if err != nil {
+		return "", fmt.Errorf("failed to render autounattend.xml: %w", err)
+	}
+
+	layout := []iso9660util.Entry{
+		{
+			Path:   "autounattend.xml",
+			Reader: bytes.NewReader(xmlBytes),
+		},
+	}
+
+	isoPath := filepath.Join(instDir, filenames.CIDataISO)
+	return args.IID, iso9660util.Write(isoPath, "autounattend", layout, iso9660util.WithJoliet())
 }
 
 func removeControlChars(s string) string {

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -22,6 +22,16 @@ var templateFS embed.FS
 
 const templateFSRoot = "cidata.TEMPLATE.d"
 
+//go:embed cidata.TEMPLATE.d.Windows.amd64
+var windowsAmd64TemplateFS embed.FS
+
+const windowsAmd64TemplateFSRoot = "cidata.TEMPLATE.d.Windows.amd64"
+
+//go:embed cidata.TEMPLATE.d.Windows.arm64
+var windowsArm64TemplateFS embed.FS
+
+const windowsArm64TemplateFSRoot = "cidata.TEMPLATE.d.Windows.arm64"
+
 type CACerts struct {
 	RemoveDefaults *bool
 	Trusted        []Cert
@@ -74,6 +84,9 @@ type Disk struct {
 	FSType string
 	FSArgs []string
 }
+
+// TemplateArgs holds all data needed to render provisioning templates.
+// TODO: Split into per-OS template args (Unix vs Windows) to avoid carrying irrelevant fields.
 type TemplateArgs struct {
 	Debug                           bool
 	OS                              limatype.OS
@@ -204,4 +217,26 @@ func ExecuteTemplateCIDataISO(args *TemplateArgs) ([]iso9660util.Entry, error) {
 	}
 
 	return layout, nil
+}
+
+// ExecuteTemplateAutounattend renders the Windows autounattend.xml template.
+// arch should be "amd64" or "arm64". Validation is skipped since ValidateTemplateArgs is Unix-specific.
+func ExecuteTemplateAutounattend(args *TemplateArgs, arch string) ([]byte, error) {
+	var templateFS embed.FS
+	var root string
+	switch arch {
+	case "arm64":
+		templateFS = windowsArm64TemplateFS
+		root = windowsArm64TemplateFSRoot
+	default:
+		templateFS = windowsAmd64TemplateFS
+		root = windowsAmd64TemplateFSRoot
+	}
+
+	xmlTemplate, err := templateFS.ReadFile(path.Join(root, "autounattend.xml"))
+	if err != nil {
+		return nil, err
+	}
+
+	return textutil.ExecuteTemplate(string(xmlTemplate), args)
 }

--- a/pkg/cidata/template_test.go
+++ b/pkg/cidata/template_test.go
@@ -4,6 +4,7 @@
 package cidata
 
 import (
+	"encoding/xml"
 	"io"
 	"strings"
 	"testing"
@@ -167,4 +168,27 @@ func TestTemplate9p(t *testing.T) {
 			assert.Assert(t, strings.Contains(string(b), "mounts:"))
 		}
 	}
+}
+
+func TestAutounattend(t *testing.T) {
+	args := &TemplateArgs{
+		Name: "default",
+	}
+	output, err := ExecuteTemplateAutounattend(args, "amd64")
+	assert.NilError(t, err)
+	t.Log(string(output))
+
+	// Verify the output is well-formed XML
+	assert.Assert(t, xml.Unmarshal(output, new(any)) == nil, "output is not valid XML")
+
+	// Verify key sections are present
+	s := string(output)
+	assert.Assert(t, strings.Contains(s, "Microsoft-Windows-Setup"), "missing disk/install component")
+	assert.Assert(t, strings.Contains(s, "Microsoft-Windows-Shell-Setup"), "missing shell setup component")
+	assert.Assert(t, strings.Contains(s, "OpenSSH.Server"), "missing OpenSSH server capability")
+	assert.Assert(t, strings.Contains(s, "administrators_authorized_keys"), "missing SSH authorized_keys setup")
+	assert.Assert(t, strings.Contains(s, "<ComputerName>"), "missing ComputerName element")
+	assert.Assert(t, strings.Contains(s, "pass=\"windowsPE\""), "missing windowsPE pass")
+	assert.Assert(t, strings.Contains(s, "pass=\"specialize\""), "missing specialize pass")
+	assert.Assert(t, strings.Contains(s, "pass=\"oobeSystem\""), "missing oobeSystem pass")
 }

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -80,6 +80,7 @@ const (
 	LINUX   OS = "Linux"
 	DARWIN  OS = "Darwin"
 	FREEBSD OS = "FreeBSD"
+	WINDOWS OS = "Windows"
 
 	X8664   Arch = "x86_64"
 	AARCH64 Arch = "aarch64"
@@ -99,7 +100,7 @@ const (
 )
 
 var (
-	OSTypes    = []OS{LINUX, DARWIN, FREEBSD}
+	OSTypes    = []OS{LINUX, DARWIN, FREEBSD, WINDOWS}
 	ArchTypes  = []Arch{X8664, AARCH64, ARMV7L, PPC64LE, RISCV64, S390X}
 	MountTypes = []MountType{REVSSHFS, NINEP, VIRTIOFS, WSLMount}
 	VMTypes    = []VMType{QEMU, VZ, WSL2}

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -50,7 +50,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 	}
 
 	switch *y.OS {
-	case limatype.LINUX, limatype.DARWIN, limatype.FREEBSD:
+	case limatype.LINUX, limatype.DARWIN, limatype.FREEBSD, limatype.WINDOWS:
 	default:
 		errs = errors.Join(errs, fmt.Errorf("field `os` must be one of %q; got %q", limatype.OSTypes, *y.OS))
 	}

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -369,7 +369,7 @@ provision:
 	err = Validate(y, false)
 	t.Logf("Validation errors: %v", err)
 
-	assert.Error(t, err, "field `os` must be one of [\"Linux\" \"Darwin\" \"FreeBSD\"]; got \"windows\"\n"+
+	assert.Error(t, err, "field `os` must be one of [\"Linux\" \"Darwin\" \"FreeBSD\" \"Windows\"]; got \"windows\"\n"+
 		"field `arch` must be one of [x86_64 aarch64 armv7l ppc64le riscv64 s390x]; got \"unsupported_arch\"\n"+
 		"field `images` must be set\n"+
 		"field `provision[0].mode` must one of \"system\", \"user\", \"boot\", \"data\", \"dependency\", \"ansible\", or \"yq\"\n"+


### PR DESCRIPTION
Updated with dual-arch support. Both amd64 and arm64 work end-to-end now. Ref: #4852

## What's in this commit

- `WINDOWS` OS type added to `limatype` and validation
- Separate `autounattend.xml` templates for amd64 and arm64 (3-pass: windowsPE, specialize, oobeSystem)
- Windows guests go through `generateWindowsISO()` which produces a Joliet-labeled ISO
- `hack/gen-autounattend-iso.go` dev tool for standalone testing (pass `-arch amd64` or `-arch arm64`)
- Unit test for template rendering

## Design choices

- arm64 uses NVMe for the disk. WinPE ARM has `stornvme.sys` built-in, so there's no need for `virtio-win.iso`.
- No product keys in either template. Removed per @AkihiroSuda's feedback. Edition selection is handled by image index.
- OpenSSH server is installed and started during OOBE so Lima's host-agent can connect.

## Testing

Tested both architectures on macOS.

### amd64 (x86_64)

Windows 10 consumer ISO from [microsoft.com](https://www.microsoft.com/en-in/software-download/windows10ISO), version 22H2 multi-edition. Pro is image index 6.

```bash
go run hack/gen-autounattend-iso.go -arch amd64 -o autounattend.iso
qemu-img create -f qcow2 disk.qcow2 64G
cp /opt/homebrew/share/qemu/edk2-i386-vars.fd ovmf_vars.fd

qemu-system-x86_64 -m 4G -smp 2 -machine q35 \
  -drive if=pflash,format=raw,readonly=on,file=/opt/homebrew/share/qemu/edk2-x86_64-code.fd \
  -drive if=pflash,format=raw,file=ovmf_vars.fd \
  -cdrom /path/to/Win10_22H2_English_x64v1.iso \
  -drive file=autounattend.iso,media=cdrom,index=3 \
  -drive file=disk.qcow2,index=0,media=disk,format=qcow2 \
  -nic user,hostfwd=tcp::2222-:22
```

This runs under emulation on Apple Silicon so it's slow, but completes successfully.

<img width="763" height="505" alt="Screenshot 2026-05-15 at 2 35 07 AM" src="https://github.com/user-attachments/assets/4f92c6ba-cdd1-49bd-b161-aa5c760af698" />

### arm64 (aarch64)

Windows 11 ARM64 25H2 ISO. Pro is image index 3. Runs natively via HVF.

```bash
go run hack/gen-autounattend-iso.go -arch arm64 -o autounattend.iso
qemu-img create -f qcow2 disk.qcow2 64G
dd if=/dev/zero of=ovmf_vars.fd bs=1M count=64

qemu-system-aarch64 \
  -machine virt,accel=hvf \
  -cpu host \
  -m 4G -smp 4 \
  -drive if=pflash,format=raw,readonly=on,file=/opt/homebrew/share/qemu/edk2-aarch64-code.fd \
  -drive if=pflash,format=raw,file=ovmf_vars.fd \
  -drive file=disk.qcow2,if=none,id=hd0,format=qcow2 \
  -device nvme,serial=lima0,drive=hd0 \
  -device qemu-xhci \
  -device usb-kbd \
  -device usb-tablet \
  -drive file=/path/to/Win11_25H2_English_Arm64.iso,if=none,id=cdrom0,media=cdrom,readonly=on \
  -device usb-storage,drive=cdrom0 \
  -drive file=autounattend.iso,if=none,id=unattend,media=cdrom,readonly=on \
  -device usb-storage,drive=unattend \
  -device ramfb \
  -nic user,hostfwd=tcp::2222-:22
```

The arm64 command is longer because the `virt` machine has no built-in controllers (no SATA, no IDE, no VGA), so each device needs to be added explicitly. On amd64, q35 provides all of that.

<img width="389" height="250" alt="Screenshot 2026-05-16 at 6 16 57 AM" src="https://github.com/user-attachments/assets/c39e76ad-42f8-4090-a836-80d4a1549644" />


## Result

Both architectures install fully unattended: partitioning, image extraction, OOBE, and OpenSSH server all complete without manual interaction.

After install completes: `ssh -p 2222 User@localhost`

## Notes

- arm64 requires `-cpu host`, not `-cpu max`. Using `max` with HVF causes page faults.
- UEFI variable store needs to be 64MB on arm64 (4MB on x86).
- `usb-kbd`/`usb-tablet` are needed on arm64 for UEFI console initialization.

## Changes since last review

- Removed product key from both templates
- Added arm64 template with NVMe disk (no virtio-win.iso needed)
- Dropped `-boot d` from amd64 (OVMF ignores it)
