### PR TITLE
qemu: use stream netdev with reconnect for socketVMNet networking

### DIFF
--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -816,9 +816,17 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 				if err != nil {
 					return "", nil, err
 				}
-				args = append(args, "-netdev", fmt.Sprintf("socket,id=net%d,fd={{ fd_connect %q }}", i+1, sock))
-				// TODO: should we also validate that the socket exists, or do we rely on the
-				// networks reconciler to throw an error when the network cannot start?
+				if strings.Contains(string(features.NetdevHelp), "stream") {
+					netdev := fmt.Sprintf("stream,id=net%d,server=off,addr.type=unix,addr.path=%s", i+1, sock)
+					if !version.LessThan(*semver.New("9.2.0")) {
+						netdev += ",reconnect-ms=500"
+					} else if !version.LessThan(*semver.New("8.0.0")) {
+						netdev += ",reconnect=1"
+					}
+					args = append(args, "-netdev", netdev)
+				} else {
+					args = append(args, "-netdev", fmt.Sprintf("socket,id=net%d,fd={{ fd_connect %q }}", i+1, sock))
+				}
 			}
 		} else if nw.Socket != "" {
 			args = append(args, "-netdev", fmt.Sprintf("socket,id=net%d,fd={{ fd_connect %q }}", i+1, nw.Socket))


### PR DESCRIPTION
## Summary

Switch QEMU socketVMNet networking on macOS from legacy `-netdev socket` with a pre-dialed fd to `-netdev stream` with built-in reconnect support. Applies to all socketVMNet modes (bridged, shared, host).

- **Feature-detected**: checks `-netdev help` output for `stream` support; falls back to `socket` if unavailable
- **Version-aware reconnect**: `reconnect-ms=500` for QEMU >= 9.2, `reconnect=1` for QEMU 8.0–9.1 (the `reconnect` parameter was renamed to `reconnect-ms` in 9.2 and the old form removed in 10.2), no reconnect for QEMU 7.2–7.9
- **Wire-compatible**: both `stream` and `socket` netdev use the same 4-byte big-endian length-prefixed Ethernet frame protocol that socket_vmnet uses

## Motivation

When the socket_vmnet daemon restarts or the UNIX socket connection breaks, the legacy `-netdev socket` with a pre-dialed fd has no way to recover — the fd is dead and the VM's network is permanently broken until manual VM restart.

The `stream` netdev connects directly to the socket_vmnet UNIX socket and can automatically reconnect, recovering VM networking without restart.

## Performance

In testing on macOS Intel (QEMU 11.0.0, HVF, socket_vmnet bridged to a 5GbE NIC), the stream netdev showed ~2x throughput improvement over legacy socket netdev:

| | socket (before) | stream (after) |
|---|---|---|
| Throughput (VM → LAN host, 3 runs avg) | ~970 Mbits/sec | ~1,840 Mbits/sec |
| QEMU CPU during iperf3 | ~219% | ~216% |
| Ping latency (100 pings) | 0.76ms avg | 0.88ms avg |

Host-to-host baseline on the same NIC is 4.66 Gbits/sec; the remaining gap is in the socket_vmnet relay path.

## Compatibility

- QEMU < 7.2: no change (falls back to existing `socket` netdev)
- QEMU 7.2+: uses `stream` netdev (available since 7.2)
- QEMU 8.0+: adds reconnect support (1-second granularity)
- QEMU 9.2+: uses `reconnect-ms` (millisecond granularity, 500ms)
- macOS only (socketVMNet code path is gated on `runtime.GOOS == "darwin"`)
- No change to usernet or raw socket networking paths

## Test plan

- [x] Verified stream netdev starts and VM boots on QEMU 11.0.0
- [x] Verified socket_vmnet reconnect works (kill/restart socket_vmnet daemon, VM recovers in ~4s)
- [x] Verified no regression in normal operation (ping, docker, k3s, limactl shell)
- [x] Throughput benchmarked before/after (iperf3)
- [ ] Soak testing on production host