### PR TITLE
Change %q in logs and errors to %#q [Part2]

### DIFF
--- a/cmd/lima-guestagent/daemon_linux.go
+++ b/cmd/lima-guestagent/daemon_linux.go
@@ -142,7 +142,7 @@ func daemonAction(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 		l = socketL
-		logrus.Infof("serving the guest agent on %q", socket)
+		logrus.Infof("serving the guest agent on %#q", socket)
 	}
 	defer logrus.Debug("exiting lima-guestagent daemon")
 	return server.StartServer(ctx, l, &server.GuestServer{Agent: agent, TunnelS: portfwdserver.NewTunnelServer()})

--- a/cmd/lima-guestagent/install_systemd_linux.go
+++ b/cmd/lima-guestagent/install_systemd_linux.go
@@ -58,10 +58,10 @@ func installSystemdAction(cmd *cobra.Command, _ []string) error {
 	unitFileChanged := true
 	if _, err := os.Stat(unitPath); !errors.Is(err, os.ErrNotExist) {
 		if existingUnit, err := os.ReadFile(unitPath); err == nil && bytes.Equal(unit, existingUnit) {
-			logrus.Infof("File %q is up-to-date", unitPath)
+			logrus.Infof("File %#q is up-to-date", unitPath)
 			unitFileChanged = false
 		} else {
-			logrus.Infof("File %q needs update", unitPath)
+			logrus.Infof("File %#q needs update", unitPath)
 		}
 	} else {
 		unitDir := filepath.Dir(unitPath)
@@ -73,7 +73,7 @@ func installSystemdAction(cmd *cobra.Command, _ []string) error {
 		if err := os.WriteFile(unitPath, unit, 0o644); err != nil {
 			return err
 		}
-		logrus.Infof("Written file %q", unitPath)
+		logrus.Infof("Written file %#q", unitPath)
 	} else if !guestAgentUpdated {
 		logrus.Info("lima-guestagent.service already up-to-date")
 		return nil

--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -146,7 +146,7 @@ func ParsePortForward(spec string) (hostPort, guestPort string, isStatic bool, e
 				return "", "", false, fmt.Errorf("invalid value for static parameter: %#q", staticValue)
 			}
 		} else {
-			return "", "", false, fmt.Errorf("invalid parameter %#q, expected 'static=' followed by a boolean value", staticPart)
+			return "", "", false, fmt.Errorf("invalid parameter %#q, expected `static=` followed by a boolean value", staticPart)
 		}
 	}
 

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -279,7 +279,7 @@ func WrapArgsError(argFn cobra.PositionalArgs) cobra.PositionalArgs {
 			return nil
 		}
 
-		return fmt.Errorf("%#q %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
+		return fmt.Errorf("%#q %s.\nSee `%s --help`.\n\nUsage:  %s\n\n%s",
 			cmd.CommandPath(), err.Error(),
 			cmd.CommandPath(),
 			cmd.UseLine(), cmd.Short,

--- a/pkg/apfs/chown.go
+++ b/pkg/apfs/chown.go
@@ -37,10 +37,10 @@ func Chown(diskPath string, volumeRole uint16, uid, gid uint32, paths ...string)
 	for _, path := range paths {
 		inodeNum, err := c.resolvePath(fsRootPhys, vol.omapTreeAddr, vol.latestXID, path)
 		if err != nil {
-			return fmt.Errorf("resolving path %q: %w", path, err)
+			return fmt.Errorf("resolving path %#q: %w", path, err)
 		}
 		if err := c.chownInode(fsRootPhys, vol.omapTreeAddr, vol.latestXID, inodeNum, uid, gid); err != nil {
-			return fmt.Errorf("chown inode %d (%q): %w", inodeNum, path, err)
+			return fmt.Errorf("chown inode %d (%#q): %w", inodeNum, path, err)
 		}
 	}
 	return nil
@@ -130,7 +130,7 @@ func findAPFSPartitionGPT(f *os.File) (int64, error) {
 		return 0, fmt.Errorf("reading GPT header: %w", err)
 	}
 	if string(gptHdr[0:8]) != gptHeaderSignature {
-		return 0, fmt.Errorf("no GPT header found (expected %q)", gptHeaderSignature)
+		return 0, fmt.Errorf("no GPT header found (expected %#q)", gptHeaderSignature)
 	}
 
 	partEntryLBA := le.Uint64(gptHdr[72:])
@@ -496,7 +496,7 @@ func (c *container) resolvePath(fsRootPhys, omapTreeAddr, maxXID uint64, path st
 		}
 		fileID, err := c.lookupDirEntry(fsRootPhys, omapTreeAddr, maxXID, cnid, name)
 		if err != nil {
-			return 0, fmt.Errorf("looking up %q in directory (cnid %d): %w", name, cnid, err)
+			return 0, fmt.Errorf("looking up %#q in directory (cnid %d): %w", name, cnid, err)
 		}
 		cnid = fileID
 	}
@@ -558,7 +558,7 @@ func (c *container) lookupDirEntry(fsRootPhys, omapTreeAddr, maxXID, parentCNID 
 				valStart := valueAreaEnd - vOff
 				return le.Uint64(blk[valStart:]), nil
 			}
-			return 0, fmt.Errorf("directory entry %q not found", name)
+			return 0, fmt.Errorf("directory entry %#q not found", name)
 		}
 
 		// Internal node: find the child to descend into.

--- a/pkg/autostart/launchd/launchd.go
+++ b/pkg/autostart/launchd/launchd.go
@@ -79,17 +79,17 @@ func RequestStart(ctx context.Context, inst *limatype.Instance) error {
 	// If disabled, `launchctl bootstrap` will fail.
 	_ = EnableDisableService(ctx, true, inst.Name)
 	if err := launchctl(ctx, "bootstrap", domainTarget(), GetPlistPath(inst.Name)); err != nil {
-		return fmt.Errorf("failed to start the instance %q via launchctl: %w", inst.Name, err)
+		return fmt.Errorf("failed to start the instance %#q via launchctl: %w", inst.Name, err)
 	}
 	return nil
 }
 
 func RequestStop(ctx context.Context, inst *limatype.Instance) (bool, error) {
-	logrus.Debugf("AutoStartedIdentifier=%q, ServiceNameFrom=%q", inst.AutoStartedIdentifier, ServiceNameFrom(inst.Name))
+	logrus.Debugf("AutoStartedIdentifier=%#q, ServiceNameFrom=%#q", inst.AutoStartedIdentifier, ServiceNameFrom(inst.Name))
 	if inst.AutoStartedIdentifier == ServiceNameFrom(inst.Name) {
-		logrus.Infof("Stopping the instance %q started by launchd", inst.Name)
+		logrus.Infof("Stopping the instance %#q started by launchd", inst.Name)
 		if err := launchctl(ctx, "bootout", serviceTarget(inst.Name)); err != nil {
-			return false, fmt.Errorf("failed to stop the instance %q via launchctl: %w", inst.Name, err)
+			return false, fmt.Errorf("failed to stop the instance %#q via launchctl: %w", inst.Name, err)
 		}
 		return true, nil
 	}

--- a/pkg/autostart/managers.go
+++ b/pkg/autostart/managers.go
@@ -74,18 +74,18 @@ func (t *TemplateFileBasedManager) IsRegistered(_ context.Context, inst *limatyp
 
 func (t *TemplateFileBasedManager) RegisterToStartAtLogin(ctx context.Context, inst *limatype.Instance) error {
 	if _, err := t.IsRegistered(ctx, inst); err != nil {
-		return fmt.Errorf("failed to check if the autostart entry for instance %q is registered: %w", inst.Name, err)
+		return fmt.Errorf("failed to check if the autostart entry for instance %#q is registered: %w", inst.Name, err)
 	}
 	content, err := t.renderTemplate(inst.Name, inst.Dir, os.Executable)
 	if err != nil {
-		return fmt.Errorf("failed to render the autostart entry for instance %q: %w", inst.Name, err)
+		return fmt.Errorf("failed to render the autostart entry for instance %#q: %w", inst.Name, err)
 	}
 	entryFilePath := t.filePath(inst.Name)
 	if err := os.MkdirAll(filepath.Dir(entryFilePath), os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create the directory for the autostart entry for instance %q: %w", inst.Name, err)
+		return fmt.Errorf("failed to create the directory for the autostart entry for instance %#q: %w", inst.Name, err)
 	}
 	if err := os.WriteFile(entryFilePath, content, 0o644); err != nil {
-		return fmt.Errorf("failed to write the autostart entry for instance %q: %w", inst.Name, err)
+		return fmt.Errorf("failed to write the autostart entry for instance %#q: %w", inst.Name, err)
 	}
 	if t.enabler != nil {
 		return t.enabler(ctx, true, inst.Name)
@@ -95,17 +95,17 @@ func (t *TemplateFileBasedManager) RegisterToStartAtLogin(ctx context.Context, i
 
 func (t *TemplateFileBasedManager) UnregisterFromStartAtLogin(ctx context.Context, inst *limatype.Instance) error {
 	if registered, err := t.IsRegistered(ctx, inst); err != nil {
-		return fmt.Errorf("failed to check if the autostart entry for instance %q is registered: %w", inst.Name, err)
+		return fmt.Errorf("failed to check if the autostart entry for instance %#q is registered: %w", inst.Name, err)
 	} else if !registered {
 		return nil
 	}
 	if t.enabler != nil {
 		if err := t.enabler(ctx, false, inst.Name); err != nil {
-			return fmt.Errorf("failed to disable the autostart entry for instance %q: %w", inst.Name, err)
+			return fmt.Errorf("failed to disable the autostart entry for instance %#q: %w", inst.Name, err)
 		}
 	}
 	if err := os.Remove(t.filePath(inst.Name)); err != nil {
-		return fmt.Errorf("failed to remove the autostart entry for instance %q: %w", inst.Name, err)
+		return fmt.Errorf("failed to remove the autostart entry for instance %#q: %w", inst.Name, err)
 	}
 	return nil
 }

--- a/pkg/autostart/systemd/systemd.go
+++ b/pkg/autostart/systemd/systemd.go
@@ -59,16 +59,16 @@ func AutoStartedUnitName() string {
 
 func RequestStart(ctx context.Context, inst *limatype.Instance) error {
 	if err := systemctl(ctx, "--user", "start", UnitNameFrom(inst.Name)); err != nil {
-		return fmt.Errorf("failed to start the instance %q via systemctl: %w", inst.Name, err)
+		return fmt.Errorf("failed to start the instance %#q via systemctl: %w", inst.Name, err)
 	}
 	return nil
 }
 
 func RequestStop(ctx context.Context, inst *limatype.Instance) (bool, error) {
 	if inst.AutoStartedIdentifier == UnitNameFrom(inst.Name) {
-		logrus.Infof("Stopping the instance %q started by systemd", inst.Name)
+		logrus.Infof("Stopping the instance %#q started by systemd", inst.Name)
 		if err := systemctl(ctx, "--user", "stop", inst.AutoStartedIdentifier); err != nil {
-			return false, fmt.Errorf("failed to stop the instance %q via systemctl: %w", inst.Name, err)
+			return false, fmt.Errorf("failed to stop the instance %#q via systemctl: %w", inst.Name, err)
 		}
 		return true, nil
 	}

--- a/pkg/cacheutil/cacheutil.go
+++ b/pkg/cacheutil/cacheutil.go
@@ -52,7 +52,7 @@ func EnsureNerdctlArchiveCache(ctx context.Context, y *limatype.LimaYAML, create
 			if downloader.IsLocal(f.Location) {
 				return f.Location, nil
 			}
-			return "", fmt.Errorf("cache did not contain %q", f.Location)
+			return "", fmt.Errorf("cache did not contain %#q", f.Location)
 		}
 		return path, nil
 	}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -66,7 +66,7 @@ func setupEnv(instConfigEnv map[string]string, propagateProxyEnv bool, slirpGate
 		for _, name := range append(lowerVars, upperVars...) {
 			if value, ok := os.LookupEnv(name); ok {
 				if _, ok := env[name]; ok && value != env[name] {
-					logrus.Infof("Overriding %q value %q with %q from limactl process environment",
+					logrus.Infof("Overriding %#q value %#q with %#q from limactl process environment",
 						name, env[name], value)
 				}
 				env[name] = value
@@ -82,7 +82,7 @@ func setupEnv(instConfigEnv map[string]string, propagateProxyEnv bool, slirpGate
 		} else if ok && !strings.EqualFold(name, "no_proxy") {
 			u, err := url.Parse(value)
 			if err != nil {
-				logrus.Warnf("Ignoring invalid proxy %q=%v: %s", name, value, err)
+				logrus.Warnf("Ignoring invalid proxy %#q=%v: %s", name, value, err)
 				continue
 			}
 
@@ -97,7 +97,7 @@ func setupEnv(instConfigEnv map[string]string, propagateProxyEnv bool, slirpGate
 				}
 			}
 			if value != env[name] {
-				logrus.Infof("Replacing %q value %q with %q", name, env[name], value)
+				logrus.Infof("Replacing %#q value %#q with %#q", name, env[name], value)
 				env[name] = value
 			}
 		}
@@ -108,7 +108,7 @@ func setupEnv(instConfigEnv map[string]string, propagateProxyEnv bool, slirpGate
 		upperName := strings.ToUpper(lowerName)
 		if _, ok := env[lowerName]; ok {
 			if _, ok := env[upperName]; ok && env[lowerName] != env[upperName] {
-				logrus.Warnf("Changing %q value from %q to %q to match %q",
+				logrus.Warnf("Changing %#q value from %#q to %#q to match %#q",
 					upperName, env[upperName], env[lowerName], lowerName)
 			}
 			env[upperName] = env[lowerName]
@@ -224,7 +224,7 @@ func templateArgs(ctx context.Context, bootScripts bool, instDir, name string, i
 				options += fmt.Sprintf(",version=%s", *f.NineP.ProtocolVersion)
 				msize, err := units.RAMInBytes(*f.NineP.Msize)
 				if err != nil {
-					return nil, fmt.Errorf("failed to parse msize for %q: %w", f.Location, err)
+					return nil, fmt.Errorf("failed to parse msize for %#q: %w", f.Location, err)
 				}
 				options += fmt.Sprintf(",msize=%d", msize)
 				options += fmt.Sprintf(",cache=%s", *f.NineP.Cache)
@@ -408,11 +408,11 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 		if strings.Contains(filename, "/") {
 			// When the filename contains a slash, it must be in the format of "boot.<OS>/<SCRIPT>"
 			if !strings.HasPrefix(filename, "boot.") || strings.Count(filename, "/") != 1 {
-				return "", fmt.Errorf("invalid boot script filename %q: must be in format 'boot.<OS>/<SCRIPT>'", filename)
+				return "", fmt.Errorf("invalid boot script filename %#q: must be in format 'boot.<OS>/<SCRIPT>'", filename)
 			}
 			layoutPath = filename
 		} else {
-			logrus.Warnf("Boot script filename %q does not contain '/', treating it as a script for Linux and prefixing with 'boot.Linux/'", filename)
+			logrus.Warnf("Boot script filename %#q does not contain '/', treating it as a script for Linux and prefixing with 'boot.Linux/'", filename)
 		}
 		layout = append(layout, iso9660util.Entry{
 			Path:   layoutPath,
@@ -442,7 +442,7 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 		case limatype.ProvisionModeAnsible:
 			continue
 		default:
-			return "", fmt.Errorf("unknown provision mode %q", f.Mode)
+			return "", fmt.Errorf("unknown provision mode %#q", f.Mode)
 		}
 	}
 

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -126,7 +126,7 @@ func ValidateTemplateArgs(args *TemplateArgs) error {
 	// args.User is intentionally not validated here; the user can override with any name they want
 	// limayaml.FillDefault will validate the default (local) username, but not an explicit setting
 	if args.User == "root" {
-		return errors.New("field User must not be \"root\"")
+		return errors.New("field User must not be `root`")
 	}
 	if args.UID == 0 {
 		return errors.New("field UID must not be 0")
@@ -143,7 +143,7 @@ func ValidateTemplateArgs(args *TemplateArgs) error {
 	for i, m := range args.Mounts {
 		f := m.MountPoint
 		if !path.IsAbs(f) {
-			return fmt.Errorf("field mounts[%d] must be absolute, got %q", i, f)
+			return fmt.Errorf("field mounts[%d] must be absolute, got %#q", i, f)
 		}
 	}
 	return nil
@@ -182,7 +182,7 @@ func ExecuteTemplateCIDataISO(args *TemplateArgs) ([]iso9660util.Entry, error) {
 			return nil
 		}
 		if !d.Type().IsRegular() {
-			return fmt.Errorf("got non-regular file %q", path)
+			return fmt.Errorf("got non-regular file %#q", path)
 		}
 		templateB, err := fs.ReadFile(fsys, path)
 		if err != nil {

--- a/pkg/cidata/template_test.go
+++ b/pkg/cidata/template_test.go
@@ -123,7 +123,7 @@ func TestTemplate(t *testing.T) {
 	layout, err := ExecuteTemplateCIDataISO(args)
 	assert.NilError(t, err)
 	for _, f := range layout {
-		t.Logf("=== %q ===", f.Path)
+		t.Logf("=== %#q ===", f.Path)
 		b, err := io.ReadAll(f.Reader)
 		assert.NilError(t, err)
 		t.Log(string(b))
@@ -158,7 +158,7 @@ func TestTemplate9p(t *testing.T) {
 	layout, err := ExecuteTemplateCIDataISO(args)
 	assert.NilError(t, err)
 	for _, f := range layout {
-		t.Logf("=== %q ===", f.Path)
+		t.Logf("=== %#q ===", f.Path)
 		b, err := io.ReadAll(f.Reader)
 		assert.NilError(t, err)
 		t.Log(string(b))

--- a/pkg/copytool/copytool.go
+++ b/pkg/copytool/copytool.go
@@ -88,7 +88,7 @@ func New(ctx context.Context, backend string, paths []string, opts *Options) (Co
 		}
 		return tool, nil
 	default:
-		return nil, fmt.Errorf("invalid backend %q, must be one of: scp, rsync, auto", backend)
+		return nil, fmt.Errorf("invalid backend %#q, must be one of: scp, rsync, auto", backend)
 	}
 }
 
@@ -122,16 +122,16 @@ func parseCopyPaths(ctx context.Context, paths []string) ([]*Path, error) {
 			inst, err := store.Inspect(ctx, cp.InstanceName)
 			if err != nil {
 				if errors.Is(err, os.ErrNotExist) {
-					return nil, fmt.Errorf("instance %q does not exist, run `limactl create %s` to create a new instance", cp.InstanceName, cp.InstanceName)
+					return nil, fmt.Errorf("instance %#q does not exist, run `limactl create %s` to create a new instance", cp.InstanceName, cp.InstanceName)
 				}
 				return nil, err
 			}
 			if inst.Status == limatype.StatusStopped {
-				return nil, fmt.Errorf("instance %q is stopped, run `limactl start %s` to start the instance", cp.InstanceName, cp.InstanceName)
+				return nil, fmt.Errorf("instance %#q is stopped, run `limactl start %s` to start the instance", cp.InstanceName, cp.InstanceName)
 			}
 			cp.Instance = inst
 		default:
-			return nil, fmt.Errorf("path %q contains multiple colons", path)
+			return nil, fmt.Errorf("path %#q contains multiple colons", path)
 		}
 
 		copyPaths = append(copyPaths, cp)

--- a/pkg/copytool/rsync.go
+++ b/pkg/copytool/rsync.go
@@ -49,7 +49,7 @@ func (t *rsyncTool) IsAvailableOnGuest(ctx context.Context, paths []string) bool
 
 	for instName, inst := range instances {
 		if !checkRsyncOnGuest(ctx, inst) {
-			logrus.Debugf("rsync not available on instance %q", instName)
+			logrus.Debugf("rsync not available on instance %#q", instName)
 			return false
 		}
 	}

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -191,7 +191,7 @@ func Download(ctx context.Context, local, remote string, opts ...Opt) (*Result, 
 			return nil, err
 		}
 		if _, err := os.Stat(localPath); err == nil {
-			logrus.Debugf("file %q already exists, skipping downloading from %q (and skipping digest validation)", localPath, remote)
+			logrus.Debugf("file %#q already exists, skipping downloading from %#q (and skipping digest validation)", localPath, remote)
 			res := &Result{
 				Status:          StatusSkipped,
 				ValidatedDigest: false,
@@ -267,9 +267,9 @@ func getCached(ctx context.Context, localPath, remote string, o options) (*Resul
 		return nil, nil
 	}
 	ext := path.Ext(remote)
-	logrus.Debugf("file %q is cached as %q", localPath, shadData)
+	logrus.Debugf("file %#q is cached as %#q", localPath, shadData)
 	if _, err := os.Stat(shadDigest); err == nil {
-		logrus.Debugf("Comparing digest %q with the cached digest file %q, not computing the actual digest of %q",
+		logrus.Debugf("Comparing digest %#q with the cached digest file %#q, not computing the actual digest of %#q",
 			o.expectedDigest, shadDigest, shadData)
 		if err := validateCachedDigest(shadDigest, o.expectedDigest); err != nil {
 			return nil, err
@@ -285,7 +285,7 @@ func getCached(ctx context.Context, localPath, remote string, o options) (*Resul
 				return nil, err
 			}
 		} else {
-			logrus.Infof("Re-downloading digest-less image: last-modified mismatch (cached: %q, remote: %q)", lmCached, lmRemote)
+			logrus.Infof("Re-downloading digest-less image: last-modified mismatch (cached: %#q, remote: %#q)", lmCached, lmRemote)
 			return nil, nil
 		}
 	}
@@ -415,7 +415,7 @@ func cacheDigestPath(shad string, expectedDigest digest.Digest) (string, error) 
 	if expectedDigest != "" {
 		algo := expectedDigest.Algorithm().String()
 		if strings.Contains(algo, "/") || strings.Contains(algo, "\\") {
-			return "", fmt.Errorf("invalid digest algorithm %q", algo)
+			return "", fmt.Errorf("invalid digest algorithm %#q", algo)
 		}
 		shadDigest = filepath.Join(shad, algo+".digest")
 	}
@@ -435,11 +435,11 @@ func canonicalLocalPath(s string) (string, error) {
 		return "", errors.New("got empty path")
 	}
 	if !IsLocal(s) {
-		return "", fmt.Errorf("got non-local path: %q", s)
+		return "", fmt.Errorf("got non-local path: %#q", s)
 	}
 	if res, ok := strings.CutPrefix(s, "file://"); ok {
 		if !filepath.IsAbs(res) {
-			return "", fmt.Errorf("got non-absolute path %q", res)
+			return "", fmt.Errorf("got non-absolute path %#q", res)
 		}
 		return res, nil
 	}
@@ -453,7 +453,7 @@ func copyLocal(ctx context.Context, dst, src, ext string, decompress bool, descr
 	}
 
 	if expectedDigest != "" {
-		logrus.Debugf("verifying digest of local file %q (%s)", srcPath, expectedDigest)
+		logrus.Debugf("verifying digest of local file %#q (%s)", srcPath, expectedDigest)
 	}
 	if err := validateLocalFileDigest(srcPath, expectedDigest); err != nil {
 		return err
@@ -582,7 +582,7 @@ func validateCachedDigest(shadDigest string, expectedDigest digest.Digest) error
 	}
 	shadDigestS := strings.TrimSpace(string(shadDigestB))
 	if shadDigestS != expectedDigest.String() {
-		return fmt.Errorf("expected digest %q, got %q", expectedDigest, shadDigestS)
+		return fmt.Errorf("expected digest %#q, got %#q", expectedDigest, shadDigestS)
 	}
 	return nil
 }
@@ -596,7 +596,7 @@ func validateLocalFileDigest(localPath string, expectedDigest digest.Digest) err
 	}
 	algo := expectedDigest.Algorithm()
 	if !algo.Available() {
-		return fmt.Errorf("expected digest algorithm %q is not available", algo)
+		return fmt.Errorf("expected digest algorithm %#q is not available", algo)
 	}
 	r, err := os.Open(localPath)
 	if err != nil {
@@ -608,7 +608,7 @@ func validateLocalFileDigest(localPath string, expectedDigest digest.Digest) err
 		return err
 	}
 	if actualDigest != expectedDigest {
-		return fmt.Errorf("expected digest %q, got %q", expectedDigest, actualDigest)
+		return fmt.Errorf("expected digest %#q, got %#q", expectedDigest, actualDigest)
 	}
 	return nil
 }
@@ -654,7 +654,7 @@ func downloadHTTP(ctx context.Context, localPath, lastModified, contentType, url
 	if localPath == "" {
 		return errors.New("downloadHTTP: got empty localPath")
 	}
-	logrus.Debugf("downloading %q into %q", url, localPath)
+	logrus.Debugf("downloading %#q into %#q", url, localPath)
 
 	resp, err := httpclientutil.Get(ctx, http.DefaultClient, url)
 	if err != nil {
@@ -694,7 +694,7 @@ func downloadHTTP(ctx context.Context, localPath, lastModified, contentType, url
 	if expectedDigest != "" {
 		algo := expectedDigest.Algorithm()
 		if !algo.Available() {
-			return fmt.Errorf("unsupported digest algorithm %q", algo)
+			return fmt.Errorf("unsupported digest algorithm %#q", algo)
 		}
 		digester = algo.Digester()
 		hasher := digester.Hash()
@@ -718,7 +718,7 @@ func downloadHTTP(ctx context.Context, localPath, lastModified, contentType, url
 	if digester != nil {
 		actualDigest := digester.Digest()
 		if actualDigest != expectedDigest {
-			return fmt.Errorf("expected digest %q, got %q", expectedDigest, actualDigest)
+			return fmt.Errorf("expected digest %#q, got %#q", expectedDigest, actualDigest)
 		}
 	}
 
@@ -788,6 +788,6 @@ func RemoveAllCacheDir(opts ...Opt) error {
 	if o.cacheDir == "" {
 		return nil
 	}
-	logrus.Infof("Pruning %q", o.cacheDir)
+	logrus.Infof("Pruning %#q", o.cacheDir)
 	return os.RemoveAll(o.cacheDir)
 }

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -199,7 +199,7 @@ func countResults(t *testing.T, results chan downloadResult) (downloaded, cached
 			case StatusUsedCache:
 				cached++
 			default:
-				t.Errorf("Unexpected download status %q", result.r.Status)
+				t.Errorf("Unexpected download status %#q", result.r.Status)
 			}
 		}
 	}

--- a/pkg/driver/krunkit/krunkit_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_darwin_arm64.go
@@ -63,18 +63,18 @@ func Cmdline(inst *limatype.Instance) (*exec.Cmd, error) {
 		for _, d := range inst.Config.AdditionalDisks {
 			disk, derr := store.InspectDisk(d.Name, d.FSType)
 			if derr != nil {
-				return nil, fmt.Errorf("failed to load disk %q: %w", d.Name, derr)
+				return nil, fmt.Errorf("failed to load disk %#q: %w", d.Name, derr)
 			}
 			if disk.Instance != "" {
-				return nil, fmt.Errorf("failed to run attach disk %q, in use by instance %q", disk.Name, disk.Instance)
+				return nil, fmt.Errorf("failed to run attach disk %#q, in use by instance %#q", disk.Name, disk.Instance)
 			}
 			if lerr := disk.Lock(inst.Dir); lerr != nil {
-				return nil, fmt.Errorf("failed to lock disk %q: %w", d.Name, lerr)
+				return nil, fmt.Errorf("failed to lock disk %#q: %w", d.Name, lerr)
 			}
 			extraDiskPath := filepath.Join(disk.Dir, filenames.DataDisk)
-			logrus.Infof("Mounting disk %q on %q", disk.Name, disk.MountPoint)
+			logrus.Infof("Mounting disk %#q on %#q", disk.Name, disk.MountPoint)
 			if cerr := diskUtil.Convert(ctx, raw.Type, extraDiskPath, extraDiskPath, nil, true); cerr != nil {
-				return nil, fmt.Errorf("failed to convert extra disk %q to raw: %w", extraDiskPath, cerr)
+				return nil, fmt.Errorf("failed to convert extra disk %#q to raw: %w", extraDiskPath, cerr)
 			}
 			args = append(args, "--device", fmt.Sprintf("virtio-blk,path=%s,format=raw", extraDiskPath))
 		}

--- a/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
@@ -94,7 +94,7 @@ func (l *LimaKrunkitDriver) Start(ctx context.Context) (chan error, error) {
 	}
 	krunkitCmd.Stderr = logfile
 
-	logrus.Infof("Starting krun VM (hint: to watch the progress, see %q)", logPath)
+	logrus.Infof("Starting krun VM (hint: to watch the progress, see %#q)", logPath)
 	logrus.Infof("krunkitCmd.Args: %v", krunkitCmd.Args)
 
 	if err := krunkitCmd.Start(); err != nil {
@@ -194,12 +194,12 @@ func checkKrunkitVersion() error {
 	minVersion := semver.New("1.2.1")
 	currentVersion, err := semver.NewVersion(versionStr)
 	if err != nil {
-		logrus.WithError(err).Warnf("Failed to parse krunkit version %q, skipping version check", versionStr)
+		logrus.WithError(err).Warnf("Failed to parse krunkit version %#q, skipping version check", versionStr)
 		return nil
 	}
 
 	if currentVersion.LessThan(*minVersion) {
-		return fmt.Errorf("krunkit version %q is older than required minimum 1.2.1 (needed for vsock forwarder feature)", currentVersion)
+		return fmt.Errorf("krunkit version %#q is older than required minimum 1.2.1 (needed for vsock forwarder feature)", currentVersion)
 	}
 
 	return nil
@@ -217,7 +217,7 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 		return errors.New("krunkit driver requires macOS 13 or higher to run")
 	}
 	if cfg.Arch != nil && !limatype.IsNativeArch(*cfg.Arch) {
-		return fmt.Errorf("unsupported arch: %q (krunkit requires native arch)", *cfg.Arch)
+		return fmt.Errorf("unsupported arch: %#q (krunkit requires native arch)", *cfg.Arch)
 	}
 	if _, err := exec.LookPath(vmType); err != nil {
 		return errors.New("krunkit CLI not found in PATH. Install it via:\nbrew tap slp/krun\nbrew install krunkit")
@@ -228,7 +228,7 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 	}
 
 	if cfg.MountType != nil && (*cfg.MountType != limatype.VIRTIOFS && *cfg.MountType != limatype.REVSSHFS) {
-		return fmt.Errorf("field `mountType` must be %q or %q for krunkit driver, got %q", limatype.VIRTIOFS, limatype.REVSSHFS, *cfg.MountType)
+		return fmt.Errorf("field `mountType` must be %#q or %#q for krunkit driver, got %#q", limatype.VIRTIOFS, limatype.REVSSHFS, *cfg.MountType)
 	}
 
 	if cfg.NestedVirtualization != nil && *cfg.NestedVirtualization {
@@ -405,7 +405,7 @@ func (l *LimaKrunkitDriver) cleanupStaleSockets() error {
 		filepath.Join(l.Instance.Dir, sshVsockSock),
 	} {
 		if err := os.RemoveAll(sock); err != nil {
-			errs = append(errs, fmt.Errorf("failed to remove socket %q: %w", sock, err))
+			errs = append(errs, fmt.Errorf("failed to remove socket %#q: %w", sock, err))
 		}
 	}
 

--- a/pkg/driver/qemu/entitlementutil/entitlementutil.go
+++ b/pkg/driver/qemu/entitlementutil/entitlementutil.go
@@ -22,19 +22,19 @@ import (
 func IsSigned(ctx context.Context, qExe string) error {
 	cmd := exec.CommandContext(ctx, "codesign", "--verify", qExe)
 	out, err := cmd.CombinedOutput()
-	logrus.WithError(err).Debugf("Executed %v: out=%q", cmd.Args, string(out))
+	logrus.WithError(err).Debugf("Executed %v: out=%#q", cmd.Args, string(out))
 	if err != nil {
-		return fmt.Errorf("failed to run %v: %w (out=%q)", cmd.Args, err, string(out))
+		return fmt.Errorf("failed to run %v: %w (out=%#q)", cmd.Args, err, string(out))
 	}
 
 	cmd = exec.CommandContext(ctx, "codesign", "--display", "--entitlements", "-", "--xml", qExe)
 	out, err = cmd.CombinedOutput()
-	logrus.WithError(err).Debugf("Executed %v: out=%q", cmd.Args, string(out))
+	logrus.WithError(err).Debugf("Executed %v: out=%#q", cmd.Args, string(out))
 	if err != nil {
-		return fmt.Errorf("failed to run %v: %w (out=%q)", cmd.Args, err, string(out))
+		return fmt.Errorf("failed to run %v: %w (out=%#q)", cmd.Args, err, string(out))
 	}
 	if !strings.Contains(string(out), "com.apple.security.hypervisor") {
-		return fmt.Errorf("binary %q seems signed but lacking the \"com.apple.security.hypervisor\" entitlement", qExe)
+		return fmt.Errorf("binary %#q seems signed but lacking the `com.apple.security.hypervisor` entitlement", qExe)
 	}
 	return nil
 }
@@ -56,14 +56,14 @@ func Sign(ctx context.Context, qExe string) error {
 </plist>`
 	if _, err = ent.WriteString(entXML); err != nil {
 		ent.Close()
-		return fmt.Errorf("failed to write to a temporary file %q for signing QEMU binary: %w", entName, err)
+		return fmt.Errorf("failed to write to a temporary file %#q for signing QEMU binary: %w", entName, err)
 	}
 	ent.Close()
 	signCmd := exec.CommandContext(ctx, "codesign", "--sign", "-", "--entitlements", entName, "--force", qExe)
 	out, err := signCmd.CombinedOutput()
-	logrus.WithError(err).Debugf("Executed %v: out=%q", signCmd.Args, string(out))
+	logrus.WithError(err).Debugf("Executed %v: out=%#q", signCmd.Args, string(out))
 	if err != nil {
-		return fmt.Errorf("failed to run %v: %w (out=%q)", signCmd.Args, err, string(out))
+		return fmt.Errorf("failed to run %v: %w (out=%#q)", signCmd.Args, err, string(out))
 	}
 	return nil
 }
@@ -85,13 +85,13 @@ func isColimaWrapper__useThisFunctionOnlyForPrintingHints__(qExe string) bool {
 // https://github.com/lima-vm/lima/issues/1742
 func AskToSignIfNotSignedProperly(ctx context.Context, qExe string) {
 	if isSignedErr := IsSigned(ctx, qExe); isSignedErr != nil {
-		logrus.WithError(isSignedErr).Warnf("QEMU binary %q does not seem properly signed with the \"com.apple.security.hypervisor\" entitlement", qExe)
+		logrus.WithError(isSignedErr).Warnf("QEMU binary %#q does not seem properly signed with the `com.apple.security.hypervisor` entitlement", qExe)
 		if isColimaWrapper__useThisFunctionOnlyForPrintingHints__(qExe) {
 			logrus.Info("Hint: the warning above is usually negligible for colima ( Printed due to https://github.com/abiosoft/colima/issues/796 )")
 		}
 		var ans bool
 		if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
-			message := fmt.Sprintf("Try to sign %q with the \"com.apple.security.hypervisor\" entitlement?", qExe)
+			message := fmt.Sprintf("Try to sign %#q with the `com.apple.security.hypervisor` entitlement?", qExe)
 			var askErr error
 			ans, askErr = uiutil.Confirm(message, true)
 			if askErr != nil {
@@ -100,12 +100,12 @@ func AskToSignIfNotSignedProperly(ctx context.Context, qExe string) {
 		}
 		if ans {
 			if signErr := Sign(ctx, qExe); signErr != nil {
-				logrus.WithError(signErr).Warnf("Failed to sign %q", qExe)
+				logrus.WithError(signErr).Warnf("Failed to sign %#q", qExe)
 			} else {
-				logrus.Infof("Successfully signed %q with the \"com.apple.security.hypervisor\" entitlement", qExe)
+				logrus.Infof("Successfully signed %#q with the `com.apple.security.hypervisor` entitlement", qExe)
 			}
 		} else {
-			logrus.Warn("If QEMU does not start up, you may have to sign the QEMU binary with the \"com.apple.security.hypervisor\" entitlement manually. See https://github.com/lima-vm/lima/issues/1742 .")
+			logrus.Warn("If QEMU does not start up, you may have to sign the QEMU binary with the `com.apple.security.hypervisor` entitlement manually. See https://github.com/lima-vm/lima/issues/1742 .")
 		}
 	}
 }

--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -103,13 +103,13 @@ func EnsureDisk(ctx context.Context, cfg Config) error {
 	}
 	imageInfo, err := qemuimgutil.GetInfo(ctx, imagePath)
 	if err != nil {
-		return fmt.Errorf("failed to get the information of %q: %w", imagePath, err)
+		return fmt.Errorf("failed to get the information of %#q: %w", imagePath, err)
 	}
 	if err = qemuimgutil.AcceptableAsBaseDisk(imageInfo); err != nil {
-		return fmt.Errorf("file %q is not acceptable as a disk image: %w", imagePath, err)
+		return fmt.Errorf("file %#q is not acceptable as a disk image: %w", imagePath, err)
 	}
 	if imageInfo.Format == "" {
-		return fmt.Errorf("failed to inspect the format of %q", imagePath)
+		return fmt.Errorf("failed to inspect the format of %#q", imagePath)
 	}
 	if isISO {
 		isoPath := filepath.Join(cfg.InstanceDir, filenames.ISO)
@@ -121,7 +121,7 @@ func EnsureDisk(ctx context.Context, cfg Config) error {
 		cmd := exec.CommandContext(ctx, "qemu-img", args...)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			_ = os.Rename(isoPath, imagePath)
-			return fmt.Errorf("failed to run %v: %q: %w", cmd.Args, string(out), err)
+			return fmt.Errorf("failed to run %v: %#q: %w", cmd.Args, string(out), err)
 		}
 	} else {
 		if err = os.Rename(imagePath, diskPath); err != nil {
@@ -232,7 +232,7 @@ func List(ctx context.Context, cfg Config, run bool) (string, error) {
 
 func argValue(args []string, key string) (string, bool) {
 	if !strings.HasPrefix(key, "-") {
-		panic(fmt.Errorf("got unexpected key %q", key))
+		panic(fmt.Errorf("got unexpected key %#q", key))
 	}
 	for i, s := range args {
 		if s == key {
@@ -253,11 +253,11 @@ func argValue(args []string, key string) (string, bool) {
 // appendArgsIfNoConflict cannot be used for: -drive, -cdrom, ...
 func appendArgsIfNoConflict(args []string, k, v string) []string {
 	if !strings.HasPrefix(k, "-") {
-		panic(fmt.Errorf("got unexpected key %q", k))
+		panic(fmt.Errorf("got unexpected key %#q", k))
 	}
 	switch k {
 	case "-drive", "-cdrom", "-chardev", "-blockdev", "-netdev", "-device":
-		panic(fmt.Errorf("appendArgsIfNoConflict() must not be called with k=%q", k))
+		panic(fmt.Errorf("appendArgsIfNoConflict() must not be called with k=%#q", k))
 	}
 
 	if v == "" {
@@ -268,7 +268,7 @@ func appendArgsIfNoConflict(args []string, k, v string) []string {
 	}
 
 	if origV, ok := argValue(args, k); ok {
-		logrus.Warnf("Not adding QEMU argument %q %q, as it conflicts with %q %q", k, v, k, origV)
+		logrus.Warnf("Not adding QEMU argument %#q %#q, as it conflicts with %#q %#q", k, v, k, origV)
 		return args
 	}
 	return append(args, k, v)
@@ -303,7 +303,7 @@ func inspectFeatures(ctx context.Context, exe, machine string) (*features, error
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("failed to run %v: stdout=%q, stderr=%q", cmd.Args, stdout.String(), stderr.String())
+		return nil, fmt.Errorf("failed to run %v: stdout=%#q, stderr=%#q", cmd.Args, stdout.String(), stderr.String())
 	}
 	f.AccelHelp = stdout.Bytes()
 	// on older versions qemu will write "help" output to stderr
@@ -315,7 +315,7 @@ func inspectFeatures(ctx context.Context, exe, machine string) (*features, error
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		logrus.Warnf("failed to run %v: stdout=%q, stderr=%q", cmd.Args, stdout.String(), stderr.String())
+		logrus.Warnf("failed to run %v: stdout=%#q, stderr=%#q", cmd.Args, stdout.String(), stderr.String())
 	} else {
 		f.NetdevHelp = stdout.Bytes()
 		if len(f.NetdevHelp) == 0 {
@@ -327,7 +327,7 @@ func inspectFeatures(ctx context.Context, exe, machine string) (*features, error
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		logrus.Warnf("failed to run %v: stdout=%q, stderr=%q", cmd.Args, stdout.String(), stderr.String())
+		logrus.Warnf("failed to run %v: stdout=%#q, stderr=%#q", cmd.Args, stdout.String(), stderr.String())
 	} else {
 		f.MachineHelp = stdout.Bytes()
 		if len(f.MachineHelp) == 0 {
@@ -340,7 +340,7 @@ func inspectFeatures(ctx context.Context, exe, machine string) (*features, error
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		logrus.Warnf("failed to run %v: stdout=%q, stderr=%q", cmd.Args, stdout.String(), stderr.String())
+		logrus.Warnf("failed to run %v: stdout=%#q, stderr=%#q", cmd.Args, stdout.String(), stderr.String())
 	} else {
 		f.CPUHelp = stdout.Bytes()
 		if len(f.CPUHelp) == 0 {
@@ -456,11 +456,11 @@ func resolveCPUType(y *limatype.LimaYAML) string {
 	var overrideCPUType bool
 	var qemuOpts limatype.QEMUOpts
 	if err := limayaml.Convert(y.VMOpts[limatype.QEMU], &qemuOpts, "vmOpts.qemu"); err != nil {
-		logrus.WithError(err).Warnf("Couldn't convert %q", y.VMOpts[limatype.QEMU])
+		logrus.WithError(err).Warnf("Couldn't convert %#q", y.VMOpts[limatype.QEMU])
 	}
 	for k, v := range qemuOpts.CPUType {
 		if !slices.Contains(limatype.ArchTypes, *y.Arch) {
-			logrus.Warnf("field `vmOpts.qemu.cpuType` uses unsupported arch %q", k)
+			logrus.Warnf("field `vmOpts.qemu.cpuType` uses unsupported arch %#q", k)
 			continue
 		}
 		if v != "" {
@@ -505,17 +505,17 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 		}
 		var qemuOpts limatype.QEMUOpts
 		if err := limayaml.Convert(y.VMOpts[limatype.QEMU], &qemuOpts, "vmOpts.qemu"); err != nil {
-			logrus.WithError(err).Warnf("Couldn't convert %q", y.VMOpts[limatype.QEMU])
+			logrus.WithError(err).Warnf("Couldn't convert %#q", y.VMOpts[limatype.QEMU])
 		}
 		if qemuOpts.MinimumVersion != nil && version.LessThan(*semver.New(*qemuOpts.MinimumVersion)) {
-			logrus.Fatalf("QEMU %v is too old, template requires %q or later", version, *qemuOpts.MinimumVersion)
+			logrus.Fatalf("QEMU %v is too old, template requires %#q or later", version, *qemuOpts.MinimumVersion)
 		}
 	}
 
 	// Architecture
 	accel := Accel(*y.Arch)
 	if !strings.Contains(string(features.AccelHelp), accel) {
-		return "", nil, fmt.Errorf("accelerator %q is not supported by %s", accel, exe)
+		return "", nil, fmt.Errorf("accelerator %#q is not supported by %s", accel, exe)
 	}
 
 	// Memory
@@ -538,13 +538,13 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 		switch {
 		case strings.HasPrefix(cpu, "host"), strings.HasPrefix(cpu, "max"):
 			if !strings.Contains(cpu, ",-pdpe1gb") {
-				logrus.Warnf("On Intel Mac, CPU type %q typically needs \",-pdpe1gb\" option (https://stackoverflow.com/a/72863744/5167443)", cpu)
+				logrus.Warnf("On Intel Mac, CPU type %#q typically needs `,-pdpe1gb` option (https://stackoverflow.com/a/72863744/5167443)", cpu)
 			}
 		}
 	}
 	// `qemu-system-ppc64 -help` does not show "max", but it is actually accepted
 	if cpu != "max" && !strings.Contains(string(features.CPUHelp), strings.Split(cpu, ",")[0]) {
-		return "", nil, fmt.Errorf("cpu %q is not supported by %s", cpu, exe)
+		return "", nil, fmt.Errorf("cpu %#q is not supported by %s", cpu, exe)
 	}
 	args = appendArgsIfNoConflict(args, "-cpu", cpu)
 
@@ -603,7 +603,7 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	// Firmware
 	legacyBIOS := *y.Firmware.LegacyBIOS
 	if legacyBIOS && *y.Arch != limatype.X8664 && *y.Arch != limatype.ARMV7L {
-		logrus.Warnf("field `firmware.legacyBIOS` is not supported for architecture %q, ignoring", *y.Arch)
+		logrus.Warnf("field `firmware.legacyBIOS` is not supported for architecture %#q, ignoring", *y.Arch)
 		legacyBIOS = false
 	}
 	noFirmware := *y.Arch == limatype.PPC64LE || *y.Arch == limatype.S390X || legacyBIOS
@@ -614,7 +614,7 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 			logrus.Warn("use of deprecated _LIMA_QEMU_UEFI_IN_BIOS")
 			b, err := strconv.ParseBool(envVar)
 			if err != nil {
-				logrus.WithError(err).Warnf("invalid _LIMA_QEMU_UEFI_IN_BIOS value %q", envVar)
+				logrus.WithError(err).Warnf("invalid _LIMA_QEMU_UEFI_IN_BIOS value %#q", envVar)
 			} else {
 				firmwareInBios = b
 			}
@@ -625,7 +625,7 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 		if firmwareInBios {
 			if _, stErr := os.Stat(firmwareWithVars); stErr == nil {
 				firmware = firmwareWithVars
-				logrus.Infof("Using existing firmware (%q)", firmware)
+				logrus.Infof("Using existing firmware (%#q)", firmware)
 			}
 		} else {
 			if _, stErr := os.Stat(downloadedFirmware); errors.Is(stErr, os.ErrNotExist) {
@@ -635,18 +635,18 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 					case "", limatype.QEMU:
 						if f.Arch == *y.Arch {
 							if _, err = fileutils.DownloadFile(ctx, downloadedFirmware, f.File, true, "UEFI code "+f.Location, *y.Arch); err != nil {
-								logrus.WithError(err).Warnf("failed to download %q", f.Location)
+								logrus.WithError(err).Warnf("failed to download %#q", f.Location)
 								continue loop
 							}
 							firmware = downloadedFirmware
-							logrus.Infof("Using firmware %q (downloaded from %q)", firmware, f.Location)
+							logrus.Infof("Using firmware %#q (downloaded from %#q)", firmware, f.Location)
 							break loop
 						}
 					}
 				}
 			} else {
 				firmware = downloadedFirmware
-				logrus.Infof("Using existing firmware (%q)", firmware)
+				logrus.Infof("Using existing firmware (%#q)", firmware)
 			}
 		}
 		if firmware == "" {
@@ -654,13 +654,13 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 			if err != nil {
 				return "", nil, err
 			}
-			logrus.Infof("Using system firmware (%q)", firmware)
+			logrus.Infof("Using system firmware (%#q)", firmware)
 			if firmwareInBios {
 				firmwareVars, err := getFirmwareVars(exe, *y.Arch)
 				if err != nil {
 					return "", nil, err
 				}
-				logrus.Infof("Using system firmware vars (%q)", firmwareVars)
+				logrus.Infof("Using system firmware vars (%#q)", firmwareVars)
 				varsFile, err := os.Open(firmwareVars)
 				if err != nil {
 					return "", nil, err
@@ -705,13 +705,13 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 		diskName := d.Name
 		disk, err := store.InspectDisk(diskName, d.FSType)
 		if err != nil {
-			logrus.Errorf("could not load disk %q: %q", diskName, err)
+			logrus.Errorf("could not load disk %#q: %#q", diskName, err)
 			return "", nil, err
 		}
 
-		logrus.Infof("Mounting disk %q on %q", diskName, disk.MountPoint)
+		logrus.Infof("Mounting disk %#q on %#q", diskName, disk.MountPoint)
 		if err = disk.LockForInstance(cfg.InstanceDir); err != nil {
-			logrus.Errorf("could not attach disk %q: %s", diskName, err)
+			logrus.Errorf("could not attach disk %#q: %s", diskName, err)
 			return "", nil, err
 		}
 		dataDisk := filepath.Join(disk.Dir, filenames.DataDisk)
@@ -811,7 +811,7 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 				if runtime.GOOS != "darwin" {
 					return "", nil, fmt.Errorf("networks.yaml '%s' configuration is only supported on macOS right now", nw.Lima)
 				}
-				logrus.Debugf("Using socketVMNet (%q)", nwCfg.Paths.SocketVMNet)
+				logrus.Debugf("Using socketVMNet (%#q)", nwCfg.Paths.SocketVMNet)
 				sock, err := networks.Sock(nw.Lima)
 				if err != nil {
 					return "", nil, err
@@ -1107,7 +1107,7 @@ func Exe(arch limatype.Arch) (exe string, args []string, err error) {
 	if envV := os.Getenv(envK); envV != "" {
 		ss, err := shellwords.Parse(envV)
 		if err != nil {
-			return "", nil, fmt.Errorf("failed to parse %s value %q: %w", envK, envV, err)
+			return "", nil, fmt.Errorf("failed to parse %s value %#q: %w", envK, envV, err)
 		}
 		exeBase, args = ss[0], ss[1:]
 		if len(args) != 0 {
@@ -1163,7 +1163,7 @@ func getQemuVersion(ctx context.Context, qemuExe string) (*semver.Version, error
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("failed to run %v: stdout=%q, stderr=%q", cmd.Args, stdout.String(), stderr.String())
+		return nil, fmt.Errorf("failed to run %v: stdout=%#q, stderr=%#q", cmd.Args, stdout.String(), stderr.String())
 	}
 
 	return parseQemuVersion(stdout.String())
@@ -1173,7 +1173,7 @@ func getFirmware(qemuExe string, arch limatype.Arch) (string, error) {
 	switch arch {
 	case limatype.X8664, limatype.AARCH64, limatype.ARMV7L, limatype.RISCV64:
 	default:
-		return "", fmt.Errorf("unexpected architecture: %q", arch)
+		return "", fmt.Errorf("unexpected architecture: %#q", arch)
 	}
 
 	homeDir, err := os.UserHomeDir()
@@ -1238,10 +1238,10 @@ func getFirmware(qemuExe string, arch limatype.Arch) (string, error) {
 	}
 
 	if arch == limatype.X8664 {
-		return "", fmt.Errorf("could not find firmware for %q (hint: try setting `firmware.legacyBIOS` to `true`)", arch)
+		return "", fmt.Errorf("could not find firmware for %#q (hint: try setting `firmware.legacyBIOS` to `true`)", arch)
 	}
 	qemuArch := strings.TrimPrefix(filepath.Base(qemuExe), "qemu-system-")
-	return "", fmt.Errorf("could not find firmware for %q (hint: try copying the \"edk-%s-code.fd\" firmware to $HOME/.local/share/qemu/)", arch, qemuArch)
+	return "", fmt.Errorf("could not find firmware for %#q (hint: try copying the `edk-%s-code.fd` firmware to $HOME/.local/share/qemu/)", arch, qemuArch)
 }
 
 func getFirmwareVars(qemuExe string, arch limatype.Arch) (string, error) {
@@ -1250,7 +1250,7 @@ func getFirmwareVars(qemuExe string, arch limatype.Arch) (string, error) {
 	case limatype.X8664:
 		targetArch = "i386" // vars are unified between i386 and x86_64 and normally only former is bundled
 	default:
-		return "", fmt.Errorf("unexpected architecture: %q", arch)
+		return "", fmt.Errorf("unexpected architecture: %#q", arch)
 	}
 
 	homeDir, err := os.UserHomeDir()
@@ -1278,7 +1278,7 @@ func getFirmwareVars(qemuExe string, arch limatype.Arch) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("could not find firmware vars for %q", arch)
+	return "", fmt.Errorf("could not find firmware vars for %#q", arch)
 }
 
 var hasSMEDarwin = sync.OnceValue(func() bool {

--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -110,7 +110,7 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 	}
 	if qemuOpts.MinimumVersion != nil {
 		if _, err := semver.NewVersion(*qemuOpts.MinimumVersion); err != nil {
-			return fmt.Errorf("field `vmOpts.qemu.minimumVersion` must be a semvar value, got %q: %w", *qemuOpts.MinimumVersion, err)
+			return fmt.Errorf("field `vmOpts.qemu.minimumVersion` must be a semvar value, got %#q: %w", *qemuOpts.MinimumVersion, err)
 		}
 	}
 
@@ -135,7 +135,7 @@ func validateArch(ctx context.Context, cfg *limatype.LimaYAML) error {
 func validateMountType(cfg *limatype.LimaYAML) error {
 	// 1. First, check if the user explicitly blocked this mount type in their config.
 	if cfg.MountTypesUnsupported != nil && cfg.MountType != nil && slices.Contains(cfg.MountTypesUnsupported, *cfg.MountType) {
-		return fmt.Errorf("mount type %q is explicitly unsupported", *cfg.MountType)
+		return fmt.Errorf("mount type %#q is explicitly unsupported", *cfg.MountType)
 	}
 
 	// 2. Then, check if the mount type is valid for the current Operating System.
@@ -146,14 +146,14 @@ func validateMountType(cfg *limatype.LimaYAML) error {
 			case limatype.REVSSHFS, limatype.NINEP, limatype.VIRTIOFS:
 				return nil
 			default:
-				return fmt.Errorf("field `mountType` must be one of %v for QEMU driver on Linux, got %q", []string{limatype.REVSSHFS, limatype.NINEP, limatype.VIRTIOFS}, *cfg.MountType)
+				return fmt.Errorf("field `mountType` must be one of %v for QEMU driver on Linux, got %#q", []string{limatype.REVSSHFS, limatype.NINEP, limatype.VIRTIOFS}, *cfg.MountType)
 			}
 		case "darwin":
 			switch *cfg.MountType {
 			case limatype.REVSSHFS, limatype.NINEP:
 				return nil
 			default:
-				return fmt.Errorf("field `mountType` must be %q or %q for QEMU driver on macOS, got %q", limatype.REVSSHFS, limatype.NINEP, *cfg.MountType)
+				return fmt.Errorf("field `mountType` must be %#q or %#q for QEMU driver on macOS, got %#q", limatype.REVSSHFS, limatype.NINEP, *cfg.MountType)
 			}
 		case "windows":
 			// Windows version of QEMU does not support 9p yet, so we should not suggest it.
@@ -162,14 +162,14 @@ func validateMountType(cfg *limatype.LimaYAML) error {
 			case limatype.REVSSHFS:
 				return nil
 			default:
-				return fmt.Errorf("field `mountType` must be %q for QEMU driver on Windows, got %q", limatype.REVSSHFS, *cfg.MountType)
+				return fmt.Errorf("field `mountType` must be %#q for QEMU driver on Windows, got %#q", limatype.REVSSHFS, *cfg.MountType)
 			}
 		default:
 			switch *cfg.MountType {
 			case limatype.REVSSHFS, limatype.NINEP:
 				return nil
 			default:
-				return fmt.Errorf("field `mountType` must be %q or %q for QEMU driver on %s, got %q", limatype.REVSSHFS, limatype.NINEP, runtime.GOOS, *cfg.MountType)
+				return fmt.Errorf("field `mountType` must be %#q or %#q for QEMU driver on %s, got %#q", limatype.REVSSHFS, limatype.NINEP, runtime.GOOS, *cfg.MountType)
 			}
 		}
 	}
@@ -190,7 +190,7 @@ func (l *LimaQemuDriver) FillConfig(_ context.Context, cfg *limatype.LimaYAML, f
 
 	var qemuOpts limatype.QEMUOpts
 	if err := limayaml.Convert(cfg.VMOpts[limatype.QEMU], &qemuOpts, "vmOpts.qemu"); err != nil {
-		logrus.WithError(err).Warnf("Couldn't convert %q", cfg.VMOpts[limatype.QEMU])
+		logrus.WithError(err).Warnf("Couldn't convert %#q", cfg.VMOpts[limatype.QEMU])
 	}
 	if qemuOpts.CPUType == nil {
 		qemuOpts.CPUType = limatype.CPUType{}
@@ -204,7 +204,7 @@ func (l *LimaQemuDriver) FillConfig(_ context.Context, cfg *limatype.LimaYAML, f
 				continue
 			}
 			if existing, ok := qemuOpts.CPUType[arch]; ok && existing != "" && existing != v {
-				logrus.Warnf("Conflicting cpuType for arch %q: top-level=%q, vmOpts.qemu=%q; using vmOpts.qemu value", arch, v, existing)
+				logrus.Warnf("Conflicting cpuType for arch %#q: top-level=%#q, vmOpts.qemu=%#q; using vmOpts.qemu value", arch, v, existing)
 				continue
 			}
 			qemuOpts.CPUType[arch] = v
@@ -250,7 +250,7 @@ func (l *LimaQemuDriver) FillConfig(_ context.Context, cfg *limatype.LimaYAML, f
 	}
 
 	if _, ok := mountTypesUnsupported[*cfg.MountType]; ok {
-		return fmt.Errorf("mount type %q is explicitly unsupported", *cfg.MountType)
+		return fmt.Errorf("mount type %#q is explicitly unsupported", *cfg.MountType)
 	}
 
 	return validateConfig(cfg)
@@ -391,7 +391,7 @@ func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
 		}()
 	}
 
-	logrus.Infof("Starting QEMU (hint: to watch the boot progress, see %q)", filepath.Join(qCfg.InstanceDir, "serial*.log"))
+	logrus.Infof("Starting QEMU (hint: to watch the boot progress, see %#q)", filepath.Join(qCfg.InstanceDir, "serial*.log"))
 	logrus.Debugf("qCmd.Args: %v", qCmd.Args)
 	if err := qCmd.Start(); err != nil {
 		return nil, err
@@ -457,7 +457,7 @@ func checkBinarySignature(ctx context.Context, vmArch string) error {
 	if !macOSProductVersion.LessThan(*semver.New("12.0.0")) && vmArch != "" {
 		qExe, _, err := Exe(vmArch)
 		if err != nil {
-			return fmt.Errorf("failed to find the QEMU binary for the architecture %q: %w", vmArch, err)
+			return fmt.Errorf("failed to find the QEMU binary for the architecture %#q: %w", vmArch, err)
 		}
 		if accel := Accel(vmArch); accel == "hvf" {
 			entitlementutil.AskToSignIfNotSignedProperly(ctx, qExe)
@@ -545,18 +545,18 @@ func (l *LimaQemuDriver) shutdownQEMU(ctx context.Context, timeout time.Duration
 	qmpSockPath := filepath.Join(l.Instance.Dir, filenames.QMPSock)
 	qmpClient, err := qmp.NewSocketMonitor("unix", qmpSockPath, 5*time.Second)
 	if err != nil {
-		logrus.WithError(err).Warnf("failed to open the QMP socket %q, forcibly killing QEMU", qmpSockPath)
+		logrus.WithError(err).Warnf("failed to open the QMP socket %#q, forcibly killing QEMU", qmpSockPath)
 		return l.killQEMU(ctx, timeout, qCmd, qWaitCh)
 	}
 	if err := qmpClient.Connect(); err != nil {
-		logrus.WithError(err).Warnf("failed to connect to the QMP socket %q, forcibly killing QEMU", qmpSockPath)
+		logrus.WithError(err).Warnf("failed to connect to the QMP socket %#q, forcibly killing QEMU", qmpSockPath)
 		return l.killQEMU(ctx, timeout, qCmd, qWaitCh)
 	}
 	defer func() { _ = qmpClient.Disconnect() }()
 	rawClient := raw.NewMonitor(qmpClient)
 	logrus.Info("Sending QMP system_powerdown command")
 	if err := rawClient.SystemPowerdown(); err != nil {
-		logrus.WithError(err).Warnf("failed to send system_powerdown command via the QMP socket %q, forcibly killing QEMU", qmpSockPath)
+		logrus.WithError(err).Warnf("failed to send system_powerdown command via the QMP socket %#q, forcibly killing QEMU", qmpSockPath)
 		return l.killQEMU(ctx, timeout, qCmd, qWaitCh)
 	}
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, timeout)

--- a/pkg/driver/vz/network_darwin_test.go
+++ b/pkg/driver/vz/network_darwin_test.go
@@ -24,7 +24,7 @@ func TestDialQemu(t *testing.T) {
 	listener, err := listenUnix(t.TempDir())
 	assert.NilError(t, err)
 	defer listener.Close()
-	t.Logf("Listening at %q", listener.Addr())
+	t.Logf("Listening at %#q", listener.Addr())
 
 	errc := make(chan error, 2)
 

--- a/pkg/driver/vz/vm_darwin.go
+++ b/pkg/driver/vz/vm_darwin.go
@@ -88,18 +88,18 @@ func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int, onV
 				logrus.Info("Context closed, stopping vm")
 				if machine.CanStop() {
 					_, err := machine.RequestStop()
-					logrus.Errorf("Error while stopping the VM %q", err)
+					logrus.Errorf("Error while stopping the VM %#q", err)
 				}
 			case newState := <-machine.StateChangedNotify():
 				switch newState {
 				case vz.VirtualMachineStateRunning:
 					pidFile := filepath.Join(inst.Dir, filenames.PIDFile(*inst.Config.VMType))
 					if _, err := os.Stat(pidFile); !errors.Is(err, os.ErrNotExist) {
-						logrus.Errorf("pidfile %q already exists", pidFile)
+						logrus.Errorf("pidfile %#q already exists", pidFile)
 						sendErrCh <- err
 					}
 					if err := os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
-						logrus.Errorf("error writing to pid fil %q", pidFile)
+						logrus.Errorf("error writing to pid fil %#q", pidFile)
 						sendErrCh <- err
 					}
 					logrus.Info("[VZ] - vm state change: running")
@@ -167,7 +167,7 @@ func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int, onV
 					}
 					sendErrCh <- errors.New("vz driver state stopped")
 				default:
-					logrus.Debugf("[VZ] - vm state change: %q", newState)
+					logrus.Debugf("[VZ] - vm state change: %#q", newState)
 				}
 			}
 		}
@@ -493,7 +493,7 @@ func attachNetwork(ctx context.Context, inst *limatype.Instance, vmConfig *vz.Vi
 					return err
 				}
 				if socketVMNetOk {
-					logrus.Debugf("Using socketVMNet (%q)", nwCfg.Paths.SocketVMNet)
+					logrus.Debugf("Using socketVMNet (%#q)", nwCfg.Paths.SocketVMNet)
 					sock, err := networks.Sock(nw.Lima)
 					if err != nil {
 						return err
@@ -534,11 +534,11 @@ func validateDiskFormat(diskPath string) error {
 	defer f.Close()
 	img, err := qcow2reader.Open(f)
 	if err != nil {
-		return fmt.Errorf("failed to detect the format of %q: %w", diskPath, err)
+		return fmt.Errorf("failed to detect the format of %#q: %w", diskPath, err)
 	}
 	supportedDiskTypes := []image.Type{raw.Type, asif.Type}
 	if t := img.Type(); !slices.Contains(supportedDiskTypes, t) {
-		return fmt.Errorf("expected the format of %q to be one of %v, got %q", diskPath, supportedDiskTypes, t)
+		return fmt.Errorf("expected the format of %#q to be one of %v, got %#q", diskPath, supportedDiskTypes, t)
 	}
 	// TODO: ensure that the disk is formatted with GPT or ISO9660
 	return nil
@@ -585,27 +585,27 @@ func attachDisks(ctx context.Context, inst *limatype.Instance, vmConfig *vz.Virt
 		diskName := d.Name
 		disk, err := store.InspectDisk(diskName, d.FSType)
 		if err != nil {
-			return fmt.Errorf("failed to run load disk %q: %w", diskName, err)
+			return fmt.Errorf("failed to run load disk %#q: %w", diskName, err)
 		}
 
-		logrus.Infof("Mounting disk %q on %q", diskName, disk.MountPoint)
+		logrus.Infof("Mounting disk %#q on %#q", diskName, disk.MountPoint)
 		if err = disk.LockForInstance(inst.Dir); err != nil {
-			return fmt.Errorf("failed to attach disk %q: %w", diskName, err)
+			return fmt.Errorf("failed to attach disk %#q: %w", diskName, err)
 		}
 		extraDiskPath := filepath.Join(disk.Dir, filenames.DataDisk)
 		// ConvertToRaw is a NOP if no conversion is needed
-		logrus.Debugf("Converting extra disk %q to a raw disk (if it is not a raw)", extraDiskPath)
+		logrus.Debugf("Converting extra disk %#q to a raw disk (if it is not a raw)", extraDiskPath)
 
 		if err = diskUtil.Convert(ctx, raw.Type, extraDiskPath, extraDiskPath, nil, true); err != nil {
-			return fmt.Errorf("failed to convert extra disk %q to a raw disk: %w", extraDiskPath, err)
+			return fmt.Errorf("failed to convert extra disk %#q to a raw disk: %w", extraDiskPath, err)
 		}
 		extraDiskPathAttachment, err := vz.NewDiskImageStorageDeviceAttachmentWithCacheAndSync(extraDiskPath, false, diskImageCachingMode, vz.DiskImageSynchronizationModeFsync)
 		if err != nil {
-			return fmt.Errorf("failed to create disk attachment for extra disk %q: %w", extraDiskPath, err)
+			return fmt.Errorf("failed to create disk attachment for extra disk %#q: %w", extraDiskPath, err)
 		}
 		extraDisk, err := vz.NewVirtioBlockDeviceConfiguration(extraDiskPathAttachment)
 		if err != nil {
-			return fmt.Errorf("failed to create new virtio block device config for extra disk %q: %w", extraDiskPath, err)
+			return fmt.Errorf("failed to create new virtio block device config for extra disk %#q: %w", extraDiskPath, err)
 		}
 		configurations = append(configurations, extraDisk)
 	}
@@ -657,7 +657,7 @@ func attachDisplay(inst *limatype.Instance, vmConfig *vz.VirtualMachineConfigura
 	case "none":
 		return nil
 	default:
-		return fmt.Errorf("unexpected video display %q", *inst.Config.Video.Display)
+		return fmt.Errorf("unexpected video display %#q", *inst.Config.Video.Display)
 	}
 }
 
@@ -745,7 +745,7 @@ func attachFolderMounts(inst *limatype.Instance, vmConfig *vz.VirtualMachineConf
 
 	var vzOpts limatype.VZOpts
 	if err := limayaml.Convert(inst.Config.VMOpts[limatype.VZ], &vzOpts, "vmOpts.vz"); err != nil {
-		logrus.WithError(err).Warnf("Couldn't convert %q", inst.Config.VMOpts[limatype.VZ])
+		logrus.WithError(err).Warnf("Couldn't convert %#q", inst.Config.VMOpts[limatype.VZ])
 	}
 
 	if vzOpts.Rosetta.Enabled != nil && *vzOpts.Rosetta.Enabled {
@@ -783,7 +783,7 @@ func attachAudio(inst *limatype.Instance, config *vz.VirtualMachineConfiguration
 	case "", "none":
 		return nil
 	default:
-		return fmt.Errorf("unexpected audio device %q", *inst.Config.Audio.Device)
+		return fmt.Errorf("unexpected audio device %#q", *inst.Config.Audio.Device)
 	}
 }
 
@@ -890,22 +890,22 @@ func linuxBootLoader(inst *limatype.Instance) (*vz.LinuxBootLoader, error) {
 	initrd := filepath.Join(inst.Dir, filenames.Initrd)
 	if _, err := os.Stat(kernel); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logrus.Debugf("Kernel file %q not found", kernel)
+			logrus.Debugf("Kernel file %#q not found", kernel)
 		} else {
-			logrus.WithError(err).Debugf("Error while checking kernel file %q", kernel)
+			logrus.WithError(err).Debugf("Error while checking kernel file %#q", kernel)
 		}
 		return nil, err
 	}
 	var opt []vz.LinuxBootLoaderOption
 	if b, err := os.ReadFile(kernelCmdline); err == nil {
-		logrus.Debugf("Using kernel command line %q", string(b))
+		logrus.Debugf("Using kernel command line %#q", string(b))
 		opt = append(opt, vz.WithCommandLine(string(b)))
 	}
 	if _, err := os.Stat(initrd); err == nil {
-		logrus.Debugf("Using initrd %q", initrd)
+		logrus.Debugf("Using initrd %#q", initrd)
 		opt = append(opt, vz.WithInitrd(initrd))
 	}
-	logrus.Debugf("Using Linux Boot Loader with kernel %q", kernel)
+	logrus.Debugf("Using Linux Boot Loader with kernel %#q", kernel)
 	return vz.NewLinuxBootLoader(kernel, opt...)
 }
 
@@ -961,7 +961,7 @@ func ensureIPSW(instDir string) error {
 	// The installer wants the file to have ".ipsw" suffix.
 	// The link is created as a hard link, as the installer does not accept symlinks.
 	if err := os.Link(ipswBase, ipsw); err != nil {
-		return fmt.Errorf("failed to create hard link from %q to %q: %w", ipswBase, ipsw, err)
+		return fmt.Errorf("failed to create hard link from %#q to %#q: %w", ipswBase, ipsw, err)
 	}
 	return nil
 }

--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -129,14 +129,14 @@ func (l *LimaVzDriver) Configure(_ context.Context, inst *limatype.Instance) *dr
 
 		if _, ok := mountTypesUnsupported[*l.Instance.Config.MountType]; ok {
 			// We cannot return an error here, but Validate() will return it.
-			logrus.Warnf("Unsupported mount type: %q", *l.Instance.Config.MountType)
+			logrus.Warnf("Unsupported mount type: %#q", *l.Instance.Config.MountType)
 		}
 	}
 
 	var vzOpts limatype.VZOpts
 	if l.Instance.Config.VMOpts[limatype.VZ] != nil {
 		if err := limayaml.Convert(l.Instance.Config.VMOpts[limatype.VZ], &vzOpts, "vmOpts.vz"); err != nil {
-			logrus.WithError(err).Warnf("Couldn't convert %q", l.Instance.Config.VMOpts[limatype.VZ])
+			logrus.WithError(err).Warnf("Couldn't convert %#q", l.Instance.Config.VMOpts[limatype.VZ])
 		}
 	}
 
@@ -174,7 +174,7 @@ func (l *LimaVzDriver) FillConfig(ctx context.Context, cfg *limatype.LimaYAML, _
 
 	var vzOpts limatype.VZOpts
 	if err := limayaml.Convert(cfg.VMOpts[limatype.VZ], &vzOpts, "vmOpts.vz"); err != nil {
-		logrus.WithError(err).Warnf("Couldn't convert %q", cfg.VMOpts[limatype.VZ])
+		logrus.WithError(err).Warnf("Couldn't convert %#q", cfg.VMOpts[limatype.VZ])
 	}
 
 	//nolint:staticcheck // Migration of top-level Rosetta if specified
@@ -266,11 +266,11 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 	}
 	if runtime.GOARCH == "amd64" && macOSProductVersion.LessThan(*semver.New("15.5.0")) {
 		logrus.Warnf("vmType %s: On Intel Mac, macOS 15.5 or later is required to run Linux 6.12 or later. "+
-			"Update macOS, or change vmType to \"qemu\" if the VM does not start up. (https://github.com/lima-vm/lima/issues/3334)",
+			"Update macOS, or change vmType to `qemu` if the VM does not start up. (https://github.com/lima-vm/lima/issues/3334)",
 			*cfg.VMType)
 	}
 	if cfg.MountType != nil && *cfg.MountType == limatype.NINEP {
-		return fmt.Errorf("field `mountType` must be %q or %q for VZ driver , got %q", limatype.REVSSHFS, limatype.VIRTIOFS, *cfg.MountType)
+		return fmt.Errorf("field `mountType` must be %#q or %#q for VZ driver , got %#q", limatype.REVSSHFS, limatype.VIRTIOFS, *cfg.MountType)
 	}
 	if *cfg.Firmware.LegacyBIOS {
 		logrus.Warnf("vmType %s: ignoring `firmware.legacyBIOS`", *cfg.VMType)
@@ -288,7 +288,7 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 	}
 
 	if !limatype.IsNativeArch(*cfg.Arch) {
-		return fmt.Errorf("unsupported arch: %q", *cfg.Arch)
+		return fmt.Errorf("unsupported arch: %#q", *cfg.Arch)
 	}
 
 	for i, image := range cfg.Images {
@@ -324,26 +324,26 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 	case "":
 	case "vz", "default", "none":
 	default:
-		logrus.Warnf("field `audio.device` must be \"vz\", \"default\", or \"none\" for VZ driver, got %q", audioDevice)
+		logrus.Warnf("field `audio.device` must be `vz`, `default`, or `none` for VZ driver, got %#q", audioDevice)
 	}
 
 	switch videoDisplay := *cfg.Video.Display; videoDisplay {
 	case "vz", "default", "none":
 	default:
-		logrus.Warnf("field `video.display` must be \"vz\", \"default\", or \"none\" for VZ driver , got %q", videoDisplay)
+		logrus.Warnf("field `video.display` must be `vz`, `default`, or `none` for VZ driver , got %#q", videoDisplay)
 	}
 	var vzOpts limatype.VZOpts
 	if err := limayaml.Convert(cfg.VMOpts[limatype.VZ], &vzOpts, "vmOpts.vz"); err != nil {
-		logrus.WithError(err).Warnf("Couldn't convert %q", cfg.VMOpts[limatype.VZ])
+		logrus.WithError(err).Warnf("Couldn't convert %#q", cfg.VMOpts[limatype.VZ])
 	}
 	switch *vzOpts.DiskImageFormat {
 	case raw.Type:
 	case asif.Type:
 		if macOSProductVersion.LessThan(*semver.New("26.0.0")) {
-			return fmt.Errorf("vmOpts.vz.diskImageFormat=%q requires macOS 26 or higher to run, got %q", asif.Type, macOSProductVersion)
+			return fmt.Errorf("vmOpts.vz.diskImageFormat=%#q requires macOS 26 or higher to run, got %#q", asif.Type, macOSProductVersion)
 		}
 	default:
-		return fmt.Errorf("field `vmOpts.vz.diskImageFormat` must be %q or %q, got %q", raw.Type, asif.Type, *vzOpts.DiskImageFormat)
+		return fmt.Errorf("field `vmOpts.vz.diskImageFormat` must be %#q or %#q, got %#q", raw.Type, asif.Type, *vzOpts.DiskImageFormat)
 	}
 	return nil
 }
@@ -369,7 +369,7 @@ func (l *LimaVzDriver) CreateDisk(ctx context.Context) error {
 
 		patchedMarker := disk + ".patched" // empty file
 		if !osutil.FileExists(patchedMarker) {
-			logrus.Infof("Patching macOS disk %q", disk)
+			logrus.Infof("Patching macOS disk %#q", disk)
 			if err := macos.Patch(ctx, disk); err != nil {
 				return err
 			}
@@ -394,7 +394,7 @@ func (l *LimaVzDriver) createDiskMacOSGuest(ctx context.Context) error {
 
 	diskSize, err := units.RAMInBytes(*l.Instance.Config.Disk)
 	if err != nil {
-		return fmt.Errorf("invalid disk size %q: %w", *l.Instance.Config.Disk, err)
+		return fmt.Errorf("invalid disk size %#q: %w", *l.Instance.Config.Disk, err)
 	}
 
 	switch l.diskImageFormat {
@@ -406,7 +406,7 @@ func (l *LimaVzDriver) createDiskMacOSGuest(ctx context.Context) error {
 		logrus.Debugf("Using %s disk image for macOS guest", l.diskImageFormat)
 		diskUtil := &nativeimgutil.NativeImageUtil{}
 		if err := diskUtil.CreateDisk(ctx, disk, diskSize); err != nil {
-			return fmt.Errorf("failed to create %s disk %q: %w", l.diskImageFormat, disk, err)
+			return fmt.Errorf("failed to create %s disk %#q: %w", l.diskImageFormat, disk, err)
 		}
 	default:
 		return fmt.Errorf("unsupported disk format for macOS guest: %s", l.diskImageFormat)
@@ -435,7 +435,7 @@ func (l *LimaVzDriver) createDiskMacOSGuest(ctx context.Context) error {
 	}
 	for _, file := range filesToClean {
 		if err := os.RemoveAll(file); err != nil {
-			logrus.WithError(err).Warnf("Failed to remove %q", file)
+			logrus.WithError(err).Warnf("Failed to remove %#q", file)
 		}
 	}
 
@@ -443,7 +443,7 @@ func (l *LimaVzDriver) createDiskMacOSGuest(ctx context.Context) error {
 }
 
 func (l *LimaVzDriver) Start(ctx context.Context) (chan error, error) {
-	logrus.Infof("Starting VZ (hint: to watch the boot progress, see %q)", filepath.Join(l.Instance.Dir, "serial*.log"))
+	logrus.Infof("Starting VZ (hint: to watch the boot progress, see %#q)", filepath.Join(l.Instance.Dir, "serial*.log"))
 	vm, waitSSHLocalPortAccessible, errCh, err := startVM(ctx, l.Instance, l.SSHLocalPort, l.onVsockEvent)
 	if err != nil {
 		if errors.Is(err, vz.ErrUnsupportedOSVersion) {

--- a/pkg/driver/wsl2/vm_windows.go
+++ b/pkg/driver/wsl2/vm_windows.go
@@ -31,7 +31,7 @@ func startVM(ctx context.Context, distroName string) error {
 		distroName,
 	}, executil.WithContext(ctx))
 	if err != nil {
-		return fmt.Errorf("failed to run `wsl.exe --distribution %s`: %w (out=%q)",
+		return fmt.Errorf("failed to run `wsl.exe --distribution %s`: %w (out=%#q)",
 			distroName, err, out)
 	}
 	return nil
@@ -40,7 +40,7 @@ func startVM(ctx context.Context, distroName string) error {
 // initVM calls WSL to import a new VM specifically for Lima.
 func initVM(ctx context.Context, instanceDir, distroName string) error {
 	baseDisk := filepath.Join(instanceDir, filenames.BaseDiskLegacy)
-	logrus.Infof("Importing distro from %q to %q", baseDisk, instanceDir)
+	logrus.Infof("Importing distro from %#q to %#q", baseDisk, instanceDir)
 	out, err := executil.RunUTF16leCommand([]string{
 		"wsl.exe",
 		"--import",
@@ -49,7 +49,7 @@ func initVM(ctx context.Context, instanceDir, distroName string) error {
 		baseDisk,
 	}, executil.WithContext(ctx))
 	if err != nil {
-		return fmt.Errorf("failed to run `wsl.exe --import %s %s %s`: %w (out=%q)",
+		return fmt.Errorf("failed to run `wsl.exe --import %s %s %s`: %w (out=%#q)",
 			distroName, instanceDir, baseDisk, err, out)
 	}
 	return nil
@@ -63,7 +63,7 @@ func stopVM(ctx context.Context, distroName string) error {
 		distroName,
 	}, executil.WithContext(ctx))
 	if err != nil {
-		return fmt.Errorf("failed to run `wsl.exe --terminate %s`: %w (out=%q)",
+		return fmt.Errorf("failed to run `wsl.exe --terminate %s`: %w (out=%#q)",
 			distroName, err, out)
 	}
 	return nil
@@ -125,11 +125,11 @@ func provisionVM(ctx context.Context, instanceDir, instanceName, distroName stri
 		)
 		out, err := cmd.CombinedOutput()
 		os.RemoveAll(limaBootFileWinPath)
-		logrus.Debugf("%v: %q", cmd.Args, string(out))
+		logrus.Debugf("%v: %#q", cmd.Args, string(out))
 		if err != nil {
 			errCh <- fmt.Errorf(
 				"error running wslCommand that executes boot.sh (%v): %w, "+
-					"check /var/log/lima-init.log for more details (out=%q)", cmd.Args, err, string(out))
+					"check /var/log/lima-init.log for more details (out=%#q)", cmd.Args, err, string(out))
 		}
 
 		<-ctx.Done()
@@ -172,7 +172,7 @@ func unregisterVM(ctx context.Context, distroName string) error {
 		distroName,
 	}, executil.WithContext(ctx))
 	if err != nil {
-		return fmt.Errorf("failed to run `wsl.exe --unregister %s`: %w (out=%q)",
+		return fmt.Errorf("failed to run `wsl.exe --unregister %s`: %w (out=%#q)",
 			distroName, err, out)
 	}
 	return nil
@@ -213,22 +213,22 @@ func getWslStatus(ctx context.Context, instName string) (string, error) {
 		"--verbose",
 	}, executil.WithContext(ctx))
 	if err != nil {
-		return "", fmt.Errorf("failed to run `wsl --list --verbose`, err: %w (out=%q)", err, out)
+		return "", fmt.Errorf("failed to run `wsl --list --verbose`, err: %w (out=%#q)", err, out)
 	}
 
 	if out == "" {
-		return limatype.StatusBroken, fmt.Errorf("failed to read instance state for instance %q, try running `wsl --list --verbose` to debug, err: %w", instName, err)
+		return limatype.StatusBroken, fmt.Errorf("failed to read instance state for instance %#q, try running `wsl --list --verbose` to debug, err: %w", instName, err)
 	}
 
 	// Check for edge cases first
 	if strings.Contains(out, "Windows Subsystem for Linux has no installed distributions.") {
 		if strings.Contains(out, "Wsl/WSL_E_DEFAULT_DISTRO_NOT_FOUND") {
 			return limatype.StatusBroken, fmt.Errorf(
-				"failed to read instance state for instance %q because no distro is installed,"+
+				"failed to read instance state for instance %#q because no distro is installed,"+
 					"try running `wsl --install -d Ubuntu` and then re-running Lima", instName)
 		}
 		return limatype.StatusBroken, fmt.Errorf(
-			"failed to read instance state for instance %q because there is no WSL kernel installed,"+
+			"failed to read instance state for instance %#q because there is no WSL kernel installed,"+
 				"this usually happens when WSL was installed for another user, but never for your user."+
 				"Try running `wsl --install -d Ubuntu` and `wsl --update`, and then re-running Lima", instName)
 	}
@@ -287,5 +287,5 @@ func getSSHAddress(ctx context.Context, instName string) (string, error) {
 			return strings.TrimSpace(string(out)), nil
 		}
 	}
-	return "", fmt.Errorf("failed to get hostname for instance %q, err: %w (out=%q)", instName, err, string(out))
+	return "", fmt.Errorf("failed to get hostname for instance %#q, err: %w (out=%#q)", instName, err, string(out))
 }

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -98,7 +98,7 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 		return errors.New("configuration is nil")
 	}
 	if cfg.MountType != nil && *cfg.MountType != limatype.WSLMount {
-		return fmt.Errorf("field `mountType` must be %q for WSL2 driver, got %q", limatype.WSLMount, *cfg.MountType)
+		return fmt.Errorf("field `mountType` must be %#q for WSL2 driver, got %#q", limatype.WSLMount, *cfg.MountType)
 	}
 	// TODO: revise this list for WSL2
 	if cfg.VMType != nil {
@@ -108,7 +108,7 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 	}
 
 	if !limatype.IsNativeArch(*cfg.Arch) {
-		return fmt.Errorf("unsupported arch: %q", *cfg.Arch)
+		return fmt.Errorf("unsupported arch: %#q", *cfg.Arch)
 	}
 
 	if cfg.VMType != nil {
@@ -121,7 +121,7 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 				}
 				match := tarFileRegex.MatchString(image.Location)
 				if image.Arch == *cfg.Arch && !match {
-					return fmt.Errorf("unsupported image type for vmType: %s, tarball root file system required: %q", *cfg.VMType, image.Location)
+					return fmt.Errorf("unsupported image type for vmType: %s, tarball root file system required: %#q", *cfg.VMType, image.Location)
 				}
 			}
 		}

--- a/pkg/driverutil/disk.go
+++ b/pkg/driverutil/disk.go
@@ -31,9 +31,9 @@ func MigrateDiskLayout(instDir string) error {
 
 	diffDiskPath := filepath.Join(instDir, filenames.DiffDiskLegacy)
 	if osutil.FileExists(diffDiskPath) {
-		logrus.Infof("Creating symlink %q -> %q", filenames.Disk, filenames.DiffDiskLegacy)
+		logrus.Infof("Creating symlink %#q -> %#q", filenames.Disk, filenames.DiffDiskLegacy)
 		if err := os.Symlink(filenames.DiffDiskLegacy, diskPath); err != nil {
-			return fmt.Errorf("failed to symlink %q to %q: %w", filenames.Disk, filenames.DiffDiskLegacy, err)
+			return fmt.Errorf("failed to symlink %#q to %#q: %w", filenames.Disk, filenames.DiffDiskLegacy, err)
 		}
 	}
 
@@ -45,9 +45,9 @@ func MigrateDiskLayout(instDir string) error {
 			return err
 		}
 		if isISO {
-			logrus.Infof("Creating symlink %q -> %q", filenames.ISO, filenames.BaseDiskLegacy)
+			logrus.Infof("Creating symlink %#q -> %#q", filenames.ISO, filenames.BaseDiskLegacy)
 			if err := os.Symlink(filenames.BaseDiskLegacy, isoPath); err != nil {
-				return fmt.Errorf("failed to symlink %q to %q: %w", filenames.ISO, filenames.BaseDiskLegacy, err)
+				return fmt.Errorf("failed to symlink %#q to %#q: %w", filenames.ISO, filenames.BaseDiskLegacy, err)
 			}
 		}
 		// Non-ISO basedisk is a legacy qcow2 backing file; leave it for QEMU to resolve.
@@ -92,11 +92,11 @@ func EnsureDisk(ctx context.Context, instDir, diskSize string, diskImageFormat i
 		if err := diskUtil.Convert(ctx, diskImageFormat, diskPath, diskPath, &diskSizeInBytes, false); err != nil {
 			os.Remove(diskPath)
 			_ = os.Rename(isoPath, imagePath)
-			return fmt.Errorf("failed to create disk %q: %w", diskPath, err)
+			return fmt.Errorf("failed to create disk %#q: %w", diskPath, err)
 		}
 	} else {
 		if err := diskUtil.Convert(ctx, diskImageFormat, imagePath, diskPath, &diskSizeInBytes, false); err != nil {
-			return fmt.Errorf("failed to convert %q to %q: %w", imagePath, diskPath, err)
+			return fmt.Errorf("failed to convert %#q to %#q: %w", imagePath, diskPath, err)
 		}
 		os.Remove(imagePath)
 	}

--- a/pkg/driverutil/instance.go
+++ b/pkg/driverutil/instance.go
@@ -33,15 +33,15 @@ func CreateConfiguredDriver(ctx context.Context, inst *limatype.Instance, sshLoc
 	}
 	if extDriver != nil {
 		extDriver.PIDFileOwner = pidFileOwner
-		extDriver.Logger.Debugf("Using external driver %q", extDriver.Name)
+		extDriver.Logger.Debugf("Using external driver %#q", extDriver.Name)
 		if extDriver.Client == nil || extDriver.Command == nil {
-			logrus.Debugf("Starting new instance of external driver %q", extDriver.Name)
+			logrus.Debugf("Starting new instance of external driver %#q", extDriver.Name)
 			if err := server.Start(ctx, extDriver, inst.Name); err != nil {
-				extDriver.Logger.Errorf("Failed to start external driver %q: %v", extDriver.Name, err)
+				extDriver.Logger.Errorf("Failed to start external driver %#q: %v", extDriver.Name, err)
 				return nil, err
 			}
 		} else {
-			logrus.Debugf("Reusing existing external driver %q instance", extDriver.Name)
+			logrus.Debugf("Reusing existing external driver %#q instance", extDriver.Name)
 			extDriver.InstanceName = inst.Name
 		}
 
@@ -53,7 +53,7 @@ func CreateConfiguredDriver(ctx context.Context, inst *limatype.Instance, sshLoc
 	}
 
 	info := intDriver.Info(ctx)
-	logrus.Debugf("Using internal driver %q", info.Name)
+	logrus.Debugf("Using internal driver %#q", info.Name)
 	if !info.Features.StaticSSHPort {
 		inst.SSHLocalPort = sshLocalPort
 	}

--- a/pkg/driverutil/vm.go
+++ b/pkg/driverutil/vm.go
@@ -24,7 +24,7 @@ func ResolveVMType(ctx context.Context, y *limatype.LimaYAML, filePath string) e
 		if err := validateConfigAgainstDriver(ctx, y, filePath, *y.VMType); err != nil {
 			return err
 		}
-		logrus.Debugf("Using specified vmType %q for %q", *y.VMType, filePath)
+		logrus.Debugf("Using specified vmType %#q for %#q", *y.VMType, filePath)
 		return nil
 	}
 
@@ -39,7 +39,7 @@ func ResolveVMType(ctx context.Context, y *limatype.LimaYAML, filePath string) e
 func validateConfigAgainstDriver(ctx context.Context, y *limatype.LimaYAML, filePath, vmType string) error {
 	extDriver, intDriver, exists := registry.Get(vmType)
 	if !exists {
-		return fmt.Errorf("vmType %q is not a registered driver", vmType)
+		return fmt.Errorf("vmType %#q is not a registered driver", vmType)
 	}
 
 	if extDriver != nil {
@@ -99,7 +99,7 @@ func handlePreConfiguredDriverAction(ctx context.Context, y *limatype.LimaYAML, 
 	}
 
 	*y = res
-	logrus.Debugf("Pre-configured driver action completed successfully for %q", extDriverPath)
+	logrus.Debugf("Pre-configured driver action completed successfully for %#q", extDriverPath)
 	return nil
 }
 
@@ -116,10 +116,10 @@ func InspectStatus(ctx context.Context, inst *limatype.Instance) (string, error)
 	if extDriver != nil {
 		status, err := handleInspectStatusAction(ctx, inst, extDriver.Path)
 		if err != nil {
-			extDriver.Logger.Errorf("Failed to inspect status for instance %q: %v", inst.Name, err)
+			extDriver.Logger.Errorf("Failed to inspect status for instance %#q: %v", inst.Name, err)
 			return "", err
 		}
-		extDriver.Logger.Debugf("Instance %q inspected successfully with status: %s", inst.Name, inst.Status)
+		extDriver.Logger.Debugf("Instance %#q inspected successfully with status: %s", inst.Name, inst.Status)
 		return status, nil
 	}
 
@@ -177,6 +177,6 @@ func handleInspectStatusAction(ctx context.Context, inst *limatype.Instance, ext
 	}
 
 	*inst = respInst
-	logrus.Debugf("Inspecting instance status action completed successfully for %q", extDriverPath)
+	logrus.Debugf("Inspecting instance status action completed successfully for %#q", extDriverPath)
 	return inst.Status, nil
 }

--- a/pkg/editutil/editutil.go
+++ b/pkg/editutil/editutil.go
@@ -81,9 +81,9 @@ func OpenEditor(ctx context.Context, content []byte, hdr string) ([]byte, error)
 	editorCmd.Stdin = os.Stdin
 	editorCmd.Stdout = os.Stdout
 	editorCmd.Stderr = os.Stderr
-	logrus.Debugf("opening editor %q for a file %q", editor, tmpYAMLPath)
+	logrus.Debugf("opening editor %#q for a file %#q", editor, tmpYAMLPath)
 	if err := editorCmd.Run(); err != nil {
-		return nil, fmt.Errorf("could not execute editor %q for a file %q: %w", editor, tmpYAMLPath, err)
+		return nil, fmt.Errorf("could not execute editor %#q for a file %#q: %w", editor, tmpYAMLPath, err)
 	}
 	b, err := os.ReadFile(tmpYAMLPath)
 	if err != nil {

--- a/pkg/envutil/envutil.go
+++ b/pkg/envutil/envutil.go
@@ -49,7 +49,7 @@ func validatePattern(pattern string) error {
 	if matches := invalidChar.FindStringSubmatch(pattern); matches != nil {
 		invalidCharacter := matches[1]
 		pos := strings.Index(pattern, invalidCharacter)
-		return fmt.Errorf("pattern %q contains invalid character %q at position %d",
+		return fmt.Errorf("pattern %#q contains invalid character %#q at position %d",
 			pattern, invalidCharacter, pos)
 	}
 	return nil
@@ -156,7 +156,7 @@ func filterEnvironmentWithLists(env, allowList, blockList []string) []string {
 		}
 
 		if matchesAnyPattern(name, blockList) {
-			logrus.Debugf("Blocked env variable %q", name)
+			logrus.Debugf("Blocked env variable %#q", name)
 			continue
 		}
 

--- a/pkg/envutil/envutil_test.go
+++ b/pkg/envutil/envutil_test.go
@@ -205,7 +205,7 @@ func TestGetDefaultBlockList(t *testing.T) {
 	expectedItems := []string{"PATH", "HOME", "SSH_*", "USER"}
 	for _, item := range expectedItems {
 		found := slices.Contains(blocklist, item)
-		assert.Assert(t, found, "Expected builtin blocklist to contain %q", item)
+		assert.Assert(t, found, "Expected builtin blocklist to contain %#q", item)
 	}
 }
 
@@ -233,9 +233,9 @@ func TestValidatePattern(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validatePattern(tt.pattern)
 			if tt.valid {
-				assert.NilError(t, err, "Expected pattern %q to be valid", tt.pattern)
+				assert.NilError(t, err, "Expected pattern %#q to be valid", tt.pattern)
 			} else {
-				assert.Assert(t, err != nil, "Expected pattern %q to be invalid", tt.pattern)
+				assert.Assert(t, err != nil, "Expected pattern %#q to be invalid", tt.pattern)
 			}
 		})
 	}
@@ -244,6 +244,6 @@ func TestValidatePattern(t *testing.T) {
 func TestValidatePatternErrorMessage(t *testing.T) {
 	err := validatePattern("FOO-BAR")
 	assert.Assert(t, err != nil, "Expected pattern with dash to be invalid")
-	expectedMsg := `pattern "FOO-BAR" contains invalid character "-" at position 3`
+	expectedMsg := "pattern `FOO-BAR` contains invalid character `-` at position 3"
 	assert.Equal(t, err.Error(), expectedMsg)
 }

--- a/pkg/fileutils/download.go
+++ b/pkg/fileutils/download.go
@@ -21,7 +21,7 @@ var ErrSkipped = errors.New("skipped to download")
 // DownloadFile downloads a file to the cache, optionally copying it to the destination. Returns path in cache.
 func DownloadFile(ctx context.Context, dest string, f limatype.File, decompress bool, description string, expectedArch limatype.Arch) (string, error) {
 	if f.Arch != expectedArch {
-		return "", fmt.Errorf("%w: %q: unsupported arch: %q", ErrSkipped, f.Location, f.Arch)
+		return "", fmt.Errorf("%w: %#q: unsupported arch: %#q", ErrSkipped, f.Location, f.Arch)
 	}
 	fields := logrus.Fields{"location": f.Location, "arch": f.Arch, "digest": f.Digest}
 	logrus.WithFields(fields).Infof("Attempting to download %s", description)
@@ -32,14 +32,14 @@ func DownloadFile(ctx context.Context, dest string, f limatype.File, decompress 
 		downloader.WithExpectedDigest(f.Digest),
 	)
 	if err != nil {
-		return "", fmt.Errorf("failed to download %q: %w", f.Location, err)
+		return "", fmt.Errorf("failed to download %#q: %w", f.Location, err)
 	}
 	logrus.Debugf("res.ValidatedDigest=%v", res.ValidatedDigest)
 	switch res.Status {
 	case downloader.StatusDownloaded:
-		logrus.Infof("Downloaded %s from %q", description, f.Location)
+		logrus.Infof("Downloaded %s from %#q", description, f.Location)
 	case downloader.StatusUsedCache:
-		logrus.Infof("Using cache %q", res.CachePath)
+		logrus.Infof("Using cache %#q", res.CachePath)
 	default:
 		logrus.Warnf("Unexpected result from downloader.Download(): %+v", res)
 	}
@@ -52,7 +52,7 @@ func CachedFile(f limatype.File) (string, error) {
 		downloader.WithCache(),
 		downloader.WithExpectedDigest(f.Digest))
 	if err != nil {
-		return "", fmt.Errorf("cache did not contain %q: %w", f.Location, err)
+		return "", fmt.Errorf("cache did not contain %#q: %w", f.Location, err)
 	}
 	return res.CachePath, nil
 }

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -214,7 +214,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 			y.User.UID = ptr.Of(uint32(uid))
 		} else {
 			// This should never happen; LimaUser() makes sure that .Uid is numeric
-			logrus.WithError(err).Warnf("Can't parse `user.uid` %q", uidString)
+			logrus.WithError(err).Warnf("Can't parse `user.uid` %#q", uidString)
 			y.User.UID = ptr.Of(uint32(1000))
 		}
 		// warn = false
@@ -222,7 +222,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 	if out, err := executeGuestTemplate(*y.User.Home, instDir, y.User, y.Param); err == nil {
 		y.User.Home = ptr.Of(out.String())
 	} else {
-		logrus.WithError(err).Warnf("Couldn't process `user.home` value %q as a template", *y.User.Home)
+		logrus.WithError(err).Warnf("Couldn't process `user.home` value %#q as a template", *y.User.Home)
 	}
 
 	if y.VMType == nil {
@@ -404,7 +404,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 		logrus.Warn("The environment variable LIMA_SSH_OVER_VSOCK is deprecated in favor of the YAML field .ssh.overVsock")
 		b, err := strconv.ParseBool(envVar)
 		if err != nil {
-			logrus.WithError(err).Warnf("invalid LIMA_SSH_OVER_VSOCK value %q", envVar)
+			logrus.WithError(err).Warnf("invalid LIMA_SSH_OVER_VSOCK value %#q", envVar)
 		} else {
 			logrus.Debugf("Overriding ssh.overVsock from %v to %v via LIMA_SSH_OVER_VSOCK", y.SSH.OverVsock, &b)
 			y.SSH.OverVsock = ptr.Of(b)
@@ -434,7 +434,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 				if out, err := executeGuestTemplate(*provision.Content, instDir, y.User, y.Param); err == nil {
 					provision.Content = ptr.Of(out.String())
 				} else {
-					logrus.WithError(err).Warnf("Couldn't process data content %q as a template", *provision.Content)
+					logrus.WithError(err).Warnf("Couldn't process data content %#q as a template", *provision.Content)
 				}
 			}
 			if provision.Overwrite == nil {
@@ -446,7 +446,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 				if out, err := executeGuestTemplate(*provision.Expression, instDir, y.User, y.Param); err == nil {
 					provision.Expression = ptr.Of(out.String())
 				} else {
-					logrus.WithError(err).Warnf("Couldn't process expression %q as a template", *provision.Expression)
+					logrus.WithError(err).Warnf("Couldn't process expression %#q as a template", *provision.Expression)
 				}
 			}
 			if provision.Format == nil {
@@ -465,7 +465,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 				if out, err := executeGuestTemplate(*provision.Owner, instDir, y.User, y.Param); err == nil {
 					provision.Owner = ptr.Of(out.String())
 				} else {
-					logrus.WithError(err).Warnf("Couldn't process owner %q as a template", *provision.Owner)
+					logrus.WithError(err).Warnf("Couldn't process owner %#q as a template", *provision.Owner)
 				}
 			}
 			// Path is required; validation will throw an error when it is nil
@@ -473,7 +473,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 				if out, err := executeGuestTemplate(*provision.Path, instDir, y.User, y.Param); err == nil {
 					provision.Path = ptr.Of(out.String())
 				} else {
-					logrus.WithError(err).Warnf("Couldn't process path %q as a template", *provision.Path)
+					logrus.WithError(err).Warnf("Couldn't process path %#q as a template", *provision.Path)
 				}
 			}
 			if provision.Permissions == nil {
@@ -487,7 +487,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 			if out, err := executeGuestTemplate(*provision.Script, instDir, y.User, y.Param); err == nil {
 				*provision.Script = out.String()
 			} else {
-				logrus.WithError(err).Warnf("Couldn't process provisioning script %q as a template", *provision.Script)
+				logrus.WithError(err).Warnf("Couldn't process provisioning script %#q as a template", *provision.Script)
 			}
 		}
 	}
@@ -562,7 +562,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 		if out, err := executeGuestTemplate(*probe.Script, instDir, y.User, y.Param); err == nil {
 			probe.Script = ptr.Of(out.String())
 		} else {
-			logrus.WithError(err).Warnf("Couldn't process probing script %q as a template", *probe.Script)
+			logrus.WithError(err).Warnf("Couldn't process probing script %#q as a template", *probe.Script)
 		}
 	}
 
@@ -618,7 +618,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 			if nw.Lima != "" {
 				if nw.Socket != "" {
 					// We can't return an error, so just log it, and prefer `lima` over `socket`
-					logrus.Errorf("Network %q has both socket=%q and lima=%q fields; ignoring socket",
+					logrus.Errorf("Network %#q has both socket=%#q and lima=%#q fields; ignoring socket",
 						nw.Interface, nw.Socket, nw.Lima)
 				}
 				networks[i].Lima = nw.Lima
@@ -681,14 +681,14 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 		if out, err := executeHostTemplate(mount.Location, instDir, y.Param); err == nil {
 			mount.Location = filepath.Clean(out.String())
 		} else {
-			logrus.WithError(err).Warnf("Couldn't process mount location %q as a template", mount.Location)
+			logrus.WithError(err).Warnf("Couldn't process mount location %#q as a template", mount.Location)
 		}
 		// Expand a path that begins with `~`. Relative paths are not modified, and rejected by Validate() later.
 		if localpathutil.IsTildePath(mount.Location) {
 			if location, err := localpathutil.Expand(mount.Location); err == nil {
 				mount.Location = location
 			} else {
-				logrus.WithError(err).Warnf("Couldn't expand location %q", mount.Location)
+				logrus.WithError(err).Warnf("Couldn't expand location %#q", mount.Location)
 			}
 		}
 		if mount.MountPoint == nil {
@@ -697,7 +697,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 				var err error
 				mountLocation, err = ioutilx.WindowsSubsystemPath(ctx, mountLocation)
 				if err != nil {
-					logrus.WithError(err).Warnf("Couldn't convert location %q into mount target", mount.Location)
+					logrus.WithError(err).Warnf("Couldn't convert location %#q into mount target", mount.Location)
 				}
 			}
 			mount.MountPoint = ptr.Of(mountLocation)
@@ -705,7 +705,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 			if out, err := executeGuestTemplate(*mount.MountPoint, instDir, y.User, y.Param); err == nil {
 				mount.MountPoint = ptr.Of(out.String())
 			} else {
-				logrus.WithError(err).Warnf("Couldn't process mount point %q as a template", *mount.MountPoint)
+				logrus.WithError(err).Warnf("Couldn't process mount point %#q as a template", *mount.MountPoint)
 			}
 		}
 		if i, ok := mountPoint[*mount.MountPoint]; ok {
@@ -850,7 +850,7 @@ func ExistingLimaVersion(instDir string) string {
 	if b, err := os.ReadFile(limaVersionFile); err == nil {
 		return strings.TrimSpace(string(b))
 	} else if !errors.Is(err, os.ErrNotExist) {
-		logrus.WithError(err).Warnf("Failed to read %q", limaVersionFile)
+		logrus.WithError(err).Warnf("Failed to read %#q", limaVersionFile)
 	}
 
 	return version.Version
@@ -962,14 +962,14 @@ func FillPortForwardDefaults(rule *limatype.PortForward, instDir string, user li
 		if out, err := executeGuestTemplate(rule.GuestSocket, instDir, user, param); err == nil {
 			rule.GuestSocket = out.String()
 		} else {
-			logrus.WithError(err).Warnf("Couldn't process guestSocket %q as a template", rule.GuestSocket)
+			logrus.WithError(err).Warnf("Couldn't process guestSocket %#q as a template", rule.GuestSocket)
 		}
 	}
 	if rule.HostSocket != "" {
 		if out, err := executeHostTemplate(rule.HostSocket, instDir, param); err == nil {
 			rule.HostSocket = out.String()
 		} else {
-			logrus.WithError(err).Warnf("Couldn't process hostSocket %q as a template", rule.HostSocket)
+			logrus.WithError(err).Warnf("Couldn't process hostSocket %#q as a template", rule.HostSocket)
 		}
 		if !filepath.IsAbs(rule.HostSocket) {
 			rule.HostSocket = filepath.Join(instDir, filenames.SocketDir, rule.HostSocket)
@@ -989,14 +989,14 @@ func FillCopyToHostDefaults(rule *limatype.CopyToHost, instDir string, user lima
 		if out, err := executeGuestTemplate(rule.GuestFile, instDir, user, param); err == nil {
 			rule.GuestFile = out.String()
 		} else {
-			logrus.WithError(err).Warnf("Couldn't process guest %q as a template", rule.GuestFile)
+			logrus.WithError(err).Warnf("Couldn't process guest %#q as a template", rule.GuestFile)
 		}
 	}
 	if rule.HostFile != "" {
 		if out, err := executeHostTemplate(rule.HostFile, instDir, param); err == nil {
 			rule.HostFile = out.String()
 		} else {
-			logrus.WithError(err).Warnf("Couldn't process host %q as a template", rule.HostFile)
+			logrus.WithError(err).Warnf("Couldn't process host %#q as a template", rule.HostFile)
 		}
 	}
 }

--- a/pkg/limayaml/load.go
+++ b/pkg/limayaml/load.go
@@ -34,7 +34,7 @@ func LoadWithWarnings(ctx context.Context, b []byte, filePath string) (*limatype
 func load(ctx context.Context, b []byte, filePath string, warn bool) (*limatype.LimaYAML, error) {
 	var y, d, o limatype.LimaYAML
 
-	if err := Unmarshal(b, &y, fmt.Sprintf("main file %q", filePath)); err != nil {
+	if err := Unmarshal(b, &y, fmt.Sprintf("main file %#q", filePath)); err != nil {
 		return nil, err
 	}
 	configDir, err := dirnames.LimaConfigDir()
@@ -45,8 +45,8 @@ func load(ctx context.Context, b []byte, filePath string, warn bool) (*limatype.
 	defaultPath := filepath.Join(configDir, filenames.Default)
 	bytes, err := os.ReadFile(defaultPath)
 	if err == nil {
-		logrus.Debugf("Mixing %q into %q", defaultPath, filePath)
-		if err := Unmarshal(bytes, &d, fmt.Sprintf("default file %q", defaultPath)); err != nil {
+		logrus.Debugf("Mixing %#q into %#q", defaultPath, filePath)
+		if err := Unmarshal(bytes, &d, fmt.Sprintf("default file %#q", defaultPath)); err != nil {
 			return nil, err
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
@@ -56,8 +56,8 @@ func load(ctx context.Context, b []byte, filePath string, warn bool) (*limatype.
 	overridePath := filepath.Join(configDir, filenames.Override)
 	bytes, err = os.ReadFile(overridePath)
 	if err == nil {
-		logrus.Debugf("Mixing %q into %q", overridePath, filePath)
-		if err := Unmarshal(bytes, &o, fmt.Sprintf("override file %q", overridePath)); err != nil {
+		logrus.Debugf("Mixing %#q into %#q", overridePath, filePath)
+		if err := Unmarshal(bytes, &o, fmt.Sprintf("override file %#q", overridePath)); err != nil {
 			return nil, err
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -40,22 +40,22 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 
 	if y.MinimumLimaVersion != nil {
 		if _, err := versionutil.Parse(*y.MinimumLimaVersion); err != nil {
-			errs = errors.Join(errs, fmt.Errorf("field `minimumLimaVersion` must be a semvar value, got %q: %w", *y.MinimumLimaVersion, err))
+			errs = errors.Join(errs, fmt.Errorf("field `minimumLimaVersion` must be a semvar value, got %#q: %w", *y.MinimumLimaVersion, err))
 		}
 		// Unparsable version.Version (like commit hashes or "<unknown>") is treated as "latest/greatest"
 		// and will pass all version comparisons, allowing development builds to work.
 		if !versionutil.GreaterEqual(version.Version, *y.MinimumLimaVersion) {
-			errs = errors.Join(errs, fmt.Errorf("template requires Lima version %q; this is only %q", *y.MinimumLimaVersion, version.Version))
+			errs = errors.Join(errs, fmt.Errorf("template requires Lima version %#q; this is only %#q", *y.MinimumLimaVersion, version.Version))
 		}
 	}
 
 	switch *y.OS {
 	case limatype.LINUX, limatype.DARWIN, limatype.FREEBSD:
 	default:
-		errs = errors.Join(errs, fmt.Errorf("field `os` must be one of %q; got %q", limatype.OSTypes, *y.OS))
+		errs = errors.Join(errs, fmt.Errorf("field `os` must be one of %#q; got %#q", limatype.OSTypes, *y.OS))
 	}
 	if !slices.Contains(limatype.ArchTypes, *y.Arch) {
-		errs = errors.Join(errs, fmt.Errorf("field `arch` must be one of %v; got %q", limatype.ArchTypes, *y.Arch))
+		errs = errors.Join(errs, fmt.Errorf("field `arch` must be one of %v; got %#q", limatype.ArchTypes, *y.Arch))
 	}
 
 	if len(y.Images) == 0 {
@@ -72,7 +72,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 				errs = errors.Join(errs, err)
 			}
 			if f.Kernel.Arch != f.Arch {
-				errs = errors.Join(errs, fmt.Errorf("images[%d].kernel has unexpected architecture %q, must be %q", i, f.Kernel.Arch, f.Arch))
+				errs = errors.Join(errs, fmt.Errorf("images[%d].kernel has unexpected architecture %#q, must be %#q", i, f.Kernel.Arch, f.Arch))
 			}
 		}
 		if f.Initrd != nil {
@@ -81,7 +81,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 				errs = errors.Join(errs, err)
 			}
 			if f.Initrd.Arch != f.Arch {
-				errs = errors.Join(errs, fmt.Errorf("images[%d].initrd has unexpected architecture %q, must be %q", i, f.Initrd.Arch, f.Arch))
+				errs = errors.Join(errs, fmt.Errorf("images[%d].initrd has unexpected architecture %#q, must be %#q", i, f.Initrd.Arch, f.Arch))
 			}
 		}
 	}
@@ -106,24 +106,24 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 
 	for i, f := range y.Mounts {
 		if !filepath.IsAbs(f.Location) && !strings.HasPrefix(f.Location, "~") {
-			errs = errors.Join(errs, fmt.Errorf("field `mounts[%d].location` must be an absolute path, got %q",
+			errs = errors.Join(errs, fmt.Errorf("field `mounts[%d].location` must be an absolute path, got %#q",
 				i, f.Location))
 		}
 		// f.Location has already been expanded in FillDefaults(), but that function cannot return errors.
 		loc, err := localpathutil.Expand(f.Location)
 		if err != nil {
-			errs = errors.Join(errs, fmt.Errorf("field `mounts[%d].location` refers to an unexpandable path: %q: %w", i, f.Location, err))
+			errs = errors.Join(errs, fmt.Errorf("field `mounts[%d].location` refers to an unexpandable path: %#q: %w", i, f.Location, err))
 		}
 		st, err := os.Stat(loc)
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
-				errs = errors.Join(errs, fmt.Errorf("field `mounts[%d].location` refers to an inaccessible path: %q: %w", i, f.Location, err))
+				errs = errors.Join(errs, fmt.Errorf("field `mounts[%d].location` refers to an inaccessible path: %#q: %w", i, f.Location, err))
 			}
 			if warn {
-				logrus.Warnf("field `mounts[%d].location` refers to a non-existent directory: %q:", i, f.Location)
+				logrus.Warnf("field `mounts[%d].location` refers to a non-existent directory: %#q:", i, f.Location)
 			}
 		} else if !st.IsDir() {
-			errs = errors.Join(errs, fmt.Errorf("field `mounts[%d].location` refers to a non-directory path: %q: %w", i, f.Location, err))
+			errs = errors.Join(errs, fmt.Errorf("field `mounts[%d].location` refers to a non-directory path: %#q: %w", i, f.Location, err))
 		}
 
 		switch *f.MountPoint {
@@ -131,7 +131,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 			errs = errors.Join(errs, fmt.Errorf("field `mounts[%d].mountPoint` must not be a system path such as /etc or /usr", i))
 		// home directory defined in "cidata.iso:/user-data"
 		case *y.User.Home:
-			errs = errors.Join(errs, fmt.Errorf("field `mounts[%d].mountPoint` is the reserved internal home directory %q", i, *y.User.Home))
+			errs = errors.Join(errs, fmt.Errorf("field `mounts[%d].mountPoint` is the reserved internal home directory %#q", i, *y.User.Home))
 		}
 		// There is no tilde-expansion for guest filenames
 		if strings.HasPrefix(*f.MountPoint, "~") {
@@ -153,11 +153,11 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		switch *y.MountType {
 		case limatype.REVSSHFS, limatype.NINEP, limatype.VIRTIOFS, limatype.WSLMount:
 		default:
-			errs = errors.Join(errs, fmt.Errorf("field `mountType` must be %q or %q or %q, or %q, got %q", limatype.REVSSHFS, limatype.NINEP, limatype.VIRTIOFS, limatype.WSLMount, *y.MountType))
+			errs = errors.Join(errs, fmt.Errorf("field `mountType` must be %#q or %#q or %#q, or %#q, got %#q", limatype.REVSSHFS, limatype.NINEP, limatype.VIRTIOFS, limatype.WSLMount, *y.MountType))
 		}
 
 		if slices.Contains(y.MountTypesUnsupported, *y.MountType) {
-			errs = errors.Join(errs, fmt.Errorf("field `mountType` must not be one of %v (`mountTypesUnsupported`), got %q", y.MountTypesUnsupported, *y.MountType))
+			errs = errors.Join(errs, fmt.Errorf("field `mountType` must not be one of %v (`mountTypesUnsupported`), got %#q", y.MountTypesUnsupported, *y.MountType))
 		}
 	}
 
@@ -183,11 +183,11 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		switch p.Mode {
 		case limatype.ProvisionModeSystem, limatype.ProvisionModeUser, limatype.ProvisionModeBoot, limatype.ProvisionModeData, limatype.ProvisionModeDependency, limatype.ProvisionModeAnsible, limatype.ProvisionModeYQ:
 		default:
-			errs = errors.Join(errs, fmt.Errorf("field `provision[%d].mode` must one of %q, %q, %q, %q, %q, %q, or %q",
+			errs = errors.Join(errs, fmt.Errorf("field `provision[%d].mode` must one of %#q, %#q, %#q, %#q, %#q, %#q, or %#q",
 				i, limatype.ProvisionModeSystem, limatype.ProvisionModeUser, limatype.ProvisionModeBoot, limatype.ProvisionModeData, limatype.ProvisionModeDependency, limatype.ProvisionModeAnsible, limatype.ProvisionModeYQ))
 		}
 		if p.Mode != limatype.ProvisionModeDependency && p.SkipDefaultDependencyResolution != nil {
-			errs = errors.Join(errs, fmt.Errorf("field `provision[%d].mode` cannot set skipDefaultDependencyResolution, only valid on scripts of type %q",
+			errs = errors.Join(errs, fmt.Errorf("field `provision[%d].mode` cannot set skipDefaultDependencyResolution, only valid on scripts of type %#q",
 				i, limatype.ProvisionModeDependency))
 		}
 
@@ -195,17 +195,17 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		switch p.Mode {
 		case limatype.ProvisionModeData, limatype.ProvisionModeYQ:
 			if p.Path == nil {
-				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].path` must not be empty when mode is %q", i, p.Mode))
+				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].path` must not be empty when mode is %#q", i, p.Mode))
 				return errs
 			}
 			if !path.IsAbs(*p.Path) {
 				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].path` must be an absolute path", i))
 			}
 			if p.Mode == limatype.ProvisionModeData && p.Content == nil {
-				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].content` must not be empty when mode is %q", i, p.Mode))
+				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].content` must not be empty when mode is %#q", i, p.Mode))
 			}
 			if p.Mode == limatype.ProvisionModeYQ && p.Expression == nil {
-				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].expression` must not be empty when mode is %q", i, p.Mode))
+				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].expression` must not be empty when mode is %#q", i, p.Mode))
 			}
 			// FillDefaults makes sure that p.Permissions is not nil
 			if _, err := strconv.ParseInt(*p.Permissions, 8, 64); err != nil {
@@ -216,36 +216,36 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].script` must not be empty", i))
 			}
 			if p.Content != nil {
-				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].content` can only be set when mode is %q", i, limatype.ProvisionModeData))
+				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].content` can only be set when mode is %#q", i, limatype.ProvisionModeData))
 			}
 			if p.Overwrite != nil {
-				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].overwrite` can only be set when mode is %q", i, limatype.ProvisionModeData))
+				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].overwrite` can only be set when mode is %#q", i, limatype.ProvisionModeData))
 			}
 			if p.Owner != nil {
-				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].owner` can only be set when mode is %q", i, limatype.ProvisionModeData))
+				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].owner` can only be set when mode is %#q", i, limatype.ProvisionModeData))
 			}
 			if p.Path != nil {
-				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].path` can only be set when mode is %q, or %q", i, limatype.ProvisionModeData, limatype.ProvisionModeYQ))
+				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].path` can only be set when mode is %#q, or %#q", i, limatype.ProvisionModeData, limatype.ProvisionModeYQ))
 			}
 			if p.Permissions != nil {
-				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].permissions` can only be set when mode is %q, or %q", i, limatype.ProvisionModeData, limatype.ProvisionModeYQ))
+				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].permissions` can only be set when mode is %#q, or %#q", i, limatype.ProvisionModeData, limatype.ProvisionModeYQ))
 			}
 			if p.Format != nil {
-				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].format` can only be set when mode is %q", i, limatype.ProvisionModeYQ))
+				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].format` can only be set when mode is %#q", i, limatype.ProvisionModeYQ))
 			}
 		}
 		if p.Playbook != "" {
 			if p.Mode != limatype.ProvisionModeAnsible {
-				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].playbook can only be set when mode is %q", i, limatype.ProvisionModeAnsible))
+				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].playbook can only be set when mode is %#q", i, limatype.ProvisionModeAnsible))
 			}
 			if p.Script != nil && *p.Script != "" {
 				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].script must be empty if playbook is set", i))
 			}
 			playbook := p.Playbook
 			if _, err := os.Stat(playbook); err != nil {
-				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].playbook` refers to an inaccessible path: %q: %w", i, playbook, err))
+				errs = errors.Join(errs, fmt.Errorf("field `provision[%d].playbook` refers to an inaccessible path: %#q: %w", i, playbook, err))
 			}
-			logrus.Warnf("provision mode %q is deprecated, use `ansible-playbook %q` instead", limatype.ProvisionModeAnsible, playbook)
+			logrus.Warnf("provision mode %#q is deprecated, use `ansible-playbook %#q` instead", limatype.ProvisionModeAnsible, playbook)
 		}
 		if p.Script != nil {
 			if strings.Contains(*p.Script, "LIMA_CIDATA") {
@@ -280,7 +280,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		switch p.Mode {
 		case limatype.ProbeModeReadiness:
 		default:
-			errs = errors.Join(errs, fmt.Errorf("field `probe[%d].mode` can only be %q", i, limatype.ProbeModeReadiness))
+			errs = errors.Join(errs, fmt.Errorf("field `probe[%d].mode` can only be %#q", i, limatype.ProbeModeReadiness))
 		}
 	}
 	for i, rule := range y.PortForwards {
@@ -330,7 +330,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		}
 		if rule.GuestSocket != "" {
 			if !path.IsAbs(rule.GuestSocket) {
-				errs = errors.Join(errs, fmt.Errorf("field `%s.guestSocket` must be an absolute path, but is %q", field, rule.GuestSocket))
+				errs = errors.Join(errs, fmt.Errorf("field `%s.guestSocket` must be an absolute path, but is %#q", field, rule.GuestSocket))
 			}
 			if rule.HostSocket == "" && rule.HostPortRange[1]-rule.HostPortRange[0] > 0 {
 				errs = errors.Join(errs, fmt.Errorf("field `%s.guestSocket` can only be mapped to a single port or socket. not a range", field))
@@ -339,7 +339,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		if rule.HostSocket != "" {
 			if !filepath.IsAbs(rule.HostSocket) {
 				// should be unreachable because FillDefault() will prepend the instance directory to relative names
-				errs = errors.Join(errs, fmt.Errorf("field `%s.hostSocket` must be an absolute path, but is %q", field, rule.HostSocket))
+				errs = errors.Join(errs, fmt.Errorf("field `%s.hostSocket` must be an absolute path, but is %#q", field, rule.HostSocket))
 			}
 			if rule.GuestSocket == "" && rule.GuestPortRange[1]-rule.GuestPortRange[0] > 0 {
 				errs = errors.Join(errs, fmt.Errorf("field `%s.hostSocket` can only be mapped from a single port or socket. not a range", field))
@@ -355,7 +355,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		switch rule.Proto {
 		case limatype.ProtoTCP, limatype.ProtoUDP, limatype.ProtoAny:
 		default:
-			errs = errors.Join(errs, fmt.Errorf("field `%s.proto` must be %q, %q, or %q", field, limatype.ProtoTCP, limatype.ProtoUDP, limatype.ProtoAny))
+			errs = errors.Join(errs, fmt.Errorf("field `%s.proto` must be %#q, %#q, or %#q", field, limatype.ProtoTCP, limatype.ProtoUDP, limatype.ProtoAny))
 		}
 		if rule.Reverse && rule.GuestSocket == "" {
 			errs = errors.Join(errs, fmt.Errorf("field `%s.reverse` must be %t", field, false))
@@ -370,12 +370,12 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		field := fmt.Sprintf("CopyToHost[%d]", i)
 		if rule.GuestFile != "" {
 			if !path.IsAbs(rule.GuestFile) {
-				errs = errors.Join(errs, fmt.Errorf("field `%s.guest` must be an absolute path, but is %q", field, rule.GuestFile))
+				errs = errors.Join(errs, fmt.Errorf("field `%s.guest` must be an absolute path, but is %#q", field, rule.GuestFile))
 			}
 		}
 		if rule.HostFile != "" {
 			if !filepath.IsAbs(rule.HostFile) {
-				errs = errors.Join(errs, fmt.Errorf("field `%s.host` must be an absolute path, but is %q", field, rule.HostFile))
+				errs = errors.Join(errs, fmt.Errorf("field `%s.host` must be an absolute path, but is %#q", field, rule.HostFile))
 			}
 		}
 	}
@@ -398,11 +398,11 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 	validParamName := regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*$`)
 	for param, value := range y.Param {
 		if !validParamName.MatchString(param) {
-			errs = errors.Join(errs, fmt.Errorf("param %q name does not match regex %q", param, validParamName.String()))
+			errs = errors.Join(errs, fmt.Errorf("param %#q name does not match regex %#q", param, validParamName.String()))
 		}
 		for _, r := range value {
 			if !unicode.IsPrint(r) && r != '\t' && r != ' ' {
-				errs = errors.Join(errs, fmt.Errorf("param %q value contains unprintable character %q", param, r))
+				errs = errors.Join(errs, fmt.Errorf("param %#q value contains unprintable character %#q", param, r))
 			}
 		}
 	}
@@ -424,12 +424,12 @@ func validateFileObject(f limatype.File, fieldName string) error {
 	var errs error
 	if !strings.Contains(f.Location, "://") {
 		if _, err := localpathutil.Expand(f.Location); err != nil {
-			errs = errors.Join(errs, fmt.Errorf("field `%s.location` refers to an invalid local file path: %q: %w", fieldName, f.Location, err))
+			errs = errors.Join(errs, fmt.Errorf("field `%s.location` refers to an invalid local file path: %#q: %w", fieldName, f.Location, err))
 		}
 		// f.Location does NOT need to be accessible, so we do NOT check os.Stat(f.Location)
 	}
 	if !slices.Contains(limatype.ArchTypes, f.Arch) {
-		errs = errors.Join(errs, fmt.Errorf("field `arch` must be one of %v; got %q", limatype.ArchTypes, f.Arch))
+		errs = errors.Join(errs, fmt.Errorf("field `arch` must be one of %v; got %#q", limatype.ArchTypes, f.Arch))
 	}
 	if f.Digest != "" {
 		if err := f.Digest.Validate(); err != nil {
@@ -451,7 +451,7 @@ func validateNetwork(y *limatype.LimaYAML) error {
 				return err
 			}
 			if nwCfg.Check(nw.Lima) != nil {
-				errs = errors.Join(errs, fmt.Errorf("field `%s.lima` references network %q which is not defined in networks.yaml", field, nw.Lima))
+				errs = errors.Join(errs, fmt.Errorf("field `%s.lima` references network %#q which is not defined in networks.yaml", field, nw.Lima))
 			}
 			usernet, err := nwCfg.Usernet(nw.Lima)
 			if err != nil {
@@ -473,7 +473,7 @@ func validateNetwork(y *limatype.LimaYAML) error {
 			if fi, err := os.Stat(nw.Socket); err != nil && !errors.Is(err, os.ErrNotExist) {
 				errs = errors.Join(errs, err)
 			} else if err == nil && fi.Mode()&os.ModeSocket == 0 {
-				errs = errors.Join(errs, fmt.Errorf("field `%s.socket` %q points to a non-socket file", field, nw.Socket))
+				errs = errors.Join(errs, fmt.Errorf("field `%s.socket` %#q points to a non-socket file", field, nw.Socket))
 			}
 		case nw.VZNAT != nil && *nw.VZNAT:
 			if nw.Lima != "" {
@@ -491,21 +491,21 @@ func validateNetwork(y *limatype.LimaYAML) error {
 				errs = errors.Join(errs, fmt.Errorf("field `vmnet.mac` invalid: %w", err))
 			}
 			if len(hw) != 6 {
-				errs = errors.Join(errs, fmt.Errorf("field `%s.macAddress` must be a 48 bit (6 bytes) MAC address; actual length of %q is %d bytes", field, nw.MACAddress, len(hw)))
+				errs = errors.Join(errs, fmt.Errorf("field `%s.macAddress` must be a 48 bit (6 bytes) MAC address; actual length of %#q is %d bytes", field, nw.MACAddress, len(hw)))
 			}
 		}
 		// FillDefault() will make sure that nw.Interface is not the empty string
 		if len(nw.Interface) >= 16 {
-			errs = errors.Join(errs, fmt.Errorf("field `%s.interface` must be less than 16 bytes, but is %d bytes: %q", field, len(nw.Interface), nw.Interface))
+			errs = errors.Join(errs, fmt.Errorf("field `%s.interface` must be less than 16 bytes, but is %d bytes: %#q", field, len(nw.Interface), nw.Interface))
 		}
 		if strings.ContainsAny(nw.Interface, " \t\n/") {
 			errs = errors.Join(errs, fmt.Errorf("field `%s.interface` must not contain whitespace or slashes", field))
 		}
 		if nw.Interface == networks.SlirpNICName {
-			errs = errors.Join(errs, fmt.Errorf("field `%s.interface` must not be set to %q because it is reserved for slirp", field, networks.SlirpNICName))
+			errs = errors.Join(errs, fmt.Errorf("field `%s.interface` must not be set to %#q because it is reserved for slirp", field, networks.SlirpNICName))
 		}
 		if prev, ok := interfaceName[nw.Interface]; ok {
-			errs = errors.Join(errs, fmt.Errorf("field `%s.interface` value %q has already been used by field `networks[%d].interface`", field, nw.Interface, prev))
+			errs = errors.Join(errs, fmt.Errorf("field `%s.interface` value %#q has already been used by field `networks[%d].interface`", field, nw.Interface, prev))
 		}
 		interfaceName[nw.Interface] = i
 	}
@@ -519,7 +519,7 @@ func validateParamIsUsed(y *limatype.LimaYAML) error {
 	for key := range y.Param {
 		re, err := regexp.Compile(`{{[^}]*\.Param\.` + key + `[^}]*}}|\bPARAM_` + key + `\b`)
 		if err != nil {
-			return fmt.Errorf("field to compile regexp for key %q: %w", key, err)
+			return fmt.Errorf("field to compile regexp for key %#q: %w", key, err)
 		}
 		keyIsUsed := false
 		for _, p := range y.Provision {
@@ -569,7 +569,7 @@ func validateParamIsUsed(y *limatype.LimaYAML) error {
 			}
 		}
 		if !keyIsUsed {
-			return fmt.Errorf("field `param` key %q is not used in any provision, probe, copyToHost, or portForward", key)
+			return fmt.Errorf("field `param` key %#q is not used in any provision, probe, copyToHost, or portForward", key)
 		}
 	}
 	return nil
@@ -620,7 +620,7 @@ func ValidateAgainstLatestConfig(ctx context.Context, yNew, yLatest []byte) erro
 		errs = errors.Join(errs, err)
 	}
 	if err := driverutil.ResolveVMType(ctx, l, ""); err != nil {
-		errs = errors.Join(errs, fmt.Errorf("failed to resolve vm for %q: %w", "", err))
+		errs = errors.Join(errs, fmt.Errorf("failed to resolve vm for %#q: %w", "", err))
 	}
 	if err := Unmarshal(yNew, &n, "Unmarshal new YAML bytes"); err != nil {
 		errs = errors.Join(errs, err)

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -39,7 +39,7 @@ func TestValidateMinimumLimaVersion(t *testing.T) {
 			name:               "minimumLimaVersion greater than current version",
 			currentVersion:     "1.1.1-114-g5bf5e513",
 			minimumLimaVersion: "1.1.2",
-			wantErr:            `template requires Lima version "1.1.2"; this is only "1.1.1-114-g5bf5e513"`,
+			wantErr:            "template requires Lima version `1.1.2`; this is only `1.1.1-114-g5bf5e513`",
 		},
 		{
 			name:               "invalid current version",
@@ -51,7 +51,7 @@ func TestValidateMinimumLimaVersion(t *testing.T) {
 			name:               "invalid minimumLimaVersion",
 			currentVersion:     "1.1.1-114-g5bf5e513",
 			minimumLimaVersion: "invalid",
-			wantErr:            "field `minimumLimaVersion` must be a semvar value, got \"invalid\": invalid is not in dotted-tri format", // Only parse error, no comparison error
+			wantErr:            "field `minimumLimaVersion` must be a semvar value, got `invalid`: invalid is not in dotted-tri format", // Only parse error, no comparison error
 		},
 	}
 
@@ -142,7 +142,7 @@ func TestValidateProvisionMode(t *testing.T) {
 	assert.NilError(t, err)
 
 	err = Validate(y, false)
-	assert.Error(t, err, "field `provision[0].mode` must one of \"system\", \"user\", \"boot\", \"data\", \"dependency\", \"ansible\", or \"yq\"\n"+
+	assert.Error(t, err, "field `provision[0].mode` must one of `system`, `user`, `boot`, `data`, `dependency`, `ansible`, or `yq`\n"+
 		"field `provision[0].script` must not be empty")
 }
 
@@ -160,7 +160,7 @@ func TestValidateProvisionData(t *testing.T) {
 	assert.NilError(t, err)
 
 	err = Validate(y, false)
-	assert.Error(t, err, "field `provision[0].path` must not be empty when mode is \"data\"")
+	assert.Error(t, err, "field `provision[0].path` must not be empty when mode is `data`")
 
 	invalidData = `provision: [{mode: data, path: /tmp, content: hello, permissions: 9}]`
 	y, err = Load(t.Context(), []byte(invalidData+"\n"+images), "lima.yaml")
@@ -185,7 +185,7 @@ func TestValidateProvisionYQ(t *testing.T) {
 	y, err = Load(t.Context(), []byte(param+"\n"+invalidYQProvision+"\n"+images), "lima.yaml")
 	assert.NilError(t, err)
 	err = Validate(y, false)
-	assert.ErrorContains(t, err, "field `provision[0].path` must not be empty when mode is \"yq\"")
+	assert.ErrorContains(t, err, "field `provision[0].path` must not be empty when mode is `yq`")
 
 	// non-absolute path
 	invalidYQProvision = `provision: [{mode: yq, expression: ".features.cdi={{.Param.cdi}}", path: tmp}]`
@@ -199,7 +199,7 @@ func TestValidateProvisionYQ(t *testing.T) {
 	y, err = Load(t.Context(), []byte(param+"\n"+invalidYQProvision+"\n"+images), "lima.yaml")
 	assert.NilError(t, err)
 	err = Validate(y, false)
-	assert.ErrorContains(t, err, "field `provision[0].expression` must not be empty when mode is \"yq\"")
+	assert.ErrorContains(t, err, "field `provision[0].expression` must not be empty when mode is `yq`")
 
 	// Invalid permissions
 	invalidYQProvision = `provision: [{mode: yq, expression: ".features.cdi={{.Param.cdi}}", path: /tmp, permissions: 9}]`
@@ -299,7 +299,7 @@ func TestValidateParamIsUsed(t *testing.T) {
 	paramYaml := `param:
   name: value`
 	_, err := Load(t.Context(), []byte(paramYaml), "paramIsNotUsed.yaml")
-	assert.Error(t, err, "field `param` key \"name\" is not used in any provision, probe, copyToHost, or portForward")
+	assert.Error(t, err, "field `param` key `name` is not used in any provision, probe, copyToHost, or portForward")
 
 	fieldsUsingParam := []string{
 		`mounts: [{"location": "/tmp/{{ .Param.name }}"}]`,
@@ -344,7 +344,7 @@ func TestValidateParamIsUsed(t *testing.T) {
 	for _, fieldUsingIfParamRootfulTrue := range fieldsUsingIfParamRootfulTrue {
 		_, err = Load(t.Context(), []byte(fieldUsingIfParamRootfulTrue+"\n"+rootFulYaml), "paramIsUsed.yaml")
 		//
-		assert.Error(t, err, "field `param` key \"rootFul\" is not used in any provision, probe, copyToHost, or portForward")
+		assert.Error(t, err, "field `param` key `rootFul` is not used in any provision, probe, copyToHost, or portForward")
 	}
 }
 
@@ -369,11 +369,11 @@ provision:
 	err = Validate(y, false)
 	t.Logf("Validation errors: %v", err)
 
-	assert.Error(t, err, "field `os` must be one of [\"Linux\" \"Darwin\" \"FreeBSD\"]; got \"windows\"\n"+
-		"field `arch` must be one of [x86_64 aarch64 armv7l ppc64le riscv64 s390x]; got \"unsupported_arch\"\n"+
+	assert.Error(t, err, "field `os` must be one of [`Linux` `Darwin` `FreeBSD`]; got `windows`\n"+
+		"field `arch` must be one of [x86_64 aarch64 armv7l ppc64le riscv64 s390x]; got `unsupported_arch`\n"+
 		"field `images` must be set\n"+
-		"field `provision[0].mode` must one of \"system\", \"user\", \"boot\", \"data\", \"dependency\", \"ansible\", or \"yq\"\n"+
-		"field `provision[1].path` must not be empty when mode is \"data\"")
+		"field `provision[0].mode` must one of `system`, `user`, `boot`, `data`, `dependency`, `ansible`, or `yq`\n"+
+		"field `provision[1].path` must not be empty when mode is `data`")
 }
 
 func TestValidateAgainstLatestConfig(t *testing.T) {
@@ -387,37 +387,37 @@ func TestValidateAgainstLatestConfig(t *testing.T) {
 			name:    "Valid disk size unchanged",
 			yNew:    `disk: 100GiB`,
 			yLatest: `disk: 100GiB`,
-			wantErr: fmt.Sprintf("failed to resolve vm for \"\": vmType %q is not a registered driver", limatype.DefaultDriver()),
+			wantErr: fmt.Sprintf("failed to resolve vm for ``: vmType %#q is not a registered driver", limatype.DefaultDriver()),
 		},
 		{
 			name:    "Valid disk size increased",
 			yNew:    `disk: 200GiB`,
 			yLatest: `disk: 100GiB`,
-			wantErr: fmt.Sprintf("failed to resolve vm for \"\": vmType %q is not a registered driver", limatype.DefaultDriver()),
+			wantErr: fmt.Sprintf("failed to resolve vm for ``: vmType %#q is not a registered driver", limatype.DefaultDriver()),
 		},
 		{
 			name:    "No disk field in both YAMLs",
 			yNew:    ``,
 			yLatest: ``,
-			wantErr: fmt.Sprintf("failed to resolve vm for \"\": vmType %q is not a registered driver", limatype.DefaultDriver()),
+			wantErr: fmt.Sprintf("failed to resolve vm for ``: vmType %#q is not a registered driver", limatype.DefaultDriver()),
 		},
 		{
 			name:    "No disk field in new YAMLs",
 			yNew:    ``,
 			yLatest: `disk: 100GiB`,
-			wantErr: fmt.Sprintf("failed to resolve vm for \"\": vmType %q is not a registered driver", limatype.DefaultDriver()),
+			wantErr: fmt.Sprintf("failed to resolve vm for ``: vmType %#q is not a registered driver", limatype.DefaultDriver()),
 		},
 		{
 			name:    "No disk field in latest YAMLs",
 			yNew:    `disk: 100GiB`,
 			yLatest: ``,
-			wantErr: fmt.Sprintf("failed to resolve vm for \"\": vmType %q is not a registered driver", limatype.DefaultDriver()),
+			wantErr: fmt.Sprintf("failed to resolve vm for ``: vmType %#q is not a registered driver", limatype.DefaultDriver()),
 		},
 		{
 			name:    "Disk size shrunk",
 			yNew:    `disk: 50GiB`,
 			yLatest: `disk: 100GiB`,
-			wantErr: fmt.Sprintf("failed to resolve vm for \"\": vmType %q is not a registered driver\n", limatype.DefaultDriver()) +
+			wantErr: fmt.Sprintf("failed to resolve vm for ``: vmType %#q is not a registered driver\n", limatype.DefaultDriver()) +
 				"field `disk`: shrinking the disk (100GiB --> 50GiB) is not supported",
 		},
 	}


### PR DESCRIPTION
Change %q in logs and errors to %#q (all files in the following directories) .
- `cmd/lima-guestagent`
-  `pkg/apfs`
-  `pkg/autostart`
-  `pkg/cacheutil`
-  `pkg/cidata`
-  `pkg/copytool`
-  `pkg/downloader`
-  `pkg/driver`
-  `pkg/driverutil`
-  `pkg/editutil`
-  `pkg/envutil`
-  `pkg/fileutils`
-  `pkg/limayaml`

Related issue: #4898 

This PR is a continuation of the work from #4909 .

@jandubois 
I also addressed [your last comments in #4909 ](https://github.com/lima-vm/lima/pull/4909#pullrequestreview-4261131007) in this PR.