### PR TITLE
Add script to extract the authors from git log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _output/
 _artifacts/
+AUTHORS
 lima.REJECTED.yaml
 default-template.yaml
 schema-limayaml.json

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Anders F Björklund <anders.f.bjorklund@gmail.com>

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,10 @@ GO_BUILD := $(strip $(GO) build $(GO_BUILD_GCFLAGS) $(GO_BUILD_LDFLAGS) $(GO_BUI
 all: binaries manpages
 
 ################################################################################
+AUTHORS: .mailmap .git/HEAD
+	git shortlog --summary --email --group=Author --group=trailer:Co-Authored-By | cut -f2 | sort -fu > $@
+
+################################################################################
 # Help
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,9 @@ all: binaries manpages
 
 ################################################################################
 AUTHORS: .mailmap .git/HEAD
-	git shortlog --summary --email --group=Author --group=trailer:Co-Authored-By | cut -f2 | sort -fu > $@
+	git shortlog --summary --email --group=Author --group=trailer:Co-Authored-By | \
+		grep -vE '\[bot\]|<(bot|noreply)@' | \
+		cut -f2 | sort -fu > $@
 
 ################################################################################
 # Help


### PR DESCRIPTION
As per the AI discussion about authors, added a script to extract "The Lima Authors"

```
Lima
Copyright The Lima Authors.
```

`make AUTHORS`

(inspired by containerd AUTHORS)

The humans are still in the lead (I didn't add you to the mailmap, so you get two entries)

```
  2808	Akihiro Suda
  1286	Jan Dubois
   709	dependabot[bot] 
   337	Anders F Björklund
   185	Norio Nomura
```

The file has email, too.

But didn't list them here.