### PR TITLE
LFX: Windows guest support proof-of-concept

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -32,6 +32,7 @@ ignore:
 - hack/common.inc.sh
 - pkg/cidata/cidata.TEMPLATE.d
 - pkg/cidata/cidata.TEMPLATE.d/util/compare_version.sh
+- pkg/cidata/windows.TEMPLATE.d
 - website
 # "ubuntu-24.04" does not follow the kebab-case
 - '**/ubuntu-*\.yaml'

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -4,11 +4,13 @@
 package cidata
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"maps"
 	"net"
 	"net/url"
@@ -21,6 +23,8 @@ import (
 	"time"
 	"unicode"
 
+	backendfile "github.com/diskfs/go-diskfs/backend/file"
+	"github.com/diskfs/go-diskfs/filesystem/iso9660"
 	"github.com/docker/go-units"
 	"github.com/sirupsen/logrus"
 
@@ -359,6 +363,10 @@ func templateArgs(ctx context.Context, bootScripts bool, instDir, name string, i
 }
 
 func GenerateCloudConfig(ctx context.Context, instDir, name string, instConfig *limatype.LimaYAML) error {
+	if *instConfig.OS == limatype.WINDOWS {
+		os.RemoveAll(filepath.Join(instDir, filenames.CloudConfig)) // delete existing
+		return nil
+	}
 	args, err := templateArgs(ctx, false, instDir, name, instConfig, 0, 0, 0, "", false, false, false)
 	if err != nil {
 		return err
@@ -384,6 +392,27 @@ func GenerateCloudConfig(ctx context.Context, instDir, name string, instConfig *
 // GenerateISO9660 generates the cidata ISO9660 image (or directory, for noCloudInit)
 // in instDir. It returns the instance ID, which changes on every boot.
 func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name string, instConfig *limatype.LimaYAML, udpDNSLocalPort, tcpDNSLocalPort int, guestAgentBinary, nerdctlArchive string, vsockPort int, virtioPort string, noCloudInit, rosettaEnabled, rosettaBinFmt bool) (string, error) {
+	if *instConfig.OS == limatype.WINDOWS {
+		args, err := TemplateArgsForWindows(ctx, instDir, instConfig)
+		if err != nil {
+			return "", err
+		}
+		layout, err := ExecuteTemplateWindowsCIDataISO(args)
+		if err != nil {
+			return "", err
+		}
+		driverEntries, err := virtioDriverEntries(instConfig)
+		if err != nil {
+			return "", err
+		}
+		layout = append(layout, driverEntries...)
+		iid := fmt.Sprintf("iid-%d", time.Now().Unix())
+		if noCloudInit {
+			return iid, writeCIDataDir(filepath.Join(instDir, filenames.CIDataISODir), layout)
+		}
+		return iid, iso9660util.Write(filepath.Join(instDir, filenames.CIDataISO), "cidata", layout, iso9660util.WithJoliet())
+	}
+
 	args, err := templateArgs(ctx, true, instDir, name, instConfig, udpDNSLocalPort, tcpDNSLocalPort, vsockPort, virtioPort, noCloudInit, rosettaEnabled, rosettaBinFmt)
 	if err != nil {
 		return "", err
@@ -539,6 +568,152 @@ func getBootCmds(p []limatype.Provision) []BootCmds {
 
 func diskDeviceNameFromOrder(order int) string {
 	return fmt.Sprintf("vd%c", int('b')+order)
+}
+
+func virtioDriverEntries(instConfig *limatype.LimaYAML) ([]iso9660util.Entry, error) {
+	virtioDriverISO, err := guestDriverISO(instConfig)
+	if err != nil {
+		return nil, err
+	}
+	driverVersion := windowsVirtioVersion(instConfig)
+	driverArch, err := windowsVirtioArch(*instConfig.Arch)
+	if err != nil {
+		return nil, err
+	}
+
+	isoFile, err := os.Open(virtioDriverISO)
+	if err != nil {
+		return nil, err
+	}
+	defer isoFile.Close()
+	fileInfo, err := isoFile.Stat()
+	if err != nil {
+		return nil, err
+	}
+	fsys, err := iso9660.Read(backendfile.New(isoFile, true), fileInfo.Size(), 0, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer fsys.Close()
+
+	var layout []iso9660util.Entry
+	for _, driverName := range windowsVirtioDriverNames() {
+		srcDir := path.Join(driverName, driverVersion, driverArch)
+		dstDir := path.Join(windowsPEDriverRoot, srcDir)
+		entries, err := copyISOFilesUnder(fsys, srcDir, dstDir)
+		if err != nil {
+			return nil, err
+		}
+		if len(entries) == 0 {
+			return nil, fmt.Errorf("could not find Windows virtio driver directory %q in %q", srcDir, virtioDriverISO)
+		}
+		layout = append(layout, entries...)
+	}
+	return layout, nil
+}
+
+func guestDriverISO(instConfig *limatype.LimaYAML) (string, error) {
+	for _, image := range instConfig.GuestDrivers.Images {
+		if image.VMType != "" && image.VMType != limatype.QEMU {
+			continue
+		}
+		if image.Arch != "" && image.Arch != *instConfig.Arch {
+			continue
+		}
+		return localpathutil.Expand(image.Location)
+	}
+	return "", fmt.Errorf("field `guestDrivers.images` must contain a QEMU driver image for %q", *instConfig.Arch)
+}
+
+func windowsVirtioVersion(instConfig *limatype.LimaYAML) string {
+	if instConfig.GuestDrivers.Version != nil && strings.TrimSpace(*instConfig.GuestDrivers.Version) != "" {
+		return normalizeWindowsVirtioVersion(*instConfig.GuestDrivers.Version)
+	}
+	return "w11"
+}
+
+func normalizeWindowsVirtioVersion(version string) string {
+	v := strings.ToLower(strings.TrimSpace(version))
+	v = strings.NewReplacer(" ", "", "-", "", "_", "").Replace(v)
+	switch v {
+	case "windows11", "win11", "11":
+		return "w11"
+	case "windows10", "win10", "10":
+		return "w10"
+	case "windows8.1", "win8.1", "8.1":
+		return "w8.1"
+	case "windows8", "win8", "8":
+		return "w8"
+	case "windows7", "win7", "7":
+		return "w7"
+	case "windowsserver2025", "server2025", "2025":
+		return "2k25"
+	case "windowsserver2022", "server2022", "2022":
+		return "2k22"
+	case "windowsserver2019", "server2019", "2019":
+		return "2k19"
+	case "windowsserver2016", "server2016", "2016":
+		return "2k16"
+	case "windowsserver2012r2", "server2012r2", "2012r2":
+		return "2k12R2"
+	case "windowsserver2012", "server2012", "2012":
+		return "2k12"
+	default:
+		return strings.TrimSpace(version)
+	}
+}
+
+func windowsVirtioArch(arch limatype.Arch) (string, error) {
+	switch arch {
+	case limatype.X8664:
+		return "amd64", nil
+	default:
+		return "", fmt.Errorf("windows virtio drivers support is currently implemented only for %q guests, got %q", limatype.X8664, arch)
+	}
+}
+
+func windowsVirtioDriverNames() []string {
+	return []string{"viostor", "vioscsi", "NetKVM"}
+}
+
+const windowsPEDriverRoot = "$WinPEDriver$"
+
+func windowsVirtioDriverPaths(version, arch string) []string {
+	names := windowsVirtioDriverNames()
+	paths := make([]string, 0, len(names))
+	for _, name := range names {
+		paths = append(paths, strings.ReplaceAll(path.Join(windowsPEDriverRoot, name, version, arch), "/", `\`))
+	}
+	return paths
+}
+
+func copyISOFilesUnder(fsys fs.FS, srcDir, dstDir string) ([]iso9660util.Entry, error) {
+	var layout []iso9660util.Entry
+	srcDirLower := strings.ToLower(srcDir)
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		p = strings.TrimPrefix(p, "./")
+		pLower := strings.ToLower(p)
+		if !strings.HasPrefix(pLower, srcDirLower+"/") {
+			return nil
+		}
+		b, err := fs.ReadFile(fsys, p)
+		if err != nil {
+			return err
+		}
+		rel := p[len(srcDir)+1:]
+		layout = append(layout, iso9660util.Entry{
+			Path:   path.Join(dstDir, rel),
+			Reader: bytes.NewReader(b),
+		})
+		return nil
+	})
+	return layout, err
 }
 
 func writeCIDataDir(rootPath string, layout []iso9660util.Entry) error {

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -18,13 +18,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/lima-vm/lima/v2/pkg/identifiers"
 	"github.com/lima-vm/lima/v2/pkg/iso9660util"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/sshutil"
 	"github.com/lima-vm/lima/v2/pkg/textutil"
-	"github.com/sirupsen/logrus"
 )
 
 //go:embed cidata.TEMPLATE.d

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -5,22 +5,37 @@ package cidata
 
 import (
 	"bytes"
+	"context"
+	"crypto/rand"
 	"embed"
 	"errors"
 	"fmt"
+	"html"
 	"io/fs"
+	"math/big"
+	"os"
 	"path"
+	"path/filepath"
+	"strings"
 
 	"github.com/lima-vm/lima/v2/pkg/identifiers"
 	"github.com/lima-vm/lima/v2/pkg/iso9660util"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/sshutil"
 	"github.com/lima-vm/lima/v2/pkg/textutil"
+	"github.com/sirupsen/logrus"
 )
 
 //go:embed cidata.TEMPLATE.d
 var templateFS embed.FS
 
 const templateFSRoot = "cidata.TEMPLATE.d"
+
+//go:embed windows.TEMPLATE.d
+var windowsTemplateFS embed.FS
+
+const windowsTemplateFSRoot = "windows.TEMPLATE.d"
 
 type CACerts struct {
 	RemoveDefaults *bool
@@ -117,6 +132,10 @@ type TemplateArgs struct {
 	Plain                           bool
 	TimeZone                        string
 	NoCloudInit                     bool
+	WindowsUser                     string
+	WindowsPassword                 string
+	WindowsImageIndex               string
+	WindowsDriverPaths              []string
 }
 
 func ValidateTemplateArgs(args *TemplateArgs) error {
@@ -167,14 +186,24 @@ func ExecuteTemplateCIDataISO(args *TemplateArgs) ([]iso9660util.Entry, error) {
 	if err := ValidateTemplateArgs(args); err != nil {
 		return nil, err
 	}
-
 	fsys, err := fs.Sub(templateFS, templateFSRoot)
 	if err != nil {
 		return nil, err
 	}
+	return executeTemplateCIDataFS(fsys, args, func(p string) string { return p })
+}
 
+func ExecuteTemplateWindowsCIDataISO(args *TemplateArgs) ([]iso9660util.Entry, error) {
+	fsys, err := fs.Sub(windowsTemplateFS, windowsTemplateFSRoot)
+	if err != nil {
+		return nil, err
+	}
+	return executeTemplateCIDataFS(fsys, args, windowsTemplatePath)
+}
+
+func executeTemplateCIDataFS(fsys fs.FS, args *TemplateArgs, mapPath func(string) string) ([]iso9660util.Entry, error) {
 	var layout []iso9660util.Entry
-	walkFn := func(path string, d fs.DirEntry, walkErr error) error {
+	walkFn := func(p string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -182,9 +211,9 @@ func ExecuteTemplateCIDataISO(args *TemplateArgs) ([]iso9660util.Entry, error) {
 			return nil
 		}
 		if !d.Type().IsRegular() {
-			return fmt.Errorf("got non-regular file %q", path)
+			return fmt.Errorf("got non-regular file %q", p)
 		}
-		templateB, err := fs.ReadFile(fsys, path)
+		templateB, err := fs.ReadFile(fsys, p)
 		if err != nil {
 			return err
 		}
@@ -193,15 +222,120 @@ func ExecuteTemplateCIDataISO(args *TemplateArgs) ([]iso9660util.Entry, error) {
 			return err
 		}
 		layout = append(layout, iso9660util.Entry{
-			Path:   path,
+			Path:   mapPath(p),
 			Reader: bytes.NewReader(b),
 		})
 		return nil
 	}
-
 	if err := fs.WalkDir(fsys, ".", walkFn); err != nil {
 		return nil, err
 	}
-
 	return layout, nil
+}
+
+func windowsTemplatePath(p string) string {
+	switch {
+	case strings.HasPrefix(p, "oem/SystemRoot/"):
+		return path.Join("$OEM$", "$$", strings.TrimPrefix(p, "oem/SystemRoot/"))
+	case strings.HasPrefix(p, "oem/SystemDrive/"):
+		return path.Join("$OEM$", "$1", strings.TrimPrefix(p, "oem/SystemDrive/"))
+	default:
+		return p
+	}
+}
+
+func TemplateArgsForWindows(ctx context.Context, instDir string, instConfig *limatype.LimaYAML) (*TemplateArgs, error) {
+	loadDotSSHPubKeys := false
+	if instConfig.SSH.LoadDotSSHPubKeys != nil {
+		loadDotSSHPubKeys = *instConfig.SSH.LoadDotSSHPubKeys
+	}
+	pubKeys, err := sshutil.DefaultPubKeys(ctx, loadDotSSHPubKeys)
+	if err != nil {
+		return nil, err
+	}
+	if len(pubKeys) == 0 {
+		return nil, errors.New("no SSH key was found, run `ssh-keygen`")
+	}
+	sshPubKeys := make([]string, 0, len(pubKeys))
+	for _, f := range pubKeys {
+		sshPubKeys = append(sshPubKeys, f.Content)
+	}
+	return templateArgsForWindows(instDir, instConfig, sshPubKeys)
+}
+
+func templateArgsForWindows(instDir string, instConfig *limatype.LimaYAML, sshPubKeys []string) (*TemplateArgs, error) {
+	driverArch, err := windowsVirtioArch(*instConfig.Arch)
+	if err != nil {
+		return nil, err
+	}
+	windowsPassword, err := windowsUserPassword(instDir, instConfig)
+	if err != nil {
+		return nil, err
+	}
+	args := &TemplateArgs{
+		WindowsUser:        "lima",
+		WindowsPassword:    windowsPassword,
+		WindowsImageIndex:  "1",
+		WindowsDriverPaths: windowsVirtioDriverPaths(windowsVirtioVersion(instConfig), driverArch),
+		SSHPubKeys:         sshPubKeys,
+	}
+	if instConfig.User.Name != nil && *instConfig.User.Name != "" {
+		args.WindowsUser = *instConfig.User.Name
+	}
+	args.WindowsUser = html.EscapeString(args.WindowsUser)
+	args.WindowsPassword = html.EscapeString(args.WindowsPassword)
+	args.WindowsImageIndex = html.EscapeString(args.WindowsImageIndex)
+	for i := range args.WindowsDriverPaths {
+		args.WindowsDriverPaths[i] = html.EscapeString(args.WindowsDriverPaths[i])
+	}
+	return args, nil
+}
+
+func windowsUserPassword(instDir string, instConfig *limatype.LimaYAML) (string, error) {
+	if instConfig.User.Password != nil && *instConfig.User.Password != "" {
+		return *instConfig.User.Password, nil
+	}
+	passwordPath := filepath.Join(instDir, filenames.WindowsUserPassword)
+	if b, err := os.ReadFile(passwordPath); err == nil {
+		if password := strings.TrimSpace(string(b)); password != "" {
+			if isAlphaNumeric(password) {
+				return password, nil
+			}
+			logrus.Infof("Replacing generated Windows user password in %q because it contains non-alphanumeric characters", passwordPath)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	generated, err := generateAlphaNumericPassword(24)
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(passwordPath, []byte(generated+"\n"), 0o600); err != nil {
+		return "", err
+	}
+	logrus.Infof("Generated Windows user password and stored it in %q", passwordPath)
+	return generated, nil
+}
+
+func generateAlphaNumericPassword(length int) (string, error) {
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(alphabet))))
+		if err != nil {
+			return "", err
+		}
+		b[i] = alphabet[n.Int64()]
+	}
+	return string(b), nil
+}
+
+func isAlphaNumeric(s string) bool {
+	for _, r := range s {
+		if r >= '0' && r <= '9' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' {
+			continue
+		}
+		return false
+	}
+	return s != ""
 }

--- a/pkg/cidata/windows.TEMPLATE.d/autounattend.xml
+++ b/pkg/cidata/windows.TEMPLATE.d/autounattend.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <DiskConfiguration>
+        <Disk wcm:action="add">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Type>EFI</Type>
+              <Size>100</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>MSR</Type>
+              <Size>16</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>3</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionID>1</PartitionID>
+              <Format>FAT32</Format>
+              <Label>System</Label>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionID>3</PartitionID>
+              <Format>NTFS</Format>
+              <Label>Windows</Label>
+              <Letter>C</Letter>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/IMAGE/INDEX</Key>
+              <Value>{{.WindowsImageIndex}}</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>3</PartitionID>
+          </InstallTo>
+        </OSImage>
+      </ImageInstall>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <ProductKey>
+          <Key></Key>
+          <WillShowUI>OnError</WillShowUI>
+        </ProductKey>
+      </UserData>
+      <UseConfigurationSet>true</UseConfigurationSet>
+    </component>
+    <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <DriverPaths>
+{{range $i, $path := .WindowsDriverPaths}}
+        <PathAndCredentials wcm:action="add" wcm:keyValue="{{$i}}">
+          <Path>{{$path}}</Path>
+        </PathAndCredentials>
+{{end}}
+      </DriverPaths>
+    </component>
+  </settings>
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <ComputerName>lima-windows</ComputerName>
+      <TimeZone>UTC</TimeZone>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>1</ProtectYourPC>
+      </OOBE>
+      <UserAccounts>
+        <LocalAccounts>
+          <LocalAccount wcm:action="add">
+            <Name>{{.WindowsUser}}</Name>
+            <Group>Administrators</Group>
+            <Password>
+              <Value>{{.WindowsPassword}}</Value>
+              <PlainText>true</PlainText>
+            </Password>
+          </LocalAccount>
+        </LocalAccounts>
+      </UserAccounts>
+    </component>
+  </settings>
+</unattend>

--- a/pkg/cidata/windows.TEMPLATE.d/oem/SystemDrive/ProgramData/Lima/ssh_authorized_keys
+++ b/pkg/cidata/windows.TEMPLATE.d/oem/SystemDrive/ProgramData/Lima/ssh_authorized_keys
@@ -1,0 +1,2 @@
+{{range .SSHPubKeys}}{{.}}
+{{end}}

--- a/pkg/cidata/windows.TEMPLATE.d/oem/SystemDrive/ProgramData/Lima/windows-setup.ps1
+++ b/pkg/cidata/windows.TEMPLATE.d/oem/SystemDrive/ProgramData/Lima/windows-setup.ps1
@@ -1,0 +1,51 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$limaDir = Join-Path $env:ProgramData 'Lima'
+$sourceKeys = Join-Path $limaDir 'ssh_authorized_keys'
+$targetKeys = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'
+$targetKeysDir = Split-Path -Parent $targetKeys
+$setupDone = Join-Path $limaDir 'setup.done'
+
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+
+New-ItemProperty -Path 'HKLM:\SOFTWARE\OpenSSH' -Name DefaultShell -Value "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force | Out-Null
+
+Set-Service -Name sshd -StartupType Automatic
+$sshdService = Get-Service -Name sshd
+if ($sshdService.Status -ne 'Running') {
+    try {
+        Start-Service -Name sshd
+        $sshdService = Get-Service -Name sshd
+        $sshdService.WaitForStatus('Running', (New-TimeSpan -Minutes 5))
+    } catch {
+        throw "sshd did not start: $($_.Exception.Message)"
+    }
+    $sshdService = Get-Service -Name sshd
+    if ($sshdService.Status -ne 'Running') {
+        throw "sshd did not reach Running state; current state is $($sshdService.Status)"
+    }
+}
+if (-not (Test-Path -LiteralPath $targetKeysDir -PathType Container)) {
+    throw "OpenSSH did not create $targetKeysDir"
+}
+
+Copy-Item -Force $sourceKeys $targetKeys
+
+icacls.exe $targetKeys /inheritance:r | Out-Null
+icacls.exe $targetKeys /grant '*S-1-5-18:F' '*S-1-5-32-544:F' | Out-Null
+
+$ethernetProfile = Get-NetConnectionProfile |
+    Where-Object { $_.InterfaceAlias -like 'Ethernet*' } |
+    Select-Object -First 1
+if ($null -ne $ethernetProfile -and $ethernetProfile.NetworkCategory -ne 'Private') {
+    Set-NetConnectionProfile -InterfaceIndex $ethernetProfile.InterfaceIndex -NetworkCategory Private
+}
+$openSSHRule = Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue
+if ($null -ne $openSSHRule) {
+    Enable-NetFirewallRule -Name 'OpenSSH-Server-In-TCP'
+} else {
+    New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 -Profile Private | Out-Null
+}
+
+Set-Content -Path $setupDone -Value (Get-Date -Format o)

--- a/pkg/cidata/windows.TEMPLATE.d/oem/SystemRoot/Setup/Scripts/SetupComplete.cmd
+++ b/pkg/cidata/windows.TEMPLATE.d/oem/SystemRoot/Setup/Scripts/SetupComplete.cmd
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -File "%ProgramData%\Lima\windows-setup.ps1"
+exit /b 0

--- a/pkg/driver/qemu/firmware.go
+++ b/pkg/driver/qemu/firmware.go
@@ -1,0 +1,410 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package qemu
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/osutil"
+)
+
+const (
+	qemuFirmwareInterfaceUEFI = "uefi"
+
+	qemuFirmwareDeviceFlash = "flash"
+
+	qemuFirmwareFlashModeSplit = "split"
+
+	qemuFirmwareFeatureEnrolledKeys = "enrolled-keys"
+	qemuFirmwareFeatureRequiresSMM  = "requires-smm"
+	qemuFirmwareFeatureSecureBoot   = "secure-boot"
+
+	qemuFirmwareFormatRaw   = "raw"
+	qemuFirmwareFormatQCOW2 = "qcow2"
+)
+
+type qemuFirmwareDescriptor struct {
+	InterfaceTypes []string `json:"interface-types"`
+	Mapping        struct {
+		Device string `json:"device"`
+		// Mode is optional in QEMU descriptors. For flash mappings, an empty
+		// mode is treated like "split".
+		Mode string `json:"mode"`
+
+		Executable struct {
+			Filename string `json:"filename"`
+			Format   string `json:"format"`
+		} `json:"executable"`
+
+		NVRAMTemplate struct {
+			Filename string `json:"filename"`
+			Format   string `json:"format"`
+		} `json:"nvram-template"`
+
+		// Other mapping variants, not currently used by Lima's Secure Boot path.
+		Filename string `json:"filename"`
+		UEFIVars struct {
+			Template string `json:"template"`
+		} `json:"uefi-vars"`
+	} `json:"mapping"`
+	Targets []struct {
+		Architecture string   `json:"architecture"`
+		Machines     []string `json:"machines"`
+	} `json:"targets"`
+	Features []string `json:"features"`
+}
+
+type firmwareFile struct {
+	Path   string
+	Format string
+}
+
+type qemuFirmware struct {
+	Code           firmwareFile
+	Vars           *firmwareFile
+	DescriptorPath string
+}
+
+func getFirmwareTemplate(qemuExe string, arch limatype.Arch, secureBoot, preEnrollSecureBootKeys bool, descriptorPaths []string) (qemuFirmware, error) {
+	descriptors, err := qemuFirmwareDescriptorPaths(qemuExe)
+	if err != nil {
+		return qemuFirmware{}, err
+	}
+	descriptorPaths = append(slices.Clone(descriptorPaths), descriptors...)
+	if firmware, err := getFirmwareFromDescriptorFiles(descriptorPaths, arch, secureBoot, preEnrollSecureBootKeys); err == nil {
+		return firmware, nil
+	} else if secureBoot {
+		return qemuFirmware{}, err
+	} else {
+		logrus.WithError(err).Debug("failed to find firmware via QEMU descriptors")
+	}
+
+	code, err := getFirmwareCode(qemuExe, arch)
+	if err != nil {
+		return qemuFirmware{}, err
+	}
+	return qemuFirmware{Code: firmwareFile{Path: code, Format: qemuFirmwareFormatRaw}}, nil
+}
+
+func (f qemuFirmware) instanceCodePath(instanceDir string) string {
+	if f.Code.Format == qemuFirmwareFormatQCOW2 {
+		return filepath.Join(instanceDir, filenames.QemuEfiCodeQCOW2)
+	}
+	return filepath.Join(instanceDir, filenames.QemuEfiCodeFD)
+}
+
+func (f qemuFirmware) instanceVarsPath(instanceDir string) string {
+	if f.Vars != nil && f.Vars.Format == qemuFirmwareFormatQCOW2 {
+		return filepath.Join(instanceDir, filenames.QemuEfiVarsQCOW2)
+	}
+	return filepath.Join(instanceDir, filenames.QemuEfiVarsFD)
+}
+
+func qemuFirmwareDescriptorDirs(qemuExe string) []string {
+	var dirs []string
+
+	if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+		dirs = append(dirs, filepath.Join(xdgConfigHome, "qemu", "firmware"))
+	} else if homeDir, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(homeDir, ".config", "qemu", "firmware"))
+	}
+	if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
+		dirs = append(dirs, filepath.Join(xdgDataHome, "qemu", "firmware"))
+	} else if homeDir, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(homeDir, ".local", "share", "qemu", "firmware"))
+	}
+
+	dirs = append(dirs, filepath.Join(string(os.PathSeparator), "etc", "qemu", "firmware"))
+
+	binDir := filepath.Dir(qemuExe)  // "/usr/local/bin"
+	localDir := filepath.Dir(binDir) // "/usr/local"
+
+	dirs = append(dirs,
+		filepath.Join(localDir, "share", "qemu", "firmware"), // macOS Homebrew, Linux custom prefixes
+		filepath.Join(binDir, "share", "firmware"),           // Windows installer
+	)
+	if localDir != "/usr" {
+		dirs = append(dirs, filepath.Join(string(os.PathSeparator), "usr", "share", "qemu", "firmware"))
+	}
+
+	return dirs
+}
+
+func getFirmwareFromDescriptorFiles(descriptorPaths []string, arch limatype.Arch, secureBoot, preEnrollSecureBootKeys bool) (qemuFirmware, error) {
+	var matches []qemuFirmware
+	for _, descriptorPath := range descriptorPaths {
+		if descriptorPath == "" {
+			continue
+		}
+		b, err := os.ReadFile(descriptorPath)
+		if err != nil {
+			return qemuFirmware{}, err
+		}
+		var descriptor qemuFirmwareDescriptor
+		if err = json.Unmarshal(b, &descriptor); err != nil {
+			return qemuFirmware{}, err
+		}
+		firmware, ok := firmwareFromDescriptor(descriptor, descriptorPath, arch, secureBoot, preEnrollSecureBootKeys)
+		if ok {
+			matches = append(matches, firmware)
+		}
+	}
+	for _, firmware := range matches {
+		if firmwareUses4M(firmware) {
+			return firmware, nil
+		}
+	}
+	if len(matches) > 0 {
+		return matches[0], nil
+	}
+	return qemuFirmware{}, fmt.Errorf("no QEMU firmware descriptor from %v matches arch %q secureBoot=%v preEnrollSecureBootKeys=%v", descriptorPaths, arch, secureBoot, preEnrollSecureBootKeys)
+}
+
+func qemuFirmwareDescriptorPaths(qemuExe string) ([]string, error) {
+	// QEMU descriptor lookup supports overriding descriptors by filename. More
+	// specific directories are listed first here. A zero-length descriptor file
+	// masks descriptors with the same basename from less-specific directories.
+	seen := map[string]bool{}
+	var descriptors []string
+
+	for _, dir := range qemuFirmwareDescriptorDirs(qemuExe) {
+		matches, err := filepath.Glob(filepath.Join(dir, "*.json"))
+		if err != nil {
+			return nil, err
+		}
+		slices.Sort(matches)
+
+		for _, descriptorPath := range matches {
+			base := filepath.Base(descriptorPath)
+			if seen[base] {
+				continue
+			}
+			seen[base] = true
+
+			info, err := os.Stat(descriptorPath)
+			if err != nil {
+				logrus.WithError(err).Debugf("failed to stat QEMU firmware descriptor %q", descriptorPath)
+				continue
+			}
+			if info.Size() == 0 {
+				logrus.Debugf("QEMU firmware descriptor %q masks less-specific descriptors", descriptorPath)
+				continue
+			}
+
+			descriptors = append(descriptors, descriptorPath)
+		}
+	}
+
+	return descriptors, nil
+}
+
+func firmwareFromDescriptor(descriptor qemuFirmwareDescriptor, descriptorPath string, arch limatype.Arch, secureBoot, preEnrollSecureBootKeys bool) (qemuFirmware, bool) {
+	if !slices.Contains(descriptor.InterfaceTypes, qemuFirmwareInterfaceUEFI) {
+		return qemuFirmware{}, false
+	}
+	if secureBoot && !slices.Contains(descriptor.Features, qemuFirmwareFeatureSecureBoot) {
+		return qemuFirmware{}, false
+	}
+	if !secureBoot && slices.Contains(descriptor.Features, qemuFirmwareFeatureSecureBoot) {
+		return qemuFirmware{}, false
+	}
+	if secureBoot && !slices.Contains(descriptor.Features, qemuFirmwareFeatureRequiresSMM) {
+		return qemuFirmware{}, false
+	}
+	if preEnrollSecureBootKeys && !slices.Contains(descriptor.Features, qemuFirmwareFeatureEnrolledKeys) {
+		return qemuFirmware{}, false
+	}
+	if !preEnrollSecureBootKeys && slices.Contains(descriptor.Features, qemuFirmwareFeatureEnrolledKeys) {
+		return qemuFirmware{}, false
+	}
+	if !firmwareTargetsQ35(descriptor.Targets, arch) {
+		return qemuFirmware{}, false
+	}
+	if descriptor.Mapping.Device != qemuFirmwareDeviceFlash {
+		return qemuFirmware{}, false
+	}
+	if descriptor.Mapping.Mode != "" && descriptor.Mapping.Mode != qemuFirmwareFlashModeSplit {
+		return qemuFirmware{}, false
+	}
+
+	code := descriptor.Mapping.Executable.Filename
+	vars := descriptor.Mapping.NVRAMTemplate.Filename
+	if code == "" || vars == "" {
+		return qemuFirmware{}, false
+	}
+
+	codeFormat := firmwareFormat(descriptor.Mapping.Executable.Format, code)
+	if !supportedFirmwareFormat(codeFormat) {
+		return qemuFirmware{}, false
+	}
+	varsFormat := firmwareFormat(descriptor.Mapping.NVRAMTemplate.Format, vars)
+	if !supportedFirmwareFormat(varsFormat) {
+		return qemuFirmware{}, false
+	}
+
+	if !osutil.FileExists(code) || !osutil.FileExists(vars) {
+		return qemuFirmware{}, false
+	}
+
+	firmware := qemuFirmware{
+		Code:           firmwareFile{Path: code, Format: codeFormat},
+		Vars:           &firmwareFile{Path: vars, Format: varsFormat},
+		DescriptorPath: descriptorPath,
+	}
+	return firmware, true
+}
+
+func firmwareTargetsQ35(targets []struct {
+	Architecture string   `json:"architecture"`
+	Machines     []string `json:"machines"`
+}, arch limatype.Arch) bool {
+	for _, target := range targets {
+		if target.Architecture != "x86_64" || arch != limatype.X8664 {
+			continue
+		}
+		for _, machine := range target.Machines {
+			if strings.HasPrefix(machine, "pc-q35-") || strings.Contains(machine, "q35") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func firmwareUses4M(firmware qemuFirmware) bool {
+	s := strings.ToLower(filepath.Base(firmware.Code.Path))
+	if firmware.Vars != nil {
+		s += " " + strings.ToLower(filepath.Base(firmware.Vars.Path))
+	}
+	return strings.Contains(s, "4m")
+}
+
+func prepareFirmwareTemplate(instanceDir string, firmware qemuFirmware, secureBoot bool) (codePath, varsPath, codeFormat, varsFormat string, err error) {
+	codeFormat = firmware.Code.Format
+	varsFormat = qemuFirmwareFormatRaw
+	if firmware.DescriptorPath == "" {
+		logrus.Infof("Using system firmware %q", firmware.Code.Path)
+		return firmware.Code.Path, "", codeFormat, varsFormat, nil
+	}
+	if firmware.Vars == nil {
+		return "", "", "", "", fmt.Errorf("firmware descriptor %q is missing a variable store template", firmware.DescriptorPath)
+	}
+
+	codePath = firmware.instanceCodePath(instanceDir)
+	varsPath = firmware.instanceVarsPath(instanceDir)
+	varsFormat = firmware.Vars.Format
+	if err = ensureFirmwareFile(codePath, firmware.Code); err != nil {
+		return "", "", "", "", err
+	}
+	if err = ensureFirmwareFileIfMissing(varsPath, *firmware.Vars); err != nil {
+		return "", "", "", "", err
+	}
+	if secureBoot {
+		logrus.Infof("Using Secure Boot firmware %q from %q with variable store %q (template %q, descriptor %q)", codePath, firmware.Code.Path, varsPath, firmware.Vars.Path, firmware.DescriptorPath)
+	} else {
+		logrus.Infof("Using firmware %q from %q with variable store %q (template %q, descriptor %q)", codePath, firmware.Code.Path, varsPath, firmware.Vars.Path, firmware.DescriptorPath)
+	}
+	return codePath, varsPath, codeFormat, varsFormat, nil
+}
+
+func supportedFirmwareFormat(format string) bool {
+	switch format {
+	case "", qemuFirmwareFormatRaw, qemuFirmwareFormatQCOW2:
+		return true
+	default:
+		return false
+	}
+}
+
+func firmwareFormat(format, path string) string {
+	if format != "" {
+		return format
+	}
+	if strings.EqualFold(filepath.Ext(path), ".qcow2") {
+		return qemuFirmwareFormatQCOW2
+	}
+	return qemuFirmwareFormatRaw
+}
+
+func ensureFirmwareFile(dst string, src firmwareFile) error {
+	if !supportedFirmwareFormat(src.Format) {
+		return fmt.Errorf("unsupported firmware format %q for %q", src.Format, src.Path)
+	}
+	return copyFileIfChanged(dst, src.Path)
+}
+
+func ensureFirmwareFileIfMissing(dst string, src firmwareFile) error {
+	if _, err := os.Stat(dst); err == nil {
+		logrus.Infof("Preserving existing firmware variable store %q", dst)
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return ensureFirmwareFile(dst, src)
+}
+
+func copyFileIfChanged(dst, src string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+		return err
+	}
+	tmp := dst + ".tmp"
+	if err := os.Remove(tmp); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+	dstFile, err := os.OpenFile(tmp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err = io.Copy(dstFile, srcFile); err != nil {
+		_ = dstFile.Close()
+		return err
+	}
+	if err = dstFile.Close(); err != nil {
+		return err
+	}
+	return replaceFileIfChanged(dst, tmp)
+}
+
+func replaceFileIfChanged(dst, tmp string) error {
+	same, err := sameFileContents(dst, tmp)
+	if err != nil {
+		return err
+	}
+	if same {
+		return os.Remove(tmp)
+	}
+	return os.Rename(tmp, dst)
+}
+
+func sameFileContents(a, b string) (bool, error) {
+	aBytes, err := os.ReadFile(a)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	bBytes, err := os.ReadFile(b)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(aBytes, bBytes), nil
+}

--- a/pkg/driver/qemu/firmware.go
+++ b/pkg/driver/qemu/firmware.go
@@ -84,13 +84,14 @@ func getFirmwareTemplate(qemuExe string, arch limatype.Arch, secureBoot, preEnro
 		return qemuFirmware{}, err
 	}
 	descriptorPaths = append(slices.Clone(descriptorPaths), descriptors...)
-	if firmware, err := getFirmwareFromDescriptorFiles(descriptorPaths, arch, secureBoot, preEnrollSecureBootKeys); err == nil {
+	firmware, err := getFirmwareFromDescriptorFiles(descriptorPaths, arch, secureBoot, preEnrollSecureBootKeys)
+	if err == nil {
 		return firmware, nil
-	} else if secureBoot {
-		return qemuFirmware{}, err
-	} else {
-		logrus.WithError(err).Debug("failed to find firmware via QEMU descriptors")
 	}
+	if secureBoot {
+		return qemuFirmware{}, err
+	}
+	logrus.WithError(err).Debug("failed to find firmware via QEMU descriptors")
 
 	code, err := getFirmwareCode(qemuExe, arch)
 	if err != nil {
@@ -267,10 +268,13 @@ func firmwareFromDescriptor(descriptor qemuFirmwareDescriptor, descriptorPath st
 	return firmware, true
 }
 
-func firmwareTargetsQ35(targets []struct {
-	Architecture string   `json:"architecture"`
-	Machines     []string `json:"machines"`
-}, arch limatype.Arch) bool {
+func firmwareTargetsQ35(
+	targets []struct {
+		Architecture string   `json:"architecture"`
+		Machines     []string `json:"machines"`
+	},
+	arch limatype.Arch,
+) bool {
 	for _, target := range targets {
 		if target.Architecture != "x86_64" || arch != limatype.X8664 {
 			continue

--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -551,6 +551,7 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	// Secure boot
 	secureBoot := y.Firmware.SecureBoot != nil && *y.Firmware.SecureBoot
 	preEnrollSecureBootKeys := y.Firmware.PreEnrollSecureBootKeys != nil && *y.Firmware.PreEnrollSecureBootKeys
+	tpm2 := y.Firmware.TPM2 != nil && *y.Firmware.TPM2
 
 	// Machine
 	switch *y.Arch {
@@ -608,8 +609,23 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	args = appendArgsIfNoConflict(args, "-smp",
 		fmt.Sprintf("%d,sockets=1,cores=%d,threads=1", *y.CPUs, *y.CPUs))
 
+	// TPM
+	if tpm2 {
+		if *y.Arch != limatype.X8664 {
+			return "", nil, fmt.Errorf("field `firmware.tpm2` is currently implemented only for arch %q, got %q", limatype.X8664, *y.Arch)
+		}
+		tpmSock := filepath.Join(cfg.InstanceDir, filenames.SwtpmSock)
+		args = append(args,
+			"-chardev", "socket,id=chrtpm,path="+tpmSock,
+			"-tpmdev", "emulator,id=tpm0,chardev=chrtpm",
+			"-device", "tpm-crb,tpmdev=tpm0")
+	}
+
 	// Firmware
 	legacyBIOS := *y.Firmware.LegacyBIOS
+	if legacyBIOS && tpm2 {
+		return "", nil, errors.New("field `firmware.tpm2` requires UEFI firmware, but firmware.legacyBIOS is true")
+	}
 	if legacyBIOS && *y.Arch != limatype.X8664 && *y.Arch != limatype.ARMV7L {
 		logrus.Warnf("field `firmware.legacyBIOS` is not supported for architecture %q, ignoring", *y.Arch)
 		legacyBIOS = false

--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -792,7 +792,7 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 
 	isoPresent := osutil.FileExists(isoPath)
 	if osutil.FileExists(diskPath) {
-		if isoPresent {
+		if isoPresent && *y.OS != limatype.WINDOWS {
 			args = append(args, "-drive", fmt.Sprintf("file=%s,if=virtio,discard=on", diskPath))
 		} else {
 			// bootindex=1 fixes non-deterministic boot order when extra disks are present (#4936)
@@ -801,7 +801,14 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 		}
 	}
 	if isoPresent {
-		args = appendArgsIfNoConflict(args, "-boot", "order=d,splash-time=0,menu=on")
+		if *y.OS == limatype.WINDOWS {
+			// The Windows ISO still requires one keypress on the first boot, but
+			// the installed hard disk must remain the first bootable device after
+			// the installer reboots.
+			args = appendArgsIfNoConflict(args, "-boot", "order=cd,splash-time=0,menu=on")
+		} else {
+			args = appendArgsIfNoConflict(args, "-boot", "order=d,splash-time=0,menu=on")
+		}
 		args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,media=cdrom,readonly=on", isoPath))
 	} else {
 		args = appendArgsIfNoConflict(args, "-boot", "order=c,splash-time=0,menu=on")
@@ -811,10 +818,16 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	}
 
 	// cloud-init
-	args = append(args,
-		"-drive", "id=cdrom0,if=none,format=raw,readonly=on,file="+filepath.Join(cfg.InstanceDir, filenames.CIDataISO),
-		"-device", "virtio-scsi,id=scsi0",
-		"-device", "scsi-cd,bus=scsi0.0,drive=cdrom0")
+	args = append(args, "-drive", "id=cdrom0,if=none,format=raw,readonly=on,file="+filepath.Join(cfg.InstanceDir, filenames.CIDataISO))
+	if *y.OS == limatype.WINDOWS {
+		args = append(args,
+			"-device", "ich9-ahci,id=ahci0",
+			"-device", "ide-cd,bus=ahci0.0,drive=cdrom0")
+	} else {
+		args = append(args,
+			"-device", "virtio-scsi,id=scsi0",
+			"-device", "scsi-cd,bus=scsi0.0,drive=cdrom0")
+	}
 
 	// Kernel
 	kernel := filepath.Join(cfg.InstanceDir, filenames.Kernel)

--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -548,13 +548,21 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	}
 	args = appendArgsIfNoConflict(args, "-cpu", cpu)
 
+	// Secure boot
+	secureBoot := y.Firmware.SecureBoot != nil && *y.Firmware.SecureBoot
+	preEnrollSecureBootKeys := y.Firmware.PreEnrollSecureBootKeys != nil && *y.Firmware.PreEnrollSecureBootKeys
+
 	// Machine
 	switch *y.Arch {
 	case limatype.X8664:
+		q35 := "q35"
+		if secureBoot {
+			q35 += ",smm=on"
+		}
 		switch accel {
 		case "tcg":
 			// use q35 machine with vmware io port disabled.
-			args = appendArgsIfNoConflict(args, "-machine", "q35,vmport=off")
+			args = appendArgsIfNoConflict(args, "-machine", q35+",vmport=off")
 			// use tcg accelerator with multi threading with 512MB translation block size
 			// https://qemu-project.gitlab.io/qemu/devel/multi-thread-tcg.html?highlight=tcg
 			// https://qemu-project.gitlab.io/qemu/system/invocation.html?highlight=tcg%20opts
@@ -567,12 +575,12 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 			if version.LessThan(*semver.New("11.0.0")) {
 				// Older versions of QEMU required disabling `kernel-irqchip` explicitly.
 				// It is not recommended to keep using this with QEMU 11.0.0 and newer.
-				args = appendArgsIfNoConflict(args, "-machine", "q35,accel="+accel+",kernel-irqchip=off")
+				args = appendArgsIfNoConflict(args, "-machine", q35+",accel="+accel+",kernel-irqchip=off")
 			} else {
-				args = appendArgsIfNoConflict(args, "-machine", "q35,accel="+accel)
+				args = appendArgsIfNoConflict(args, "-machine", q35+",accel="+accel)
 			}
 		default:
-			args = appendArgsIfNoConflict(args, "-machine", "q35,accel="+accel)
+			args = appendArgsIfNoConflict(args, "-machine", q35+",accel="+accel)
 		}
 	case limatype.AARCH64:
 		machine := "virt,accel=" + accel
@@ -609,6 +617,7 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	noFirmware := *y.Arch == limatype.PPC64LE || *y.Arch == limatype.S390X || legacyBIOS
 	if !noFirmware {
 		var firmware string
+		var firmwareVars string
 		firmwareInBios := runtime.GOOS == "windows" && version.LessThan(*semver.New("11.0.0"))
 		if envVar := os.Getenv("_LIMA_QEMU_UEFI_IN_BIOS"); envVar != "" {
 			logrus.Warn("use of deprecated _LIMA_QEMU_UEFI_IN_BIOS")
@@ -620,12 +629,38 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 			}
 		}
 		firmwareInBios = firmwareInBios && *y.Arch == limatype.X8664
+		if secureBoot && firmwareInBios {
+			return "", nil, errors.New("field `firmware.secureBoot` requires pflash firmware; -bios firmware is not supported")
+		}
 		downloadedFirmware := filepath.Join(cfg.InstanceDir, filenames.QemuEfiCodeFD)
 		firmwareWithVars := filepath.Join(cfg.InstanceDir, filenames.QemuEfiFullFD)
+		firmwareFormat := qemuFirmwareFormatRaw
+		firmwareVarsFormat := qemuFirmwareFormatRaw
 		if firmwareInBios {
 			if _, stErr := os.Stat(firmwareWithVars); stErr == nil {
 				firmware = firmwareWithVars
 				logrus.Infof("Using existing firmware (%q)", firmware)
+			}
+		} else if secureBoot {
+			firmwareTemplate, err := getFirmwareTemplate(exe, *y.Arch, true, preEnrollSecureBootKeys, y.Firmware.Descriptors)
+			if err != nil {
+				return "", nil, err
+			}
+			if len(y.Firmware.Images) > 0 {
+				logrus.Warn("field `firmware.images` is ignored when `firmware.secureBoot` is true; use `firmware.descriptors` instead")
+			}
+			firmware, firmwareVars, firmwareFormat, firmwareVarsFormat, err = prepareFirmwareTemplate(cfg.InstanceDir, firmwareTemplate, secureBoot)
+			if err != nil {
+				return "", nil, err
+			}
+		} else if len(y.Firmware.Descriptors) > 0 {
+			firmwareTemplate, err := getFirmwareTemplate(exe, *y.Arch, false, false, y.Firmware.Descriptors)
+			if err != nil {
+				return "", nil, err
+			}
+			firmware, firmwareVars, firmwareFormat, firmwareVarsFormat, err = prepareFirmwareTemplate(cfg.InstanceDir, firmwareTemplate, secureBoot)
+			if err != nil {
+				return "", nil, err
 			}
 		} else {
 			if _, stErr := os.Stat(downloadedFirmware); errors.Is(stErr, os.ErrNotExist) {
@@ -650,12 +685,12 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 			}
 		}
 		if firmware == "" {
-			firmware, err = getFirmware(exe, *y.Arch)
-			if err != nil {
-				return "", nil, err
-			}
-			logrus.Infof("Using system firmware (%q)", firmware)
 			if firmwareInBios {
+				firmware, err = getFirmwareCode(exe, *y.Arch)
+				if err != nil {
+					return "", nil, err
+				}
+				logrus.Infof("Using system firmware (%q)", firmware)
 				firmwareVars, err := getFirmwareVars(exe, *y.Arch)
 				if err != nil {
 					return "", nil, err
@@ -685,6 +720,15 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 					return "", nil, err
 				}
 				firmware = firmwareWithVars
+			} else {
+				firmwareTemplate, err := getFirmwareTemplate(exe, *y.Arch, false, false, y.Firmware.Descriptors)
+				if err != nil {
+					return "", nil, err
+				}
+				firmware, firmwareVars, firmwareFormat, firmwareVarsFormat, err = prepareFirmwareTemplate(cfg.InstanceDir, firmwareTemplate, secureBoot)
+				if err != nil {
+					return "", nil, err
+				}
 			}
 		}
 		if firmware != "" {
@@ -692,7 +736,13 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 				logrus.Warn("firmware in `-bios` is deprecated, consider upgrading to QEMU supporting `-drive if=pflash`")
 				args = append(args, "-bios", firmware)
 			} else {
-				args = append(args, "-drive", fmt.Sprintf("if=pflash,format=raw,readonly=on,file=%s", firmware))
+				if secureBoot {
+					args = append(args, "-global", "driver=cfi.pflash01,property=secure,value=on")
+				}
+				args = append(args, "-drive", fmt.Sprintf("if=pflash,unit=0,format=%s,readonly=on,file=%s", firmwareFormat, firmware))
+				if firmwareVars != "" {
+					args = append(args, "-drive", fmt.Sprintf("if=pflash,unit=1,format=%s,file=%s", firmwareVarsFormat, firmwareVars))
+				}
 			}
 		}
 	}
@@ -1169,7 +1219,7 @@ func getQemuVersion(ctx context.Context, qemuExe string) (*semver.Version, error
 	return parseQemuVersion(stdout.String())
 }
 
-func getFirmware(qemuExe string, arch limatype.Arch) (string, error) {
+func getFirmwareCode(qemuExe string, arch limatype.Arch) (string, error) {
 	switch arch {
 	case limatype.X8664, limatype.AARCH64, limatype.ARMV7L, limatype.RISCV64:
 	default:

--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -652,12 +652,13 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 		firmwareWithVars := filepath.Join(cfg.InstanceDir, filenames.QemuEfiFullFD)
 		firmwareFormat := qemuFirmwareFormatRaw
 		firmwareVarsFormat := qemuFirmwareFormatRaw
-		if firmwareInBios {
+		switch {
+		case firmwareInBios:
 			if _, stErr := os.Stat(firmwareWithVars); stErr == nil {
 				firmware = firmwareWithVars
 				logrus.Infof("Using existing firmware (%q)", firmware)
 			}
-		} else if secureBoot {
+		case secureBoot:
 			firmwareTemplate, err := getFirmwareTemplate(exe, *y.Arch, true, preEnrollSecureBootKeys, y.Firmware.Descriptors)
 			if err != nil {
 				return "", nil, err
@@ -669,7 +670,7 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 			if err != nil {
 				return "", nil, err
 			}
-		} else if len(y.Firmware.Descriptors) > 0 {
+		case len(y.Firmware.Descriptors) > 0:
 			firmwareTemplate, err := getFirmwareTemplate(exe, *y.Arch, false, false, y.Firmware.Descriptors)
 			if err != nil {
 				return "", nil, err
@@ -678,7 +679,7 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 			if err != nil {
 				return "", nil, err
 			}
-		} else {
+		default:
 			if _, stErr := os.Stat(downloadedFirmware); errors.Is(stErr, os.ErrNotExist) {
 			loop:
 				for _, f := range y.Firmware.Images {

--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -50,6 +50,8 @@ type LimaQemuDriver struct {
 	qWaitCh chan error
 
 	vhostCmds []*exec.Cmd
+	tpmCmd    *exec.Cmd
+	tpmWaitCh <-chan error
 }
 
 var _ driver.Driver = (*LimaQemuDriver)(nil)
@@ -294,6 +296,20 @@ func (l *LimaQemuDriver) Start(_ context.Context) (chan error, error) {
 		return nil, err
 	}
 
+	var swtpmCmd *exec.Cmd
+	var swtpmWaitCh <-chan error
+	if l.Instance.Config.Firmware.TPM2 != nil && *l.Instance.Config.Firmware.TPM2 {
+		swtpmCmd, swtpmWaitCh, err = startSwtpm(ctx, qCfg.InstanceDir)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			if l.qCmd == nil {
+				_ = killProcess(swtpmCmd, swtpmWaitCh, "swtpm")
+			}
+		}()
+	}
+
 	var vhostCmds []*exec.Cmd
 	if *l.Instance.Config.MountType == limatype.VIRTIOFS {
 		vhostExe, err := FindVirtiofsd(ctx, qExe)
@@ -404,6 +420,8 @@ func (l *LimaQemuDriver) Start(_ context.Context) (chan error, error) {
 		l.qWaitCh <- qCmd.Wait()
 	}()
 	l.vhostCmds = vhostCmds
+	l.tpmCmd = swtpmCmd
+	l.tpmWaitCh = swtpmWaitCh
 	go func() {
 		if usernetIndex := limayaml.FirstUsernetIndex(l.Instance.Config); usernetIndex != -1 {
 			client := usernet.NewClientByName(l.Instance.Config.Networks[usernetIndex].Lima)
@@ -567,7 +585,7 @@ func (l *LimaQemuDriver) shutdownQEMU(ctx context.Context, timeout time.Duration
 		if !ok {
 			logrus.Info("QEMU wait channel was closed")
 			_ = l.removeVNCFiles()
-			return l.killVhosts()
+			return errors.Join(l.killVhosts(), l.killSwtpm())
 		}
 		entry := logrus.NewEntry(logrus.StandardLogger())
 		if qWaitErr != nil {
@@ -575,12 +593,12 @@ func (l *LimaQemuDriver) shutdownQEMU(ctx context.Context, timeout time.Duration
 		}
 		entry.Info("QEMU has exited")
 		_ = l.removeVNCFiles()
-		return errors.Join(qWaitErr, l.killVhosts())
+		return errors.Join(qWaitErr, l.killVhosts(), l.killSwtpm())
 	case <-timeoutCtx.Done():
 		if qCmd.ProcessState != nil {
 			logrus.Info("QEMU has already exited")
 			_ = l.removeVNCFiles()
-			return l.killVhosts()
+			return errors.Join(l.killVhosts(), l.killSwtpm())
 		}
 		logrus.Warnf("QEMU did not exit in %v, forcibly killing QEMU", timeout)
 		return l.killQEMU(ctx, timeout, qCmd, qWaitCh)
@@ -601,7 +619,102 @@ func (l *LimaQemuDriver) killQEMU(_ context.Context, _ time.Duration, qCmd *exec
 	qemuPIDPath := filepath.Join(l.Instance.Dir, filenames.PIDFile(*l.Instance.Config.VMType))
 	_ = os.RemoveAll(qemuPIDPath)
 	_ = l.removeVNCFiles()
-	return errors.Join(qWaitErr, l.killVhosts())
+	return errors.Join(qWaitErr, l.killVhosts(), l.killSwtpm())
+}
+
+func startSwtpm(ctx context.Context, instDir string) (*exec.Cmd, <-chan error, error) {
+	exe, err := exec.LookPath("swtpm")
+	if err != nil {
+		return nil, nil, fmt.Errorf("swtpm is required for firmware.tpm2: %w", err)
+	}
+	stateDir := filepath.Join(instDir, filenames.SwtpmDir)
+	sockPath := filepath.Join(instDir, filenames.SwtpmSock)
+	if err = os.MkdirAll(stateDir, 0o700); err != nil {
+		return nil, nil, err
+	}
+	if err = os.Remove(sockPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, nil, err
+	}
+	cmd := exec.CommandContext(ctx, exe,
+		"socket",
+		"--tpm2",
+		"--tpmstate", "dir="+stateDir,
+		"--ctrl", "type=unixio,path="+sockPath,
+		"--flags", "startup-clear",
+		"--terminate")
+	cmd.SysProcAttr = executil.BackgroundSysProcAttr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	go logPipeRoutine(stdout, "swtpm[stdout]")
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	go logPipeRoutine(stderr, "swtpm[stderr]")
+
+	logrus.Debugf("swtpmCmd.Args: %v", cmd.Args)
+	if err = cmd.Start(); err != nil {
+		return nil, nil, err
+	}
+	waitCh := make(chan error, 1)
+	go func() {
+		defer close(waitCh)
+		waitCh <- cmd.Wait()
+	}()
+	if err = waitForFile(ctx, sockPath, waitCh, 5*time.Second); err != nil {
+		return nil, nil, errors.Join(err, killProcess(cmd, waitCh, "swtpm"))
+	}
+	return cmd, waitCh, nil
+}
+
+func waitForFile(ctx context.Context, path string, waitCh <-chan error, timeout time.Duration) error {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err, ok := <-waitCh:
+			if ok {
+				return fmt.Errorf("process exited before %q appeared: %w", path, err)
+			}
+			return fmt.Errorf("process exited before %q appeared", path)
+		case <-deadline.C:
+			return fmt.Errorf("timed out waiting for %q", path)
+		case <-ticker.C:
+		}
+	}
+}
+
+func killProcess(cmd *exec.Cmd, waitCh <-chan error, name string) error {
+	if cmd == nil {
+		return nil
+	}
+	if cmd.ProcessState == nil {
+		if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			return fmt.Errorf("failed to kill %s: %w", name, err)
+		}
+	}
+	if waitCh == nil {
+		return nil
+	}
+	if err, ok := <-waitCh; ok && err != nil {
+		return fmt.Errorf("%s exited with error: %w", name, err)
+	}
+	return nil
+}
+
+func (l *LimaQemuDriver) killSwtpm() error {
+	return killProcess(l.tpmCmd, l.tpmWaitCh, "swtpm")
 }
 
 func logPipeRoutine(r io.Reader, header string) {

--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -422,6 +422,9 @@ func (l *LimaQemuDriver) Start(_ context.Context) (chan error, error) {
 	l.vhostCmds = vhostCmds
 	l.tpmCmd = swtpmCmd
 	l.tpmWaitCh = swtpmWaitCh
+	if shouldSendWindowsInstallerBootKey(l.Instance.Config, qCfg.InstanceDir) {
+		go sendWindowsInstallerBootKey(qCfg)
+	}
 	go func() {
 		if usernetIndex := limayaml.FirstUsernetIndex(l.Instance.Config); usernetIndex != -1 {
 			client := usernet.NewClientByName(l.Instance.Config.Networks[usernetIndex].Lima)
@@ -432,6 +435,36 @@ func (l *LimaQemuDriver) Start(_ context.Context) (chan error, error) {
 		}
 	}()
 	return l.qWaitCh, nil
+}
+
+func shouldSendWindowsInstallerBootKey(cfg *limatype.LimaYAML, instanceDir string) bool {
+	if cfg == nil || cfg.OS == nil || *cfg.OS != limatype.WINDOWS {
+		return false
+	}
+	if !osutil.FileExists(filepath.Join(instanceDir, filenames.ISO)) {
+		return false
+	}
+	return !osutil.FileExists(filepath.Join(instanceDir, filenames.WindowsISOBootKeySent))
+}
+
+func sendWindowsInstallerBootKey(cfg Config) {
+	markerPath := filepath.Join(cfg.InstanceDir, filenames.WindowsISOBootKeySent)
+	qmpSockPath := filepath.Join(cfg.InstanceDir, filenames.QMPSock)
+	if err := waitFileExists(qmpSockPath, 5*time.Second); err != nil {
+		logrus.WithError(err).Warn("failed to wait for QMP socket before sending Windows installer boot key")
+		return
+	}
+	// Wait for the prompt.
+	time.Sleep(1500 * time.Millisecond)
+	if _, err := sendHmpCommand(cfg, "sendkey", "ret"); err != nil {
+		logrus.WithError(err).Warn("failed to send Windows installer boot key")
+		return
+	}
+	if err := os.WriteFile(markerPath, []byte("sent\n"), 0o644); err != nil {
+		logrus.WithError(err).Warnf("failed to write %q", markerPath)
+		return
+	}
+	logrus.Infof("Sent Windows installer boot key and recorded %q", markerPath)
 }
 
 func (l *LimaQemuDriver) Stop(ctx context.Context) error {

--- a/pkg/driver/qemu/qemu_test.go
+++ b/pkg/driver/qemu/qemu_test.go
@@ -4,7 +4,13 @@
 package qemu
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
 
 	"gotest.tools/v3/assert"
 )
@@ -88,4 +94,134 @@ func TestParseQemuVersion(t *testing.T) {
 		}
 		assert.Equal(t, tc.expectedValue, v.String())
 	}
+}
+
+func TestGetFirmwareFromDescriptorFiles(t *testing.T) {
+	dir := t.TempDir()
+	secureCode2M := filepath.Join(dir, "OVMF_CODE.secboot.fd")
+	secureVars2M := filepath.Join(dir, "OVMF_VARS.secboot.fd")
+	secureCode4M := filepath.Join(dir, "OVMF_CODE_4M.secboot.qcow2")
+	secureVarsWithKeys := filepath.Join(dir, "OVMF_VARS_4M.secboot.qcow2")
+	secureVarsWithoutKeys := filepath.Join(dir, "OVMF_VARS_4M.qcow2")
+	plainCode := filepath.Join(dir, "OVMF_CODE_4M.qcow2")
+	plainVars := filepath.Join(dir, "OVMF_VARS_4M.qcow2")
+	for _, path := range []string{secureCode2M, secureVars2M, secureCode4M, secureVarsWithKeys, secureVarsWithoutKeys, plainCode, plainVars} {
+		assert.NilError(t, os.WriteFile(path, nil, 0o644))
+	}
+
+	secureWithKeys2M := filepath.Join(dir, "secure-with-keys-2m.json")
+	secureWithKeys4M := filepath.Join(dir, "secure-with-keys-4m.json")
+	secureWithoutKeys := filepath.Join(dir, "secure-without-keys.json")
+	plain := filepath.Join(dir, "plain-4m.json")
+	assert.NilError(t, os.WriteFile(secureWithKeys2M, []byte(testQemuFirmwareDescriptorJSON(secureCode2M, secureVars2M, []string{"secure-boot", "requires-smm", "enrolled-keys"})), 0o644))
+	assert.NilError(t, os.WriteFile(secureWithKeys4M, []byte(testQemuFirmwareDescriptorJSON(secureCode4M, secureVarsWithKeys, []string{"secure-boot", "requires-smm", "enrolled-keys"})), 0o644))
+	assert.NilError(t, os.WriteFile(secureWithoutKeys, []byte(testQemuFirmwareDescriptorJSON(secureCode4M, secureVarsWithoutKeys, []string{"secure-boot", "requires-smm"})), 0o644))
+	assert.NilError(t, os.WriteFile(plain, []byte(testQemuFirmwareDescriptorJSON(plainCode, plainVars, nil)), 0o644))
+
+	testCases := []struct {
+		name                    string
+		descriptors             []string
+		secureBoot              bool
+		preEnrollSecureBootKeys bool
+		expectedDescriptor      string
+		expectedVars            string
+		expectedErr             string
+	}{
+		{
+			name:                    "secure boot requires pre-enrolled keys",
+			descriptors:             []string{secureWithoutKeys, secureWithKeys4M},
+			secureBoot:              true,
+			preEnrollSecureBootKeys: true,
+			expectedDescriptor:      secureWithKeys4M,
+			expectedVars:            secureVarsWithKeys,
+		},
+		{
+			name:                    "secure boot does not fallback to empty vars when pre-enrolled keys are required",
+			descriptors:             []string{secureWithoutKeys},
+			secureBoot:              true,
+			preEnrollSecureBootKeys: true,
+			expectedErr:             "no QEMU firmware descriptor",
+		},
+		{
+			name:                    "secure boot rejects pre-enrolled keys when false",
+			descriptors:             []string{secureWithKeys4M, secureWithoutKeys},
+			secureBoot:              true,
+			preEnrollSecureBootKeys: false,
+			expectedDescriptor:      secureWithoutKeys,
+			expectedVars:            secureVarsWithoutKeys,
+		},
+		{
+			name:                    "prefers 4M firmware",
+			descriptors:             []string{secureWithKeys2M, secureWithKeys4M},
+			secureBoot:              true,
+			preEnrollSecureBootKeys: true,
+			expectedDescriptor:      secureWithKeys4M,
+			expectedVars:            secureVarsWithKeys,
+		},
+		{
+			name:               "rejects secure boot when disabled",
+			descriptors:        []string{secureWithKeys4M, plain},
+			secureBoot:         false,
+			expectedDescriptor: plain,
+			expectedVars:       plainVars,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			firmware, err := getFirmwareFromDescriptorFiles(tc.descriptors, limatype.X8664, tc.secureBoot, tc.preEnrollSecureBootKeys)
+			if tc.expectedErr != "" {
+				assert.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, tc.expectedDescriptor, firmware.DescriptorPath)
+			assert.Assert(t, firmware.Vars != nil)
+			assert.Equal(t, tc.expectedVars, firmware.Vars.Path)
+		})
+	}
+}
+
+func TestEnsureFirmwareFileIfMissingPreservesExistingVars(t *testing.T) {
+	dir := t.TempDir()
+	template := filepath.Join(dir, "template.fd")
+	vars := filepath.Join(dir, "vars.fd")
+	assert.NilError(t, os.WriteFile(template, []byte("template"), 0o644))
+	assert.NilError(t, os.WriteFile(vars, []byte("guest-nvram"), 0o644))
+
+	err := ensureFirmwareFileIfMissing(vars, firmwareFile{Path: template, Format: "raw"})
+	assert.NilError(t, err)
+	b, err := os.ReadFile(vars)
+	assert.NilError(t, err)
+	assert.Equal(t, "guest-nvram", string(b))
+}
+
+func testQemuFirmwareDescriptorJSON(code, vars string, features []string) string {
+	featuresJSON, err := json.Marshal(features)
+	if err != nil {
+		panic(err)
+	}
+	raw := fmt.Sprintf(`{
+		"description": "test secure boot firmware",
+		"interface-types": ["uefi"],
+		"mapping": {
+			"device": "flash",
+			"executable": {
+				"filename": %q,
+				"format": ""
+			},
+			"nvram-template": {
+				"filename": %q,
+				"format": ""
+			}
+		},
+		"targets": [
+			{
+				"architecture": "x86_64",
+				"machines": ["pc-q35-*"]
+			}
+		],
+		"features": %s
+	}`, code, vars, string(featuresJSON))
+	return raw
 }

--- a/pkg/driver/qemu/qemu_test.go
+++ b/pkg/driver/qemu/qemu_test.go
@@ -10,9 +10,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/lima-vm/lima/v2/pkg/limatype"
-
 	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
 )
 
 func TestArgValue(t *testing.T) {

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -106,7 +106,7 @@ func prefixExportParam(script string, guestOS *limatype.OS) (string, error) {
 }
 
 func (a *HostAgent) bashAvailable() bool {
-	return *a.instConfig.OS != limatype.FREEBSD
+	return *a.instConfig.OS != limatype.FREEBSD && *a.instConfig.OS != limatype.WINDOWS
 }
 
 func (a *HostAgent) waitForRequirement(r requirement) error {
@@ -156,6 +156,50 @@ type requirement struct {
 }
 
 func (a *HostAgent) essentialRequirements() []requirement {
+	if *a.instConfig.OS == limatype.WINDOWS {
+		return []requirement{
+			{
+				description: "ssh",
+				script: `#!powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -Command -
+$ErrorActionPreference = 'Stop'
+exit 0
+`,
+				debugHint: `Failed to SSH into the guest.
+Make sure that the YAML field "ssh.localPort" is not used by other processes on the host.
+If any private key under ~/.ssh is protected with a passphrase, you need to have ssh-agent to be running.
+`,
+				noMaster: true,
+			},
+			{
+				description: "Windows setup script to complete",
+				script: `#!powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -Command -
+$ErrorActionPreference = 'Stop'
+if (!(Test-Path 'C:\ProgramData\Lima\setup.done')) {
+    throw 'C:\ProgramData\Lima\setup.done does not exist'
+}
+`,
+				debugHint: `The Windows setup script did not finish yet.
+Check "C:\ProgramData\Lima\windows-setup.ps1" and Windows event logs in the guest.
+`,
+				noMaster: true,
+			},
+			{
+				description: "sshd service to be running",
+				script: `#!powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -Command -
+$ErrorActionPreference = 'Stop'
+$service = Get-Service -Name sshd
+if ($service.Status -ne 'Running') {
+    throw "sshd status is $($service.Status)"
+}
+`,
+				debugHint: `The Windows OpenSSH Server service is not running.
+Check "C:\ProgramData\ssh\logs" and the sshd service status in the guest.
+`,
+				noMaster: true,
+			},
+		}
+	}
+
 	req := make([]requirement, 0)
 	req = append(req,
 		requirement{
@@ -268,6 +312,10 @@ Also see "/var/log/cloud-init-output.log" in the guest.
 }
 
 func (a *HostAgent) finalRequirements() []requirement {
+	if *a.instConfig.OS == limatype.WINDOWS {
+		return nil
+	}
+
 	req := make([]requirement, 0)
 	logLocation := "/var/log/cloud-init-output.log in the guest"
 	if *a.instConfig.OS == limatype.DARWIN {

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -40,6 +40,9 @@ import (
 // to be running before timing out.
 const DefaultWatchHostAgentEventsTimeout = 10 * time.Minute
 
+// DefaultWindowsWatchHostAgentEventsTimeout is longer because the first boot may install Windows from ISO.
+const DefaultWindowsWatchHostAgentEventsTimeout = 60 * time.Minute
+
 type Prepared struct {
 	Driver              driver.Driver
 	GuestAgent          string
@@ -55,6 +58,9 @@ func Prepare(ctx context.Context, inst *limatype.Instance, guestAgent string) (*
 		needsGuestAgent = true
 	case limatype.FREEBSD:
 		// guest agent is not implemented for FreeBSD yet
+		needsGuestAgent = false
+	case limatype.WINDOWS:
+		// guest agent is not implemented for Windows yet
 		needsGuestAgent = false
 	default:
 		needsGuestAgent = !*inst.Config.Plain
@@ -257,9 +263,14 @@ func StartWithPaths(ctx context.Context, inst *limatype.Instance, launchHostAgen
 		return err
 	}
 
+	watchCtx := ctx
+	if inst.Config.OS != nil && *inst.Config.OS == limatype.WINDOWS {
+		watchCtx = WithWatchHostAgentTimeout(watchCtx, DefaultWindowsWatchHostAgentEventsTimeout)
+	}
+
 	watchErrCh := make(chan error)
 	go func() {
-		watchErrCh <- watchHostAgentEvents(ctx, inst, haStdoutPath, haStderrPath, begin, showProgress)
+		watchErrCh <- watchHostAgentEvents(watchCtx, inst, haStdoutPath, haStderrPath, begin, showProgress)
 		close(watchErrCh)
 	}()
 	waitErrCh := make(chan error)
@@ -360,7 +371,7 @@ func watchHostAgentEvents(ctx context.Context, inst *limatype.Instance, haStdout
 			}
 
 			if !isLaunchingShell(ctx) {
-				if *inst.Config.Plain {
+				if *inst.Config.Plain || *inst.Config.OS == limatype.WINDOWS {
 					logrus.Infof("READY. Run `ssh -F %q %s` to open the shell.", inst.SSHConfigFile, inst.Hostname)
 				} else {
 					logrus.Infof("READY. Run `%s` to open the shell.", LimactlShellCmd(inst.Name))

--- a/pkg/limatype/filenames/filenames.go
+++ b/pkg/limatype/filenames/filenames.go
@@ -75,6 +75,8 @@ const (
 	QemuEfiVarsFD           = "qemu-efi-vars.fd"    // efi variable store; not always created
 	QemuEfiVarsQCOW2        = "qemu-efi-vars.qcow2" // efi variable store; not always created
 	QemuEfiFullFD           = "qemu-efi-full.fd"    // concatenated efi vars and code; not always created
+	WindowsISOBootKeySent   = "windows-iso-boot-key-sent"
+	WindowsUserPassword     = "windows-user-password"
 	AnsibleInventoryYAML    = "ansible-inventory.yaml"
 
 	// SocketDir is the default location for forwarded sockets with a relative paths in HostSocket.

--- a/pkg/limatype/filenames/filenames.go
+++ b/pkg/limatype/filenames/filenames.go
@@ -46,6 +46,8 @@ const (
 	KernelCmdline           = "kernel.cmdline"
 	Initrd                  = "initrd"
 	QMPSock                 = "qmp.sock"
+	SwtpmDir                = "swtpm"
+	SwtpmSock               = "swtpm.sock"
 	SerialLog               = "serial.log" // default serial (ttyS0, but ttyAMA0 on qemu-system-{arm,aarch64})
 	SerialSock              = "serial.sock"
 	SerialPCILog            = "serialp.log" // pci serial (ttyS0 on qemu-system-{arm,aarch64})

--- a/pkg/limatype/filenames/filenames.go
+++ b/pkg/limatype/filenames/filenames.go
@@ -65,11 +65,14 @@ const (
 	HostAgentStderrLog      = "ha.stderr.log"
 	ExternalDriverStderrLog = "driver.stderr.log"
 	VzIdentifier            = "vz-identifier"
-	VzHwModel               = "vz-hwmodel"       // macOS guests only
-	VzAux                   = "vz-aux"           // macOS guests only
-	VzEfi                   = "vz-efi"           // efi variable store
-	QemuEfiCodeFD           = "qemu-efi-code.fd" // efi code; not always created
-	QemuEfiFullFD           = "qemu-efi-full.fd" // concatenated efi vars and code; not always created
+	VzHwModel               = "vz-hwmodel"          // macOS guests only
+	VzAux                   = "vz-aux"              // macOS guests only
+	VzEfi                   = "vz-efi"              // efi variable store
+	QemuEfiCodeFD           = "qemu-efi-code.fd"    // efi code; not always created
+	QemuEfiCodeQCOW2        = "qemu-efi-code.qcow2" // efi code; not always created
+	QemuEfiVarsFD           = "qemu-efi-vars.fd"    // efi variable store; not always created
+	QemuEfiVarsQCOW2        = "qemu-efi-vars.qcow2" // efi variable store; not always created
+	QemuEfiFullFD           = "qemu-efi-full.fd"    // concatenated efi vars and code; not always created
 	AnsibleInventoryYAML    = "ansible-inventory.yaml"
 
 	// SocketDir is the default location for forwarded sockets with a relative paths in HostSocket.

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -215,6 +215,9 @@ type Firmware struct {
 	// PreEnrollSecureBootKeys requires pre-enrolled Secure Boot keys in the firmware variable store.
 	PreEnrollSecureBootKeys *bool `yaml:"preEnrollSecureBootKeys,omitempty" json:"preEnrollSecureBootKeys,omitempty" jsonschema:"nullable"`
 
+	// TPM2 enables a software TPM 2.0 device.
+	TPM2 *bool `yaml:"tpm2,omitempty" json:"tpm2,omitempty" jsonschema:"nullable"`
+
 	// Descriptors specifies QEMU firmware descriptor JSON files.
 	Descriptors []string `yaml:"descriptors,omitempty" json:"descriptors,omitempty"`
 

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -53,11 +53,12 @@ type LimaYAML struct {
 	PropagateProxyEnv *bool          `yaml:"propagateProxyEnv,omitempty" json:"propagateProxyEnv,omitempty" jsonschema:"nullable"`
 	CACertificates    CACertificates `yaml:"caCerts,omitempty" json:"caCerts,omitempty"`
 	// Deprecated: Use vmOpts.vz.rosetta instead.
-	Rosetta              Rosetta `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
-	Plain                *bool   `yaml:"plain,omitempty" json:"plain,omitempty" jsonschema:"nullable"`
-	TimeZone             *string `yaml:"timezone,omitempty" json:"timezone,omitempty" jsonschema:"nullable"`
-	NestedVirtualization *bool   `yaml:"nestedVirtualization,omitempty" json:"nestedVirtualization,omitempty" jsonschema:"nullable"`
-	User                 User    `yaml:"user,omitempty" json:"user,omitempty"`
+	Rosetta              Rosetta      `yaml:"rosetta,omitempty" json:"rosetta,omitempty"`
+	Plain                *bool        `yaml:"plain,omitempty" json:"plain,omitempty" jsonschema:"nullable"`
+	TimeZone             *string      `yaml:"timezone,omitempty" json:"timezone,omitempty" jsonschema:"nullable"`
+	NestedVirtualization *bool        `yaml:"nestedVirtualization,omitempty" json:"nestedVirtualization,omitempty" jsonschema:"nullable"`
+	User                 User         `yaml:"user,omitempty" json:"user,omitempty"`
+	GuestDrivers         GuestDrivers `yaml:"guestDrivers,omitempty" json:"guestDrivers,omitempty"`
 }
 
 type BaseTemplates []LocatorWithDigest
@@ -80,6 +81,7 @@ const (
 	LINUX   OS = "Linux"
 	DARWIN  OS = "Darwin"
 	FREEBSD OS = "FreeBSD"
+	WINDOWS OS = "Windows"
 
 	X8664   Arch = "x86_64"
 	AARCH64 Arch = "aarch64"
@@ -99,7 +101,7 @@ const (
 )
 
 var (
-	OSTypes    = []OS{LINUX, DARWIN, FREEBSD}
+	OSTypes    = []OS{LINUX, DARWIN, FREEBSD, WINDOWS}
 	ArchTypes  = []Arch{X8664, AARCH64, ARMV7L, PPC64LE, RISCV64, S390X}
 	MountTypes = []MountType{REVSSHFS, NINEP, VIRTIOFS, WSLMount}
 	VMTypes    = []VMType{QEMU, VZ, WSL2}
@@ -111,6 +113,8 @@ type User struct {
 	Home    *string `yaml:"home,omitempty" json:"home,omitempty" jsonschema:"nullable"`
 	Shell   *string `yaml:"shell,omitempty" json:"shell,omitempty" jsonschema:"nullable"`
 	UID     *uint32 `yaml:"uid,omitempty" json:"uid,omitempty" jsonschema:"nullable"`
+	// Password is currently used only for Windows guests.
+	Password *string `yaml:"password,omitempty" json:"password,omitempty" jsonschema:"nullable"`
 }
 
 type VMOpts map[VMType]any
@@ -118,6 +122,14 @@ type VMOpts map[VMType]any
 type QEMUOpts struct {
 	MinimumVersion *string `yaml:"minimumVersion,omitempty" json:"minimumVersion,omitempty" jsonschema:"nullable"`
 	CPUType        CPUType `yaml:"cpuType,omitempty" json:"cpuType,omitempty" jsonschema:"nullable"`
+}
+
+type GuestDrivers struct {
+	// Version identifies the guest OS version directory inside driver media.
+	// For virtio-win this is typically "w11", "w10", "2k25", or "2k22".
+	Version *string `yaml:"version,omitempty" json:"version,omitempty" jsonschema:"nullable"`
+	// Images specify driver media such as virtio-win.iso.
+	Images []FileWithVMType `yaml:"images,omitempty" json:"images,omitempty"`
 }
 
 type VZOpts struct {
@@ -360,6 +372,10 @@ func NewOS(osname string) OS {
 		return LINUX
 	case "darwin":
 		return DARWIN
+	case "freebsd":
+		return FREEBSD
+	case "windows":
+		return WINDOWS
 	default:
 		logrus.Warnf("Unknown os: %s", osname)
 		return osname

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -209,6 +209,15 @@ type Firmware struct {
 	// LegacyBIOS is ignored for aarch64.
 	LegacyBIOS *bool `yaml:"legacyBIOS,omitempty" json:"legacyBIOS,omitempty" jsonschema:"nullable"`
 
+	// SecureBoot enables UEFI Secure Boot.
+	SecureBoot *bool `yaml:"secureBoot,omitempty" json:"secureBoot,omitempty" jsonschema:"nullable"`
+
+	// PreEnrollSecureBootKeys requires pre-enrolled Secure Boot keys in the firmware variable store.
+	PreEnrollSecureBootKeys *bool `yaml:"preEnrollSecureBootKeys,omitempty" json:"preEnrollSecureBootKeys,omitempty" jsonschema:"nullable"`
+
+	// Descriptors specifies QEMU firmware descriptor JSON files.
+	Descriptors []string `yaml:"descriptors,omitempty" json:"descriptors,omitempty"`
+
 	// Images specify UEFI images (edk2-aarch64-code.fd.gz).
 	// Defaults to built-in UEFI.
 	Images []FileWithVMType `yaml:"images,omitempty" json:"images,omitempty"`

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -341,6 +341,15 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 	if y.Firmware.PreEnrollSecureBootKeys == nil {
 		y.Firmware.PreEnrollSecureBootKeys = ptr.Of(*y.Firmware.SecureBoot)
 	}
+	if y.Firmware.TPM2 == nil {
+		y.Firmware.TPM2 = d.Firmware.TPM2
+	}
+	if o.Firmware.TPM2 != nil {
+		y.Firmware.TPM2 = o.Firmware.TPM2
+	}
+	if y.Firmware.TPM2 == nil {
+		y.Firmware.TPM2 = ptr.Of(false)
+	}
 	y.Firmware.Descriptors = slices.Concat(o.Firmware.Descriptors, y.Firmware.Descriptors, d.Firmware.Descriptors)
 
 	y.Firmware.Images = slices.Concat(o.Firmware.Images, y.Firmware.Images, d.Firmware.Images)

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -323,6 +323,26 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 		y.Firmware.LegacyBIOS = ptr.Of(false)
 	}
 
+	if y.Firmware.SecureBoot == nil {
+		y.Firmware.SecureBoot = d.Firmware.SecureBoot
+	}
+	if o.Firmware.SecureBoot != nil {
+		y.Firmware.SecureBoot = o.Firmware.SecureBoot
+	}
+	if y.Firmware.SecureBoot == nil {
+		y.Firmware.SecureBoot = ptr.Of(false)
+	}
+	if y.Firmware.PreEnrollSecureBootKeys == nil {
+		y.Firmware.PreEnrollSecureBootKeys = d.Firmware.PreEnrollSecureBootKeys
+	}
+	if o.Firmware.PreEnrollSecureBootKeys != nil {
+		y.Firmware.PreEnrollSecureBootKeys = o.Firmware.PreEnrollSecureBootKeys
+	}
+	if y.Firmware.PreEnrollSecureBootKeys == nil {
+		y.Firmware.PreEnrollSecureBootKeys = ptr.Of(*y.Firmware.SecureBoot)
+	}
+	y.Firmware.Descriptors = slices.Concat(o.Firmware.Descriptors, y.Firmware.Descriptors, d.Firmware.Descriptors)
+
 	y.Firmware.Images = slices.Concat(o.Firmware.Images, y.Firmware.Images, d.Firmware.Images)
 	for i := range y.Firmware.Images {
 		f := &y.Firmware.Images[i]

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -171,6 +171,9 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 	if y.User.UID == nil {
 		y.User.UID = d.User.UID
 	}
+	if y.User.Password == nil {
+		y.User.Password = d.User.Password
+	}
 	if o.User.Name != nil {
 		y.User.Name = o.User.Name
 	}
@@ -185,6 +188,9 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 	}
 	if o.User.UID != nil {
 		y.User.UID = o.User.UID
+	}
+	if o.User.Password != nil {
+		y.User.Password = o.User.Password
 	}
 	if y.User.Name == nil {
 		y.User.Name = ptr.Of(osutil.LimaUser(ctx, existingLimaVersion, warn, y.OS).Username)
@@ -355,6 +361,29 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 	y.Firmware.Images = slices.Concat(o.Firmware.Images, y.Firmware.Images, d.Firmware.Images)
 	for i := range y.Firmware.Images {
 		f := &y.Firmware.Images[i]
+		if f.Arch == "" {
+			f.Arch = *y.Arch
+		}
+	}
+
+	if y.GuestDrivers.Version == nil {
+		y.GuestDrivers.Version = d.GuestDrivers.Version
+	}
+	if o.GuestDrivers.Version != nil {
+		y.GuestDrivers.Version = o.GuestDrivers.Version
+	}
+	y.GuestDrivers.Images = slices.Concat(o.GuestDrivers.Images, y.GuestDrivers.Images, d.GuestDrivers.Images)
+	if runtime.GOOS == "linux" && *y.OS == limatype.WINDOWS && len(y.GuestDrivers.Images) == 0 {
+		y.GuestDrivers.Images = append(y.GuestDrivers.Images, limatype.FileWithVMType{
+			File: limatype.File{
+				Location: "/usr/share/virtio-win/virtio-win.iso",
+				Arch:     *y.Arch,
+			},
+			VMType: limatype.QEMU,
+		})
+	}
+	for i := range y.GuestDrivers.Images {
+		f := &y.GuestDrivers.Images[i]
 		if f.Arch == "" {
 			f.Arch = *y.Arch
 		}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -96,7 +96,9 @@ func TestFillDefault(t *testing.T) {
 		},
 		TimeZone: ptr.Of(hostTimeZone()),
 		Firmware: limatype.Firmware{
-			LegacyBIOS: ptr.Of(false),
+			LegacyBIOS:              ptr.Of(false),
+			SecureBoot:              ptr.Of(false),
+			PreEnrollSecureBootKeys: ptr.Of(false),
 		},
 		Audio: limatype.Audio{
 			Device: ptr.Of(""),
@@ -292,8 +294,10 @@ func TestFillDefault(t *testing.T) {
 	// Set firmware expectations to match what FillDefault actually does
 	// FillDefault uses the builtin default values, which include LegacyBIOS: ptr.Of(false)
 	expect.Firmware = limatype.Firmware{
-		LegacyBIOS: ptr.Of(false), // This matches what FillDefault actually sets
-		Images:     nil,
+		LegacyBIOS:              ptr.Of(false), // This matches what FillDefault actually sets
+		SecureBoot:              ptr.Of(false),
+		PreEnrollSecureBootKeys: ptr.Of(false),
+		Images:                  nil,
 	}
 
 	expect.NestedVirtualization = ptr.Of(false)
@@ -338,7 +342,9 @@ func TestFillDefault(t *testing.T) {
 		},
 		TimeZone: ptr.Of("Zulu"),
 		Firmware: limatype.Firmware{
-			LegacyBIOS: ptr.Of(true),
+			LegacyBIOS:              ptr.Of(true),
+			SecureBoot:              ptr.Of(false),
+			PreEnrollSecureBootKeys: ptr.Of(false),
 			// Remove driver-specific firmware images from defaults
 		},
 		Audio: limatype.Audio{
@@ -549,7 +555,9 @@ func TestFillDefault(t *testing.T) {
 		},
 		TimeZone: ptr.Of("Universal"),
 		Firmware: limatype.Firmware{
-			LegacyBIOS: ptr.Of(true),
+			LegacyBIOS:              ptr.Of(true),
+			SecureBoot:              ptr.Of(false),
+			PreEnrollSecureBootKeys: ptr.Of(false),
 		},
 		Audio: limatype.Audio{
 			Device: ptr.Of("coreaudio"),

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -99,6 +99,7 @@ func TestFillDefault(t *testing.T) {
 			LegacyBIOS:              ptr.Of(false),
 			SecureBoot:              ptr.Of(false),
 			PreEnrollSecureBootKeys: ptr.Of(false),
+			TPM2:                    ptr.Of(false),
 		},
 		Audio: limatype.Audio{
 			Device: ptr.Of(""),
@@ -297,6 +298,7 @@ func TestFillDefault(t *testing.T) {
 		LegacyBIOS:              ptr.Of(false), // This matches what FillDefault actually sets
 		SecureBoot:              ptr.Of(false),
 		PreEnrollSecureBootKeys: ptr.Of(false),
+		TPM2:                    ptr.Of(false),
 		Images:                  nil,
 	}
 
@@ -345,6 +347,7 @@ func TestFillDefault(t *testing.T) {
 			LegacyBIOS:              ptr.Of(true),
 			SecureBoot:              ptr.Of(false),
 			PreEnrollSecureBootKeys: ptr.Of(false),
+			TPM2:                    ptr.Of(false),
 			// Remove driver-specific firmware images from defaults
 		},
 		Audio: limatype.Audio{
@@ -558,6 +561,7 @@ func TestFillDefault(t *testing.T) {
 			LegacyBIOS:              ptr.Of(true),
 			SecureBoot:              ptr.Of(false),
 			PreEnrollSecureBootKeys: ptr.Of(false),
+			TPM2:                    ptr.Of(false),
 		},
 		Audio: limatype.Audio{
 			Device: ptr.Of("coreaudio"),

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -173,12 +173,23 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 	if y.Firmware.LegacyBIOS != nil && *y.Firmware.LegacyBIOS && y.Firmware.SecureBoot != nil && *y.Firmware.SecureBoot {
 		errs = errors.Join(errs, errors.New("field `firmware.secureBoot` requires UEFI, but `firmware.legacyBIOS` is true"))
 	}
+	if y.Firmware.LegacyBIOS != nil && *y.Firmware.LegacyBIOS && y.Firmware.TPM2 != nil && *y.Firmware.TPM2 {
+		errs = errors.Join(errs, errors.New("field `firmware.tpm2` requires UEFI, but `firmware.legacyBIOS` is true"))
+	}
 	if y.Firmware.SecureBoot != nil && *y.Firmware.SecureBoot {
 		if *y.VMType != limatype.QEMU {
 			errs = errors.Join(errs, fmt.Errorf("field `firmware.secureBoot` is currently implemented only for vmType %q, got %q", limatype.QEMU, *y.VMType))
 		}
 		if *y.Arch != limatype.X8664 {
 			errs = errors.Join(errs, fmt.Errorf("field `firmware.secureBoot` is currently implemented only for arch %q, got %q", limatype.X8664, *y.Arch))
+		}
+	}
+	if y.Firmware.TPM2 != nil && *y.Firmware.TPM2 {
+		if *y.VMType != limatype.QEMU {
+			errs = errors.Join(errs, fmt.Errorf("field `firmware.tpm2` is currently implemented only for vmType %q, got %q", limatype.QEMU, *y.VMType))
+		}
+		if *y.Arch != limatype.X8664 {
+			errs = errors.Join(errs, fmt.Errorf("field `firmware.tpm2` is currently implemented only for arch %q, got %q", limatype.X8664, *y.Arch))
 		}
 	}
 

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -50,7 +50,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 	}
 
 	switch *y.OS {
-	case limatype.LINUX, limatype.DARWIN, limatype.FREEBSD:
+	case limatype.LINUX, limatype.DARWIN, limatype.FREEBSD, limatype.WINDOWS:
 	default:
 		errs = errors.Join(errs, fmt.Errorf("field `os` must be one of %q; got %q", limatype.OSTypes, *y.OS))
 	}
@@ -190,6 +190,12 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		}
 		if *y.Arch != limatype.X8664 {
 			errs = errors.Join(errs, fmt.Errorf("field `firmware.tpm2` is currently implemented only for arch %q, got %q", limatype.X8664, *y.Arch))
+		}
+	}
+	for i, f := range y.GuestDrivers.Images {
+		err := validateFileObject(f.File, fmt.Sprintf("guestDrivers.images[%d]", i))
+		if err != nil {
+			errs = errors.Join(errs, err)
 		}
 	}
 

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -170,6 +170,17 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 	}
 
 	// y.Firmware.LegacyBIOS is ignored for aarch64, but not a fatal error.
+	if y.Firmware.LegacyBIOS != nil && *y.Firmware.LegacyBIOS && y.Firmware.SecureBoot != nil && *y.Firmware.SecureBoot {
+		errs = errors.Join(errs, errors.New("field `firmware.secureBoot` requires UEFI, but `firmware.legacyBIOS` is true"))
+	}
+	if y.Firmware.SecureBoot != nil && *y.Firmware.SecureBoot {
+		if *y.VMType != limatype.QEMU {
+			errs = errors.Join(errs, fmt.Errorf("field `firmware.secureBoot` is currently implemented only for vmType %q, got %q", limatype.QEMU, *y.VMType))
+		}
+		if *y.Arch != limatype.X8664 {
+			errs = errors.Join(errs, fmt.Errorf("field `firmware.secureBoot` is currently implemented only for arch %q, got %q", limatype.X8664, *y.Arch))
+		}
+	}
 
 	for i, p := range y.Provision {
 		if p.File != nil {

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -350,7 +350,7 @@ func TestValidateParamIsUsed(t *testing.T) {
 
 func TestValidateMultipleErrors(t *testing.T) {
 	yamlWithMultipleErrors := `
-os: windows
+os: unsupported_os
 arch: unsupported_arch
 portForwards:
   - guestPort: 22
@@ -369,7 +369,7 @@ provision:
 	err = Validate(y, false)
 	t.Logf("Validation errors: %v", err)
 
-	assert.Error(t, err, "field `os` must be one of [\"Linux\" \"Darwin\" \"FreeBSD\"]; got \"windows\"\n"+
+	assert.Error(t, err, "field `os` must be one of [\"Linux\" \"Darwin\" \"FreeBSD\" \"Windows\"]; got \"unsupported_os\"\n"+
 		"field `arch` must be one of [x86_64 aarch64 armv7l ppc64le riscv64 s390x]; got \"unsupported_arch\"\n"+
 		"field `images` must be set\n"+
 		"field `provision[0].mode` must one of \"system\", \"user\", \"boot\", \"data\", \"dependency\", \"ansible\", or \"yq\"\n"+

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -358,6 +358,10 @@ user:
   # Full name or display name of the user.
   # 🟢 Builtin default: user information from the host
   comment: null
+  # Password for the user. Currently used only for Windows guests.
+  # When unset or empty for Windows guests, Lima generates a per-instance password in the instance directory.
+  # 🟢 Builtin default: null
+  password: null
   # Numeric user id. It is not currently possible to specify a group id.
   # 🟢 Builtin default: same as the host user id of the current user (NOT a lookup of the specified "username").
   uid: null
@@ -440,6 +444,14 @@ firmware:
 #    arch: "aarch64"
 #    digest: "sha256:..."
 #    vmType: "qemu"
+
+guestDrivers:
+  # Guest driver media version. For virtio-win this is typically "w11", "w10", "2k25", or "2k22".
+  # 🟢 Builtin default: "w11" for Windows guests
+  version: null
+  # Guest driver media images, such as virtio-win.iso for Windows guests.
+  # 🟢 Builtin default: /usr/share/virtio-win/virtio-win.iso for Windows guests on Linux hosts
+  images: []
 
 audio:
   # EXPERIMENTAL

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -420,6 +420,15 @@ firmware:
   # Use legacy BIOS instead of UEFI. Ignored for aarch64 and vz.
   # 🟢 Builtin default: false
   legacyBIOS: null
+  # Enable UEFI Secure Boot. Currently implemented for qemu + x86_64.
+  # 🟢 Builtin default: false
+  secureBoot: null
+  # Require pre-enrolled Secure Boot keys in the firmware variable store.
+  # 🟢 Builtin default: same as firmware.secureBoot
+  preEnrollSecureBootKeys: null
+  # QEMU firmware descriptor JSON files.
+  # 🟢 Builtin default: []
+  descriptors: []
 #  # Override UEFI images
 #  # 🟢 Builtin default: uses VM's default UEFI, except for qemu + aarch64.
 #  # See <https://lists.gnu.org/archive/html/qemu-devel/2023-12/msg01694.html>

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -426,6 +426,9 @@ firmware:
   # Require pre-enrolled Secure Boot keys in the firmware variable store.
   # 🟢 Builtin default: same as firmware.secureBoot
   preEnrollSecureBootKeys: null
+  # Enable a software TPM 2.0 device. Requires UEFI.
+  # 🟢 Builtin default: false
+  tpm2: null
   # QEMU firmware descriptor JSON files.
   # 🟢 Builtin default: []
   descriptors: []

--- a/templates/windows.yaml
+++ b/templates/windows.yaml
@@ -24,6 +24,9 @@ containerd:
   system: false
   user: false
 
+video:
+  display: default
+
 firmware:
   secureBoot: true
   preEnrollSecureBootKeys: true

--- a/templates/windows.yaml
+++ b/templates/windows.yaml
@@ -1,0 +1,36 @@
+# This template expects a Windows installer ISO.
+# Replace the image location with the path to your Windows ISO.
+minimumLimaVersion: 2.0.0
+
+os: "Windows"
+arch: "x86_64"
+vmType: "qemu"
+
+images:
+- location: "~/Downloads/Win11.iso"
+  arch: "x86_64"
+
+cpus: 4
+memory: "4GiB"
+disk: "80GiB"
+
+mounts: []
+mountType: "reverse-sshfs"
+provision: []
+probes: []
+portForwards: []
+
+containerd:
+  system: false
+  user: false
+
+firmware:
+  secureBoot: true
+  preEnrollSecureBootKeys: true
+  tpm2: true
+
+guestDrivers:
+  version: "w11"
+  images:
+  - location: "/usr/share/virtio-win/virtio-win.iso"
+    arch: "x86_64"


### PR DESCRIPTION
 Changes in this pull request:
 
## Secure Boot support

This is the first prerequisite for proper Windows guest support.

1. Add QEMU firmware descriptor support for selecting UEFI firmware.
2. Use descriptor-based firmware selection when Secure Boot is enabled through `firmware.secureBoot: true` in the template.
3. Secure Boot defaults to disabled, `preEnrollSecureBootKeys` defaults to the same value as `secureBoot`.
4. Keep the existing firmware selection path as the fallback when Secure Boot is disabled.
5. Keep the existing firmware selection path for legacy BIOS.
6. Support both raw and QCOW2 firmware code/vars files.
7. Support Secure Boot with pre-enrolled keys, typically Microsoft keys provided by the distribution firmware packages.
8. Support Secure Boot with an empty variable store, for guests such as Talos that enroll their own PK, KEK, and db.
9. Support custom QEMU firmware descriptor paths, useful when the distribution does not ship working Secure Boot firmware, e.g. Arch Linux: https://wiki.archlinux.org/title/QEMU#Enabling_Secure_Boot

## TPM support

This is the second prerequisite for proper Windows guest support.

1. Add TPM 2.0 support for QEMU using `swtpm`, which can be enabled through `firmware.tpm2: true` in the template.
2. Use the modern CRB TPM device model instead of legacy TIS.
3. TPM 2.0 defaults to disabled.

## Windows guest support

This adds initial support for automated Windows guest installation using QEMU, with limited configuration support.

1. Add a `windows` template for installing Windows from an ISO.
2. Generate `autounattend.xml` for unattended Windows installation.
3. Add the one-time boot-key workaround needed for Windows installer ISOs that prompt with "Press any key to boot from CD or DVD".
4. Add support for copying selected VirtIO drivers from a configured VirtIO driver ISO into the cidata ISO.
5. Install VirtIO storage and network drivers through `autounattend.xml`.
6. Create the default local Windows user account during unattended setup.
7. Generate and store a per-instance local user password when one is not provided in the template.
8. Install and enable OpenSSH Server during first boot.
9. Configure `administrators_authorized_keys` from Lima's SSH public keys for key-based SSH access.
10. Mark the first Ethernet network profile as Private as a temporary workaround so the OpenSSH firewall rule can apply; more precise networking configuration support will be worked on later.

## Testing and research notes

1. Tested on an Arch Linux x86_64 host with the QEMU driver using OVMF firmware from Fedora.
2. Tested Secure Boot support with Debian and Fedora guests.
3. Tested Secure Boot and TPM 2.0 support with Windows guests.
4. Support for non-QEMU drivers is not included in this pull request.
5. Support for non-Linux hosts and non-x86_64 architectures may be incomplete.
6. Legacy BIOS was not tested.