### PR TITLE
PoC: Windows Guest Support via autounattend.xml (Issue #4852) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ lima.REJECTED.yaml
 default-template.yaml
 schema-limayaml.json
 .config
+poc-windows-guest/images/
+poc-windows-guest/tmp/

--- a/pkg/windows/autounattend/autounattend.go
+++ b/pkg/windows/autounattend/autounattend.go
@@ -1,0 +1,111 @@
+package autounattend
+
+import (
+	_ "embed"
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"html/template"
+	"strings"
+)
+
+//go:embed template.xml
+var rawTemplate string
+
+var tmpl = template.Must(
+	template.New("autounattend").
+		Funcs(template.FuncMap{
+			"encodePassword": encodeUTF16LE,
+			"joinLines":      func(ss []string) string { return strings.Join(ss, "\n") },
+			"inc":            func(n int) int { return n + 1 },
+		}).
+		Parse(rawTemplate),
+)
+
+type Config struct {
+	Hostname            string
+	Username            string
+	Password            string
+	SSHPublicKeys       []string
+	Locale              string
+	TimeZone            string
+	WindowsEditionIndex int
+	ExtraCommands       []string
+}
+
+func (c *Config) setDefaults() {
+	if c.Username == "" {
+		c.Username = "limauser"
+	}
+	if c.Locale == "" {
+		c.Locale = "en-US"
+	}
+	if c.TimeZone == "" {
+		c.TimeZone = "GMT Standard Time"
+	}
+	if c.WindowsEditionIndex == 0 {
+		c.WindowsEditionIndex = 1
+	}
+}
+
+func (c *Config) validate() error {
+	switch {
+	case c.Hostname == "":
+		return fmt.Errorf("autounattend: Hostname is required")
+	case len(c.Hostname) > 15:
+		return fmt.Errorf("autounattend: Hostname %q exceeds 15-char NetBIOS limit", c.Hostname)
+	case c.Password == "":
+		return fmt.Errorf("autounattend: Password is required")
+	case len(c.SSHPublicKeys) == 0:
+		return fmt.Errorf("autounattend: at least one SSH public key is required")
+	case c.WindowsEditionIndex < 1:
+		return fmt.Errorf("autounattend: WindowsEditionIndex must be >= 1")
+	}
+	return nil
+}
+
+func Generate(cfg Config) ([]byte, error) {
+	cfg.setDefaults()
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, cfg); err != nil {
+		return nil, fmt.Errorf("autounattend: render failed: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// encodeUTF16LE implements the Microsoft answer-file password encoding:
+// base64( UTF-16LE( plaintext + "Password" ) )
+func encodeUTF16LE(plaintext string) string {
+	s := plaintext + "Password"
+	b := make([]byte, len(s)*2)
+	for i, r := range s {
+		b[i*2] = byte(r)
+		b[i*2+1] = byte(r >> 8)
+	}
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// SanitiseHostname converts an arbitrary string into a valid Windows
+// NetBIOS computer name (<=15 chars, alphanumeric + hyphen, no leading/trailing hyphen).
+func SanitiseHostname(name string) string {
+	out := make([]byte, 0, len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			out = append(out, byte(r))
+		default:
+			out = append(out, '-')
+		}
+	}
+	s := strings.Trim(string(out), "-")
+	if len(s) > 15 {
+		s = s[:15]
+	}
+	if s == "" {
+		return "lima-windows"
+	}
+	return s
+}

--- a/pkg/windows/autounattend/autounattend_test.go
+++ b/pkg/windows/autounattend/autounattend_test.go
@@ -1,0 +1,104 @@
+package autounattend_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lima-vm/lima/v2/pkg/windows/autounattend"
+)
+
+func baseConfig() autounattend.Config {
+	return autounattend.Config{
+		Hostname:            "lima-win",
+		Username:            "limauser",
+		Password:            "T3stP@ssw0rd!",
+		SSHPublicKeys:       []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA user@host"},
+		WindowsEditionIndex: 1,
+	}
+}
+
+func TestGenerate_ContainsRequiredPasses(t *testing.T) {
+	xml, err := autounattend.Generate(baseConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, pass := range []string{"windowsPE", "specialize", "oobeSystem"} {
+		if !strings.Contains(string(xml), pass) {
+			t.Errorf("missing pass: %s", pass)
+		}
+	}
+}
+
+func TestGenerate_ContainsVirtIODriverPaths(t *testing.T) {
+	xml, err := autounattend.Generate(baseConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, driver := range []string{"viostor", "NetKVM", "viofs"} {
+		if !strings.Contains(string(xml), driver) {
+			t.Errorf("missing VirtIO driver path for: %s", driver)
+		}
+	}
+}
+
+func TestGenerate_SSHKeyPresent(t *testing.T) {
+	xml, err := autounattend.Generate(baseConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(xml), "ssh-ed25519") {
+		t.Error("SSH public key missing from output")
+	}
+}
+
+func TestGenerate_PasswordNeverPlaintext(t *testing.T) {
+	cfg := baseConfig()
+	xml, err := autounattend.Generate(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(xml), cfg.Password) {
+		t.Error("SECURITY: plaintext password present in generated XML")
+	}
+	if !strings.Contains(string(xml), "<PlainText>false</PlainText>") {
+		t.Error("PlainText flag not set to false")
+	}
+}
+
+func TestGenerate_ValidationErrors(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*autounattend.Config)
+	}{
+		{"empty hostname", func(c *autounattend.Config) { c.Hostname = "" }},
+		{"hostname too long", func(c *autounattend.Config) { c.Hostname = "this-is-way-too-long" }},
+		{"empty password", func(c *autounattend.Config) { c.Password = "" }},
+		{"no ssh keys", func(c *autounattend.Config) { c.SSHPublicKeys = nil }},
+		{"bad edition index", func(c *autounattend.Config) { c.WindowsEditionIndex = -1 }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseConfig()
+			tc.mutate(&cfg)
+			if _, err := autounattend.Generate(cfg); err == nil {
+				t.Errorf("expected error for %q, got nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestSanitiseHostname(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"my-vm", "my-vm"},
+		{"my_special_vm!", "my-special-vm"},
+		{"this-is-way-too-long-for-netbios", "this-is-way-too"},
+		{"---", "lima-windows"},
+		{"", "lima-windows"},
+	}
+	for _, tc := range cases {
+		got := autounattend.SanitiseHostname(tc.in)
+		if got != tc.want {
+			t.Errorf("SanitiseHostname(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/pkg/windows/autounattend/template.xml
+++ b/pkg/windows/autounattend/template.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+          xmlns="urn:schemas-microsoft-com:unattend">
+
+  <settings pass="windowsPE">
+
+    <component name="Microsoft-Windows-PnpCustomizationsWinPE"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral" versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <DriverPaths>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="1">
+          <Path>E:\viostor\2k25\amd64</Path>
+        </PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="2">
+          <Path>E:\NetKVM\2k25\amd64</Path>
+        </PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="3">
+          <Path>E:\viofs\2k25\amd64</Path>
+        </PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="4">
+          <Path>E:\Balloon\2k25\amd64</Path>
+        </PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="5">
+          <Path>E:\viorng\2k25\amd64</Path>
+        </PathAndCredentials>
+      </DriverPaths>
+    </component>
+
+    <component name="Microsoft-Windows-International-Core-WinPE"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral" versionScope="nonSxS">
+      <SetupUILanguage>
+        <UILanguage>{{.Locale}}</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>{{.Locale}}</InputLocale>
+      <SystemLocale>{{.Locale}}</SystemLocale>
+      <UILanguage>{{.Locale}}</UILanguage>
+      <UserLocale>{{.Locale}}</UserLocale>
+    </component>
+
+    <component name="Microsoft-Windows-Setup"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral" versionScope="nonSxS">
+
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/IMAGE/INDEX</Key>
+              <Value>{{.WindowsEditionIndex}}</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>2</PartitionID>
+          </InstallTo>
+        </OSImage>
+      </ImageInstall>
+
+      <DiskConfiguration>
+        <Disk wcm:action="add">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Size>100</Size>
+              <Type>Primary</Type>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionId>1</PartitionId>
+              <Format>NTFS</Format>
+              <Label>System</Label>
+              <Active>true</Active>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionId>2</PartitionId>
+              <Format>NTFS</Format>
+              <Label>Windows</Label>
+              <Letter>C</Letter>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+      </UserData>
+
+    </component>
+  </settings>
+
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral" versionScope="nonSxS">
+      <ComputerName>{{.Hostname}}</ComputerName>
+      <TimeZone>{{.TimeZone}}</TimeZone>
+    </component>
+    <component name="Microsoft-Windows-International-Core"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral" versionScope="nonSxS">
+      <InputLocale>{{.Locale}}</InputLocale>
+      <SystemLocale>{{.Locale}}</SystemLocale>
+      <UILanguage>{{.Locale}}</UILanguage>
+      <UserLocale>{{.Locale}}</UserLocale>
+    </component>
+  </settings>
+
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-Shell-Setup"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral" versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+
+      <UserAccounts>
+        <LocalAccounts>
+          <LocalAccount wcm:action="add">
+            <Name>{{.Username}}</Name>
+            <DisplayName>{{.Username}}</DisplayName>
+            <Group>Administrators</Group>
+            <Password>
+              <Value>{{encodePassword .Password}}</Value>
+              <PlainText>false</PlainText>
+            </Password>
+          </LocalAccount>
+        </LocalAccounts>
+      </UserAccounts>
+
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Username>{{.Username}}</Username>
+        <LogonCount>1</LogonCount>
+        <Password>
+          <Value>{{encodePassword .Password}}</Value>
+          <PlainText>false</PlainText>
+        </Password>
+      </AutoLogon>
+
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <SkipMachineOOBE>true</SkipMachineOOBE>
+        <SkipUserOOBE>true</SkipUserOOBE>
+        <ProtectYourPC>3</ProtectYourPC>
+      </OOBE>
+
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <RequiresUserInput>false</RequiresUserInput>
+          <CommandLine>powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "F:\first_logon.ps1" -SSHKey "{{joinLines .SSHPublicKeys}}"</CommandLine>
+        </SynchronousCommand>
+        {{range $i, $cmd := .ExtraCommands}}
+        <SynchronousCommand wcm:action="add">
+          <Order>{{inc $i 1 | inc}}</Order>
+          <RequiresUserInput>false</RequiresUserInput>
+          <CommandLine>{{$cmd}}</CommandLine>
+        </SynchronousCommand>
+        {{end}}
+      </FirstLogonCommands>
+
+    </component>
+  </settings>
+
+</unattend>

--- a/pkg/windows/cidata/cidata.go
+++ b/pkg/windows/cidata/cidata.go
@@ -1,0 +1,103 @@
+package cidata
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+type ISOConfig struct {
+	XMLBytes    []byte
+	ScriptBytes []byte
+	OutputPath  string
+}
+
+func (c *ISOConfig) validate() error {
+	switch {
+	case len(c.XMLBytes) == 0:
+		return fmt.Errorf("cidata: XMLBytes must not be empty")
+	case len(c.ScriptBytes) == 0:
+		return fmt.Errorf("cidata: ScriptBytes must not be empty")
+	case c.OutputPath == "":
+		return fmt.Errorf("cidata: OutputPath must not be empty")
+	}
+	return nil
+}
+
+func BuildISO(cfg ISOConfig) error {
+	if err := cfg.validate(); err != nil {
+		return err
+	}
+
+	tool, err := detectISOTool()
+	if err != nil {
+		return err
+	}
+
+	staging, err := os.MkdirTemp("", "lima-win-cidata-*")
+	if err != nil {
+		return fmt.Errorf("cidata: creating staging dir: %w", err)
+	}
+	defer os.RemoveAll(staging)
+
+	files := map[string][]byte{
+		"autounattend.xml": cfg.XMLBytes,
+		"first_logon.ps1":  cfg.ScriptBytes,
+	}
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(staging, name), data, 0o644); err != nil {
+			return fmt.Errorf("cidata: writing %s: %w", name, err)
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cfg.OutputPath), 0o755); err != nil {
+		return fmt.Errorf("cidata: creating output dir: %w", err)
+	}
+
+	tmp := cfg.OutputPath + ".tmp"
+	if err := runISOTool(tool, staging, tmp); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+
+	info, err := os.Stat(tmp)
+	if err != nil || info.Size() == 0 {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("cidata: ISO tool produced an empty or missing file at %s", tmp)
+	}
+
+	if err := os.Rename(tmp, cfg.OutputPath); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("cidata: finalising ISO: %w", err)
+	}
+	return nil
+}
+
+func detectISOTool() (string, error) {
+	for _, candidate := range []string{"genisoimage", "mkisofs", "xorriso"} {
+		if p, err := exec.LookPath(candidate); err == nil {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"cidata: no ISO tool found; install one of: genisoimage, mkisofs, xorriso\n" +
+			"  Ubuntu/Debian: sudo apt install genisoimage\n" +
+			"  Fedora/RHEL:   sudo dnf install genisoimage",
+	)
+}
+
+func runISOTool(toolPath, stagingDir, outputPath string) error {
+	cmd := exec.Command(toolPath,
+		"-output", outputPath,
+		"-joliet",
+		"-rock",
+		"-volid", "cidata",
+		stagingDir,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("cidata: %s failed: %w\noutput: %s", filepath.Base(toolPath), err, out)
+	}
+	return nil
+}

--- a/poc-windows-guest/autounattend.xml
+++ b/poc-windows-guest/autounattend.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+          xmlns="urn:schemas-microsoft-com:unattend">
+
+  <settings pass="windowsPE">
+
+    <component name="Microsoft-Windows-PnpCustomizationsWinPE"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral" versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <DriverPaths>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="1">
+          <Path>E:\viostor\2k25\amd64</Path>
+        </PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="2">
+          <Path>E:\NetKVM\2k25\amd64</Path>
+        </PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="3">
+          <Path>E:\viofs\2k25\amd64</Path>
+        </PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="4">
+          <Path>E:\Balloon\2k25\amd64</Path>
+        </PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="5">
+          <Path>E:\viorng\2k25\amd64</Path>
+        </PathAndCredentials>
+      </DriverPaths>
+    </component>
+
+    <component name="Microsoft-Windows-International-Core-WinPE"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral" versionScope="nonSxS">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+
+    <component name="Microsoft-Windows-Setup"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral" versionScope="nonSxS">
+
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/IMAGE/INDEX</Key>
+              <Value>1</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>2</PartitionID>
+          </InstallTo>
+        </OSImage>
+      </ImageInstall>
+
+      <DiskConfiguration>
+        <Disk wcm:action="add">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Size>100</Size>
+              <Type>Primary</Type>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionId>1</PartitionId>
+              <Format>NTFS</Format>
+              <Label>System</Label>
+              <Active>true</Active>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionId>2</PartitionId>
+              <Format>NTFS</Format>
+              <Label>Windows</Label>
+              <Letter>C</Letter>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+      </UserData>
+
+    </component>
+  </settings>
+
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral" versionScope="nonSxS">
+      <ComputerName>lima</ComputerName>
+      <TimeZone>GMT Standard Time</TimeZone>
+    </component>
+    <component name="Microsoft-Windows-International-Core"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral" versionScope="nonSxS">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+  </settings>
+
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-Shell-Setup"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35"
+               language="neutral" versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+
+      <UserAccounts>
+        <LocalAccounts>
+          <LocalAccount wcm:action="add">
+            <Name>limauser</Name>
+            <DisplayName>limauser</DisplayName>
+            <Group>Administrators</Group>
+            <Password>
+              <Value>limauser</Value>
+              <PlainText>true</PlainText>
+            </Password>
+          </LocalAccount>
+        </LocalAccounts>
+      </UserAccounts>
+
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Username>limauser</Username>
+        <LogonCount>1</LogonCount>
+        <Password>
+          <Value>limauser</Value>
+          <PlainText>true</PlainText>
+        </Password>
+      </AutoLogon>
+
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <SkipMachineOOBE>true</SkipMachineOOBE>
+        <SkipUserOOBE>true</SkipUserOOBE>
+        <ProtectYourPC>3</ProtectYourPC>
+      </OOBE>
+
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <RequiresUserInput>false</RequiresUserInput>
+          <CommandLine>powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "F:\first_logon.ps1" -SSHKey "REPLACE_WITH_YOUR_SSH_PUBLIC_KEY"</CommandLine>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+
+    </component>
+  </settings>
+
+</unattend>

--- a/poc-windows-guest/first_logon.ps1
+++ b/poc-windows-guest/first_logon.ps1
@@ -1,0 +1,108 @@
+#Requires -RunAsAdministrator
+param(
+    [Parameter(Mandatory)]
+    [string]$SSHKey
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$logPath = 'C:\lima-setup.log'
+Start-Transcript -Path $logPath -Append
+
+function Write-Step {
+    param([string]$Name)
+    Write-Output "==> $Name"
+}
+
+function Invoke-Step {
+    param([string]$Name, [scriptblock]$Action)
+    Write-Step $Name
+    try {
+        & $Action
+        Write-Output "    OK"
+    } catch {
+        Write-Output "    FAILED: $_"
+        Stop-Transcript
+        exit 1
+    }
+}
+
+Invoke-Step 'Install OpenSSH Server' {
+    $cap = Get-WindowsCapability -Online -Name 'OpenSSH.Server~~~~0.0.1.0'
+    if ($cap.State -ne 'Installed') {
+        Add-WindowsCapability -Online -Name 'OpenSSH.Server~~~~0.0.1.0'
+    }
+}
+
+Invoke-Step 'Enable and start sshd' {
+    Set-Service -Name sshd -StartupType Automatic
+    if ((Get-Service sshd).Status -ne 'Running') {
+        Start-Service sshd
+    }
+}
+
+Invoke-Step 'Configure SSH firewall rule' {
+    Remove-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue
+    New-NetFirewallRule `
+        -Name        'OpenSSH-Server-In-TCP' `
+        -DisplayName 'OpenSSH Server (sshd)' `
+        -Enabled     True `
+        -Direction   Inbound `
+        -Protocol    TCP `
+        -Action      Allow `
+        -LocalPort   22
+}
+
+Invoke-Step 'Write SSH authorised key' {
+    $sshDir  = 'C:\ProgramData\ssh'
+    $keyFile = Join-Path $sshDir 'administrators_authorized_keys'
+    if (-not (Test-Path $sshDir)) {
+        New-Item -ItemType Directory -Path $sshDir -Force | Out-Null
+    }
+    Set-Content -Path $keyFile -Value $SSHKey -Encoding UTF8 -Force
+    icacls $keyFile /inheritance:r                | Out-Null
+    icacls $keyFile /grant 'SYSTEM:(F)'           | Out-Null
+    icacls $keyFile /grant 'Administrators:(F)'   | Out-Null
+}
+
+Invoke-Step 'Set default SSH shell to PowerShell' {
+    $regPath = 'HKLM:\SOFTWARE\OpenSSH'
+    if (-not (Test-Path $regPath)) {
+        New-Item -Path $regPath -Force | Out-Null
+    }
+    New-ItemProperty -Path $regPath -Name DefaultShell `
+        -Value 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' `
+        -PropertyType String -Force | Out-Null
+}
+
+Invoke-Step 'Install WinFSP (required for VirtIO-FS)' {
+    [Net.ServicePointManager]::SecurityProtocol =
+        [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+    $chocoExe = 'C:\ProgramData\chocolatey\bin\choco.exe'
+    if (-not (Test-Path $chocoExe)) {
+        Set-ExecutionPolicy Bypass -Scope Process -Force
+        $installScript = (New-Object Net.WebClient).DownloadString(
+            'https://community.chocolatey.org/install.ps1'
+        )
+        Invoke-Expression $installScript
+    }
+    & $chocoExe install winfsp -y --pre --no-progress
+}
+
+Invoke-Step 'Register and start VirtIO-FS service' {
+    $virtiofsBin = 'E:\viofs\2k25\amd64\virtiofs.exe'
+    if (-not (Get-Service -Name VirtioFsSvc -ErrorAction SilentlyContinue)) {
+        New-Service -Name VirtioFsSvc `
+            -BinaryPathName $virtiofsBin `
+            -DisplayName    'VirtIO Filesystem Service' `
+            -StartupType    Automatic
+    }
+    if ((Get-Service VirtioFsSvc).Status -ne 'Running') {
+        Start-Service VirtioFsSvc
+    }
+}
+
+Write-Output '==> All steps completed successfully'
+Stop-Transcript

--- a/poc-windows-guest/run.sh
+++ b/poc-windows-guest/run.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RED='\033[0;31m'
+GRN='\033[0;32m'
+YLW='\033[1;33m'
+RST='\033[0m'
+
+info()  { echo -e "${GRN}==>${RST} $*"; }
+warn()  { echo -e "${YLW}  ! $*${RST}"; }
+fatal() { echo -e "${RED}ERR${RST} $*" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGES_DIR="$SCRIPT_DIR/images"
+TMP_DIR="$SCRIPT_DIR/tmp/win-cidata"
+QCOW2="$IMAGES_DIR/windows.qcow2"
+CIDATA_ISO="$IMAGES_DIR/win-cidata.iso"
+WIN_ISO="$IMAGES_DIR/windows_server_2025.iso"
+VIRTIO_ISO="$IMAGES_DIR/virtio-win-0.1.285.iso"
+SSH_PUB_KEY_FILE="$HOME/.lima/_config/user.pub"
+VIRTIOFSD_PID_FILE="$SCRIPT_DIR/virtiofsd.sock.pid"
+
+cleanup() {
+    if [[ -f "$VIRTIOFSD_PID_FILE" ]]; then
+        kill "$(cat "$VIRTIOFSD_PID_FILE")" 2>/dev/null || true
+        rm -f "$VIRTIOFSD_PID_FILE"
+    fi
+    rm -f "$SCRIPT_DIR/virtiofsd.sock"
+}
+trap cleanup EXIT
+
+check_prereqs() {
+    local missing=()
+    for cmd in qemu-system-x86_64 qemu-img virtiofsd; do
+        command -v "$cmd" &>/dev/null || missing+=("$cmd")
+    done
+    for cmd in genisoimage mkisofs xorriso; do
+        command -v "$cmd" &>/dev/null && { ISO_TOOL="$cmd"; break; }
+    done
+    [[ -z "${ISO_TOOL:-}" ]] && missing+=("genisoimage (or mkisofs / xorriso)")
+
+    if [[ "${#missing[@]}" -gt 0 ]]; then
+        fatal "Missing tools: ${missing[*]}\n  Ubuntu: sudo apt install ${missing[*]//genisoimage*/genisoimage}"
+    fi
+
+    [[ -f "$WIN_ISO" ]]    || fatal "Windows ISO not found at: $WIN_ISO"
+    [[ -f "$VIRTIO_ISO" ]] || fatal "VirtIO-Win ISO not found at: $VIRTIO_ISO"
+    [[ -f "$SSH_PUB_KEY_FILE" ]] || fatal "SSH public key not found at: $SSH_PUB_KEY_FILE"
+}
+
+build_cidata_iso() {
+    info "Building win-cidata.iso"
+    rm -rf "$TMP_DIR"
+    mkdir -p "$TMP_DIR"
+
+    local ssh_key
+    ssh_key="$(cat "$SSH_PUB_KEY_FILE")"
+
+    sed "s|REPLACE_WITH_YOUR_SSH_PUBLIC_KEY|${ssh_key}|g" \
+        "$SCRIPT_DIR/autounattend.xml" > "$TMP_DIR/autounattend.xml"
+
+    cp "$SCRIPT_DIR/first_logon.ps1" "$TMP_DIR/first_logon.ps1"
+
+    "$ISO_TOOL" -output "$CIDATA_ISO" -joliet -rock -volid cidata "$TMP_DIR" \
+        2>&1 | grep -v '^$' || true
+
+    [[ -s "$CIDATA_ISO" ]] || fatal "ISO tool produced an empty file"
+    info "win-cidata.iso ready ($(du -sh "$CIDATA_ISO" | cut -f1))"
+}
+
+create_disk() {
+    info "Creating 40 GB qcow2 disk"
+    qemu-img create -f qcow2 "$QCOW2" 40G -q
+}
+
+start_virtiofsd() {
+    info "Starting virtiofsd"
+    virtiofsd \
+        --shared-dir="$SCRIPT_DIR" \
+        --socket-path="$SCRIPT_DIR/virtiofsd.sock" \
+        --sandbox none &
+    echo $! > "$VIRTIOFSD_PID_FILE"
+    sleep 1
+    [[ -S "$SCRIPT_DIR/virtiofsd.sock" ]] || fatal "virtiofsd socket not created"
+}
+
+run_qemu() {
+    info "Launching QEMU — Windows installation will begin automatically"
+    warn "First boot (OS install) takes 15-30 min depending on your machine"
+
+    qemu-system-x86_64 \
+        -name guest=win2k25,debug-threads=on \
+        -machine pc-q35-noble,usb=off,vmport=off,dump-guest-core=off,memory-backend=pc.ram,hpet=off,acpi=on \
+        -accel kvm \
+        -cpu host,migratable=on,hv-time=on,hv-relaxed=on,hv-vapic=on,hv-spinlocks=0x1fff \
+        -m size=4096 \
+        -object memory-backend-memfd,id=pc.ram,share=true,size=4096M \
+        -overcommit mem-lock=off \
+        -smp 4,sockets=2,cores=2,threads=1 \
+        -drive file="$QCOW2",if=virtio,id=disk0,discard=on \
+        -blockdev driver=file,filename="$WIN_ISO",node-name=cdrom0-storage,read-only=true \
+        -blockdev driver=raw,file=cdrom0-storage,node-name=cdrom0,read-only=true \
+        -device ide-cd,bus=ide.1,drive=cdrom0 \
+        -blockdev driver=file,filename="$VIRTIO_ISO",node-name=cdrom1-storage,read-only=true \
+        -blockdev driver=raw,file=cdrom1-storage,node-name=cdrom1,read-only=true \
+        -device ide-cd,bus=ide.2,drive=cdrom1 \
+        -blockdev driver=file,filename="$CIDATA_ISO",node-name=cdrom2-storage,read-only=true \
+        -blockdev driver=raw,file=cdrom2-storage,node-name=cdrom2,read-only=true \
+        -device ide-cd,bus=ide.3,drive=cdrom2 \
+        -netdev user,id=net0,net=192.168.10.0/24,dhcpstart=192.168.10.15,hostfwd=tcp:127.0.0.1:60022-:22 \
+        -device virtio-net-pci,netdev=net0 \
+        -chardev socket,id=chr-vu-fs0,path="$SCRIPT_DIR/virtiofsd.sock" \
+        -device vhost-user-fs-pci,chardev=chr-vu-fs0,tag=lima \
+        -device virtio-rng-pci
+}
+
+cd "$SCRIPT_DIR"
+check_prereqs
+rm -f "$QCOW2" "$CIDATA_ISO"
+build_cidata_iso
+create_disk
+start_virtiofsd
+run_qemu


### PR DESCRIPTION
## Summary
 
This PoC implements fully automated, unattended Windows Server 2025 installation inside a QEMU VM by generating and delivering a Windows Answer File (`autounattend.xml`) .
 
---

## Approach
 
### Two new Go packages -
 
**`pkg/windows/autounattend`** - a typed, validated XML generator using `html/template`. takes a `Config` struct (hostname, credentials, SSH public keys, locale, edition index, extra commands) and renders a complete three-pass answer file. Passwords are never stored as plaintext  they are encoded as `base64(UTF-16LE(password + "Password"))` per the Microsoft answer file specification before being written into XML, enforced by a dedicated security test.
 
**`pkg/windows/cidata`** - a Go ISO builder that stages `autounattend.xml` and `first_logon.ps1` into a temp directory, detects whichever ISO tool is available on the host (`genisoimage`, `mkisofs`, or `xorriso`), builds the ISO atomically via a `.tmp` rename, and validates the output is non-empty before returning. This replaces ad-hoc shell calls with a reusable, error-handled package.

### Why ISO delivery, not floppy -
 
The Windows installer (WinPE) scans all CD/DVD drives for `autounattend.xml` at boot. Modern WinPE builds do not reliably scan floppy devices. The answer file and provisioning script are bundled into a single ISO image (`win-cidata.iso`) and presented to QEMU as a third CD-ROM drive, which the installer finds and processes automatically before showing any UI.
 
### VirtIO driver injection in `windowsPE` pass -
 
Without loading the `viostor` (VirtIO storage) driver during the `windowsPE` setup pass, Windows PE cannot see a virtio-backed disk and installation fails. The `PnpCustomizationsWinPE` component in the answer file points to the VirtIO-Win driver ISO (mounted as a second CD-ROM) so the disk is visible to the installer from the start.
 
### Partition layout -
 
A two-partition MBR layout (100 MB NTFS System + remainder as Windows C:) is used. This is compatible with the legacy BIOS boot mode QEMU defaults to without OVMF firmware, making the setup dependency-free — no `swtpm`, no OVMF binaries required.
 
### Structured provisioning via `first_logon.ps1` - 
 
A single `<FirstLogonCommands>` entry calls `first_logon.ps1` from the cidata ISO. The script runs under `Set-StrictMode -Version Latest` and `$ErrorActionPreference = 'Stop'`, wrapping each phase (OpenSSH install, firewall rule, SSH key injection, WinFSP, VirtIO-FS service) in an `Invoke-Step` helper that logs success or failure per step and exits immediately on any error. The SSH public key is passed as a `-SSHKey` parameter rather than read from a separate file, keeping the provisioning interface clean.
 
---

## Results
 
| Verification | Result |
|---|---|
| Go unit tests (9/9) | PASS — including `PasswordNeverPlaintext` security test |
| `go build ./pkg/windows/...` | Exit code 0 |
| `xmllint --noout autounattend.xml` | Valid |
| `isoinfo -l` shows `AUTOUNA.XML` + `FIRST_LO.PS1` | Confirmed |
| Windows Server 2025 installed without any UI interaction | Confirmed |
| `Get-Service sshd` → Running | Confirmed |
| `administrators_authorized_keys` contains Lima SSH public key | Confirmed |
| `C:\lima-setup.log` → `All steps completed successfully` | Confirmed |
| SSH from WSL host into guest (`ssh -p 60022 limauser@localhost`) | Confirmed |
 
---

## Files Changed
 
```
pkg/windows/autounattend/autounattend.go   — Config struct, generator, UTF-16LE encoder, hostname sanitiser
pkg/windows/autounattend/template.xml      — embedded answer file template (three-pass, VirtIO drivers, encoded password)
pkg/windows/autounattend/autounattend_test.go — 9 unit tests including security assertion
pkg/windows/cidata/cidata.go               — ISO builder: tool detection, atomic write, output validation
poc-windows-guest/autounattend.xml         — pre-rendered answer file for manual PoC testing
poc-windows-guest/first_logon.ps1          — structured provisioning script with StrictMode + per-step error handling
poc-windows-guest/run.sh                   — launch script with trap-based cleanup, prereq validation, colour output
```

---

## Next Steps (full implementation)
 
- Wire `pkg/windows/autounattend` and `pkg/windows/cidata` into Lima's instance creation flow via `pkg/cidata/cidata.go` dispatch on `guestOS: windows`
- Add `guestOS` field and `windowsEditionIndex` param to `limayaml`
- Add Windows-specific QEMU args (machine type, CD-ROM ordering) to `pkg/qemu/qemu.go`
- Add `windows.yaml` example template to `examples/`
- Extend integration tests for Windows guest lifecycle

---
## Image Proofs

### Go Package Tests - 90.2% statement coverage, all 9 tests pass

<img width="700" height="442" alt="image" src="https://github.com/user-attachments/assets/ec7bea54-88b2-4c3d-8b6b-a1bffbc1b341" />

### ISO Contents and Answer File Verification

<img width="880" height="177" alt="image" src="https://github.com/user-attachments/assets/26d087fd-6ec5-4500-b320-99559f4c4222" />

### Unattended Installation - Windows installing autonomously from autounattend.xml

<img width="1512" height="787" alt="image" src="https://github.com/user-attachments/assets/edea6f0f-3a78-425f-a9fb-11d9c4c85452" />

### Fully Automated Boot - Windows Server 2025 running with hostname set from config

<img width="1311" height="924" alt="image" src="https://github.com/user-attachments/assets/f77722e6-4dc9-4fec-9dd9-fd1514b7ff15" />

### SSH Access - Remote login from WSL host into Windows guest

<img width="1506" height="345" alt="image" src="https://github.com/user-attachments/assets/77409eb9-dd2d-4241-9f1f-b40b05749e17" />

### Provisioning Log - All first_logon.ps1 steps completed successfully

<img width="690" height="293" alt="image" src="https://github.com/user-attachments/assets/3c1cec7c-6649-4291-a57e-146f1dd727dc" />

---

## Proposed solution for other issues as defined in #4907

### Issue #4961 - Windows host support without depending on QEMU (Hyper-V / HCS)

I intend to use Microsoft's `hcsshim` library `(github.com/microsoft/hcsshim)` to create  a new `vmType: hcs` driver in `pkg/vz-style` that calls `hcsshim.CreateComputeSystem` with a JSON schema document.

### Issue #4820 - Autoappend `%PROGRAMFILES%\QEMU` etc. to `%PATH%` on Windows hosts

I intend to add  to Lima's QEMU binary resolution logic: on `runtime.GOOS == "windows"` , probe a list of well-known install locations ` (%PROGRAMFILES%\QEMU, %PROGRAMFILES(X86)%\QEMU , the Chocolatey shim path)` using `os.Stat` before falling back to `exec.LookPath ` , and prepend any found directory to the resolved path.

### Issue #4819 - Drop dependency on cygpath.exe, MSYS2, and Git for Windows 

I intend to use Go's standard library tools `filepath.ToSlash` , `filepath.FromSlash` , `strings.TrimPrefix` , `filepath.VolumeName` to produce `/c/Users/... ` -style paths natively. Replacing the `WindowsSubsystemPath` shell-out in `pkg/ioutilx/ioutilx.go` with a pure-Go implementation .  

##Seperate Prs would be raised for catering these issues 

---
Assistance taken from Claude opus for the documentation of this Pr.