### PR TITLE
POC - LFX( TERM 2 ) - add Windows support with autounattend.xml generation

### DIFF
--- a/pkg/cidata/autounattend.xml.tmpl
+++ b/pkg/cidata/autounattend.xml.tmpl
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <ComputerName>{{ .Hostname }}</ComputerName>
+      <RegisteredOwner>{{ .User }}</RegisteredOwner>
+{{- if .TimeZone }}
+      <TimeZone>{{ .TimeZone }}</TimeZone>
+{{- end }}
+    </component>
+  </settings>
+  <!-- Lima SSH keys (placeholder, consumed by later Windows provisioning):
+{{- range .SSHPubKeys }}
+    {{ . }}
+{{- end }}
+  -->
+</unattend>

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -359,6 +359,10 @@ func templateArgs(ctx context.Context, bootScripts bool, instDir, name string, i
 }
 
 func GenerateCloudConfig(ctx context.Context, instDir, name string, instConfig *limatype.LimaYAML) error {
+	if instConfig.OS != nil && *instConfig.OS == limatype.WINDOWS {
+		return GenerateAutounattendXML(ctx, instDir, name, instConfig)
+	}
+
 	args, err := templateArgs(ctx, false, instDir, name, instConfig, 0, 0, 0, "", false, false, false)
 	if err != nil {
 		return err
@@ -379,6 +383,25 @@ func GenerateCloudConfig(ctx context.Context, instDir, name string, instConfig *
 
 	os.RemoveAll(filepath.Join(instDir, filenames.CloudConfig)) // delete existing
 	return os.WriteFile(filepath.Join(instDir, filenames.CloudConfig), config, 0o444)
+}
+
+func GenerateAutounattendXML(ctx context.Context, instDir, name string, instConfig *limatype.LimaYAML) error {
+	args, err := templateArgs(ctx, false, instDir, name, instConfig, 0, 0, 0, "", false, false, false)
+	if err != nil {
+		return err
+	}
+
+	if err := ValidateTemplateArgs(args); err != nil {
+		return err
+	}
+
+	config, err := ExecuteTemplateAutounattendXML(args)
+	if err != nil {
+		return err
+	}
+
+	os.RemoveAll(filepath.Join(instDir, filenames.AutounattendXML))
+	return os.WriteFile(filepath.Join(instDir, filenames.AutounattendXML), config, 0o444)
 }
 
 // GenerateISO9660 generates the cidata ISO9660 image (or directory, for noCloudInit)

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -20,6 +20,9 @@ import (
 //go:embed cidata.TEMPLATE.d
 var templateFS embed.FS
 
+//go:embed autounattend.xml.tmpl
+var autounattendTemplate []byte
+
 const templateFSRoot = "cidata.TEMPLATE.d"
 
 type CACerts struct {
@@ -204,4 +207,12 @@ func ExecuteTemplateCIDataISO(args *TemplateArgs) ([]iso9660util.Entry, error) {
 	}
 
 	return layout, nil
+}
+
+func ExecuteTemplateAutounattendXML(args *TemplateArgs) ([]byte, error) {
+	if err := ValidateTemplateArgs(args); err != nil {
+		return nil, err
+	}
+
+	return textutil.ExecuteTemplate(string(autounattendTemplate), args)
 }

--- a/pkg/cidata/template_test.go
+++ b/pkg/cidata/template_test.go
@@ -168,3 +168,22 @@ func TestTemplate9p(t *testing.T) {
 		}
 	}
 }
+
+func TestAutounattendTemplate(t *testing.T) {
+	args := &TemplateArgs{
+		Name:     "default",
+		Hostname: "lima-win",
+		User:     "foo",
+		UID:      501,
+		Comment:  "Foo",
+		Home:     "/home/foo.guest",
+		Shell:    "/bin/bash",
+		SSHPubKeys: []string{
+			"ssh-rsa dummy foo@example.com",
+		},
+	}
+	config, err := ExecuteTemplateAutounattendXML(args)
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(string(config), "<ComputerName>lima-win</ComputerName>"))
+	assert.Assert(t, strings.Contains(string(config), "ssh-rsa dummy"))
+}

