### PR TITLE
Windows: support native OpenSSH; no Git for Windows / MSYS2 required

### DIFF
--- a/.github/actions/windows_msys2_prep/action.yml
+++ b/.github/actions/windows_msys2_prep/action.yml
@@ -1,0 +1,19 @@
+name: 'windows msys2 prep'
+description: >
+  Adds C:\msys64\usr\bin to PATH and installs the MSYS2 packages required by
+  hack/test-templates.sh. The PATH prepend persists into subsequent job steps
+  via $GITHUB_PATH, so the test step can call cygpath / bash / pacman tools
+  directly without re-prepending.
+runs:
+  using: composite
+  steps:
+  - name: Prepend MSYS2 to PATH and install test dependencies
+    shell: pwsh
+    # The value written to $GITHUB_PATH is the static literal C:\msys64\usr\bin,
+    # which is the canonical pattern for adding a directory to subsequent
+    # steps' PATH. No PR-controlled data reaches the env file.
+    run: | # zizmor: ignore[github-env]
+      $ErrorActionPreference = 'Stop'
+      Add-Content -Path $env:GITHUB_PATH -Value 'C:\msys64\usr\bin'
+      & 'C:\msys64\usr\bin\pacman.exe' -Sy --noconfirm openbsd-netcat diffutils socat w3m
+      if ($LASTEXITCODE -ne 0) { throw "pacman failed: $LASTEXITCODE" }

--- a/.github/actions/windows_plain_build/action.yml
+++ b/.github/actions/windows_plain_build/action.yml
@@ -1,0 +1,22 @@
+name: 'windows plain build'
+description: >
+  Builds limactl.exe and the Linux/amd64 guest agent with `go build` on a
+  vanilla Windows host (no MSYS2 make / bash). The guest agent must be built
+  separately because limactl looks it up at
+  _output/share/lima/lima-guestagent.Linux-x86_64 when starting an instance,
+  and `go build ./cmd/limactl` does not produce that file.
+runs:
+  using: composite
+  steps:
+  - name: Build limactl and Linux/amd64 guest agent
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      go build -o _output\bin\limactl.exe .\cmd\limactl
+      if ($LASTEXITCODE -ne 0) { throw "limactl build failed: $LASTEXITCODE" }
+      New-Item -ItemType Directory -Force -Path _output\share\lima | Out-Null
+      $env:CGO_ENABLED = '0'
+      $env:GOOS = 'linux'
+      $env:GOARCH = 'amd64'
+      go build -o _output\share\lima\lima-guestagent.Linux-x86_64 .\cmd\lima-guestagent
+      if ($LASTEXITCODE -ne 0) { throw "lima-guestagent build failed: $LASTEXITCODE" }

--- a/.github/actions/windows_plain_host/action.yml
+++ b/.github/actions/windows_plain_host/action.yml
@@ -1,0 +1,161 @@
+name: 'windows plain host'
+description: >
+  Uninstalls MSYS2 and Git for Windows from the windows-2025 runner so the
+  job runs against a vanilla Windows toolchain: native OpenSSH from
+  %SystemRoot%\System32\OpenSSH, wsl.exe, and tar. Then verifies they are
+  gone across four layers (filesystem, PATH, binaries, registry) so a
+  runner-image change that reinstalls them fails the job loudly.
+
+  Run AFTER steps that need git CLI (checkout, windows_plain_templates) and
+  BEFORE the build / smoke test steps.
+runs:
+  using: composite
+  steps:
+  - name: Uninstall Git for Windows
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      $uninstaller = 'C:\Program Files\Git\unins000.exe'
+      if (Test-Path $uninstaller) {
+        Write-Host "Running Git for Windows Inno Setup uninstaller..."
+        & $uninstaller /VERYSILENT /NORESTART /SUPPRESSMSGBOXES
+        # The uninstaller forks and the parent exits immediately; wait for
+        # the worker process to finish before we wipe the leftover dir.
+        Wait-Process -Name unins000 -Timeout 120 -ErrorAction SilentlyContinue
+      } else {
+        Write-Host "No Git for Windows uninstaller at $uninstaller; skipping."
+      }
+      foreach ($d in 'C:\Program Files\Git', 'C:\Program Files (x86)\Git') {
+        if (Test-Path $d) {
+          Write-Host "Removing leftover $d"
+          Remove-Item $d -Recurse -Force -ErrorAction SilentlyContinue
+        }
+      }
+
+  - name: Uninstall MSYS2 and standalone mingw
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      # MSYS2 on this runner image is an extracted tree, not a package, so
+      # "uninstall" means killing any process still mapping msys-2.0.dll
+      # then removing the dir. C:\mingw64 and C:\mingw32 are the same shape.
+      $procs = Get-Process | Where-Object {
+        try { $_.Modules.ModuleName -contains 'msys-2.0.dll' } catch { $false }
+      }
+      if ($procs) {
+        Write-Host "Stopping $($procs.Count) process(es) still mapping msys-2.0.dll"
+        $procs | Stop-Process -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 1
+      }
+      foreach ($d in 'C:\msys64', 'C:\tools\msys64', 'C:\msys32',
+                     'C:\mingw64', 'C:\mingw32') {
+        if (Test-Path $d) {
+          Write-Host "Removing $d"
+          Remove-Item $d -Recurse -Force -ErrorAction SilentlyContinue
+        }
+      }
+
+  - name: Scrub forbidden entries from Machine + User PATH
+    shell: pwsh
+    # The PATH= we publish here is the runner's own Machine + User PATH
+    # with a static deny-list of toolchain prefixes removed — no
+    # PR-controlled data reaches the env file.
+    run: | # zizmor: ignore[github-env]
+      # The uninstall removes the dirs, but the Machine/User PATH still has
+      # stale entries (C:\mingw64\bin stays registered). Rewrite both scopes
+      # so the verify step sees a clean host, then publish the combined PATH
+      # via $GITHUB_ENV — registry changes do not reach the running runner
+      # process. Later steps adding entries (QEMU) must also write PATH= via
+      # $GITHUB_ENV; $GITHUB_PATH is suppressed once $GITHUB_ENV sets PATH.
+      $forbidden = '(?i)(msys|mingw|cygwin|\\Git\\(cmd|bin|usr))'
+      foreach ($scope in @('Machine','User')) {
+        $orig = [Environment]::GetEnvironmentVariable('Path', $scope)
+        if (-not $orig) { continue }
+        $cleaned = ($orig -split ';' | Where-Object { $_ -and ($_ -notmatch $forbidden) }) -join ';'
+        if ($cleaned -ne $orig) {
+          Write-Host "Scrubbing $scope PATH"
+          [Environment]::SetEnvironmentVariable('Path', $cleaned, $scope)
+        }
+      }
+      $machine = [Environment]::GetEnvironmentVariable('Path','Machine')
+      $user = [Environment]::GetEnvironmentVariable('Path','User')
+      $combined = (@($machine, $user) | Where-Object { $_ }) -join ';'
+      Add-Content -Path $env:GITHUB_ENV -Value "PATH=$combined"
+
+  - name: Verify host is vanilla Windows (no MSYS2 / Git for Windows / Cygwin)
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      # This process inherited PATH before the scrub above; refresh it from
+      # the scrubbed Machine + User values so Layer 2 reflects what later
+      # steps inherit.
+      $machine = [Environment]::GetEnvironmentVariable('Path','Machine')
+      $user = [Environment]::GetEnvironmentVariable('Path','User')
+      $env:PATH = (@($machine, $user) | Where-Object { $_ }) -join ';'
+      $fail = @()
+
+      # --- Layer 1: filesystem ---
+      $fsForbidden = @(
+        'C:\msys64', 'C:\tools\msys64', 'C:\msys32',
+        'C:\Program Files\Git', 'C:\Program Files (x86)\Git',
+        'C:\mingw64', 'C:\mingw32',
+        'C:\cygwin', 'C:\cygwin64', 'C:\tools\cygwin'
+      )
+      foreach ($d in $fsForbidden) {
+        if (Test-Path $d) { $fail += "filesystem: $d still exists" }
+      }
+
+      # --- Layer 2: PATH (process + machine + user) ---
+      $pathRegex = '(?i)(msys|mingw|cygwin|\\Git\\(cmd|bin|usr))'
+      foreach ($scope in @('Process','Machine','User')) {
+        $p = [Environment]::GetEnvironmentVariable('Path', $scope)
+        if (-not $p) { continue }
+        foreach ($entry in $p -split ';') {
+          if ($entry -and ($entry -match $pathRegex)) {
+            $fail += ("PATH ({0}): {1}" -f $scope, $entry)
+          }
+        }
+      }
+
+      # --- Layer 3: smoking-gun binaries ---
+      # Any of these resolving on PATH means a toolchain is still reachable.
+      # bash is special: WSL ships %SystemRoot%\System32\bash.exe which is
+      # legitimately present on the wsl2 plain job, so allow only that path.
+      $forbiddenCmds = @('cygpath','pacman','mintty','git','git-bash','git-cmd')
+      foreach ($cmd in $forbiddenCmds) {
+        $g = Get-Command $cmd -ErrorAction SilentlyContinue
+        if ($g) { $fail += ("binary: {0} -> {1}" -f $cmd, $g.Source) }
+      }
+      $allowedBash = Join-Path $env:SystemRoot 'System32\bash.exe'
+      $bash = Get-Command bash -ErrorAction SilentlyContinue
+      if ($bash -and ($bash.Source -ne $allowedBash)) {
+        $fail += "binary: bash -> $($bash.Source) (only $allowedBash is allowed)"
+      }
+      $sh = Get-Command sh -ErrorAction SilentlyContinue
+      if ($sh) { $fail += "binary: sh -> $($sh.Source)" }
+
+      # --- Layer 4: registry uninstall keys ---
+      $uninstallRoots = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+        'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall'
+      )
+      foreach ($root in $uninstallRoots) {
+        if (-not (Test-Path $root)) { continue }
+        $keys = Get-ChildItem $root -ErrorAction SilentlyContinue
+        foreach ($k in $keys) {
+          $props = Get-ItemProperty $k.PSPath -ErrorAction SilentlyContinue
+          if ($props -and $props.DisplayName -and
+              ($props.DisplayName -match '(?i)(msys|git for windows|cygwin|mingw)')) {
+            $fail += ("registry: {0} -> DisplayName='{1}'" -f $k.PSPath, $props.DisplayName)
+          }
+        }
+      }
+
+      if ($fail.Count -gt 0) {
+        Write-Host "Plain-Windows verification FAILED:" -ForegroundColor Red
+        $fail | ForEach-Object { Write-Host "  $_" }
+        Write-Error "Toolchain remnants detected; this runner is not in plain-Windows state."
+        exit 1
+      }
+      Write-Host "Plain-Windows verification PASSED."

