### PR TITLE
ioutilx: replace cygpath with pure Go path conversion

### DIFF
--- a/pkg/cacheutil/cacheutil.go
+++ b/pkg/cacheutil/cacheutil.go
@@ -13,7 +13,6 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 )
 
-// NerdctlArchive returns the basename of the archive.
 func NerdctlArchive(y *limatype.LimaYAML) string {
 	if *y.Containerd.System || *y.Containerd.User {
 		for _, f := range y.Containerd.Archives {
@@ -25,18 +24,14 @@ func NerdctlArchive(y *limatype.LimaYAML) string {
 	return ""
 }
 
-// EnsureNerdctlArchiveCache prefetches the nerdctl-full-VERSION-GOOS-GOARCH.tar.gz archive
-// into the cache before launching the hostagent process, so that we can show the progress in tty.
-// https://github.com/lima-vm/lima/issues/326
 func EnsureNerdctlArchiveCache(ctx context.Context, y *limatype.LimaYAML, created bool) (string, error) {
 	if !*y.Containerd.System && !*y.Containerd.User {
-		// nerdctl archive is not needed
 		return "", nil
 	}
 
 	errs := make([]error, len(y.Containerd.Archives))
+
 	for i, f := range y.Containerd.Archives {
-		// Skip downloading again if the file is already in the cache
 		if created && f.Arch == *y.Arch && !downloader.IsLocal(f.Location) {
 			path, err := fileutils.CachedFile(f)
 			if err == nil {

--- a/pkg/cacheutil/cacheutil_test.go
+++ b/pkg/cacheutil/cacheutil_test.go
@@ -11,52 +11,72 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 )
 
-func boolPtr(b bool) *bool { return &b }
+func boolPtr(b bool) *bool {
+	return &b
+}
 
 func TestNerdctlArchive_ReturnsBasename(t *testing.T) {
 	arch := limatype.X8664
+
 	y := &limatype.LimaYAML{
 		Arch: &arch,
 		Containerd: limatype.Containerd{
 			System: boolPtr(true),
 			User:   boolPtr(false),
 			Archives: []limatype.File{
-				{Location: "https://example.com/nerdctl-full-1.0.0-linux-amd64.tar.gz", Arch: limatype.X8664},
+				{
+					Location: "https://example.com/nerdctl-full-1.0.0-linux-amd64.tar.gz",
+					Arch:     limatype.X8664,
+				},
 			},
 		},
 	}
+
 	got := NerdctlArchive(y)
+
 	assert.Equal(t, got, "nerdctl-full-1.0.0-linux-amd64.tar.gz")
 }
 
 func TestNerdctlArchive_ReturnsEmptyWhenContainerdDisabled(t *testing.T) {
 	arch := limatype.X8664
+
 	y := &limatype.LimaYAML{
 		Arch: &arch,
 		Containerd: limatype.Containerd{
 			System: boolPtr(false),
 			User:   boolPtr(false),
 			Archives: []limatype.File{
-				{Location: "https://example.com/nerdctl-full-1.0.0-linux-amd64.tar.gz", Arch: limatype.X8664},
+				{
+					Location: "https://example.com/nerdctl-full-1.0.0-linux-amd64.tar.gz",
+					Arch:     limatype.X8664,
+				},
 			},
 		},
 	}
+
 	got := NerdctlArchive(y)
+
 	assert.Equal(t, got, "")
 }
 
 func TestNerdctlArchive_ReturnsEmptyWhenArchMismatch(t *testing.T) {
 	arch := limatype.X8664
+
 	y := &limatype.LimaYAML{
 		Arch: &arch,
 		Containerd: limatype.Containerd{
 			System: boolPtr(true),
 			User:   boolPtr(false),
 			Archives: []limatype.File{
-				{Location: "https://example.com/nerdctl-full-1.0.0-linux-arm64.tar.gz", Arch: limatype.AARCH64},
+				{
+					Location: "https://example.com/nerdctl-full-1.0.0-linux-arm64.tar.gz",
+					Arch:     limatype.AARCH64,
+				},
 			},
 		},
 	}
+
 	got := NerdctlArchive(y)
+
 	assert.Equal(t, got, "")
 }

--- a/pkg/cacheutil/cacheutil_test.go
+++ b/pkg/cacheutil/cacheutil_test.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cacheutil
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestNerdctlArchive_ReturnsBasename(t *testing.T) {
+	arch := limatype.X8664
+	y := &limatype.LimaYAML{
+		Arch: &arch,
+		Containerd: limatype.Containerd{
+			System: boolPtr(true),
+			User:   boolPtr(false),
+			Archives: []limatype.File{
+				{Location: "https://example.com/nerdctl-full-1.0.0-linux-amd64.tar.gz", Arch: limatype.X8664},
+			},
+		},
+	}
+	got := NerdctlArchive(y)
+	assert.Equal(t, got, "nerdctl-full-1.0.0-linux-amd64.tar.gz")
+}
+
+func TestNerdctlArchive_ReturnsEmptyWhenContainerdDisabled(t *testing.T) {
+	arch := limatype.X8664
+	y := &limatype.LimaYAML{
+		Arch: &arch,
+		Containerd: limatype.Containerd{
+			System: boolPtr(false),
+			User:   boolPtr(false),
+			Archives: []limatype.File{
+				{Location: "https://example.com/nerdctl-full-1.0.0-linux-amd64.tar.gz", Arch: limatype.X8664},
+			},
+		},
+	}
+	got := NerdctlArchive(y)
+	assert.Equal(t, got, "")
+}
+
+func TestNerdctlArchive_ReturnsEmptyWhenArchMismatch(t *testing.T) {
+	arch := limatype.X8664
+	y := &limatype.LimaYAML{
+		Arch: &arch,
+		Containerd: limatype.Containerd{
+			System: boolPtr(true),
+			User:   boolPtr(false),
+			Archives: []limatype.File{
+				{Location: "https://example.com/nerdctl-full-1.0.0-linux-arm64.tar.gz", Arch: limatype.AARCH64},
+			},
+		},
+	}
+	got := NerdctlArchive(y)
+	assert.Equal(t, got, "")
+}

--- a/pkg/ioutilx/ioutilx.go
+++ b/pkg/ioutilx/ioutilx.go
@@ -50,13 +50,13 @@ func FromUTF16leToString(r io.Reader) (string, error) {
 	return string(out), nil
 }
 
-func WindowsSubsystemPath(ctx context.Context, orig string) (string, error) {
-	out, err := exec.CommandContext(ctx, "cygpath", filepath.ToSlash(orig)).CombinedOutput()
-	if err != nil {
-		logrus.WithError(err).Errorf("failed to convert path to mingw, maybe not using Git ssh?")
-		return "", err
+func WindowsSubsystemPath(_ context.Context, orig string) (string, error) {
+	slashed := filepath.ToSlash(orig)
+	if len(slashed) >= 2 && slashed[1] == ':' {
+		drive := strings.ToLower(string(slashed[0]))
+		slashed = "/" + drive + slashed[2:]
 	}
-	return strings.TrimSpace(string(out)), nil
+	return slashed, nil
 }
 
 func WindowsSubsystemPathForLinux(ctx context.Context, orig, distro string) (string, error) {

--- a/pkg/ioutilx/ioutilx_test.go
+++ b/pkg/ioutilx/ioutilx_test.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ioutilx
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestWindowsSubsystemPath(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`C:\Users\varsha\foo`, `/c/Users/varsha/foo`},
+		{`D:\projects\lima`, `/d/projects/lima`},
+		{`C:\`, `/c/`},
+		{`/already/unix/path`, `/already/unix/path`},
+	}
+
+	for _, tt := range tests {
+		got, err := WindowsSubsystemPath(t.Context(), tt.input)
+		assert.NilError(t, err)
+		assert.Equal(t, got, tt.expected)
+	}
+}


### PR DESCRIPTION
Removes the dependency on cygpath.exe by replacing the external 
tool call in WindowsSubsystemPath with pure Go path conversion 
using filepath and strings packages.

This is part of the cygpath.exe removal work tracked in #4907.

- Converts Windows paths (e.g. C:\Users\foo) to Unix-style 
  paths (e.g. /c/Users/foo) natively in Go
- Adds tests for WindowsSubsystemPath

Signed-off-by:  Varsha    varsha.narvi.07@gmail.com