### PR TITLE
PoC: Run Windows guest VM with VirtIO-FS filesystem mount

### DIFF
--- a/poc-windows-guest/.gitignore
+++ b/poc-windows-guest/.gitignore
@@ -1,0 +1,6 @@
+images/virtio-win-0.1.285.iso
+images/win-cidata.iso
+images/windows.qcow2
+images/windows_server_2025.iso
+tmp/*
+*virtiofsd.sock*

--- a/poc-windows-guest/README.md
+++ b/poc-windows-guest/README.md
@@ -1,0 +1,120 @@
+## PoC: Windows guest VM with VirtIO-FS filesystem mount
+This PoC creates a Windows Server 2025 guest VM using QEMU. This PoC supports:
+- Fully automated installation via autounattend
+- Install VirtIO drivers for performance improvements, and VirtIO-FS
+- Filesystem mounts through VirtIO-FS
+- SSH from host computer with a public key
+
+### Files
+- autounattend.xml
+  - This automates OS installation
+- first_logon.ps1
+  - It installs/sets up various tools on Windows guest. It is called through autounattend.xml.
+- images/
+  - This directory contains ISO and qcow2 files
+
+### Host environment
+I tested the code on:
+CPU arch: x86_64
+OS: Ubuntu 24.04
+
+### Prerequisites
+You should have:
+- QEMU binary
+- mkisofs (or altanatives) for creating ISO file
+  - Through apt, you can install it via `apt install genisoimage`
+- virtiofsd binary
+  - You can install via `cargo install virtiofsd`
+
+### Prepare ISO files
+#### Download Windows Server 2025 ISO
+You can download the ISO file from https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2025.
+Note that you need to register your name, email, company, and so on.
+After downloading it, you should place the ISO file as `poc-windows-guest/images/windows_server_2025.iso`.
+
+#### Download VirtIO-Win ISO
+You can download the ISO file from https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-0.1.285-1/.
+After downloading it, please place the ISO file under `poc-windows-guest/images/`. You don't need to rename it.
+
+### Launch Windows VM
+You can also use poc-windows-guest/run.sh for executing those commands.
+Please move to `./poc-windows-guest` before executing those commands.
+
+#### Create autounattend ISO file
+The ISO file contains autounattend.xml, first_logon.ps1, and a public key.
+```bash
+mkdir -p tmp/win-cidata
+cp autounattend.xml ./tmp/win-cidata/
+cp first_logon.ps1 ./tmp/win-cidata/
+cp ~/.lima/_config/user.pub ./tmp/win-cidata/
+mkisofs -o ./images/win-cidata.iso -J -r -V "autoanattend" ./tmp/win-cidata/
+```
+
+#### Run virtiofsd
+```bash
+virtiofsd --shared-dir=./ --socket-path=./virtiofsd.sock --sandbox none &
+```
+
+#### Create qcow2 file
+```bash
+qemu-img create -f qcow2 ./images/windows.qcow2 40G
+```
+
+#### Run QEMU
+```bash
+qemu-system-x86_64 \
+    -name guest=win2k25,debug-threads=on \
+    -machine pc-q35-noble,usb=off,vmport=off,dump-guest-core=off,memory-backend=pc.ram,hpet=off,acpi=on \
+    -accel kvm \
+    -cpu host,migratable=on,hv-time=on,hv-relaxed=on,hv-vapic=on,hv-spinlocks=0x1fff \
+    -m size=2048 \
+    -object memory-backend-memfd,id=pc.ram,share=true,size=2048M \
+    -overcommit mem-lock=off \
+    -smp 2,sockets=2,cores=1,threads=1 \
+    -drive file=./images/windows.qcow2,if=virtio,id=disk0,discard=on \
+    -blockdev driver=file,filename=./images/windows_server_2025.iso,node-name=cdrom0-storage,read-only=true \
+    -blockdev driver=raw,file=cdrom0-storage,node-name=cdrom0,read-only=true \
+    -device ide-cd,bus=ide.1,drive=cdrom0 \
+    -blockdev driver=file,filename=./images/virtio-win-0.1.285.iso,node-name=cdrom1-storage,read-only=true \
+    -blockdev driver=raw,file=cdrom1-storage,node-name=cdrom1,read-only=true \
+    -device ide-cd,bus=ide.2,drive=cdrom1 \
+    -blockdev driver=file,filename=./images/win-cidata.iso,node-name=cdrom2-storage,read-only=true \
+    -blockdev driver=raw,file=cdrom2-storage,node-name=cdrom2,read-only=true \
+    -device ide-cd,bus=ide.3,drive=cdrom2 \
+    -netdev user,id=net0,net=192.168.10.0/24,dhcpstart=192.168.10.15,hostfwd=tcp:127.0.0.1:60022-:22 \
+    -device virtio-net-pci,netdev=net0 \
+    -chardev socket,id=chr-vu-fs0,path=./virtiofsd.sock \
+    -device vhost-user-fs-pci,chardev=chr-vu-fs0,tag=hoge \
+    -device virtio-rng-pci
+```
+
+#### Try SSH
+```bash
+ssh -p 60022 limauser@localhost -i ~/.lima/_config/user
+Microsoft Windows [Version 10.0.26100.32230]
+(c) Microsoft Corporation. All rights reserved.
+
+limauser@LIMA C:\Users\limauser>
+```
+
+#### Check shared filesystem
+By default, VirtIO-FS mounts a shared filesystem on `Z:`
+```bash
+limauser@LIMA C:\Users\limauser>dir Z:\
+ Volume in drive Z is lima
+ Volume Serial Number is 0000-0000
+
+ Directory of Z:\
+
+01/01/1970  01:00 AM    <DIR>          .
+01/01/1970  01:00 AM    <DIR>          ..
+05/17/2026  10:17 AM             3,652 README.md
+05/17/2026  10:01 AM             7,363 autounattend.xml
+05/17/2026  10:01 AM             2,014 first_logon.ps1
+05/17/2026  10:05 AM    <DIR>          images
+05/17/2026  10:00 AM             2,153 run.sh
+05/17/2026  10:05 AM    <DIR>          tmp
+05/17/2026  10:05 AM                 6 virtiofsd.sock.pid
+               5 File(s)         23,380 bytes
+               4 Dir(s)  29,202,513,920 bytes free
+```

--- a/poc-windows-guest/autounattend.xml
+++ b/poc-windows-guest/autounattend.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:schemas-microsoft-com:unattend">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-PnpCustomizationsWinPE" publicKeyToken="31bf3856ad364e35"
+        language="neutral" versionScope="nonSxS" processorArchitecture="amd64"
+        xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+        <DriverPaths>
+            <PathAndCredentials wcm:action="add" wcm:keyValue="2">
+                <Path>E:\viostor\2k25\amd64</Path>
+            </PathAndCredentials>
+            <PathAndCredentials wcm:action="add" wcm:keyValue="3">
+                <Path>E:\NetKVM\2k25\amd64</Path>
+            </PathAndCredentials>
+            <PathAndCredentials wcm:action="add" wcm:keyValue="4">
+                <Path>E:\viofs\2k25\amd64</Path>
+            </PathAndCredentials>
+            <PathAndCredentials wcm:action="add" wcm:keyValue="5">
+                <Path>E:\Balloon\2k25\amd64</Path>
+            </PathAndCredentials>
+            <PathAndCredentials wcm:action="add" wcm:keyValue="6">
+                <Path>E:\viorng\2k25\amd64</Path>
+            </PathAndCredentials>
+        </DriverPaths>
+    </component>
+
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/IMAGE/INDEX</Key>
+              <Value>1</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>2</PartitionID>
+          </InstallTo>
+        </OSImage>
+      </ImageInstall>
+      <DiskConfiguration>
+        <Disk wcm:action="add">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Size>100</Size>
+              <Type>Primary</Type>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionId>1</PartitionId>
+              <Format>NTFS</Format>
+              <Label>System</Label>
+              <Active>true</Active>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionId>2</PartitionId>
+              <Format>NTFS</Format>
+              <Label>Windows</Label>
+              <Letter>C</Letter>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <FullName />
+        <Organization />
+      </UserData>
+    </component>
+  </settings>
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <ComputerName>lima</ComputerName>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <UserAccounts>
+        <LocalAccounts>
+          <LocalAccount wcm:action="add">
+            <Password>
+              <Value>limauser</Value>
+              <PlainText>true</PlainText>
+            </Password>
+            <Description>This is limauser</Description>
+            <DisplayName>limauser</DisplayName>
+            <Group>Administrators</Group>
+            <Name>limauser</Name>
+          </LocalAccount>
+        </LocalAccounts>
+      </UserAccounts>
+      <OOBE>
+        <ProtectYourPC>1</ProtectYourPC>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+      </OOBE>
+      <TimeZone>GMT Standard Time</TimeZone>
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <RequiresUserInput>false</RequiresUserInput>
+          <CommandLine>powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "F:\first_logon.ps1"</CommandLine>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Username>limauser</Username>
+        <Password>
+            <Value>limauser</Value>
+            <PlainText>true</PlainText>
+        </Password>
+        <LogonCount>1</LogonCount>
+      </AutoLogon>
+    </component>
+  </settings>
+</unattend>

--- a/poc-windows-guest/first_logon.ps1
+++ b/poc-windows-guest/first_logon.ps1
@@ -1,0 +1,40 @@
+$logfile = "C:\Users\limauser\lima-setup.log"
+
+# Record logs
+Start-Transcript -Path $logfile -Append
+
+# Install OpenSSH server, then enable it
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+Start-Service sshd
+Set-Service -Name sshd -StartupType Automatic
+
+# Modify firewall rule
+# Note that Windows server may have a firewall rule for SSH by default, but it doesn't work on my env.
+# So I remove and recreate the rule.
+Remove-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction Ignore
+New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+
+# Set a public key. Since a user `lima` is in Administrators group,
+# The pubelic key should be located under C:\ProgramData\ssh instead of under C:\Users\lima\.ssh.
+$pubkey = Get-Content -Path F:\user.pub
+$pubkeyLocation = 'C:\ProgramData\ssh\administrators_authorized_keys'
+Add-Content -Force -Path $pubkeyLocation -Value $pubkey
+icacls $pubkeyLocation /inheritance:r
+icacls $pubkeyLocation /grant "SYSTEM:F"
+icacls $pubkeyLocation /grant "Administrators:F"
+
+# Install chocolatey for installing WinFSP.
+# WinFSP can be installed through winget as well, but currently winget is unstable in Windows Server Core
+# See: https://github.com/microsoft/winget-cli/discussions/5230
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+# Install WinFSP for VirtioFS
+C:\ProgramData\chocolatey\choco.exe install winfsp -y --pre
+
+# Create VirtioFs service from virtio-win, and enable it
+# By default, the host directory is mounted on Z:
+New-Service -Name VirtioFsSvc -BinaryPathName 'E:\viofs\2k25\amd64\virtiofs.exe' -DisplayName VirtioFsSvc -StartupType Automatic
+Start-Service -Name VirtioFsSvc
+
+# Finish recording logs
+Stop-Transcript

--- a/poc-windows-guest/run.sh
+++ b/poc-windows-guest/run.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Note that this script expects that you've already set Windows OS ISO (windows_server_2025.iso) and virtio-win ISO (virtio-win-0.1.285.iso) in ./images/
+
+set -e
+
+# Cleanup
+rm -f images/windows.qcow2
+rm -f images/win-cidata.iso
+
+# Build win-cidata.iso
+mkdir -p tmp/win-cidata
+cp autounattend.xml ./tmp/win-cidata/
+cp first_logon.ps1 ./tmp/win-cidata/
+cp ~/.lima/_config/user.pub ./tmp/win-cidata/
+mkisofs -o ./images/win-cidata.iso -J -r -V "autoanattend" ./tmp/win-cidata/
+
+# Create qcow2
+qemu-img create -f qcow2 ./images/windows.qcow2 40G
+
+# Run virtiofsd in background
+virtiofsd --shared-dir=./ --socket-path=./virtiofsd.sock --sandbox none &
+
+# Run QEMU
+qemu-system-x86_64 \
+    -name guest=win2k25,debug-threads=on \
+    -machine pc-q35-noble,usb=off,vmport=off,dump-guest-core=off,memory-backend=pc.ram,hpet=off,acpi=on \
+    -accel kvm \
+    -cpu host,migratable=on,hv-time=on,hv-relaxed=on,hv-vapic=on,hv-spinlocks=0x1fff \
+    -m size=2048 \
+    -object memory-backend-memfd,id=pc.ram,share=true,size=2048M \
+    -overcommit mem-lock=off \
+    -smp 2,sockets=2,cores=1,threads=1 \
+    -drive file=./images/windows.qcow2,if=virtio,id=disk0,discard=on \
+    -blockdev driver=file,filename=./images/windows_server_2025.iso,node-name=cdrom0-storage,read-only=true \
+    -blockdev driver=raw,file=cdrom0-storage,node-name=cdrom0,read-only=true \
+    -device ide-cd,bus=ide.1,drive=cdrom0 \
+    -blockdev driver=file,filename=./images/virtio-win-0.1.285.iso,node-name=cdrom1-storage,read-only=true \
+    -blockdev driver=raw,file=cdrom1-storage,node-name=cdrom1,read-only=true \
+    -device ide-cd,bus=ide.2,drive=cdrom1 \
+    -blockdev driver=file,filename=./images/win-cidata.iso,node-name=cdrom2-storage,read-only=true \
+    -blockdev driver=raw,file=cdrom2-storage,node-name=cdrom2,read-only=true \
+    -device ide-cd,bus=ide.3,drive=cdrom2 \
+    -netdev user,id=net0,net=192.168.10.0/24,dhcpstart=192.168.10.15,hostfwd=tcp:127.0.0.1:60022-:22 \
+    -device virtio-net-pci,netdev=net0 \
+    -chardev socket,id=chr-vu-fs0,path=./virtiofsd.sock \
+    -device vhost-user-fs-pci,chardev=chr-vu-fs0,tag=lima \
+    -device virtio-rng-pci


### PR DESCRIPTION
This draft PR is a PoC for LFX mentorship program (#4852  ).

## Description
This PR introduces how to launch Windows Server 2025 guest VM with QEMU. It supports:
- Fully automated OS installation including VirtIO drivers installation through autounattend
- Automated tool installations/setting ups through a PowerShell script. The script is called by autounattend
- SSH from host computer using a public key
- Host filesystem mount through VirtIO-FS

Please also read poc-windows-guest/README.md.

## Host environment
I tested the PoC on:
CPU architecture: x86_64
OS: Ubuntu 24.04

## Screenshots
QEMU opens a Windows guest VM:
<img width="1023" height="823" alt="Screenshot from 2026-05-17 10-38-00" src="https://github.com/user-attachments/assets/a1806466-574f-4480-b846-dd013f9751ef" />

Host filesystem is mounted on `Z:`
<img width="1023" height="823" alt="Screenshot from 2026-05-17 10-38-11" src="https://github.com/user-attachments/assets/b59d1092-9fbb-47b0-be12-c4fa85e10372" />