--- a/.github/actions/windows_plain_smoke_test/action.yml
+++ b/.github/actions/windows_plain_smoke_test/action.yml
@@ -1,0 +1,87 @@
+name: 'windows plain smoke test'
+description: >
+  Runs Lima's create / start / shell / copy / stop / delete cycle against a
+  given template on a plain Windows host. Each limactl invocation runs with
+  --debug so traces land in the workflow log, and on failure the workflow
+  dumps the instance's hostagent / serial logs so the run carries enough
+  context to diagnose without re-running.
+inputs:
+  template:
+    description: Path to the Lima template (e.g. .\templates\experimental\wsl2.yaml).
+    required: true
+  instance-name:
+    description: Name to use for the test instance.
+    required: false
+    default: plain
+  lima-home-suffix:
+    description: >
+      Suffix appended to runner.temp for LIMA_HOME (e.g. "plain-wsl2"). Must be
+      unique per job sharing a runner so concurrent jobs cannot collide.
+    required: true
+  vm-type:
+    description: >
+      Lima vmType to force via `--vm-type` (e.g. "qemu" or "wsl2"). When empty,
+      `limactl create` auto-selects, which on Windows prefers wsl2 over qemu
+      even when the template ships a disk image incompatible with wsl2.
+    required: false
+    default: ''
+runs:
+  using: composite
+  steps:
+  - name: Smoke test (create / start / shell / copy / stop / delete)
+    shell: pwsh
+    env:
+      LIMA_HOME: ${{ runner.temp }}\lima-${{ inputs.lima-home-suffix }}
+      INSTANCE: ${{ inputs.instance-name }}
+      TEMPLATE: ${{ inputs.template }}
+      VM_TYPE: ${{ inputs.vm-type }}
+    run: |
+      $ErrorActionPreference = 'Stop'
+      # $ErrorActionPreference does not propagate to native commands; wrap
+      # limactl so a non-zero exit aborts the whole script instead of
+      # silently continuing past the failure.
+      function Invoke-Limactl {
+        & .\_output\bin\limactl.exe --debug @args
+        if ($LASTEXITCODE -ne 0) { throw "limactl $($args -join ' ') exited $LASTEXITCODE" }
+      }
+      if (Test-Path $env:LIMA_HOME) { Remove-Item $env:LIMA_HOME -Recurse -Force }
+      New-Item -ItemType Directory -Path $env:LIMA_HOME | Out-Null
+      $createArgs = @('--tty=false', "--name=$env:INSTANCE")
+      if ($env:VM_TYPE) { $createArgs += "--vm-type=$env:VM_TYPE" }
+      $createArgs += $env:TEMPLATE
+      Invoke-Limactl create @createArgs
+      Invoke-Limactl start $env:INSTANCE
+      Invoke-Limactl shell --tty=false $env:INSTANCE -- uname -srm
+      'roundtrip' | Out-File -Encoding ascii "$env:LIMA_HOME\rt.txt"
+      Invoke-Limactl copy "$env:LIMA_HOME\rt.txt" "${env:INSTANCE}:/tmp/rt.txt"
+      Invoke-Limactl shell --tty=false $env:INSTANCE -- cat /tmp/rt.txt
+      # Cover the guest -> host direction too: it runs through different
+      # parseCopyPaths plumbing than the upload above.
+      Invoke-Limactl copy "${env:INSTANCE}:/tmp/rt.txt" "$env:LIMA_HOME\rt-back.txt"
+      $back = (Get-Content "$env:LIMA_HOME\rt-back.txt" -Raw).Trim()
+      if ($back -ne 'roundtrip') {
+        throw "round-trip mismatch: expected 'roundtrip', got '$back'"
+      }
+      Invoke-Limactl stop $env:INSTANCE
+      Invoke-Limactl delete --force $env:INSTANCE
+
+  - name: Dump Lima logs on failure
+    if: failure()
+    shell: pwsh
+    env:
+      LIMA_HOME: ${{ runner.temp }}\lima-${{ inputs.lima-home-suffix }}
+      INSTANCE: ${{ inputs.instance-name }}
+    run: |
+      $instDir = Join-Path $env:LIMA_HOME $env:INSTANCE
+      if (-not (Test-Path $instDir)) {
+        Write-Host "No instance directory at $instDir, nothing to dump."
+        exit 0
+      }
+      Get-ChildItem $instDir | Format-Table Name, Length, LastWriteTime
+      foreach ($name in 'ha.stdout.log','ha.stderr.log','serial.log','lima.yaml','ssh.config') {
+        $p = Join-Path $instDir $name
+        if (Test-Path $p) {
+          Write-Host ("===== {0} =====" -f $p)
+          Get-Content $p
+        }
+      }

--- a/.github/actions/windows_plain_templates/action.yml
+++ b/.github/actions/windows_plain_templates/action.yml
@@ -28,7 +28,12 @@ runs:
       Copy-Item -Path "$srcRoot\*" -Destination $dstRoot -Recurse -Force
 
       $linkTargets = @{}