--- a/pkg/limatype/filenames/filenames.go
+++ b/pkg/limatype/filenames/filenames.go
@@ -36,6 +36,7 @@ const (
 	CIDataISO               = "cidata.iso"
 	CIDataISODir            = "cidata"
 	CloudConfig             = "cloud-config.yaml"
+	AutounattendXML         = "autounattend.xml"
 	Image                   = "image"      // downloaded VM image; renamed to Disk or ISO during setup
 	ImageIPSW               = "image.ipsw" // hardlink to Image for macOS guests
 	Disk                    = "disk"       // VM disk (or symlink to DiffDiskLegacy for migrated instances)

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -80,6 +80,7 @@ const (
 	LINUX   OS = "Linux"
 	DARWIN  OS = "Darwin"
 	FREEBSD OS = "FreeBSD"
+	WINDOWS OS = "Windows"
 
 	X8664   Arch = "x86_64"
 	AARCH64 Arch = "aarch64"
@@ -99,7 +100,7 @@ const (
 )
 
 var (
-	OSTypes    = []OS{LINUX, DARWIN, FREEBSD}
+	OSTypes    = []OS{LINUX, DARWIN, FREEBSD, WINDOWS}
 	ArchTypes  = []Arch{X8664, AARCH64, ARMV7L, PPC64LE, RISCV64, S390X}
 	MountTypes = []MountType{REVSSHFS, NINEP, VIRTIOFS, WSLMount}
 	VMTypes    = []VMType{QEMU, VZ, WSL2}
@@ -348,6 +349,8 @@ func NewOS(osname string) OS {
 		return LINUX
 	case "darwin":
 		return DARWIN
+	case "windows", "Windows":
+		return WINDOWS
 	default:
 		logrus.Warnf("Unknown os: %s", osname)
 		return osname

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -50,7 +50,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 	}
 
 	switch *y.OS {
-	case limatype.LINUX, limatype.DARWIN, limatype.FREEBSD:
+	case limatype.LINUX, limatype.DARWIN, limatype.FREEBSD, limatype.WINDOWS:
 	default:
 		errs = errors.Join(errs, fmt.Errorf("field `os` must be one of %q; got %q", limatype.OSTypes, *y.OS))
 	}

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -369,8 +369,7 @@ provision:
 	err = Validate(y, false)
 	t.Logf("Validation errors: %v", err)
 
-	assert.Error(t, err, "field `os` must be one of [\"Linux\" \"Darwin\" \"FreeBSD\"]; got \"windows\"\n"+
-		"field `arch` must be one of [x86_64 aarch64 armv7l ppc64le riscv64 s390x]; got \"unsupported_arch\"\n"+
+	assert.Error(t, err, "field `arch` must be one of [x86_64 aarch64 armv7l ppc64le riscv64 s390x]; got \"unsupported_arch\"\n"+
 		"field `images` must be set\n"+
 		"field `provision[0].mode` must one of \"system\", \"user\", \"boot\", \"data\", \"dependency\", \"ansible\", or \"yq\"\n"+
 		"field `provision[1].path` must not be empty when mode is \"data\"")


### PR DESCRIPTION
### PR Description

This PR is a proof of concept for Windows guest support. It adds a minimal autounattend.xml generation flow and allows [os: windows](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in the Lima config, producing the file during instance creation. The template is intentionally minimal (hostname/owner plus SSH keys placeholder) to demonstrate the end-to-end path without changing QEMU boot wiring yet.

### Changes

- Allow Windows as a valid guest OS in config validation.
- Generate autounattend.xml for Windows guests instead of cloud-config.yaml.
- Add an embedded autounattend template and a unit test.
- Introduce autounattend.xml as an instance file name constant.