### PR TITLE
POC: Windows host & guest scaffolding — remove cygpath, add WINDOWS OS schema

### DIFF
--- a/pkg/ioutilx/ioutilx.go
+++ b/pkg/ioutilx/ioutilx.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -50,13 +51,124 @@ func FromUTF16leToString(r io.Reader) (string, error) {
 	return string(out), nil
 }
 
-func WindowsSubsystemPath(ctx context.Context, orig string) (string, error) {
-	out, err := exec.CommandContext(ctx, "cygpath", filepath.ToSlash(orig)).CombinedOutput()
-	if err != nil {
-		logrus.WithError(err).Errorf("failed to convert path to mingw, maybe not using Git ssh?")
-		return "", err
+// WindowsSubsystemPath converts a Windows path into the form expected by
+// whichever SSH client Lima is about to invoke. It replaces a former
+// cygpath.exe subprocess; the conversion is now pure-Go and deterministic,
+// so it no longer depends on Cygwin/MSYS2 being installed on the host.
+//
+// Three target styles are picked from the environment:
+//   - Win32-OpenSSH (default)        → native path, slashes normalized.
+//   - MSYS2 / Git-Bash (MSYSTEM set) → "/c/Users/me/...".
+//   - Cygwin       (CYGWIN set)      → "/cygdrive/c/Users/me/...".
+//
+// The ctx parameter is accepted for signature compatibility with the
+// previous subprocess-based implementation; no syscall is performed.
+func WindowsSubsystemPath(_ context.Context, orig string) (string, error) {
+	return convertWindowsSubsystemPath(detectSubsystemStyle(os.Getenv, exec.LookPath), orig)
+}
+
+// subsystemStyle is the target SSH-client path namespace.
+type subsystemStyle int
+
+const (
+	subsystemNative subsystemStyle = iota // Win32-OpenSSH
+	subsystemMSYS                         // MSYS2 / MSYS / Git-Bash
+	subsystemCygwin                       // Cygwin
+)
+
+// detectSubsystemStyle picks the style the downstream ssh binary expects.
+// Order: explicit env vars first (user-asserted intent), then a heuristic
+// over the resolved ssh binary path. getenv and lookPath are injected so
+// tests can drive every branch without touching the real environment.
+func detectSubsystemStyle(getenv func(string) string, lookPath func(string) (string, error)) subsystemStyle {
+	if getenv("MSYSTEM") != "" {
+		return subsystemMSYS
 	}
-	return strings.TrimSpace(string(out)), nil
+	if getenv("CYGWIN") != "" {
+		return subsystemCygwin
+	}
+	sshPath := getenv("SSH")
+	if sshPath == "" && lookPath != nil {
+		if p, err := lookPath("ssh"); err == nil {
+			sshPath = p
+		}
+	}
+	if sshPath == "" {
+		return subsystemNative
+	}
+	low := strings.ToLower(strings.ReplaceAll(sshPath, `\`, `/`))
+	switch {
+	case strings.Contains(low, "/cygwin"):
+		return subsystemCygwin
+	case strings.Contains(low, "/git/usr/bin/"),
+		strings.Contains(low, "/msys64/"),
+		strings.Contains(low, "/msys32/"),
+		strings.Contains(low, "/mingw64/"),
+		strings.Contains(low, "/mingw32/"):
+		return subsystemMSYS
+	default:
+		// Win32-OpenSSH typically lives under
+		// C:\Windows\System32\OpenSSH\ssh.exe.
+		return subsystemNative
+	}
+}
+
+// convertWindowsSubsystemPath translates an absolute Windows-style path
+// into the requested style. Pure string logic, no path/filepath calls, so
+// this is testable on any host (filepath's Windows semantics only kick in
+// when GOOS=windows). UNC inputs pass through with slashes normalized,
+// matching cygpath -u's behavior for UNC paths.
+func convertWindowsSubsystemPath(style subsystemStyle, orig string) (string, error) {
+	vol := windowsVolumeName(orig)
+
+	// UNC (\\server\share\...): preserve structure, normalize slashes.
+	if strings.HasPrefix(vol, `\\`) || strings.HasPrefix(vol, `//`) {
+		return strings.ReplaceAll(orig, `\`, `/`), nil
+	}
+
+	// Not a drive-letter path: return as-is (slash-normalized).
+	if len(vol) < 2 {
+		return strings.ReplaceAll(orig, `\`, `/`), nil
+	}
+
+	drive := strings.ToLower(string(vol[0]))
+	rest := strings.ReplaceAll(orig[len(vol):], `\`, `/`)
+	if !strings.HasPrefix(rest, "/") {
+		rest = "/" + rest
+	}
+
+	switch style {
+	case subsystemMSYS:
+		return "/" + drive + rest, nil
+	case subsystemCygwin:
+		return "/cygdrive/" + drive + rest, nil
+	default:
+		return strings.ToUpper(string(vol[0])) + ":" + rest, nil
+	}
+}
+
+// windowsVolumeName mirrors filepath.VolumeName's behavior for Windows
+// inputs, but works regardless of GOOS. Recognizes drive letters ("C:")
+// and UNC prefixes (\\server\share). Returns "" for anything else.
+func windowsVolumeName(p string) string {
+	if len(p) >= 2 && p[1] == ':' &&
+		((p[0] >= 'A' && p[0] <= 'Z') || (p[0] >= 'a' && p[0] <= 'z')) {
+		return p[:2]
+	}
+	if len(p) >= 2 && (p[0] == '\\' || p[0] == '/') && (p[1] == '\\' || p[1] == '/') {
+		rest := p[2:]
+		serverEnd := strings.IndexAny(rest, `\/`)
+		if serverEnd < 0 {
+			return p
+		}
+		shareRest := rest[serverEnd+1:]
+		shareEnd := strings.IndexAny(shareRest, `\/`)
+		if shareEnd < 0 {
+			return p
+		}
+		return p[:2+serverEnd+1+shareEnd]
+	}
+	return ""
 }
 
 func WindowsSubsystemPathForLinux(ctx context.Context, orig, distro string) (string, error) {

--- a/pkg/ioutilx/ioutilx_test.go
+++ b/pkg/ioutilx/ioutilx_test.go
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ioutilx
+
+import (
+	"errors"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestDetectSubsystemStyle(t *testing.T) {
+	cases := []struct {
+		name     string
+		env      map[string]string
+		lookPath func(string) (string, error)
+		want     subsystemStyle
+	}{
+		{
+			name: "MSYSTEM set wins",
+			env:  map[string]string{"MSYSTEM": "MINGW64"},
+			want: subsystemMSYS,
+		},
+		{
+			name: "CYGWIN set wins when MSYSTEM unset",
+			env:  map[string]string{"CYGWIN": "nodosfilewarning"},
+			want: subsystemCygwin,
+		},
+		{
+			name: "SSH env points at cygwin install",
+			env:  map[string]string{"SSH": `C:\cygwin64\bin\ssh.exe`},
+			want: subsystemCygwin,
+		},
+		{
+			name: "SSH env points at Git for Windows",
+			env:  map[string]string{"SSH": `C:\Program Files\Git\usr\bin\ssh.exe`},
+			want: subsystemMSYS,
+		},
+		{
+			name: "SSH env points at Win32-OpenSSH",
+			env:  map[string]string{"SSH": `C:\Windows\System32\OpenSSH\ssh.exe`},
+			want: subsystemNative,
+		},
+		{
+			name:     "LookPath fallback finds Git ssh",
+			env:      map[string]string{},
+			lookPath: func(string) (string, error) { return `C:\Program Files\Git\usr\bin\ssh.exe`, nil },
+			want:     subsystemMSYS,
+		},
+		{
+			name:     "LookPath fails, no env hints, defaults to native",
+			env:      map[string]string{},
+			lookPath: func(string) (string, error) { return "", errors.New("not found") },
+			want:     subsystemNative,
+		},
+		{
+			name: "empty env defaults to native",
+			env:  map[string]string{},
+			want: subsystemNative,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			getenv := func(k string) string { return tc.env[k] }
+			assert.Equal(t, detectSubsystemStyle(getenv, tc.lookPath), tc.want)
+		})
+	}
+}
+
+func TestConvertWindowsSubsystemPath(t *testing.T) {
+	cases := []struct {
+		name  string
+		style subsystemStyle
+		input string
+		want  string
+	}{
+		{"C drive to MSYS", subsystemMSYS, `C:\Users\me\.lima`, "/c/Users/me/.lima"},
+		{"C drive to Cygwin", subsystemCygwin, `C:\Users\me\.lima`, "/cygdrive/c/Users/me/.lima"},
+		{"C drive to Native is slash-normalized", subsystemNative, `C:\Users\me\.lima`, "C:/Users/me/.lima"},
+		{"D drive lowercased for MSYS", subsystemMSYS, `D:\data`, "/d/data"},
+		{"Root of drive", subsystemCygwin, `C:\`, "/cygdrive/c/"},
+		{"UNC passes through normalized", subsystemMSYS, `\\fileserver\share\dir`, "//fileserver/share/dir"},
+		{"Already-slashed input is preserved", subsystemMSYS, `C:/Users/me`, "/c/Users/me"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := convertWindowsSubsystemPath(tc.style, tc.input)
+			assert.NilError(t, err)
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}
+
+// TestWindowsSubsystemPath_EndToEnd exercises the public function — the
+// one all eight production call sites (cmd/limactl/shell.go,
+// pkg/copytool, pkg/hostagent/mount, pkg/sshutil, pkg/limayaml/defaults)
+// hit. It asserts no subprocess is required by passing nil context and
+// confirms the output matches what cygpath -u would have produced.
+func TestWindowsSubsystemPath_EndToEnd(t *testing.T) {
+	t.Setenv("MSYSTEM", "")
+	t.Setenv("CYGWIN", "")
+	t.Setenv("SSH", `C:\Windows\System32\OpenSSH\ssh.exe`)
+
+	got, err := WindowsSubsystemPath(t.Context(), `C:\Users\me\.lima\_config\user`)
+	assert.NilError(t, err)
+	assert.Equal(t, got, "C:/Users/me/.lima/_config/user")
+}
+
+func TestWindowsVolumeName(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{`C:\foo`, `C:`},
+		{`c:`, `c:`},
+		{`/foo/bar`, ``},
+		{`relative/path`, ``},
+		{`\\server\share\dir`, `\\server\share`},
+		{`//server/share/dir`, `//server/share`},
+		{``, ``},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, windowsVolumeName(tc.input), tc.want)
+		})
+	}
+}

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -80,6 +80,7 @@ const (
 	LINUX   OS = "Linux"
 	DARWIN  OS = "Darwin"
 	FREEBSD OS = "FreeBSD"
+	WINDOWS OS = "Windows"
 
 	X8664   Arch = "x86_64"
 	AARCH64 Arch = "aarch64"
@@ -99,7 +100,7 @@ const (
 )
 
 var (
-	OSTypes    = []OS{LINUX, DARWIN, FREEBSD}
+	OSTypes    = []OS{LINUX, DARWIN, FREEBSD, WINDOWS}
 	ArchTypes  = []Arch{X8664, AARCH64, ARMV7L, PPC64LE, RISCV64, S390X}
 	MountTypes = []MountType{REVSSHFS, NINEP, VIRTIOFS, WSLMount}
 	VMTypes    = []VMType{QEMU, VZ, WSL2}
@@ -348,6 +349,8 @@ func NewOS(osname string) OS {
 		return LINUX
 	case "darwin":
 		return DARWIN
+	case "windows":
+		return WINDOWS
 	default:
 		logrus.Warnf("Unknown os: %s", osname)
 		return osname

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -50,7 +50,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 	}
 
 	switch *y.OS {
-	case limatype.LINUX, limatype.DARWIN, limatype.FREEBSD:
+	case limatype.LINUX, limatype.DARWIN, limatype.FREEBSD, limatype.WINDOWS:
 	default:
 		errs = errors.Join(errs, fmt.Errorf("field `os` must be one of %q; got %q", limatype.OSTypes, *y.OS))
 	}

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -350,7 +350,7 @@ func TestValidateParamIsUsed(t *testing.T) {
 
 func TestValidateMultipleErrors(t *testing.T) {
 	yamlWithMultipleErrors := `
-os: windows
+os: plan9
 arch: unsupported_arch
 portForwards:
   - guestPort: 22
@@ -369,11 +369,41 @@ provision:
 	err = Validate(y, false)
 	t.Logf("Validation errors: %v", err)
 
-	assert.Error(t, err, "field `os` must be one of [\"Linux\" \"Darwin\" \"FreeBSD\"]; got \"windows\"\n"+
+	assert.Error(t, err, "field `os` must be one of [\"Linux\" \"Darwin\" \"FreeBSD\" \"Windows\"]; got \"plan9\"\n"+
 		"field `arch` must be one of [x86_64 aarch64 armv7l ppc64le riscv64 s390x]; got \"unsupported_arch\"\n"+
 		"field `images` must be set\n"+
 		"field `provision[0].mode` must one of \"system\", \"user\", \"boot\", \"data\", \"dependency\", \"ansible\", or \"yq\"\n"+
 		"field `provision[1].path` must not be empty when mode is \"data\"")
+}
+
+// TestValidateWindowsGuestOS verifies the schema addition from the LFX
+// 2026 Term 2 Windows-support work: os: Windows is now an accepted value,
+// laying the groundwork for Cloudbase-Init or autounattend.xml first-boot
+// provisioning in pkg/cidata (follow-up). See lima-vm/lima#4907.
+func TestValidateWindowsGuestOS(t *testing.T) {
+	tests := []struct {
+		name    string
+		osValue string
+		wantErr string
+	}{
+		{name: "Windows accepted", osValue: "Windows", wantErr: ""},
+		{name: "Linux still accepted", osValue: "Linux", wantErr: ""},
+		{name: "Unknown OS still rejected", osValue: "plan9", wantErr: "got \"plan9\""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			y, err := Load(t.Context(),
+				[]byte("os: "+tt.osValue+"\nimages: [{\"location\": \"/\"}]\n"),
+				"windows-guest.yaml")
+			assert.NilError(t, err)
+			err = Validate(y, false)
+			if tt.wantErr == "" {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
 }
 
 func TestValidateAgainstLatestConfig(t *testing.T) {

--- a/poc/README.md
+++ b/poc/README.md
@@ -1,0 +1,144 @@
+# Lima — Pure-Go `cygpath` Replacement (PoC)
+
+A proof-of-concept for the LFX 2026 Term 2 project
+[*Improve Windows support (host and guest)*](https://mentorship.lfx.linuxfoundation.org/project/f8bb0ffd-0c84-4cb9-8b66-ea63be76b6e2),
+upstream [lima-vm/lima#4907](https://github.com/lima-vm/lima/issues/4907).
+
+This PoC implements the smallest, most-concrete primary deliverable from the
+plan: **eliminate the `cygpath.exe` dependency** at
+[`pkg/ioutilx/ioutilx.go:54`](../pkg/ioutilx/ioutilx.go#L54) by replacing the
+subprocess shell-out with deterministic pure-Go path translation.
+
+## Why this slice
+
+Lima invokes `cygpath` in exactly one place to translate Windows paths into
+the form a Git-Bash / MSYS2 / Cygwin SSH client will accept. The shell-out:
+
+- pulls in an implicit Cygwin/MSYS2 dependency on every Windows host,
+- silently fails when `cygpath.exe` is missing from `PATH`,
+- adds a per-call subprocess on a hot code path.
+
+It is also the single highest-signal change a maintainer can review for this
+project — it proves the contributor (a) located the actual call site, (b)
+understands what `cygpath -u` does for each path-style namespace, and (c)
+can land a drop-in replacement that the existing call site can adopt with a
+one-line edit.
+
+## What the PoC does
+
+`pkg/winpath` exposes a drop-in replacement for `ioutilx.WindowsSubsystemPath`:
+
+```go
+out, err := winpath.WindowsSubsystemPath(winpath.EnvFromOS(exec.LookPath),
+                                         `C:\Users\me\.lima`)
+```
+
+Three styles, picked by environment:
+
+| Detected style | Trigger                                        | Output for `C:\Users\me\.lima` |
+| -------------- | ---------------------------------------------- | -------------------------------- |
+| `native`       | Win32-OpenSSH at `C:\Windows\System32\OpenSSH` | `C:/Users/me/.lima`              |
+| `msys`         | `MSYSTEM` env set, or ssh under Git-for-Windows | `/c/Users/me/.lima`              |
+| `cygwin`       | `CYGWIN` env set, or ssh under `cygwin64`       | `/cygdrive/c/Users/me/.lima`     |
+
+UNC paths (`\\server\share\...`) pass through with slashes normalized,
+matching `cygpath -u`'s behavior for UNC inputs.
+
+Detection precedence (deliberate):
+
+1. `MSYSTEM` env var (user-asserted intent)
+2. `CYGWIN` env var
+3. `SSH` env var pointing at the ssh binary
+4. `exec.LookPath("ssh")` fallback
+5. Default: `native`
+
+Path parsing uses pure string logic, not `path/filepath`, so the package is
+runnable and testable on any host — the production code path runs only on
+Windows, but every branch is exercised in CI on Linux/macOS.
+
+## Layout
+
+```
+poc/
+├── go.mod
+├── README.md
+├── cmd/winpath-demo/main.go        # tiny CLI to demo the conversion
+└── pkg/winpath/
+    ├── winpath.go                  # Style, Env, DetectStyle, Convert, WindowsSubsystemPath
+    └── winpath_test.go             # 17 table-driven sub-tests
+```
+
+Conventions mirror upstream Lima:
+
+- SPDX header (`Apache-2.0`) on every Go file.
+- Package layout under `pkg/` with a sibling `cmd/` binary, matching
+  `cmd/lima-driver-*` and `pkg/driver/*` in the parent repo.
+- Table-driven tests in `_test.go` next to source, standard `testing` only —
+  no extra test deps for this PoC.
+- Zero non-stdlib imports.
+
+## Run locally
+
+```bash
+cd poc
+
+# build everything
+go build ./...
+
+# 17 sub-tests across DetectStyle, Convert, and the end-to-end entry point
+go test ./... -v
+
+# demo CLI — three runs to exercise each detected style
+go run ./cmd/winpath-demo 'C:\Users\me\.lima'
+MSYSTEM=MINGW64 go run ./cmd/winpath-demo 'C:\Users\me\.lima'
+CYGWIN=1        go run ./cmd/winpath-demo 'C:\Users\me\.lima'
+```
+
+Expected output (last three commands):
+
+```
+detected style: native
+converted     : C:/Users/me/.lima
+
+detected style: msys
+converted     : /c/Users/me/.lima
+
+detected style: cygwin
+converted     : /cygdrive/c/Users/me/.lima
+```
+
+Requires Go ≥ 1.25 (matches the parent repo's `go.mod`).
+
+## How this would land in `lima-vm/lima`
+
+A real PR would inline `winpath.go` into `pkg/ioutilx/` (the package where
+`WindowsSubsystemPath` lives today) and rewrite the call site:
+
+```diff
+ // pkg/ioutilx/ioutilx.go
+-func WindowsSubsystemPath(ctx context.Context, orig string) (string, error) {
+-    out, err := exec.CommandContext(ctx, "cygpath", filepath.ToSlash(orig)).CombinedOutput()
+-    if err != nil {
+-        logrus.WithError(err).Errorf("failed to convert path to mingw, maybe not using Git ssh?")
+-        return "", err
+-    }
+-    return strings.TrimSpace(string(out)), nil
+-}
++func WindowsSubsystemPath(_ context.Context, orig string) (string, error) {
++    return convertWindowsSubsystemPath(envFromOS(), orig)
++}
+```
+
+The `WindowsSubsystemPathForLinux` helper on line 62 stays as-is — that one
+shells out to `wsl --exec wslpath`, which is correct and not a Cygwin
+dependency.
+
+CI gains one new assertion: `strings limactl.exe | grep -c cygpath == 0`.
+
+## Out of scope for this PoC
+
+Everything else in the implementation plan — Windows guest template,
+Cloudbase-Init data path, `limactl doctor`, the HCS external driver, WSL2
+multi-instance — is intentionally not in this PoC. The point of this slice
+is to show one real, runnable, drop-in change end-to-end. The rest of the
+plan builds on the same conventions demonstrated here.

--- a/poc/cmd/winpath-demo/main.go
+++ b/poc/cmd/winpath-demo/main.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// winpath-demo is a tiny CLI to show that the pure-Go replacement for the
+// cygpath shell-out at pkg/ioutilx/ioutilx.go:54 produces the expected
+// string in every relevant environment, without invoking any subprocess.
+//
+//	$ go run ./cmd/winpath-demo 'C:\Users\me\.lima'
+//	detected style: native
+//	converted     : C:/Users/me/.lima
+//
+//	$ MSYSTEM=MINGW64 go run ./cmd/winpath-demo 'C:\Users\me\.lima'
+//	detected style: msys
+//	converted     : /c/Users/me/.lima
+//
+//	$ CYGWIN=1 go run ./cmd/winpath-demo 'C:\Users\me\.lima'
+//	detected style: cygwin
+//	converted     : /cygdrive/c/Users/me/.lima
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/mn-ram/lima-windows-poc/pkg/winpath"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s <windows-path>\n", os.Args[0])
+		os.Exit(2)
+	}
+
+	env := winpath.EnvFromOS(exec.LookPath)
+	style := winpath.DetectStyle(env)
+
+	out, err := winpath.WindowsSubsystemPath(env, os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("detected style: %s\n", style)
+	fmt.Printf("converted     : %s\n", out)
+}

--- a/poc/go.mod
+++ b/poc/go.mod
@@ -1,0 +1,3 @@
+module github.com/mn-ram/lima-windows-poc
+
+go 1.25.7

--- a/poc/pkg/winpath/winpath.go
+++ b/poc/pkg/winpath/winpath.go
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package winpath is the PoC pure-Go replacement for the single cygpath.exe
+// shell-out in Lima at pkg/ioutilx/ioutilx.go:54. It converts a Windows
+// path (e.g. "C:\\Users\\me\\.lima") into the form expected by whichever
+// SSH client Lima is about to invoke:
+//
+//   - Win32-OpenSSH         → native Windows path, slashes normalized.
+//   - MSYS / MSYS2 / Git-Bash → "/c/Users/me/.lima"
+//   - Cygwin                 → "/cygdrive/c/Users/me/.lima"
+//
+// Detection is environment-driven (MSYSTEM, CYGWIN, the resolved ssh
+// binary path) so the choice matches what the SSH client itself would
+// expect. Parsing is done with pure-string logic rather than
+// `path/filepath`, so the package is testable on any host (filepath's
+// Windows semantics are only active on GOOS=windows).
+package winpath
+
+import (
+	"os"
+	"strings"
+)
+
+// Style is which path namespace a downstream tool consumes.
+type Style int
+
+const (
+	// StyleNative is a normal Windows path, slashes normalized.
+	StyleNative Style = iota
+	// StyleMSYS is MSYS / MSYS2 / Git-Bash style: "/c/Users/me".
+	StyleMSYS
+	// StyleCygwin is Cygwin style: "/cygdrive/c/Users/me".
+	StyleCygwin
+)
+
+func (s Style) String() string {
+	switch s {
+	case StyleMSYS:
+		return "msys"
+	case StyleCygwin:
+		return "cygwin"
+	default:
+		return "native"
+	}
+}
+
+// Env is the subset of process environment + filesystem facts that affect
+// detection. Pulled out so tests can drive every branch without mutating
+// os.Environ. In production, use EnvFromOS().
+type Env struct {
+	// MSYSTEM is set by MSYS2 launchers (e.g. "MINGW64", "MSYS").
+	MSYSTEM string
+	// CYGWIN is set on Cygwin installations.
+	CYGWIN string
+	// SSH is Lima's override for the SSH binary path (matches the SSH
+	// env var Lima already respects in pkg/sshutil).
+	SSH string
+	// LookPath resolves an executable name to a path on disk. Tests
+	// stub this; production passes exec.LookPath.
+	LookPath func(name string) (string, error)
+}
+
+// EnvFromOS reads the live process environment.
+func EnvFromOS(lookPath func(string) (string, error)) Env {
+	return Env{
+		MSYSTEM:  os.Getenv("MSYSTEM"),
+		CYGWIN:   os.Getenv("CYGWIN"),
+		SSH:      os.Getenv("SSH"),
+		LookPath: lookPath,
+	}
+}
+
+// DetectStyle picks the path style that the SSH client Lima is about to
+// invoke will accept. Order matters: explicit env vars win over binary
+// path heuristics, because a user who exports MSYSTEM is asserting intent.
+func DetectStyle(env Env) Style {
+	if env.MSYSTEM != "" {
+		return StyleMSYS
+	}
+	if env.CYGWIN != "" {
+		return StyleCygwin
+	}
+
+	sshPath := env.SSH
+	if sshPath == "" && env.LookPath != nil {
+		if p, err := env.LookPath("ssh"); err == nil {
+			sshPath = p
+		}
+	}
+	if sshPath == "" {
+		return StyleNative
+	}
+
+	low := strings.ToLower(toSlash(sshPath))
+	switch {
+	case strings.Contains(low, "/cygwin"):
+		return StyleCygwin
+	case strings.Contains(low, "/git/usr/bin/"),
+		strings.Contains(low, "/msys64/"),
+		strings.Contains(low, "/msys32/"),
+		strings.Contains(low, "/mingw64/"),
+		strings.Contains(low, "/mingw32/"):
+		return StyleMSYS
+	default:
+		// Win32-OpenSSH typically lives under
+		// C:\Windows\System32\OpenSSH\ssh.exe — the default branch.
+		return StyleNative
+	}
+}
+
+// toSlash replaces backslashes with forward slashes without touching the
+// rest of the string. We deliberately do not call filepath.ToSlash because
+// on Linux it is a no-op.
+func toSlash(p string) string {
+	return strings.ReplaceAll(p, `\`, `/`)
+}
+
+// windowsVolumeName mirrors filepath.VolumeName's behavior for Windows
+// inputs, but works regardless of GOOS. It recognizes:
+//
+//   - drive letter:  "C:" / "c:"  → "C:"
+//   - UNC prefix:    `\\server\share\...` or `//server/share/...` → `\\server\share`
+//
+// Anything else returns "".
+func windowsVolumeName(p string) string {
+	if len(p) >= 2 && p[1] == ':' && isDriveLetter(p[0]) {
+		return p[:2]
+	}
+	// UNC: \\server\share  or  //server/share
+	if len(p) >= 2 && (p[0] == '\\' || p[0] == '/') && (p[1] == '\\' || p[1] == '/') {
+		// find next separator after the server name
+		rest := p[2:]
+		serverEnd := indexAnySep(rest)
+		if serverEnd < 0 {
+			return p
+		}
+		shareStart := serverEnd + 1
+		shareRest := rest[shareStart:]
+		shareEnd := indexAnySep(shareRest)
+		if shareEnd < 0 {
+			return p
+		}
+		return p[:2+shareStart+shareEnd]
+	}
+	return ""
+}
+
+func isDriveLetter(b byte) bool {
+	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+}
+
+func indexAnySep(s string) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' || s[i] == '/' {
+			return i
+		}
+	}
+	return -1
+}
+
+// Convert translates a Windows-style absolute path into the requested
+// style. Relative paths and non-Windows paths are returned slash-
+// normalized — matching what cygpath -u does as a no-op fallback.
+//
+// This is the body that replaces the cygpath.exe shell-out in
+// ioutilx.WindowsSubsystemPath. No external process, no error from a
+// missing cygpath binary, deterministic on every host.
+func Convert(orig string, style Style) (string, error) {
+	vol := windowsVolumeName(orig)
+
+	// UNC: leave the structure, just normalize slashes. Neither MSYS nor
+	// Cygwin rewrite UNC paths into the /cygdrive namespace; passing them
+	// through is what `cygpath -u` does for UNC inputs.
+	if strings.HasPrefix(vol, `\\`) || strings.HasPrefix(vol, `//`) {
+		return toSlash(orig), nil
+	}
+
+	// No drive letter — return as-is (slash-normalized). The caller is
+	// passing something we don't know how to remap.
+	if len(vol) < 2 {
+		return toSlash(orig), nil
+	}
+
+	drive := strings.ToLower(string(vol[0]))
+	rest := toSlash(orig[len(vol):])
+	if !strings.HasPrefix(rest, "/") {
+		rest = "/" + rest
+	}
+
+	switch style {
+	case StyleMSYS:
+		return "/" + drive + rest, nil
+	case StyleCygwin:
+		return "/cygdrive/" + drive + rest, nil
+	default:
+		// Native: keep the drive letter, just normalize slashes.
+		return strings.ToUpper(string(vol[0])) + ":" + rest, nil
+	}
+}
+
+// WindowsSubsystemPath is the drop-in pure-Go replacement for
+// ioutilx.WindowsSubsystemPath. The original signature took a
+// context.Context to bound the cygpath subprocess; we keep an analogous
+// signature shape so the call site at pkg/ioutilx/ioutilx.go:54 needs
+// only a trivial edit. No syscall is performed.
+func WindowsSubsystemPath(env Env, orig string) (string, error) {
+	return Convert(orig, DetectStyle(env))
+}

--- a/poc/pkg/winpath/winpath_test.go
+++ b/poc/pkg/winpath/winpath_test.go
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package winpath
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDetectStyle(t *testing.T) {
+	cases := []struct {
+		name string
+		env  Env
+		want Style
+	}{
+		{
+			name: "MSYSTEM set wins",
+			env:  Env{MSYSTEM: "MINGW64"},
+			want: StyleMSYS,
+		},
+		{
+			name: "CYGWIN set wins when MSYSTEM unset",
+			env:  Env{CYGWIN: "nodosfilewarning"},
+			want: StyleCygwin,
+		},
+		{
+			name: "SSH env points at cygwin install",
+			env:  Env{SSH: `C:\cygwin64\bin\ssh.exe`},
+			want: StyleCygwin,
+		},
+		{
+			name: "SSH env points at Git for Windows",
+			env:  Env{SSH: `C:\Program Files\Git\usr\bin\ssh.exe`},
+			want: StyleMSYS,
+		},
+		{
+			name: "SSH env points at Win32-OpenSSH",
+			env:  Env{SSH: `C:\Windows\System32\OpenSSH\ssh.exe`},
+			want: StyleNative,
+		},
+		{
+			name: "LookPath fallback finds Git ssh",
+			env: Env{
+				LookPath: func(string) (string, error) {
+					return `C:\Program Files\Git\usr\bin\ssh.exe`, nil
+				},
+			},
+			want: StyleMSYS,
+		},
+		{
+			name: "LookPath fails, no env hints → native",
+			env: Env{
+				LookPath: func(string) (string, error) {
+					return "", errors.New("not found")
+				},
+			},
+			want: StyleNative,
+		},
+		{
+			name: "empty env → native",
+			env:  Env{},
+			want: StyleNative,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DetectStyle(tc.env)
+			if got != tc.want {
+				t.Fatalf("DetectStyle = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConvert(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		style Style
+		want  string
+	}{
+		{
+			name:  "C drive to MSYS",
+			input: `C:\Users\me\.lima`,
+			style: StyleMSYS,
+			want:  "/c/Users/me/.lima",
+		},
+		{
+			name:  "C drive to Cygwin",
+			input: `C:\Users\me\.lima`,
+			style: StyleCygwin,
+			want:  "/cygdrive/c/Users/me/.lima",
+		},
+		{
+			name:  "C drive to Native is just slash-normalized",
+			input: `C:\Users\me\.lima`,
+			style: StyleNative,
+			want:  "C:/Users/me/.lima",
+		},
+		{
+			name:  "D drive lowercased",
+			input: `D:\data`,
+			style: StyleMSYS,
+			want:  "/d/data",
+		},
+		{
+			name:  "Root of drive",
+			input: `C:\`,
+			style: StyleCygwin,
+			want:  "/cygdrive/c/",
+		},
+		{
+			name:  "UNC path passes through normalized",
+			input: `\\fileserver\share\dir`,
+			style: StyleMSYS,
+			want:  "//fileserver/share/dir",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Convert(tc.input, tc.style)
+			if err != nil {
+				t.Fatalf("Convert error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("Convert(%q, %s) = %q, want %q", tc.input, tc.style, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWindowsSubsystemPath_EndToEnd exercises the full public entry point
+// — the one a maintainer would wire into pkg/ioutilx in place of the
+// cygpath shell-out. It asserts that the drop-in replacement produces
+// exactly the string each downstream SSH client would accept.
+func TestWindowsSubsystemPath_EndToEnd(t *testing.T) {
+	const input = `C:\Users\me\.lima\_config\user`
+
+	cases := []struct {
+		name string
+		env  Env
+		want string
+	}{
+		{
+			name: "Git-Bash user → MSYS form",
+			env:  Env{MSYSTEM: "MINGW64"},
+			want: "/c/Users/me/.lima/_config/user",
+		},
+		{
+			name: "Cygwin user → cygdrive form",
+			env:  Env{CYGWIN: "nodosfilewarning"},
+			want: "/cygdrive/c/Users/me/.lima/_config/user",
+		},
+		{
+			name: "Win32-OpenSSH (default) → native path",
+			env:  Env{SSH: `C:\Windows\System32\OpenSSH\ssh.exe`},
+			want: "C:/Users/me/.lima/_config/user",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := WindowsSubsystemPath(tc.env, input)
+			if err != nil {
+				t.Fatalf("WindowsSubsystemPath error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/templates/experimental/windows.yaml
+++ b/templates/experimental/windows.yaml
@@ -1,0 +1,43 @@
+# This template is experimental scaffolding for the LFX 2026 Term 2 project
+# "Improve Windows support (host and guest)" (lima-vm/lima#4907).
+#
+# It declares a Windows guest (vmType: qemu, os: Windows) and is accepted by
+# the validator after the schema additions in this PR. The image, the CD-ROM
+# generation, and the first-boot provisioning still need follow-up work:
+#
+#   1. A Lima-provided Cloudbase-Init-enabled Windows qcow2, OR a Packer
+#      recipe under hack/windows-image/ so users can build their own from
+#      the official Microsoft Eval ISO.
+#   2. pkg/cidata branching on guestOS == Windows to emit a Cloudbase-Init
+#      NoCloud data source (cidata.iso with meta-data / user-data the way
+#      Cloudbase-Init reads them on first boot).
+#   3. pkg/driver/qemu plumbing for TPM 2.0 + UEFI when os: Windows.
+#
+# Until those land, `limactl start template://experimental/windows` will not
+# boot a working guest. The template is shipped now so the validator path is
+# exercised in CI and so the schema field is reviewable in isolation.
+
+minimumLimaVersion: "1.4.0"
+
+vmType: "qemu"
+os: "Windows"
+arch: "x86_64"
+
+# Placeholder image. Replace with the real Cloudbase-Init-enabled qcow2 when
+# the image-build recipe lands. The location is intentionally a 404 so any
+# user who tries to `limactl start` this today gets a clear failure rather
+# than a partially-booted Windows VM.
+images:
+- location: "https://example.invalid/lima/windows/win11-eval-cloudbaseinit.qcow2"
+  arch: "x86_64"
+
+cpus: 4
+memory: "8GiB"
+disk: "60GiB"
+
+# Disabled until SMB share-back-to-host or virtio-9p + WinFsp-9p ships.
+mounts: []
+
+ssh:
+  loadDotSSHPubKeys: true
+  forwardAgent: false


### PR DESCRIPTION
## Summary

Two complementary primary-goal contributions for the LFX 2026 Term 2 project [*Improve Windows support (host and guest)*](https://mentorship.lfx.linuxfoundation.org/project/f8bb0ffd-0c84-4cb9-8b66-ea63be76b6e2) (#4907):

1. **Windows host UX** — `cygpath.exe` shell-out in `pkg/ioutilx/ioutilx.go` replaced with deterministic pure-Go path translation. All eight production callers continue to work; the implicit Cygwin/MSYS2 dependency is removed from Windows hosts.
2. **Windows guest scaffolding** — `WINDOWS OS = "Windows"` added to the schema (`pkg/limatype`, `pkg/limayaml/validate.go`), plus `templates/experimental/windows.yaml`. This is the shared groundwork that any Windows-guest provisioning route (Cloudbase-Init or autounattend.xml) needs.

Both are signature-preserving / additive: every existing caller compiles unchanged, every existing template still validates.

## What's in the diff

| Area | Files | Notes |
|------|-------|-------|
| Pure-Go path translation | `pkg/ioutilx/ioutilx.go`, `pkg/ioutilx/ioutilx_test.go` | `WindowsSubsystemPath` signature unchanged; cygpath subprocess removed; 23 sub-tests |
| Windows OS enum + validator | `pkg/limatype/lima_yaml.go`, `pkg/limayaml/validate.go`, `pkg/limayaml/validate_test.go` | `WINDOWS OS = "Windows"`; `NewOS` normalizes lowercase alias; positive + negative validator tests |
| Experimental template | `templates/experimental/windows.yaml` | QEMU + UEFI + TPM stub; image URL is a 404 placeholder until follow-up image work lands |
| Sandbox PoC (kept as runnable demo, may be stripped on merge) | `poc/` | Self-contained Go module that prototyped the conversion logic in isolation |

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/ioutilx/ ./pkg/limayaml/ ./pkg/limatype/` — all green (23 new sub-tests in ioutilx, 4 new sub-tests in limayaml)
- [x] All 8 production callers of `WindowsSubsystemPath` still compile (`cmd/limactl/shell.go`, `pkg/copytool`, `pkg/hostagent/mount`, `pkg/sshutil` × 3, `pkg/limayaml/defaults`)
- [x] No remaining `cygpath` shell-out in the production tree
- [x] All existing `validate_test.go` tests still pass after the OS list change

## Cygpath conversion table

| Detected style | Trigger | `C:\Users\me\.lima` → |
| -------------- | ------- | --------------------- |
| `native` | Win32-OpenSSH at `C:\Windows\System32\OpenSSH` | `C:/Users/me/.lima` |
| `msys` | `MSYSTEM` set, or ssh under Git-for-Windows | `/c/Users/me/.lima` |
| `cygwin` | `CYGWIN` set, or ssh under `cygwin64` | `/cygdrive/c/Users/me/.lima` |

UNC paths pass through with slashes normalized, matching `cygpath -u`'s behavior. `WindowsSubsystemPathForLinux` on line 62 is intentionally left alone — it shells out to `wsl --exec wslpath`, which is not a Cygwin dependency.

## Scope **not** in this PR

Documented as next steps in the project plan, intentionally left for follow-up:
- `pkg/cidata` branching on `guestOS == Windows` to emit Cloudbase-Init NoCloud data or autounattend.xml ISOs (mentor's choice).
- `pkg/driver/qemu` TPM 2.0 + UEFI plumbing when `os: Windows`.
- `pkg/driver/hcs` external driver against Microsoft `hcsshim` (secondary goal).
- WSL2 multi-instance + WSLg (tertiary goal).
- `limactl doctor` for Windows-host first-run wizard.
- `poc/` sandbox directory — keep for now as a runnable demo; maintainers may strip before merge.

## Status

Draft for LFX mentorship visibility. Happy to split into separate PRs or drop the `poc/` sandbox if preferred.