-      foreach ($line in (git ls-tree -r HEAD $srcRoot)) {
+      # Capture before iterating: a partial `git ls-tree` failure would let
+      # foreach run on truncated data, and later `git cat-file` calls would
+      # overwrite $LASTEXITCODE before the failure could be seen.
+      $lsTreeOutput = git ls-tree -r HEAD $srcRoot
+      if ($LASTEXITCODE -ne 0) { throw "git ls-tree failed: $LASTEXITCODE" }
+      foreach ($line in $lsTreeOutput) {
         if ($line -notmatch '^120000\s') { continue }
         $parts = $line -split "`t", 2
         $sha = ($parts[0] -split '\s+')[2]
@@ -37,7 +42,6 @@ runs:
         if ($LASTEXITCODE -ne 0) { throw "git cat-file $sha failed: $LASTEXITCODE" }
         $linkTargets[$posixPath] = $target
       }
-      if ($LASTEXITCODE -ne 0) { throw "git ls-tree failed: $LASTEXITCODE" }
 
       foreach ($posixPath in $linkTargets.Keys) {
         $resolved = $posixPath

--- a/.github/actions/windows_plain_templates/action.yml
+++ b/.github/actions/windows_plain_templates/action.yml
@@ -1,0 +1,70 @@
+name: 'windows plain templates'
+description: >
+  Resolves Lima's template symlinks and copies templates/ to
+  _output/share/lima/templates/, replicating `make`'s TEMPLATES target without
+  needing MSYS2 / Git for Windows.
+
+  Several files under templates/ are git symlinks (mode 120000) pointing at
+  sibling files, and some chain (opensuse.yaml -> opensuse-leap.yaml ->
+  opensuse-leap-16.yaml). The working-tree representation varies: a runner
+  with Developer Mode (or admin) preserves them as NTFS symlinks; a plain
+  Windows checkout with core.symlinks=false writes 17-byte plaintext stubs.
+  Reading targets directly from git's object store makes resolution
+  independent of which representation the checkout used.
+
+  This action MUST run before windows_plain_host (which uninstalls Git for
+  Windows), because it shells out to `git ls-tree` and `git cat-file`.
+runs:
+  using: composite
+  steps:
+  - name: Install templates (replicating make's TEMPLATES target)
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      $srcRoot = 'templates'
+      $dstRoot = '_output\share\lima\templates'
+      if (Test-Path $dstRoot) { Remove-Item $dstRoot -Recurse -Force }
+      New-Item -ItemType Directory -Force -Path $dstRoot | Out-Null
+      Copy-Item -Path "$srcRoot\*" -Destination $dstRoot -Recurse -Force
+
+      $linkTargets = @{}
+      foreach ($line in (git ls-tree -r HEAD $srcRoot)) {
+        if ($line -notmatch '^120000\s') { continue }
+        $parts = $line -split "`t", 2
+        $sha = ($parts[0] -split '\s+')[2]
+        $posixPath = $parts[1]
+        $target = (git cat-file blob $sha).Trim()
+        if ($LASTEXITCODE -ne 0) { throw "git cat-file $sha failed: $LASTEXITCODE" }
+        $linkTargets[$posixPath] = $target
+      }
+      if ($LASTEXITCODE -ne 0) { throw "git ls-tree failed: $LASTEXITCODE" }
+
+      foreach ($posixPath in $linkTargets.Keys) {
+        $resolved = $posixPath
+        $depth = 0
+        while ($linkTargets.ContainsKey($resolved)) {
+          if ($depth++ -gt 16) { throw "Symlink chain too deep starting from $posixPath" }
+          $target = $linkTargets[$resolved]
+          $slash = $resolved.LastIndexOf('/')
+          $resolved = if ($slash -ge 0) { "$($resolved.Substring(0, $slash))/$target" } else { $target }
+          $segs = New-Object System.Collections.ArrayList
+          foreach ($s in ($resolved -split '/')) {
+            if ($s -eq '' -or $s -eq '.') { continue }
+            if ($s -eq '..') {
+              if ($segs.Count -gt 0) { $segs.RemoveAt($segs.Count - 1) | Out-Null }
+              continue
+            }
+            $segs.Add($s) | Out-Null
+          }
+          $resolved = $segs -join '/'
+        }
+        # Defensive: the '..' handling above silently underflows. Guard against
+        # a future symlink edit whose chain resolves outside templates/.
+        if (-not $resolved.StartsWith("$srcRoot/")) {
+          throw "Symlink $posixPath resolved to $resolved, which escapes $srcRoot/"
+        }
+        $srcFile = $resolved -replace '/', '\'
+        $dstFile = Join-Path '_output\share\lima' ($posixPath -replace '/', '\')
+        Write-Host "Resolving symlink: $posixPath -> $resolved"
+        Copy-Item -Force -Path $srcFile -Destination $dstFile
+      }

--- a/.github/actions/windows_qemu_install/action.yml
+++ b/.github/actions/windows_qemu_install/action.yml
@@ -1,0 +1,11 @@
+name: 'windows qemu install'
+description: Installs QEMU on the Windows runner via winget.
+runs:
+  using: composite
+  steps:
+  - name: Install QEMU
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      winget install --silent --accept-source-agreements --accept-package-agreements --disable-interactivity SoftwareFreedomConservancy.QEMU
+      if ($LASTEXITCODE -ne 0) { throw "winget install QEMU failed: $LASTEXITCODE" }

--- a/.github/actions/windows_wsl2_setup/action.yml
+++ b/.github/actions/windows_wsl2_setup/action.yml
@@ -1,0 +1,44 @@
+name: 'windows wsl2 setup'
+description: >
+  Enables WSL2 on the Windows runner and imports a dummy distro. The dummy
+  distro is required because `wsl --list --verbose` (called from Lima) fails
+  when no distro is installed -- see lima-vm/lima#1826. Starting with WSL2
+  2.5.7.0 the imported tarball must contain /bin/sh and /etc, hence the
+  scaffolding here.
+runs:
+  using: composite
+  steps:
+  - name: Enable WSL2
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      # PowerShell's $ErrorActionPreference does not propagate to native
+      # commands; check $LASTEXITCODE after every wsl invocation that
+      # gates the runner state.
+      wsl --set-default-version 2
+      if ($LASTEXITCODE -ne 0) { throw "wsl --set-default-version failed: $LASTEXITCODE" }
+      wsl --shutdown
+      if ($LASTEXITCODE -ne 0) { throw "wsl --shutdown failed: $LASTEXITCODE" }
+      # --update reaches a Microsoft update service that returns
+      # transient 403s; treat it as informational, like --status /
+      # --version / --list --online below.
+      wsl --update
+      wsl --status
+      wsl --version
+      wsl --list --online
+  - name: Install dummy WSL2 distro
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      # Write the scratch tarball under $RUNNER_TEMP so the action stays
+      # idempotent for local re-runs and leaves no untracked files in
+      # the checked-out workspace.
+      $scratch = Join-Path $env:RUNNER_TEMP 'wsl2-dummy'
+      New-Item -ItemType Directory -Force -Path "$scratch\bin","$scratch\etc" | Out-Null
+      Set-Content -Path "$scratch\bin\sh" -Value ''
+      $tarball = Join-Path $env:RUNNER_TEMP 'wsl2-dummy.tar'
+      tar -cf $tarball --format ustar -C $scratch .
+      if ($LASTEXITCODE -ne 0) { throw "tar -cf $tarball failed: $LASTEXITCODE" }
+      wsl --import dummy $env:TEMP $tarball
+      if ($LASTEXITCODE -ne 0) { throw "wsl --import dummy failed: $LASTEXITCODE" }
+      wsl --list --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -248,46 +248,10 @@ jobs:
     - uses: ./.github/actions/windows_wsl2_setup
     - uses: ./.github/actions/windows_plain_host
     - uses: ./.github/actions/windows_plain_build
-    - name: Smoke test (create / start / shell / copy / stop / delete)
-      env:
-        LIMA_HOME: ${{ runner.temp }}\lima-plain-wsl2
-      run: |
-        $ErrorActionPreference = 'Stop'
-        # Wrap each limactl invocation so a non-zero exit aborts the whole
-        # script. Without this, $ErrorActionPreference does not catch native
-        # command failures and the script silently continues past errors.
-        function Invoke-Limactl {
-          & .\_output\bin\limactl.exe --debug @args
-          if ($LASTEXITCODE -ne 0) { throw "limactl $($args -join ' ') exited $LASTEXITCODE" }
-        }
-        if (Test-Path $env:LIMA_HOME) { Remove-Item $env:LIMA_HOME -Recurse -Force }
-        New-Item -ItemType Directory -Path $env:LIMA_HOME | Out-Null
-        Invoke-Limactl create --tty=false --name=plain .\templates\experimental\wsl2.yaml
-        Invoke-Limactl start plain
-        Invoke-Limactl shell --tty=false plain -- uname -srm
-        'roundtrip' | Out-File -Encoding ascii "$env:LIMA_HOME\rt.txt"
-        Invoke-Limactl copy "$env:LIMA_HOME\rt.txt" plain:/tmp/rt.txt
-        Invoke-Limactl shell --tty=false plain -- cat /tmp/rt.txt
-        Invoke-Limactl stop plain
-        Invoke-Limactl delete --force plain
-    - name: Dump Lima logs on failure
-      if: failure()
-      env:
-        LIMA_HOME: ${{ runner.temp }}\lima-plain-wsl2
-      run: |
-        $instDir = "$env:LIMA_HOME\plain"
-        if (-not (Test-Path $instDir)) {
-          Write-Host "No instance directory at $instDir, nothing to dump."
-          exit 0
-        }
-        Get-ChildItem $instDir | Format-Table Name, Length, LastWriteTime
-        foreach ($name in 'ha.stdout.log','ha.stderr.log','serial.log','lima.yaml','ssh.config') {
-          $p = Join-Path $instDir $name
-          if (Test-Path $p) {
-            Write-Host ("===== {0} =====" -f $p)
-            Get-Content $p
-          }
-        }
+    - uses: ./.github/actions/windows_plain_smoke_test
+      with:
+        template: .\templates\experimental\wsl2.yaml
+        lima-home-suffix: plain-wsl2
 
   windows-plain-qemu:
     # Same shape as windows-plain-wsl2 but exercises the QEMU driver. Covers
@@ -327,6 +291,10 @@ jobs:
       with:
         template: .\templates\default.yaml
         lima-home-suffix: plain-qemu
+        # Force qemu: on Windows, `limactl create` auto-selects wsl2
+        # over qemu, and templates/default.yaml ships a cloud disk
+        # image that the wsl2 driver rejects.
+        vm-type: qemu
 
   qemu:
     name: "Integration tests (QEMU, macOS host)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,36 +162,11 @@ jobs:
     - name: Uninstall
       run: sudo make uninstall
 
-  windows:
+  windows-wsl2:
     name: "Windows tests (WSL2)"
     runs-on: windows-2025
     timeout-minutes: 30
     steps:
-    - name: Enable WSL2
-      run: |
-        wsl --set-default-version 2
-        wsl --shutdown
-        wsl --update
-        wsl --status
-        wsl --version
-        wsl --list --online
-    - name: Install WSL2 distro
-      timeout-minutes: 1
-      run: |
-        # FIXME: At least one distro has to be installed here,
-        # otherwise `wsl --list --verbose` (called from Lima) fails:
-        # https://github.com/lima-vm/lima/pull/1826#issuecomment-1729993334
-        # The distro image itself is not consumed by Lima.
-        # Starting with WSL2 version 2.5.7.0 the distro will be rejected
-        # if it doesn't contain /bin/sh and /etc.
-        # ------------------------------------------------------------------
-        mkdir dummy
-        mkdir dummy\bin
-        mkdir dummy\etc
-        echo "" >dummy\bin\sh
-        tar -cf dummy.tar --format ustar -C dummy .
-        wsl --import dummy $env:TEMP dummy.tar
-        wsl --list --verbose
     - name: Set gitconfig
       run: |
         git config --global core.autocrlf false
@@ -203,19 +178,19 @@ jobs:
       with:
         go-version: stable
         cache: false
+    - uses: ./.github/actions/windows_wsl2_setup
+    - uses: ./.github/actions/windows_msys2_prep
     - name: Unit tests
       run: go test -v ./...
     - name: Make
       run: make
     - name: Integration tests (WSL2, Windows host)
       run: |
-        $env:PATH = "$pwd\_output\bin;" + 'C:\msys64\usr\bin;' + $env:PATH
-        pacman -Sy --noconfirm openbsd-netcat diffutils socat w3m
-        $env:MSYS2_ENV_CONV_EXCL = 'HOME_HOST;HOME_GUEST;_LIMA_WINDOWS_EXTRA_PATH'
+        $env:PATH = "$pwd\_output\bin;" + $env:PATH
+        $env:MSYS2_ENV_CONV_EXCL = 'HOME_HOST;HOME_GUEST'
         $env:HOME_HOST = $(cygpath.exe "$env:USERPROFILE")
         $env:HOME_GUEST = "/mnt$env:HOME_HOST"
         $env:LIMACTL_CREATE_ARGS = '--vm-type=wsl2 --mount-type=wsl2 --containerd=system'
-        $env:_LIMA_WINDOWS_EXTRA_PATH = 'C:\Program Files\Git\usr\bin'
         bash.exe -c "./hack/test-templates.sh templates/experimental/wsl2.yaml"
 
   windows-qemu:
@@ -234,21 +209,124 @@ jobs:
       with:
         go-version: stable
         cache: false
+    - uses: ./.github/actions/windows_qemu_install
+    - uses: ./.github/actions/windows_msys2_prep
     - name: Make
       run: make
-    - name: Install QEMU
-      run: |
-        winget install --silent --accept-source-agreements --accept-package-agreements --disable-interactivity SoftwareFreedomConservancy.QEMU
     - name: Integration tests (QEMU, Windows host)
       run: |
-        $env:PATH = "$pwd\_output\bin;" + 'C:\msys64\usr\bin;' + 'C:\Program Files\QEMU;' + $env:PATH
-        pacman -Sy --noconfirm openbsd-netcat diffutils socat w3m
-        $env:MSYS2_ENV_CONV_EXCL = 'HOME_HOST;HOME_GUEST;_LIMA_WINDOWS_EXTRA_PATH'
+        $env:PATH = "$pwd\_output\bin;" + 'C:\Program Files\QEMU;' + $env:PATH
+        $env:MSYS2_ENV_CONV_EXCL = 'HOME_HOST;HOME_GUEST'
         $env:HOME_HOST = $(cygpath.exe "$env:USERPROFILE")
         $env:HOME_GUEST = "$env:HOME_HOST"
         $env:LIMACTL_CREATE_ARGS = '--vm-type=qemu'
-        $env:_LIMA_WINDOWS_EXTRA_PATH = 'C:\Program Files\Git\usr\bin'
         bash.exe -c "./hack/test-templates.sh templates/default.yaml"
+
+  windows-plain-wsl2:
+    # Smoke test that Lima's WSL2 driver works on a Windows host with only
+    # the bits that ship in a default Windows 10/11 install (native OpenSSH,
+    # wsl.exe, tar). Notably: no Git for Windows, no MSYS2, no cygpath, no
+    # Cygwin/MSYS2 ssh. Builds with `go build` (instead of `make`) and
+    # exercises the main commands in PowerShell. If this job ever needs to
+    # add MSYS2 / Git for Windows back to make a step pass, that means a new
+    # external-binary dependency was introduced and should be evaluated.
+    name: "Windows tests (WSL2, plain Windows host)"
+    runs-on: windows-2025
+    timeout-minutes: 30
+    steps:
+    - name: Set gitconfig
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+      with:
+        go-version: stable
+        cache: false
+    - uses: ./.github/actions/windows_wsl2_setup
+    - uses: ./.github/actions/windows_plain_host
+    - uses: ./.github/actions/windows_plain_build
+    - name: Smoke test (create / start / shell / copy / stop / delete)
+      env:
+        LIMA_HOME: ${{ runner.temp }}\lima-plain-wsl2
+      run: |
+        $ErrorActionPreference = 'Stop'
+        # Wrap each limactl invocation so a non-zero exit aborts the whole
+        # script. Without this, $ErrorActionPreference does not catch native
+        # command failures and the script silently continues past errors.
+        function Invoke-Limactl {
+          & .\_output\bin\limactl.exe --debug @args
+          if ($LASTEXITCODE -ne 0) { throw "limactl $($args -join ' ') exited $LASTEXITCODE" }
+        }
+        if (Test-Path $env:LIMA_HOME) { Remove-Item $env:LIMA_HOME -Recurse -Force }
+        New-Item -ItemType Directory -Path $env:LIMA_HOME | Out-Null
+        Invoke-Limactl create --tty=false --name=plain .\templates\experimental\wsl2.yaml
+        Invoke-Limactl start plain
+        Invoke-Limactl shell --tty=false plain -- uname -srm
+        'roundtrip' | Out-File -Encoding ascii "$env:LIMA_HOME\rt.txt"
+        Invoke-Limactl copy "$env:LIMA_HOME\rt.txt" plain:/tmp/rt.txt
+        Invoke-Limactl shell --tty=false plain -- cat /tmp/rt.txt
+        Invoke-Limactl stop plain
+        Invoke-Limactl delete --force plain
+    - name: Dump Lima logs on failure
+      if: failure()
+      env:
+        LIMA_HOME: ${{ runner.temp }}\lima-plain-wsl2
+      run: |
+        $instDir = "$env:LIMA_HOME\plain"
+        if (-not (Test-Path $instDir)) {
+          Write-Host "No instance directory at $instDir, nothing to dump."
+          exit 0
+        }
+        Get-ChildItem $instDir | Format-Table Name, Length, LastWriteTime
+        foreach ($name in 'ha.stdout.log','ha.stderr.log','serial.log','lima.yaml','ssh.config') {
+          $p = Join-Path $instDir $name
+          if (Test-Path $p) {
+            Write-Host ("===== {0} =====" -f $p)
+            Get-Content $p
+          }
+        }
+
+  windows-plain-qemu:
+    # Same shape as windows-plain-wsl2 but exercises the QEMU driver. Covers
+    # native OpenSSH + native sftp-server + cygpath-free path translation
+    # end-to-end without MSYS2 / Git-for-Windows on PATH.
+    name: "Windows tests (QEMU, plain Windows host)"
+    runs-on: windows-2025
+    timeout-minutes: 30
+    steps:
+    - name: Set gitconfig
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+      with:
+        go-version: stable
+        cache: false
+    - uses: ./.github/actions/windows_qemu_install
+    - uses: ./.github/actions/windows_plain_templates
+    - uses: ./.github/actions/windows_plain_host
+    # winget's QEMU manifest does not register a PATH entry, and
+    # windows_plain_host has just published a scrubbed PATH= through
+    # $GITHUB_ENV. Subsequent $GITHUB_PATH prepending is suppressed
+    # once $GITHUB_ENV defines PATH, so prepend the QEMU install dir
+    # through $GITHUB_ENV too, so the smoke test resolves
+    # qemu-system-x86_64.
+    - name: Add QEMU to PATH
+      shell: pwsh
+      # zizmor: ignore[github-env]
+      run: |
+        Add-Content -Path $env:GITHUB_ENV -Value "PATH=C:\Program Files\QEMU;$env:PATH"
+    - uses: ./.github/actions/windows_plain_build
+    - uses: ./.github/actions/windows_plain_smoke_test
+      with:
+        template: .\templates\default.yaml
+        lima-home-suffix: plain-qemu
 
   qemu:
     name: "Integration tests (QEMU, macOS host)"

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -38,16 +38,6 @@ func main() {
 	}
 
 	yq.MaybeRunYQ()
-	if runtime.GOOS == "windows" {
-		extras, hasExtra := os.LookupEnv("_LIMA_WINDOWS_EXTRA_PATH")
-		if hasExtra && strings.TrimSpace(extras) != "" {
-			p := os.Getenv("PATH")
-			err := os.Setenv("PATH", strings.TrimSpace(extras)+string(filepath.ListSeparator)+p)
-			if err != nil {
-				logrus.Warning("Can't add extras to PATH, relying entirely on system PATH")
-			}
-		}
-	}
 	err := newApp().Execute()
 	server.StopAllExternalDrivers()
 	osutil.HandleExitError(err)

--- a/pkg/copytool/copytool.go
+++ b/pkg/copytool/copytool.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/lima-vm/lima/v2/pkg/ioutilx"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/sshutil"
 	"github.com/lima-vm/lima/v2/pkg/store"
 )
 
@@ -119,18 +119,46 @@ func hasRemoteSourceAndDestination(ctx context.Context, paths []string) bool {
 func parseCopyPaths(ctx context.Context, paths []string) ([]*Path, error) {
 	var copyPaths []*Path
 
+	// Resolve sshExe lazily, once per call — NewSSHExe is uncached and may
+	// exec.LookPath each time.
+	var (
+		sshExe       sshutil.SSHExe
+		sshExeErr    error
+		sshExeLoaded bool
+	)
+	ensureSSHExe := func() (sshutil.SSHExe, error) {
+		if !sshExeLoaded {
+			sshExe, sshExeErr = sshutil.NewSSHExe()
+			sshExeLoaded = true
+		}
+		return sshExe, sshExeErr
+	}
+
 	for _, path := range paths {
 		cp := &Path{}
 		if runtime.GOOS == "windows" {
+			// Detect local absolute paths (C:\, C:/, UNC) before the ":"
+			// split so a drive letter is not read as an instance name.
+			// IsAbs is deliberate: a drive-relative "C:foo" is not absolute,
+			// so it still splits as instance "C" path "foo", preserving
+			// single-letter instance names. UNC passes IsAbs and flows
+			// through PathForSSH as //server/share/... (untested; no CI
+			// sends scp a UNC path).
 			if filepath.IsAbs(path) {
-				var err error
-				path, err = ioutilx.WindowsSubsystemPath(ctx, path)
+				sshExe, err := ensureSSHExe()
 				if err != nil {
 					return nil, err
 				}
-			} else {
-				path = filepath.ToSlash(path)
+				path, err = sshutil.PathForSSH(ctx, sshExe, path)
+				if err != nil {
+					return nil, err
+				}
+				cp.Path = path
+				cp.IsRemote = false
+				copyPaths = append(copyPaths, cp)
+				continue
 			}
+			path = filepath.ToSlash(path)
 		}
 
 		parts := strings.SplitN(path, ":", 2)

--- a/pkg/copytool/copytool_test.go
+++ b/pkg/copytool/copytool_test.go
@@ -4,6 +4,8 @@
 package copytool
 
 import (
+	"runtime"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -24,4 +26,41 @@ func TestCommandDoesNotMutateOptions(t *testing.T) {
 
 	assert.Equal(t, tool.Options.Verbose, false, "Command() must not mutate stored Options.Verbose")
 	assert.Equal(t, tool.Options.Recursive, false, "Command() must not mutate stored Options.Recursive")
+}
+
+// TestParseCopyPathsWindowsDriveLetter locks in the distinction between
+// Windows absolute paths (local, routed through PathForSSH) and drive-
+// relative paths like "C:foo.txt" — not absolute, and we must interpret
+// them as instance "C" path "foo.txt" so single-letter instance names
+// keep working.
+func TestParseCopyPathsWindowsDriveLetter(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only path handling")
+	}
+	ctx := t.Context()
+
+	// Absolute drive-letter paths are local; they must not be classified
+	// as instance "C".
+	for _, p := range []string{`C:\foo`, `C:/foo`} {
+		cps, err := parseCopyPaths(ctx, []string{p})
+		if err != nil {
+			// A stripped test env may lack ssh, so PathForSSH can error;
+			// the guarantee is only that it is not an instance-name lookup.
+			assert.Assert(t, !strings.Contains(err.Error(), "instance `C`"),
+				"%q must not be classified as instance C: %v", p, err)
+			continue
+		}
+		assert.Equal(t, len(cps), 1)
+		assert.Equal(t, cps[0].IsRemote, false, "%q must be a local path", p)
+	}
+
+	// "C:foo" is drive-relative (not absolute). It must reach the
+	// instance-lookup branch as instance "C" path "foo" and fail at
+	// store.Inspect with an instance-not-found error.
+	_, err := parseCopyPaths(ctx, []string{"C:foo"})
+	assert.ErrorContains(t, err, "instance `C`")
+
+	// Explicit instance:path behaves the same.
+	_, err = parseCopyPaths(ctx, []string{"nonexistent-instance-for-test:/tmp/x"})
+	assert.ErrorContains(t, err, "instance `nonexistent-instance-for-test`")
 }

--- a/pkg/copytool/rsync.go
+++ b/pkg/copytool/rsync.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"al.essio.dev/pkg/shellescape"
@@ -36,7 +37,10 @@ func (t *rsyncTool) Name() string {
 func (t *rsyncTool) IsAvailableOnGuest(ctx context.Context, paths []string) bool {
 	copyPaths, err := parseCopyPaths(ctx, paths)
 	if err != nil {
-		logrus.Debugf("failed to parse copy paths for rsync availability check: %v", err)
+		// Warn, not Debug: New()'s fallback then reports "scp not found on
+		// host" instead of the real cause (often no ssh.exe on Windows),
+		// so the user needs this line to diagnose.
+		logrus.Warnf("rsync availability check skipped: %v", err)
 		return false
 	}
 	instances := make(map[string]*limatype.Instance)
@@ -67,6 +71,12 @@ func checkRsyncOnGuest(ctx context.Context, inst *limatype.Instance) bool {
 	if err != nil {
 		logrus.Debugf("failed to get SSH options for rsync check: %v", err)
 		return false
+	}
+	if runtime.GOOS == "windows" {
+		// Mirror rsyncTool.Command: native Windows OpenSSH has no mux support,
+		// and Cygwin ssh's mux is unreliable. Strip the mux options so the
+		// probe does not falsely reject a working rsync install.
+		sshOpts = sshutil.SSHOptsRemovingControlPath(sshOpts)
 	}
 
 	sshArgs := append([]string{}, sshExe.Args...)
@@ -126,6 +136,13 @@ func (t *rsyncTool) Command(ctx context.Context, paths []string, opts *Options) 
 				sshOpts, err := sshutil.SSHOpts(ctx, sshExe, cp.Instance.Dir, *cp.Instance.Config.User.Name, false, false, false, false)
 				if err != nil {
 					return nil, err
+				}
+				if runtime.GOOS == "windows" {
+					// Strip mux options so rsync's ssh transport does not try to
+					// use a ControlMaster socket — unavailable or unreliable on
+					// Windows. See the equivalent comment in scp.go.
+					logrus.Debug("rsync: stripping ControlMaster/ControlPath/ControlPersist (Windows)")
+					sshOpts = sshutil.SSHOptsRemovingControlPath(sshOpts)
 				}
 
 				sshArgs := []string{sshExe.Exe}

--- a/pkg/copytool/scp.go
+++ b/pkg/copytool/scp.go
@@ -8,8 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"runtime"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/sirupsen/logrus"
 
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/sshutil"
@@ -119,6 +121,14 @@ func (t *scpTool) Command(ctx context.Context, paths []string, opts *Options) (*
 		if err != nil {
 			return nil, err
 		}
+	}
+	if runtime.GOOS == "windows" {
+		// Strip ControlMaster/ControlPath/ControlPersist so scp's ssh runs
+		// without multiplexing — native Windows OpenSSH has no mux support,
+		// and Cygwin ssh's mux is unreliable for sftp. Same as hostagent
+		// and limactl shell.
+		logrus.Debug("scp: stripping ControlMaster/ControlPath/ControlPersist (Windows)")
+		sshOpts = sshutil.SSHOptsRemovingControlPath(sshOpts)
 	}
 	sshArgs := sshutil.SSHArgsFromOpts(sshOpts)
 

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -5,6 +5,7 @@ package downloader
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"errors"
@@ -525,8 +526,6 @@ func decompressorByMagic(file string) string {
 }
 
 func decompressLocal(ctx context.Context, decompressCmd, dst, src, ext, description string) error {
-	logrus.Infof("decompressing %s with %v", ext, decompressCmd)
-
 	st, err := os.Stat(src)
 	if err != nil {
 		return err
@@ -549,11 +548,6 @@ func decompressLocal(ctx context.Context, decompressCmd, dst, src, ext, descript
 		return err
 	}
 	defer out.Close()
-	buf := new(bytes.Buffer)
-	cmd := exec.CommandContext(ctx, decompressCmd, "-d") // -d --decompress
-	cmd.Stdin = bar.NewProxyReader(in)
-	cmd.Stdout = out
-	cmd.Stderr = buf
 	if !HideProgress {
 		if description == "" {
 			description = filepath.Base(src)
@@ -561,6 +555,37 @@ func decompressLocal(ctx context.Context, decompressCmd, dst, src, ext, descript
 		logrus.Infof("Decompressing %s", description)
 	}
 	bar.Start()
+	defer bar.Finish()
+	reader := bar.NewProxyReader(in)
+
+	// Prefer the external decompressor; fall back to a built-in pure-Go
+	// gzip decoder only when the binary is missing, so a plain Windows
+	// host with no gzip can still unpack a .tar.gz image. xz, bzip2, and
+	// zstd stay external-only.
+	if _, lookErr := exec.LookPath(decompressCmd); lookErr != nil {
+		var r io.Reader
+		switch decompressCmd {
+		case "gzip":
+			gz, err := gzip.NewReader(reader)
+			if err != nil {
+				return err
+			}
+			defer gz.Close()
+			r = gz
+		default:
+			return fmt.Errorf("decompressor %q not found and no built-in fallback: %w", decompressCmd, lookErr)
+		}
+		logrus.Infof("decompressing %s with built-in %s (external %q not found)", ext, decompressCmd, decompressCmd)
+		_, err = io.Copy(out, &ctxReader{ctx: ctx, r: r})
+		return err
+	}
+
+	logrus.Infof("decompressing %s with external %q", ext, decompressCmd)
+	buf := new(bytes.Buffer)
+	cmd := exec.CommandContext(ctx, decompressCmd, "-d")
+	cmd.Stdin = reader
+	cmd.Stdout = out
+	cmd.Stderr = buf
 	err = cmd.Run()
 	if err != nil {
 		var exitErr *exec.ExitError
@@ -568,8 +593,22 @@ func decompressLocal(ctx context.Context, decompressCmd, dst, src, ext, descript
 			exitErr.Stderr = buf.Bytes()
 		}
 	}
-	bar.Finish()
 	return err
+}
+
+// ctxReader makes an uninterruptible in-process decode cancellable: once ctx
+// is cancelled each Read returns its error, unwinding the io.Copy that drives
+// the decoder.
+type ctxReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (c *ctxReader) Read(p []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return c.r.Read(p)
 }
 
 func validateCachedDigest(shadDigest string, expectedDigest digest.Digest) error {

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -4,6 +4,8 @@
 package downloader
 
 import (
+	"compress/gzip"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -320,31 +322,48 @@ func TestDownloadLocal(t *testing.T) {
 }
 
 func TestDownloadCompressed(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		// FIXME: `assertion failed: error is not nil: exec: "gzip": executable file not found in %PATH%`
-		t.Skip("Skipping on windows")
-	}
+	testContents := []byte("TestDownloadCompressed")
 
-	t.Run("gzip", func(t *testing.T) {
-		ctx := t.Context()
+	// check builds a compressed fixture via write, downloads it with
+	// decompression, and asserts the result round-trips. With noExternal set,
+	// PATH is emptied so the built-in decoder runs instead of a host binary.
+	check := func(t *testing.T, ext string, write func(io.Writer) error, noExternal bool) {
+		t.Helper()
+		if noExternal {
+			t.Setenv("PATH", t.TempDir())
+		}
 		localPath := filepath.Join(t.TempDir(), t.Name())
-		localFile := filepath.Join(t.TempDir(), "test-file")
-		testDownloadCompressedContents := []byte("TestDownloadCompressed")
-		assert.NilError(t, os.WriteFile(localFile, testDownloadCompressedContents, 0o644))
-		assert.NilError(t, exec.CommandContext(ctx, "gzip", localFile).Run())
-		localFile += ".gz"
-		testLocalFileURL := "file://" + localFile
+		localFile := filepath.Join(t.TempDir(), "test-file"+ext)
+		f, err := os.Create(localFile)
+		assert.NilError(t, err)
+		assert.NilError(t, write(f))
+		assert.NilError(t, f.Close())
 
-		r, err := Download(ctx, localPath, testLocalFileURL, WithDecompress(true))
+		r, err := Download(t.Context(), localPath, "file://"+localFile, WithDecompress(true))
 		assert.NilError(t, err)
 		assert.Equal(t, StatusDownloaded, r.Status)
-
 		got, err := os.ReadFile(localPath)
 		assert.NilError(t, err)
-		assert.Equal(t, string(got), string(testDownloadCompressedContents))
-	})
+		assert.Equal(t, string(got), string(testContents))
+	}
+	writeGz := func(w io.Writer) error {
+		gz := gzip.NewWriter(w)
+		if _, err := gz.Write(testContents); err != nil {
+			return err
+		}
+		return gz.Close()
+	}
+
+	t.Run("gzip", func(t *testing.T) { check(t, ".gz", writeGz, false) })
+	t.Run("gzip without external binary", func(t *testing.T) { check(t, ".gz", writeGz, true) })
 
 	t.Run("bzip2", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			// External bzip2 ships with MSYS2/Git for Windows but not
+			// vanilla Windows, and there is no in-process equivalent
+			// in the standard library.
+			t.Skip("bzip2 binary required to build the fixture")
+		}
 		ctx := t.Context()
 		localPath := filepath.Join(t.TempDir(), t.Name())
 		localFile := filepath.Join(t.TempDir(), "test-file")

--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -13,7 +13,6 @@ import (
 	"github.com/lima-vm/sshocker/pkg/reversesshfs"
 	"github.com/sirupsen/logrus"
 
-	"github.com/lima-vm/lima/v2/pkg/ioutilx"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/sshutil"
 )
@@ -53,12 +52,29 @@ func (a *HostAgent) setupMount(ctx context.Context, m limatype.Mount) (*mount, e
 	logrus.Infof("Mounting %#q on %#q", m.Location, *m.MountPoint)
 
 	resolvedLocation := m.Location
+	var sftpServerBinary string
 	if runtime.GOOS == "windows" {
-		var err error
-		resolvedLocation, err = ioutilx.WindowsSubsystemPath(ctx, m.Location)
+		// LocalPath and the spawned sftp-server must use the same Windows
+		// path form, so anchor both to one ssh.exe: PathForSSH for the path,
+		// SftpServerForSSH for a matching sftp-server (else sshocker may
+		// auto-detect a mismatched one off PATH).
+		sshExe, err := sshutil.NewSSHExe()
 		if err != nil {
 			return nil, err
 		}
+		resolvedLocation, err = sshutil.PathForSSH(ctx, sshExe, m.Location)
+		if err != nil {
+			return nil, err
+		}
+		sftpServerBinary = sshutil.SftpServerForSSH(ctx, sshExe)
+		if sftpServerBinary == "" {
+			// Empty means sshocker auto-detects from PATH, possibly a
+			// mismatched toolchain. On plain Windows this usually means the
+			// OpenSSH.Server feature is missing; warn so it is not a silent
+			// mount failure.
+			logrus.Warnf("reverse-sshfs: no sftp-server matching %q found; sshocker will auto-detect from PATH (Windows OpenSSH.Server may be missing)", sshExe.Exe)
+		}
+		logrus.Debugf("reverse-sshfs: host path %q resolved to %q for sftp-server %q", m.Location, resolvedLocation, sftpServerBinary)
 	}
 
 	sshAddress, sshPort := a.sshAddressPort()
@@ -66,14 +82,15 @@ func (a *HostAgent) setupMount(ctx context.Context, m limatype.Mount) (*mount, e
 	// modifying HostAgent's sshConfig in case of Windows
 	sshConfig := *a.sshConfig
 	rsf := &reversesshfs.ReverseSSHFS{
-		Driver:              *m.SSHFS.SFTPDriver,
-		SSHConfig:           &sshConfig,
-		LocalPath:           resolvedLocation,
-		Host:                sshAddress,
-		Port:                sshPort,
-		RemotePath:          *m.MountPoint,
-		Readonly:            !(*m.Writable),
-		SSHFSAdditionalArgs: []string{"-o", sshfsOptions},
+		Driver:                  *m.SSHFS.SFTPDriver,
+		OpensshSftpServerBinary: sftpServerBinary,
+		SSHConfig:               &sshConfig,
+		LocalPath:               resolvedLocation,
+		Host:                    sshAddress,
+		Port:                    sshPort,
+		RemotePath:              *m.MountPoint,
+		Readonly:                !(*m.Writable),
+		SSHFSAdditionalArgs:     []string{"-o", sshfsOptions},
 	}
 	if runtime.GOOS == "windows" {
 		// cygwin/msys2 doesn't support full feature set over mux socket, this has at least 2 side effects:

--- a/pkg/ioutilx/ioutilx.go
+++ b/pkg/ioutilx/ioutilx.go
@@ -50,13 +50,39 @@ func FromUTF16leToString(r io.Reader) (string, error) {
 	return string(out), nil
 }
 
+// WindowsSubsystemPath converts a Windows path to a Cygwin/MSYS form
+// (C:\Users\jan -> /c/Users/jan) via cygpath on PATH. A caller holding a
+// specific ssh toolchain should use WindowsSubsystemPathWithCygpath, which
+// runs that toolchain's own cygpath and respects its fstab.
 func WindowsSubsystemPath(ctx context.Context, orig string) (string, error) {
-	out, err := exec.CommandContext(ctx, "cygpath", filepath.ToSlash(orig)).CombinedOutput()
-	if err != nil {
-		logrus.WithError(err).Errorf("failed to convert path to mingw, maybe not using Git ssh?")
-		return "", err
+	return WindowsSubsystemPathWithCygpath(ctx, "cygpath", orig)
+}
+
+// WindowsSubsystemPathWithCygpath converts a Windows path with the given
+// cygpathExe ("cygpath" for PATH, or an absolute path to bind the
+// conversion to one Cygwin install). When cygpath is unavailable it falls
+// back to a native conversion of the drive-letter case; UNC and other
+// non-drive-letter inputs return an error.
+func WindowsSubsystemPathWithCygpath(ctx context.Context, cygpathExe, orig string) (string, error) {
+	out, err := exec.CommandContext(ctx, cygpathExe, filepath.ToSlash(orig)).CombinedOutput()
+	if err == nil {
+		return strings.TrimSpace(string(out)), nil
 	}
-	return strings.TrimSpace(string(out)), nil
+	logrus.WithError(err).Debugf("cygpath unavailable for %q (output: %q), attempting native conversion", orig, strings.TrimSpace(string(out)))
+	// Only an absolute drive-letter path has a well-defined Cygwin form
+	// here. A drive-relative "C:foo" would become an unrelated absolute
+	// path, so reject it.
+	if filepath.IsAbs(orig) {
+		if vol := filepath.VolumeName(orig); len(vol) == 2 && vol[1] == ':' {
+			// orig[2:] starts with a separator for an absolute drive path
+			// (C:\foo, C:/foo); strip it so the result stays canonical.
+			tail := strings.TrimPrefix(filepath.ToSlash(orig[2:]), "/")
+			converted := "/" + strings.ToLower(vol[:1]) + "/" + tail
+			logrus.Debugf("native cygpath fallback: %q -> %q", orig, converted)
+			return converted, nil
+		}
+	}
+	return "", fmt.Errorf("cannot convert %q to a Cygwin-style path: cygpath unavailable and input is not an absolute drive-letter path", orig)
 }
 
 func WindowsSubsystemPathForLinux(ctx context.Context, orig, distro string) (string, error) {

--- a/pkg/ioutilx/ioutilx_test.go
+++ b/pkg/ioutilx/ioutilx_test.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ioutilx
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// TestWindowsSubsystemPathWithCygpath_Fallback exercises the native
+// drive-letter fallback path: when the cygpath binary is unreachable,
+// absolute drive-letter inputs convert in-process (e.g. C:\foo -> /c/foo)
+// and inputs without a drive letter return an error.
+func TestWindowsSubsystemPathWithCygpath_Fallback(t *testing.T) {
+	ctx := t.Context()
+	// A bogus binary name guarantees the fallback path runs on every
+	// platform without inventing a Windows-only test.
+	const bogusCygpath = "no-such-cygpath-binary-xyz"
+
+	t.Run("drive-letter backslash", func(t *testing.T) {
+		if runtime.GOOS != "windows" {
+			t.Skip("filepath.VolumeName / IsAbs treat C:\\foo as a relative path on non-Windows")
+		}
+		got, err := WindowsSubsystemPathWithCygpath(ctx, bogusCygpath, `C:\Users\USER`)
+		assert.NilError(t, err)
+		assert.Equal(t, got, "/c/Users/USER")
+	})
+
+	t.Run("drive-letter forward-slash", func(t *testing.T) {
+		if runtime.GOOS != "windows" {
+			t.Skip("filepath.VolumeName / IsAbs only recognize drive letters on Windows")
+		}
+		got, err := WindowsSubsystemPathWithCygpath(ctx, bogusCygpath, `C:/Users/USER`)
+		assert.NilError(t, err)
+		assert.Equal(t, got, "/c/Users/USER")
+	})
+
+	t.Run("non-drive-letter rejected", func(t *testing.T) {
+		// UNC and POSIX inputs both lack a drive letter; on every
+		// platform the fallback must refuse rather than fabricate.
+		for _, input := range []string{`\\server\share\foo`, "/etc/hosts", "relative.txt"} {
+			_, err := WindowsSubsystemPathWithCygpath(ctx, bogusCygpath, input)
+			assert.ErrorContains(t, err, "cannot convert", "input=%q", input)
+		}
+	})
+
+	t.Run("lowercases drive letter", func(t *testing.T) {
+		if runtime.GOOS != "windows" {
+			t.Skip("Windows-only")
+		}
+		got, err := WindowsSubsystemPathWithCygpath(ctx, bogusCygpath, `D:\path`)
+		assert.NilError(t, err)
+		assert.Assert(t, strings.HasPrefix(got, "/d/"), "got %q", got)
+	})
+}

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -594,7 +594,9 @@ func SSHOptsRemovingControlPath(opts []string) []string {
 }
 
 func ParseOpenSSHVersion(version []byte) *semver.Version {
-	regex := regexp.MustCompile(`(?m)^OpenSSH_(\d+\.\d+)(?:p(\d+))?\b`)
+	// Also matches Win32-OpenSSH: OpenSSH_for_Windows_9.5p2, and older
+	// releases with a space before the version (OpenSSH_for_Windows 9.5p2).
+	regex := regexp.MustCompile(`(?m)^OpenSSH(?:_for_Windows[_ ]|_)(\d+\.\d+)(?:p(\d+))?\b`)
 	matches := regex.FindSubmatch(version)
 	if len(matches) == 3 {
 		if len(matches[2]) == 0 {
@@ -602,6 +604,9 @@ func ParseOpenSSHVersion(version []byte) *semver.Version {
 		}
 		return semver.New(fmt.Sprintf("%s.%s", matches[1], matches[2]))
 	}
+	// A 0.0.0 return silently downgrades version-gated behaviour (cipher
+	// choice, scp URL form), so log the unparsed banner for --debug traces.
+	logrus.Debugf("ParseOpenSSHVersion: no match in %q; returning 0.0.0", string(version))
 	return &semver.Version{}
 }
 

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -61,6 +61,13 @@ func NewSSHExe() (SSHExe, error) {
 		}
 	}
 
+	if runtime.GOOS == "windows" {
+		if exe := pickCompleteSSHOnWindows(); exe != "" {
+			sshExe.Exe = exe
+			return sshExe, nil
+		}
+	}
+
 	executable, err := exec.LookPath("ssh")
 	if err != nil {
 		return SSHExe{}, err
@@ -68,6 +75,164 @@ func NewSSHExe() (SSHExe, error) {
 	sshExe.Exe = executable
 
 	return sshExe, nil
+}
+
+// pickCompleteSSHOnWindows returns an ssh.exe whose directory also has
+// scp.exe and ssh-keygen.exe, which Lima needs for create and copy.
+// MinGit ships ssh.exe without those, so a partial install is skipped for
+// the next complete one on PATH, then the native install under
+// %SystemRoot%\System32\OpenSSH. Returns "" when none qualifies, so the
+// caller falls through to exec.LookPath instead of picking a partial one.
+func pickCompleteSSHOnWindows() string {
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			continue
+		}
+		sshPath := filepath.Join(dir, "ssh.exe")
+		if _, err := os.Stat(sshPath); err != nil {
+			continue
+		}
+		if missing := missingSiblings(dir, "scp.exe", "ssh-keygen.exe"); len(missing) > 0 {
+			logrus.Debugf("skipping ssh at %q: missing %v in same directory (likely MinGit or another partial install)", sshPath, missing)
+			continue
+		}
+		return sshPath
+	}
+	nativeSSH := filepath.Join(systemRoot(), "System32", "OpenSSH", "ssh.exe")
+	if _, err := os.Stat(nativeSSH); err == nil {
+		return nativeSSH
+	}
+	return ""
+}
+
+// systemRoot returns %SystemRoot%, or C:\Windows when unset — honouring
+// installs (Windows PE, some enterprise setups) that put it off the C: drive.
+func systemRoot() string {
+	if r := os.Getenv("SystemRoot"); r != "" {
+		return r
+	}
+	return `C:\Windows`
+}
+
+func missingSiblings(dir string, siblings ...string) []string {
+	var missing []string
+	for _, s := range siblings {
+		if _, err := os.Stat(filepath.Join(dir, s)); err != nil {
+			missing = append(missing, s)
+		}
+	}
+	return missing
+}
+
+var (
+	// cygwinDetectCache maps a resolved ssh path to its sibling cygpath.exe,
+	// or "" when that ssh is not Cygwin-based. Each path is probed once.
+	cygwinDetectCache   = map[string]string{}
+	cygwinDetectCacheRW sync.RWMutex
+)
+
+// IsSSHCygwin reports whether sshExe is a Cygwin-based OpenSSH (Git for
+// Windows, MSYS2, Cygwin) rather than native Windows OpenSSH; always false
+// on non-Windows. See cygpathForSSH for the detection and caching.
+func IsSSHCygwin(sshExe SSHExe) bool {
+	_, ok := cygpathForSSH(sshExe)
+	return ok
+}
+
+// cygpathForSSH returns the cygpath.exe beside sshExe (resolved through
+// symlinks) and whether sshExe is Cygwin-based. Callers pass the returned
+// path to exec.Command so conversions run through that toolchain's own
+// cygpath, even when $SSH points outside PATH. ("", false) on non-Windows
+// or empty input; results are cached per resolved path.
+func cygpathForSSH(sshExe SSHExe) (string, bool) {
+	if runtime.GOOS != "windows" || sshExe.Exe == "" {
+		return "", false
+	}
+	path := sshExe.Exe
+	if !filepath.IsAbs(path) {
+		resolved, err := exec.LookPath(path)
+		if err != nil {
+			logrus.WithError(err).Debugf("cygpathForSSH: cannot resolve %q via PATH; assuming native", sshExe.Exe)
+			return "", false
+		}
+		path = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	cygwinDetectCacheRW.RLock()
+	cached, ok := cygwinDetectCache[path]
+	cygwinDetectCacheRW.RUnlock()
+	if ok {
+		return cached, cached != ""
+	}
+	cygpathExe := filepath.Join(filepath.Dir(path), "cygpath.exe")
+	if _, err := os.Stat(cygpathExe); err != nil {
+		logrus.Debugf("ssh at %q detected as native Windows OpenSSH (no cygpath.exe alongside)", path)
+		cygpathExe = ""
+	} else {
+		logrus.Debugf("ssh at %q detected as Cygwin-based (found %q alongside)", path, cygpathExe)
+	}
+	cygwinDetectCacheRW.Lock()
+	cygwinDetectCache[path] = cygpathExe
+	cygwinDetectCacheRW.Unlock()
+	return cygpathExe, cygpathExe != ""
+}
+
+// PathForSSH converts orig to the path form Lima's ssh-family invocations
+// expect; unchanged on non-Windows. On Windows, Cygwin-based ssh (Git for
+// Windows, MSYS2) gets a /c/Users/... form from the sibling cygpath, which
+// respects the toolchain's fstab; native Windows OpenSSH gets forward
+// slashes (C:/Users/...), which native ssh, ssh-keygen, and scp accept.
+func PathForSSH(ctx context.Context, sshExe SSHExe, orig string) (string, error) {
+	if runtime.GOOS != "windows" {
+		return orig, nil
+	}
+	if cygpathExe, ok := cygpathForSSH(sshExe); ok {
+		return ioutilx.WindowsSubsystemPathWithCygpath(ctx, cygpathExe, orig)
+	}
+	return filepath.ToSlash(orig), nil
+}
+
+// SftpServerForSSH returns the sftp-server binary from sshExe's toolchain,
+// so a locally-spawned sftp-server (reverse-sshfs) uses the same path form
+// PathForSSH produces. For Cygwin-based ssh the sibling cygpath resolves
+// /usr/lib/ssh/sftp-server; for native OpenSSH it is sftp-server.exe beside
+// ssh.exe. Returns "" on non-Windows, empty input, or no match, leaving the
+// caller to fall back to its library's auto-detection.
+func SftpServerForSSH(ctx context.Context, sshExe SSHExe) string {
+	if runtime.GOOS != "windows" || sshExe.Exe == "" {
+		return ""
+	}
+	if cygpathExe, ok := cygpathForSSH(sshExe); ok {
+		out, err := exec.CommandContext(ctx, cygpathExe, "-w", "/usr/lib/ssh/sftp-server").Output()
+		if err != nil {
+			return ""
+		}
+		candidate := strings.TrimSpace(string(out))
+		for _, p := range []string{candidate, candidate + ".exe"} {
+			if _, err := os.Stat(p); err == nil {
+				return p
+			}
+		}
+		return ""
+	}
+	path := sshExe.Exe
+	if !filepath.IsAbs(path) {
+		resolved, err := exec.LookPath(path)
+		if err != nil {
+			return ""
+		}
+		path = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	sftpServer := filepath.Join(filepath.Dir(path), "sftp-server.exe")
+	if _, err := os.Stat(sftpServer); err != nil {
+		return ""
+	}
+	return sftpServer
 }
 
 type PubKey struct {
@@ -111,7 +276,11 @@ func DefaultPubKeys(ctx context.Context, loadDotSSH bool) ([]PubKey, error) {
 			// no passphrase, no user@host comment
 			privPath := filepath.Join(configDir, filenames.UserPrivateKey)
 			if runtime.GOOS == "windows" {
-				privPath, err = ioutilx.WindowsSubsystemPath(ctx, privPath)
+				sshExe, sshErr := NewSSHExe()
+				if sshErr != nil {
+					return sshErr
+				}
+				privPath, err = PathForSSH(ctx, sshExe, privPath)
 				if err != nil {
 					return err
 				}
@@ -198,7 +367,7 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 		return nil, err
 	}
 	var opts []string
-	idf, err := identityFileEntry(ctx, privateKeyPath)
+	idf, err := identityFileEntry(ctx, sshExe, privateKeyPath)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +402,7 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 				// Fail on permission-related and other path errors
 				return nil, err
 			}
-			idf, err = identityFileEntry(ctx, privateKeyPath)
+			idf, err = identityFileEntry(ctx, sshExe, privateKeyPath)
 			if err != nil {
 				return nil, err
 			}
@@ -285,9 +454,9 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 	return opts, nil
 }
 
-func identityFileEntry(ctx context.Context, privateKeyPath string) (string, error) {
+func identityFileEntry(ctx context.Context, sshExe SSHExe, privateKeyPath string) (string, error) {
 	if runtime.GOOS == "windows" {
-		privateKeyPath, err := ioutilx.WindowsSubsystemPath(ctx, privateKeyPath)
+		privateKeyPath, err := PathForSSH(ctx, sshExe, privateKeyPath)
 		if err != nil {
 			return "", err
 		}
@@ -381,7 +550,7 @@ func SSHOpts(ctx context.Context, sshExe SSHExe, instDir, username string, useDo
 	}
 	controlPath := fmt.Sprintf(`ControlPath="%s"`, controlSock)
 	if runtime.GOOS == "windows" {
-		controlSock, err = ioutilx.WindowsSubsystemPath(ctx, controlSock)
+		controlSock, err = PathForSSH(ctx, sshExe, controlSock)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -166,6 +166,12 @@ func TestParseOpenSSHVersion(t *testing.T) {
 	// NixOS 25.05
 	assert.Check(t, ParseOpenSSHVersion([]byte(`command-line line 0: Unsupported option "gssapiauthentication"
 OpenSSH_10.0p2, OpenSSL 3.4.1 11 Feb 2025`)).Equal(*semver.New("10.0.2")))
+
+	// Native Windows OpenSSH (Win32-OpenSSH)
+	assert.Check(t, ParseOpenSSHVersion([]byte("OpenSSH_for_Windows_9.5p2, LibreSSL 3.8.2")).Equal(*semver.New("9.5.2")))
+
+	// Older Win32-OpenSSH releases separate "Windows" and the version with a space.
+	assert.Check(t, ParseOpenSSHVersion([]byte("OpenSSH_for_Windows 9.5p2, LibreSSL 3.8.2")).Equal(*semver.New("9.5.2")))
 }
 
 func TestParseOpenSSHGSSAPISupported(t *testing.T) {

--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/coreos/go-semver/semver"
@@ -22,6 +23,132 @@ func TestDefaultPubKeys(t *testing.T) {
 	for _, key := range keys {
 		t.Logf("%s: %#q", key.Filename, key.Content)
 	}
+}
+
+// TestPickCompleteSSHOnWindows: an ssh.exe missing scp.exe or
+// ssh-keygen.exe (MinGit's shape) is skipped for the next complete
+// install on PATH.
+func TestPickCompleteSSHOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only PATH walk")
+	}
+
+	mkDir := func(t *testing.T, exes ...string) string {
+		t.Helper()
+		dir := resolvedTempDir(t)
+		for _, exe := range exes {
+			assert.NilError(t, os.WriteFile(filepath.Join(dir, exe), nil, 0o644))
+		}
+		return dir
+	}
+
+	t.Run("complete install on PATH is picked", func(t *testing.T) {
+		full := mkDir(t, "ssh.exe", "scp.exe", "ssh-keygen.exe")
+		t.Setenv("PATH", full)
+		assert.Equal(t, pickCompleteSSHOnWindows(), filepath.Join(full, "ssh.exe"))
+	})
+
+	t.Run("incomplete install before complete install is skipped", func(t *testing.T) {
+		mingit := mkDir(t, "ssh.exe")
+		full := mkDir(t, "ssh.exe", "scp.exe", "ssh-keygen.exe")
+		t.Setenv("PATH", mingit+string(os.PathListSeparator)+full)
+		assert.Equal(t, pickCompleteSSHOnWindows(), filepath.Join(full, "ssh.exe"))
+	})
+
+	t.Run("falls back to native install when nothing on PATH is complete", func(t *testing.T) {
+		nativeSSH := filepath.Join(systemRoot(), "System32", "OpenSSH", "ssh.exe")
+		if _, err := os.Stat(nativeSSH); err != nil {
+			t.Skipf("native OpenSSH not present at %q on this host", nativeSSH)
+		}
+		mingit := mkDir(t, "ssh.exe")
+		t.Setenv("PATH", mingit)
+		assert.Equal(t, pickCompleteSSHOnWindows(), nativeSSH)
+	})
+}
+
+// resolvedTempDir is t.TempDir() run through EvalSymlinks, matching what
+// the production helpers compute. On GitHub Windows runners t.TempDir()
+// is an 8.3 short path (C:\Users\RUNNER~1\...) that the helpers expand,
+// so a raw compare would fail.
+func resolvedTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	assert.NilError(t, err)
+	return resolved
+}
+
+// TestCygpathForSSH: cygpathForSSH must return the cygpath beside the
+// given ssh.exe, not one off PATH — PathForSSH runs it directly, so a
+// regression would route conversions through the wrong toolchain.
+func TestCygpathForSSH(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("cygpath detection only runs on Windows")
+	}
+
+	t.Run("cygwin", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		sshExe := filepath.Join(dir, "ssh.exe")
+		cygpathExe := filepath.Join(dir, "cygpath.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+		assert.NilError(t, os.WriteFile(cygpathExe, nil, 0o644))
+
+		got, ok := cygpathForSSH(SSHExe{Exe: sshExe})
+		assert.Equal(t, ok, true, "ssh.exe next to cygpath.exe should be Cygwin")
+		assert.Equal(t, got, cygpathExe, "should return the sibling cygpath, not bare 'cygpath'")
+		assert.Equal(t, IsSSHCygwin(SSHExe{Exe: sshExe}), true)
+	})
+
+	t.Run("native", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		sshExe := filepath.Join(dir, "ssh.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+
+		got, ok := cygpathForSSH(SSHExe{Exe: sshExe})
+		assert.Equal(t, ok, false, "ssh.exe with no sibling cygpath.exe should be native")
+		assert.Equal(t, got, "")
+		assert.Equal(t, IsSSHCygwin(SSHExe{Exe: sshExe}), false)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		got, ok := cygpathForSSH(SSHExe{})
+		assert.Equal(t, ok, false)
+		assert.Equal(t, got, "")
+	})
+}
+
+// TestSftpServerForSSH: the sftp-server returned must come from the same
+// install as sshExe, so its Windows path form matches what reverse-sshfs
+// feeds to sshocker.
+func TestSftpServerForSSH(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only path handling")
+	}
+	ctx := t.Context()
+
+	t.Run("native: sibling sftp-server.exe next to ssh.exe", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		sshExe := filepath.Join(dir, "ssh.exe")
+		sftpExe := filepath.Join(dir, "sftp-server.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+		assert.NilError(t, os.WriteFile(sftpExe, nil, 0o644))
+
+		got := SftpServerForSSH(ctx, SSHExe{Exe: sshExe})
+		assert.Equal(t, got, sftpExe)
+	})
+
+	t.Run("native: no sibling sftp-server.exe returns empty", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		sshExe := filepath.Join(dir, "ssh.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+
+		got := SftpServerForSSH(ctx, SSHExe{Exe: sshExe})
+		assert.Equal(t, got, "", "no sftp-server.exe sibling -> caller falls back to sshocker auto-detect")
+	})
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		assert.Equal(t, SftpServerForSSH(ctx, SSHExe{}), "")
+	})
 }
 
 func TestParseOpenSSHVersion(t *testing.T) {

--- a/website/content/en/docs/config/environment-variables.md
+++ b/website/content/en/docs/config/environment-variables.md
@@ -147,20 +147,6 @@ This page documents the environment variables used in Lima.
   export LIMA_USERNET_RESOLVE_IP_ADDRESS_TIMEOUT=5
   ```
 
-### `_LIMA_WINDOWS_EXTRA_PATH`
-
-- **Description**: Additional directories which will be added to PATH by `limactl.exe` process to search for tools.
-  It is useful, when there is a need to prevent collisions between binaries available in active shell and ones
-  used by `limactl.exe` - injecting them only for the running process w/o altering PATH observed by user shell.
-  Is is Windows specific and does nothing for other platforms.
-- **Default**: unset
-- **Usage**:
-  ```bat
-  set _LIMA_WINDOWS_EXTRA_PATH=C:\Program Files\Git\usr\bin
-  ```
-- **Note**: It is an experimental setting and has no guarantees being ever promoted to stable. It may be removed
-  or changed at any stage of project development.
-
 ### `QEMU_SYSTEM_AARCH64`
 
 - **Description**: Path to the `qemu-system-aarch64` binary.

--- a/website/content/en/docs/config/vmtype/wsl2.md
+++ b/website/content/en/docs/config/vmtype/wsl2.md
@@ -42,7 +42,6 @@ containerd:
 - "wsl2" currently doesn't support many of Lima's options. See [this file](https://github.com/lima-vm/lima/blob/master/pkg/wsl2/wsl_driver_windows.go#L19) for the latest supported options.
 - When running lima using "wsl2", `${LIMA_HOME}/<INSTANCE>/serial.log` will not contain kernel boot logs
 - WSL2 requires a `tar` formatted rootfs archive instead of a VM image. Standard VM disk images (like `.qcow2`, `.raw`, etc.) or `.squashfs` images cannot be natively imported by WSL2.
-- Windows doesn't ship with ssh.exe, gzip.exe, etc. which are used by Lima at various points. The easiest way around this is to run `winget install -e --id Git.MinGit` (winget is now built in to Windows as well), and add the resulting `C:\Program Files\Git\usr\bin\` directory to your path.
 
 ### Rootfs Image Requirements & Building Custom Images
 
@@ -76,3 +75,44 @@ If you want to build and use your own custom rootfs, you can build it from a sta
    docker build -o type=tar,dest=custom-rootfs.tar .
    ```
 
+### Windows toolchain
+
+Lima uses an OpenSSH installation on the host. On a default Windows
+install that is the native binaries in `C:\Windows\System32\OpenSSH\`:
+
+- **OpenSSH Client** (`ssh.exe`, `scp.exe`, `ssh-keygen.exe`) ships by default
+  on Windows 10 build 1803 and later, and covers the WSL2 driver.
+- **`sftp-server.exe`** is part of OpenSSH Server, an [optional Feature on Demand](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse).
+  Only the QEMU driver's reverse-sshfs mounts need it. Install via
+  `Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0` from an
+  elevated PowerShell, or via Settings → Apps → Optional features.
+
+Installing [Git for Windows](https://gitforwindows.org/)
+(`winget install -e --id Git.Git`) remains supported as an alternative
+to the native binaries. Use the full Git for Windows installer, not
+MinGit — MinGit omits `scp.exe`, `ssh-keygen.exe`, and `cygpath.exe`,
+all of which Lima needs.
+
+Lima detects which ssh toolchain is in use on each `limactl start` and
+picks both the path form and the matching `sftp-server` binary so both
+sides consume the same shape:
+
+- **Cygwin-based ssh** (Git for Windows, MSYS2): paths are converted by
+  `cygpath` to a POSIX form like `/c/Users/USER`, respecting any custom
+  MSYS2 fstab the user has configured. `sftp-server` is resolved from
+  the same toolchain.
+- **Native Windows OpenSSH**: paths are returned with forward slashes,
+  like `C:/Users/USER` — native `ssh`, `ssh-keygen`, and `scp` accept
+  this form directly. `sftp-server.exe` is picked from the sibling
+  directory of `ssh.exe`.
+
+When no matching `sftp-server` is found, the hostagent logs a warning at
+start and lets `sshocker` auto-detect from `PATH`; a missing
+OpenSSH.Server install on a native-only host typically shows up there.
+
+Note: a custom MSYS2 `fstab` that remaps drive prefixes (rare) makes
+Cygwin's `/c/...` and native's `C:/...` resolve to different directories
+on disk. On such a host, do not swap toolchains between `limactl create`
+and `limactl start` on a QEMU instance with a reverse-sshfs mount —
+the mount would point at a different directory across the swap. Default
+installs without `fstab` overrides are unaffected.


### PR DESCRIPTION
This PR has been created with assistance by Claude Opus 4.7.

It is a refactored and cleaned up version of #4885.

This PR consists of 9 commits that I've kept separate to ease review. I believe they should not be squashed for merging, so we can keep the separate commit messages.

## Summary

`limactl` now works on Windows hosts that have only the toolchain shipped in a default Windows 10/11 install (native OpenSSH, `wsl.exe`, `tar`). Lima previously required Git for Windows or MSYS2 on `PATH` for `cygpath`, `ssh`, `ssh-keygen`, `scp`, and `gzip`. After this branch, none of those external tools are required for the core flow on plain
Windows.

Two coupled root causes drove the historical Git-for-Windows / MSYS2 requirement:

1. **Native Windows OpenSSH does not implement SSH multiplexing** ([PowerShell/Win32-OpenSSH#1328](https://github.com/PowerShell/Win32-OpenSSH/issues/1328)). When Lima needed `ControlMaster` for the legacy ssh-based dynamic port forwarder, native ssh would not work, so Cygwin-built ssh was required.

2. **Cygwin-built ssh expects Cygwin-style paths** (`/c/Users/USER/...`), driving the `cygpath` dependency throughout the codebase.

Three things make the dependency droppable:

- **Lima's default port forwarder has been Go-native since v1.1.0** (`pkg/portfwd/forward.go`, gRPC-tunnelled via vsock). The legacy ssh-based forwarder is opt-in via `LIMA_SSH_PORT_FORWARDER=true`, so `ControlMaster` is not actually needed by the default flow.

- **Native Windows OpenSSH ships `sftp-server.exe`** (when the OpenSSH Server optional feature is installed) and is auto-detected by `sshocker`. Reverse-sshfs works natively once the host-path translation is corrected.

- **Native Windows OpenSSH treats `-F /dev/null` as an empty config**, the same way Cygwin ssh does. Lima's hardcoded `-F /dev/null` argument did not need to change.

## Detection mechanism

`sshutil.IsSSHCygwin(sshExe)` checks whether `cygpath.exe` lives in the same directory as `ssh.exe` (the layout used by Git for Windows and MSYS2), after resolving symlinks so chocolatey/scoop shims do not throw the directory check off. Results are cached per resolved absolute path.

`sshutil.PathForSSH(ctx, sshExe, path)` dispatches:

- Cygwin-based ssh → sibling `cygpath` for path translation (preserves any custom MSYS2 fstab the user has configured)

- Native Windows OpenSSH → `filepath.ToSlash` (e.g. `C:/Users/USER/...`), which native `ssh`, `ssh-keygen`, `scp`, and `sftp-server` accept

`sshutil.SftpServerForSSH(ctx, sshExe)` resolves an `sftp-server` binary that matches `ssh.exe`'s toolchain, so reverse-sshfs's locally-spawned sftp-server consumes paths in the form `PathForSSH` produces. Falls back to sshocker's PATH auto-detection (with a Warn log) when no match is found.

`ioutilx.WindowsSubsystemPath` keeps `cygpath` as the preferred backend but falls back to a native drive-letter conversion (`C:\Users\USER` → `/c/Users/USER`) when `cygpath` is unavailable, so the on-disk Lima config remains identical regardless of toolchain.

## CI changes

This PR introduces `.github/actions/windows_*` composite actions (host scrub, plain-host build, smoke test, WSL2 setup, QEMU install, MSYS2 prep, templates installer) and reorganizes the Windows jobs around them.

### Jobs that already existed on master

- **`windows-wsl2`** (formerly keyed `windows:`, renamed for symmetry with the new plain variant) and **`windows-qemu`** now build on the new composite actions instead of inlined steps. `_LIMA_WINDOWS_EXTRA_PATH` is gone from both; the toolchain they exercise is a strict subset of before.

### New jobs

- **`windows-plain-wsl2`** — builds with `go build` (no `make`, no MSYS2 bash), uninstalls MSYS2 and Git for Windows from the Windows runner, verifies across filesystem / PATH / smoking-gun binaries / registry that the host is genuinely vanilla, then runs a PowerShell smoke test (`create` → `start` → `shell` → `copy` → `stop` → `delete`) against `templates/experimental/wsl2.yaml`.

- **`windows-plain-qemu`** — same shape, with QEMU installed via winget and a templates installer that resolves Lima's template symlinks from git's object store (so the action does not need Developer Mode / admin to materialize NTFS symlinks). Smoke test exercises the same lifecycle plus a guest→host copy round-trip against `templates/default.yaml`.

Both new jobs:

- Pass `--debug` to every `limactl` invocation so the workflow log captures the toolchain-detection result, ssh args, path-translation decisions, etc.

- `if: failure()` step dumps `ha.stderr.log`, `ha.stdout.log`, `serial.log`, `lima.yaml`, `ssh.config` from the instance directory.
