### PR TITLE
fix(CI): skip cache for `golangci-lint`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,7 @@ jobs:
       with:
         version: ${{ steps.golangci-lint-version.outputs.GOLANGCI_LINT_VERSION }}
         args: --verbose
+        skip-cache: true
 
   security:
     name: "Vulncheck"


### PR DESCRIPTION
After the recent dependency bump #5014, `nolintlint` reported `//nolint:staticcheck` directives as unused because the CI is restoring a stale `golangci‑lint` cache.
https://github.com/lima-vm/lima/actions/runs/26149042201/job/77061679285?pr=5015#step:6:42

>   Error: pkg/driver/external/client/client.go:35:2: directive `//nolint:staticcheck // grpc.Dial is used for compatibility reasons` is unused for linter "staticcheck" (nolintlint)

>   Error: pkg/guestagent/api/client/credentials.go:47:2: directive `//nolint:staticcheck // c.info.ServerName is used for compatibility reason` is unused for linter "staticcheck" (nolintlint)