### PR TITLE
Change %q in logs and errors to %#q [Part3]

### DIFF
--- a/hack/bats/tests/url-github.bats
+++ b/hack/bats/tests/url-github.bats
@@ -100,12 +100,12 @@ done
 
 @test 'non-existing .lima.yaml returns an error' {
 	url -1 'github:jandubois//missing/'
-	assert_fatal 'file "https://raw.githubusercontent.com/jandubois/jandubois/main/missing/.lima.yaml" not found or inaccessible: status 404'
+	assert_fatal 'file `https://raw.githubusercontent.com/jandubois/jandubois/main/missing/.lima.yaml` not found or inaccessible: status 404'
 }
 
 @test 'hidden files without an extension get a .yaml extension' {
 	url -1 'github:jandubois//test/.hidden'
-	assert_fatal 'file "https://raw.githubusercontent.com/jandubois/jandubois/main/test/.hidden.yaml" not found or inaccessible: status 404'
+	assert_fatal 'file `https://raw.githubusercontent.com/jandubois/jandubois/main/test/.hidden.yaml` not found or inaccessible: status 404'
 }
 
 @test 'files that have an extension do not get a .yaml extension' {
@@ -122,56 +122,56 @@ done
 # Invalid URLs
 @test 'empty github: url returns an error' {
 	url -1 'github:'
-	assert_fatal 'github: URL must contain at least an ORG, got ""'
+	assert_fatal 'github: URL must contain at least an ORG, got ``'
 }
 
 @test 'missing org returns an error' {
 	url -1 'github:/jandubois'
-	assert_fatal 'github: URL must contain at least an ORG, got ""'
+	assert_fatal 'github: URL must contain at least an ORG, got ``'
 }
 
 # github: redirects in github:ORG// repos
 @test 'org redirects can point to different repo and may switch the branch name' {
 	url -0 'github:jandubois//redirect/'
 	# Note that the default branch in jandubois/jandubois is main, but in jandubois/lima it is master
-	assert_debug 'Locator "github:jandubois//redirect/" replaced with "github:jandubois/lima/templates/default"'
-	assert_debug 'Locator "github:jandubois/lima/templates/default" replaced with "https://raw.githubusercontent.com/jandubois/lima/master/templates/default.yaml"'
+	assert_debug 'Locator `github:jandubois//redirect/` replaced with `github:jandubois/lima/templates/default`'
+	assert_debug 'Locator `github:jandubois/lima/templates/default` replaced with `https://raw.githubusercontent.com/jandubois/lima/master/templates/default.yaml`'
 	assert_output 'https://raw.githubusercontent.com/jandubois/lima/master/templates/default.yaml'
 }
 
 @test 'org redirects propagate an explicit branch/tag to the other repo' {
 	url -0 'github:jandubois//redirect/@v1.2.1'
-	assert_debug 'Locator "github:jandubois//redirect/@v1.2.1" replaced with "github:jandubois/lima/templates/default@v1.2.1"'
-	assert_debug 'Locator "github:jandubois/lima/templates/default@v1.2.1" replaced with "https://raw.githubusercontent.com/jandubois/lima/v1.2.1/templates/default.yaml"'
+	assert_debug 'Locator `github:jandubois//redirect/@v1.2.1` replaced with `github:jandubois/lima/templates/default@v1.2.1`'
+	assert_debug 'Locator `github:jandubois/lima/templates/default@v1.2.1` replaced with `https://raw.githubusercontent.com/jandubois/lima/v1.2.1/templates/default.yaml`'
 	assert_output 'https://raw.githubusercontent.com/jandubois/lima/v1.2.1/templates/default.yaml'
 }
 
 @test 'org redirects cannot point to another org' {
 	url -1 'github:jandubois//invalid/org/'
-	assert_fatal 'redirect "github:lima-vm" is not a "github:jandubois" URL…'
+	assert_fatal 'redirect `github:lima-vm` is not a `github:jandubois` URL…'
 }
 
 @test 'org redirects with branch cannot point to another org' {
 	url -1 'github:jandubois//invalid/org/@main'
-	assert_fatal 'redirect "github:lima-vm" is not a "github:jandubois" URL…'
+	assert_fatal 'redirect `github:lima-vm` is not a `github:jandubois` URL…'
 }
 
 @test 'org redirects cannot include a branch or tag' {
 	url -1 'github:jandubois//invalid/tag/'
-	assert_fatal 'redirect "github:jandubois//@v0.0.0" must not include a branch/tag/sha…'
+	assert_fatal 'redirect `github:jandubois//@v0.0.0` must not include a branch/tag/sha…'
 }
 
 @test 'org redirects with tag cannot include a branch or tag' {
 	url -1 'github:jandubois//invalid/tag/@v0.0.0'
-	assert_fatal 'redirect "github:jandubois//@v0.0.0" must not include a branch/tag/sha…'
+	assert_fatal 'redirect `github:jandubois//@v0.0.0` must not include a branch/tag/sha…'
 }
 
 @test 'org redirects must not create circular redirects' {
 	url -1 'github:jandubois//loop/'
-	assert_fatal 'custom locator "github:jandubois//loop/" has a redirect loop'
+	assert_fatal 'custom locator `github:jandubois//loop/` has a redirect loop'
 }
 
 @test 'org redirects with branch must not create circular redirects' {
 	url -1 'github:jandubois//back/@main'
-	assert_fatal 'custom locator "github:jandubois//back/@main" has a redirect loop'
+	assert_fatal 'custom locator `github:jandubois//back/@main` has a redirect loop'
 }

--- a/pkg/guestagent/fakecloudinit/fakecloudinit_darwin.go
+++ b/pkg/guestagent/fakecloudinit/fakecloudinit_darwin.go
@@ -47,7 +47,7 @@ func enableSSHD(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, "/bin/launchctl", "load", "-w", "/System/Library/LaunchDaemons/ssh.plist")
 	logrus.Infof("Executing command: %v", cmd.Args)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to execute command %v: %w (output=%q)", cmd.Args, err, output)
+		return fmt.Errorf("failed to execute command %v: %w (output=%#q)", cmd.Args, err, output)
 	}
 	return nil
 }
@@ -56,7 +56,7 @@ func processMetaData(ctx context.Context, mnt string) error {
 	metaDataPath := filepath.Join(mnt, "meta-data")
 	metaDataB, err := os.ReadFile(metaDataPath)
 	if err != nil {
-		return fmt.Errorf("failed to read meta data file %q: %w", metaDataPath, err)
+		return fmt.Errorf("failed to read meta data file %#q: %w", metaDataPath, err)
 	}
 	var metaData cloudinittypes.MetaData
 	if err = yaml.Unmarshal(metaDataB, &metaData); err != nil {
@@ -64,7 +64,7 @@ func processMetaData(ctx context.Context, mnt string) error {
 	}
 
 	var errs []error
-	logrus.Infof("Instance ID: %q", metaData.InstanceID)
+	logrus.Infof("Instance ID: %#q", metaData.InstanceID)
 	if metaData.LocalHostname != "" {
 		if err = setLocalHostname(ctx, metaData.LocalHostname); err != nil {
 			errs = append(errs, fmt.Errorf("failed to set local hostname: %w", err))
@@ -77,7 +77,7 @@ func setLocalHostname(ctx context.Context, hostname string) error {
 	cmd := exec.CommandContext(ctx, "scutil", "--set", "LocalHostName", hostname)
 	logrus.Infof("Executing command: %v", cmd.Args)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to execute command %v: %w (output=%q)", cmd.Args, err, output)
+		return fmt.Errorf("failed to execute command %v: %w (output=%#q)", cmd.Args, err, output)
 	}
 	return nil
 }
@@ -86,7 +86,7 @@ func processUserData(ctx context.Context, mnt string) error {
 	userDataPath := filepath.Join(mnt, "user-data")
 	userDataB, err := os.ReadFile(userDataPath)
 	if err != nil {
-		return fmt.Errorf("failed to read user data file %q: %w", userDataPath, err)
+		return fmt.Errorf("failed to read user data file %#q: %w", userDataPath, err)
 	}
 	var userData cloudinittypes.UserData
 	if err = yaml.Unmarshal(userDataB, &userData); err != nil {
@@ -118,12 +118,12 @@ func processUserData(ctx context.Context, mnt string) error {
 	}
 	for _, u := range userData.Users {
 		if err := createUser(ctx, &u); err != nil {
-			errs = append(errs, fmt.Errorf("failed to create user %q: %w", u.Name, err))
+			errs = append(errs, fmt.Errorf("failed to create user %#q: %w", u.Name, err))
 		}
 	}
 	for _, entry := range userData.WriteFiles {
 		if err := writeFiles(ctx, entry); err != nil {
-			errs = append(errs, fmt.Errorf("failed to write file for path %q: %w", entry.Path, err))
+			errs = append(errs, fmt.Errorf("failed to write file for path %#q: %w", entry.Path, err))
 		}
 	}
 	if userData.ManageResolvConf && userData.ResolvConf != nil {
@@ -152,7 +152,7 @@ func mountFSTabEntry(m []string) error {
 	case "virtiofs":
 		return mountVirtiofs(src, dst)
 	default:
-		return fmt.Errorf("unsupported filesystem type %q for fstab entry: %v", fsType, m)
+		return fmt.Errorf("unsupported filesystem type %#q for fstab entry: %v", fsType, m)
 	}
 }
 
@@ -160,7 +160,7 @@ func mountFSTabEntry(m []string) error {
 // dir must not exist, or, must be a symlink to the expected source.
 func mountVirtiofs(pseudoTag, dir string) error {
 	if strings.Contains(pseudoTag, string(filepath.Separator)) {
-		return fmt.Errorf("invalid pseudo tag for virtiofs: %q", pseudoTag)
+		return fmt.Errorf("invalid pseudo tag for virtiofs: %#q", pseudoTag)
 	}
 	lnSrc := filepath.Join("/Volumes/My Shared Files", pseudoTag)
 
@@ -173,13 +173,13 @@ func mountVirtiofs(pseudoTag, dir string) error {
 		if lnExisting == lnSrc {
 			return nil // already symlinked
 		}
-		return fmt.Errorf("unexpected symlink target for virtiofs mount source %q: expected %q, got %q", lnSrc, lnSrc, lnExisting)
+		return fmt.Errorf("unexpected symlink target for virtiofs mount source %#q: expected %#q, got %#q", lnSrc, lnSrc, lnExisting)
 	}
 	if !errors.Is(err, os.ErrNotExist) {
-		logrus.WithError(err).Warnf("Failed to read existing symlink for virtiofs mount source %q", lnSrc)
+		logrus.WithError(err).Warnf("Failed to read existing symlink for virtiofs mount source %#q", lnSrc)
 	}
 	if err := os.Symlink(lnSrc, dir); err != nil {
-		return fmt.Errorf("failed to create symlink from %q to %q: %w", lnSrc, dir, err)
+		return fmt.Errorf("failed to create symlink from %#q to %#q: %w", lnSrc, dir, err)
 	}
 	return nil
 }
@@ -188,7 +188,7 @@ func setTimezone(ctx context.Context, timezone string) error {
 	cmd := exec.CommandContext(ctx, "systemsetup", "-settimezone", timezone)
 	logrus.Infof("Executing command: %v", cmd.Args)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to execute command %v: %w (output=%q)", cmd.Args, err, output)
+		return fmt.Errorf("failed to execute command %v: %w (output=%#q)", cmd.Args, err, output)
 	}
 	return nil
 }
@@ -213,7 +213,7 @@ func populateHomeDir(ctx context.Context, uid int, homedir string) error {
 		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 		logrus.Infof("Executing command: %v", cmd.Args)
 		if output, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("failed to execute command %v: %w (output=%q)", cmd.Args, err, output)
+			return fmt.Errorf("failed to execute command %v: %w (output=%#q)", cmd.Args, err, output)
 		}
 	}
 	return nil
@@ -222,22 +222,22 @@ func populateHomeDir(ctx context.Context, uid int, homedir string) error {
 func createUser(ctx context.Context, u *cloudinittypes.User) error {
 	homedir := u.Homedir
 	if homedir == "" {
-		return fmt.Errorf("homedir is required for user %q", u.Name)
+		return fmt.Errorf("homedir is required for user %#q", u.Name)
 	}
 	if osutil.FileExists(homedir) {
-		logrus.Debugf("homedir %q already exists, skipping user creation for user %q", homedir, u.Name)
+		logrus.Debugf("homedir %#q already exists, skipping user creation for user %#q", homedir, u.Name)
 		return nil
 	}
 	if u.UID == "" {
-		return fmt.Errorf("uid is required for user %q", u.Name)
+		return fmt.Errorf("uid is required for user %#q", u.Name)
 	}
 	uid, err := strconv.Atoi(u.UID)
 	if err != nil {
-		return fmt.Errorf("invalid uid %q for user %q: %w", u.UID, u.Name, err)
+		return fmt.Errorf("invalid uid %#q for user %#q: %w", u.UID, u.Name, err)
 	}
 	pw, err := generatePassword()
 	if err != nil {
-		return fmt.Errorf("failed to generate password for user %q: %w", u.Name, err)
+		return fmt.Errorf("failed to generate password for user %#q: %w", u.Name, err)
 	}
 	args := []string{
 		"-addUser", u.Name,
@@ -268,48 +268,48 @@ func createUser(ctx context.Context, u *cloudinittypes.User) error {
 	// the requested UID (e.g., when macOS Setup Assistant already created
 	// the user with a different UID).
 	if sysUser, err := user.Lookup(u.Name); err != nil {
-		logrus.WithError(err).Warnf("Failed to look up user %q, using requested UID %d", u.Name, uid)
+		logrus.WithError(err).Warnf("Failed to look up user %#q, using requested UID %d", u.Name, uid)
 	} else if actualUID, err := strconv.Atoi(sysUser.Uid); err != nil {
-		logrus.WithError(err).Warnf("Failed to parse actual UID %q for user %q, using requested UID %d", sysUser.Uid, u.Name, uid)
+		logrus.WithError(err).Warnf("Failed to parse actual UID %#q for user %#q, using requested UID %d", sysUser.Uid, u.Name, uid)
 	} else if actualUID != uid {
-		logrus.Warnf("Requested UID %d for user %q, but the system assigned UID %d; using the actual UID", uid, u.Name, actualUID)
+		logrus.Warnf("Requested UID %d for user %#q, but the system assigned UID %d; using the actual UID", uid, u.Name, actualUID)
 		uid = actualUID
 	}
 
 	// sysadminctl does not create the custom home directory
 	if err = populateHomeDir(ctx, uid, homedir); err != nil {
-		return fmt.Errorf("failed to populate home directory for user %q: %w", u.Name, err)
+		return fmt.Errorf("failed to populate home directory for user %#q: %w", u.Name, err)
 	}
 
 	cmd = exec.CommandContext(ctx, "chmod", "700", homedir)
 	logrus.Infof("Executing command: %v", cmd.Args)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to execute command %v: %w (output=%q)", cmd.Args, err, output)
+		return fmt.Errorf("failed to execute command %v: %w (output=%#q)", cmd.Args, err, output)
 	}
 
 	pwPath := filepath.Join(homedir, "password")
 	if err = os.WriteFile(pwPath, []byte(pw+"\n"), 0o400); err != nil {
-		return fmt.Errorf("failed to write password file for user %q: %w", u.Name, err)
+		return fmt.Errorf("failed to write password file for user %#q: %w", u.Name, err)
 	}
-	logrus.Infof("Created user %q. The password is stored in %q", u.Name, pwPath)
+	logrus.Infof("Created user %#q. The password is stored in %#q", u.Name, pwPath)
 
 	dotSSHPath := filepath.Join(homedir, ".ssh")
 	if err = os.MkdirAll(dotSSHPath, 0o700); err != nil {
-		return fmt.Errorf("failed to create .ssh directory for user %q: %w", u.Name, err)
+		return fmt.Errorf("failed to create .ssh directory for user %#q: %w", u.Name, err)
 	}
 	authKeysPath := filepath.Join(dotSSHPath, "authorized_keys")
 	authKeysContent := strings.Join(u.SSHAuthorizedKeys, "\n")
 	if err = os.WriteFile(authKeysPath, []byte(authKeysContent), 0o600); err != nil {
-		return fmt.Errorf("failed to write authorized_keys file for user %q: %w", u.Name, err)
+		return fmt.Errorf("failed to write authorized_keys file for user %#q: %w", u.Name, err)
 	}
 	for _, f := range []string{pwPath, dotSSHPath, authKeysPath} {
 		if err = os.Chown(f, uid, -1); err != nil {
-			return fmt.Errorf("failed to chown %q for user %q: %w", f, u.Name, err)
+			return fmt.Errorf("failed to chown %#q for user %#q: %w", f, u.Name, err)
 		}
 	}
 	if u.Sudo != "" {
 		if err := writeSudoers(u.Name, u.Sudo); err != nil {
-			return fmt.Errorf("failed to write sudoers file for user %q: %w", u.Name, err)
+			return fmt.Errorf("failed to write sudoers file for user %#q: %w", u.Name, err)
 		}
 	}
 	return nil
@@ -327,11 +327,11 @@ func writeSudoers(userName, sudo string) error {
 	sudoersPath := "/etc/sudoers.d/90-cloud-init-users"
 	f, err := os.OpenFile(sudoersPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o400)
 	if err != nil {
-		return fmt.Errorf("failed to open sudoers file %q: %w", sudoersPath, err)
+		return fmt.Errorf("failed to open sudoers file %#q: %w", sudoersPath, err)
 	}
 	if _, err = fmt.Fprintf(f, "%s %s\n", userName, sudo); err != nil {
 		_ = f.Close()
-		return fmt.Errorf("failed to write to sudoers file %q for user %q: %w", sudoersPath, userName, err)
+		return fmt.Errorf("failed to write to sudoers file %#q for user %#q: %w", sudoersPath, userName, err)
 	}
 	return f.Close()
 }
@@ -344,21 +344,21 @@ func writeFiles(ctx context.Context, entry cloudinittypes.WriteFile) error {
 	if entry.Permissions != "" {
 		p, err := strconv.ParseUint(entry.Permissions, 8, 32)
 		if err != nil {
-			return fmt.Errorf("invalid permissions %q for path %q: %w", entry.Permissions, entry.Path, err)
+			return fmt.Errorf("invalid permissions %#q for path %#q: %w", entry.Permissions, entry.Path, err)
 		}
 		perm = os.FileMode(p)
 	}
 	if err := os.MkdirAll(filepath.Dir(entry.Path), 0o755); err != nil {
-		return fmt.Errorf("failed to create parent directory for path %q: %w", entry.Path, err)
+		return fmt.Errorf("failed to create parent directory for path %#q: %w", entry.Path, err)
 	}
 	if err := os.WriteFile(entry.Path, []byte(entry.Content), perm); err != nil {
-		return fmt.Errorf("failed to write file for path %q: %w", entry.Path, err)
+		return fmt.Errorf("failed to write file for path %#q: %w", entry.Path, err)
 	}
 	if entry.Owner != "" {
 		cmd := exec.CommandContext(ctx, "chown", entry.Owner, entry.Path)
 		logrus.Infof("Executing command: %v", cmd.Args)
 		if output, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("failed to execute command %v: %w (output=%q)", cmd.Args, err, output)
+			return fmt.Errorf("failed to execute command %v: %w (output=%#q)", cmd.Args, err, output)
 		}
 	}
 	return nil
@@ -370,7 +370,7 @@ func setResolvConf(ctx context.Context, resolvConf *cloudinittypes.ResolvConf) e
 	cmd := exec.CommandContext(ctx, "networksetup", append([]string{"-setdnsservers", primaryNetwork}, resolvConf.Nameservers...)...)
 	logrus.Infof("Executing command: %v", cmd.Args)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to execute command %v: %w (output=%q)", cmd.Args, err, output)
+		return fmt.Errorf("failed to execute command %v: %w (output=%#q)", cmd.Args, err, output)
 	}
 	return nil
 }
@@ -383,7 +383,7 @@ func runBootScripts(ctx context.Context) error {
 	for _, dir := range dirs {
 		dirEntries, err := os.ReadDir(dir)
 		if err != nil {
-			return fmt.Errorf("failed to read boot scripts directory %q: %w", dir, err)
+			return fmt.Errorf("failed to read boot scripts directory %#q: %w", dir, err)
 		}
 		for _, entry := range dirEntries {
 			if entry.IsDir() {
@@ -393,11 +393,11 @@ func runBootScripts(ctx context.Context) error {
 			// entry.Type().Mode() does not seem to contain permission bits
 			entryInfo, err := entry.Info()
 			if err != nil {
-				logrus.Warnf("Skipping boot script %q due to stat error: %v", scriptPath, err)
+				logrus.Warnf("Skipping boot script %#q due to stat error: %v", scriptPath, err)
 				continue
 			}
 			if entryInfo.Mode().Perm()&0o111 == 0 {
-				logrus.Warnf("Skipping non-executable boot script %q (%v)", scriptPath, entryInfo.Mode().Perm())
+				logrus.Warnf("Skipping non-executable boot script %#q (%v)", scriptPath, entryInfo.Mode().Perm())
 				continue
 			}
 			cmd := exec.CommandContext(ctx, scriptPath)

--- a/pkg/guestagent/kubernetesservice/kubernetesservice.go
+++ b/pkg/guestagent/kubernetesservice/kubernetesservice.go
@@ -115,10 +115,10 @@ func canGetServices(ctx context.Context, kubectl, kubeconfig string) error {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to run %v: %w; stdout=%q, stderr=%q", cmd.Args, err, stdout.String(), stderr.String())
+		return fmt.Errorf("failed to run %v: %w; stdout=%#q, stderr=%#q", cmd.Args, err, stdout.String(), stderr.String())
 	}
 	if strings.TrimSpace(stdout.String()) != "yes" {
-		return fmt.Errorf("failed to run %v: expected \"yes\", got %q", cmd.Args, stdout.String())
+		return fmt.Errorf("failed to run %v: expected `yes`, got %#q", cmd.Args, stdout.String())
 	}
 	return nil
 }
@@ -133,13 +133,13 @@ func (s *ServiceWatcher) startAndStreamKubectl(cmd *exec.Cmd) error {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to run %v: %w; stderr=%q", cmd.Args, err, stderr.String())
+		return fmt.Errorf("failed to run %v: %w; stderr=%#q", cmd.Args, err, stderr.String())
 	}
 
 	readErr := s.readKubectlStream(stdout)
 	waitErr := cmd.Wait()
 	if waitErr != nil {
-		waitErr = fmt.Errorf("failed to run %v: %w; stderr=%q", cmd.Args, waitErr, stderr.String())
+		waitErr = fmt.Errorf("failed to run %v: %w; stderr=%#q", cmd.Args, waitErr, stderr.String())
 	}
 	return errors.Join(readErr, waitErr)
 }
@@ -165,12 +165,12 @@ func (s *ServiceWatcher) readKubectlStream(r io.Reader) error {
 			Object json.RawMessage `json:"object"`
 		}
 		if err := json.Unmarshal(line, &ev); err != nil {
-			return fmt.Errorf("failed to unmarshal line %q: %w", string(line), err)
+			return fmt.Errorf("failed to unmarshal line %#q: %w", string(line), err)
 		}
 
 		var svc service
 		if err := json.Unmarshal(ev.Object, &svc); err != nil {
-			return fmt.Errorf("failed to unmarshal service object: %w (line=%q)", err, line)
+			return fmt.Errorf("failed to unmarshal service object: %w (line=%#q)", err, line)
 		}
 
 		key := svc.Metadata.Namespace + "/" + svc.Metadata.Name
@@ -208,7 +208,7 @@ func (s *ServiceWatcher) GetPorts() []Entry {
 			case protocolTCP, protocolUDP:
 				// NOP
 			default:
-				logrus.Debugf("unsupported protocol %s for service %q, skipping",
+				logrus.Debugf("unsupported protocol %s for service %#q, skipping",
 					portEntry.Protocol, key)
 				continue
 			}

--- a/pkg/guestagent/sockets/sockets_linux_test.go
+++ b/pkg/guestagent/sockets/sockets_linux_test.go
@@ -61,7 +61,7 @@ func TestParseMessages_TCPv4(t *testing.T) {
 	assert.Equal(t, len(socks), 1, "unexpected number of sockets")
 	s := socks[0]
 	if s.Kind != "tcp" {
-		t.Errorf("Kind = %q want tcp", s.Kind)
+		t.Errorf("Kind = %#q want tcp", s.Kind)
 	}
 	if !s.IP.Equal(ip) {
 		t.Errorf("IP = %v want %v", s.IP, ip)
@@ -83,7 +83,7 @@ func TestParseMessages_UDPv6(t *testing.T) {
 	assert.Equal(t, len(socks), 1, "unexpected number of sockets")
 	s := socks[0]
 	if s.Kind != "udp6" {
-		t.Errorf("Kind = %q want udp6", s.Kind)
+		t.Errorf("Kind = %#q want udp6", s.Kind)
 	}
 	if !s.IP.Equal(ip) {
 		t.Errorf("IP = %v want %v", s.IP, ip)

--- a/pkg/guestpatch/macos/macos_darwin.go
+++ b/pkg/guestpatch/macos/macos_darwin.go
@@ -61,18 +61,18 @@ func patchWriteGuestFiles(ctx context.Context, disk string) error {
 	defer func() {
 		// Detaching the data slice is enough to detach the whole ASIF.
 		if err := asifutil.DetachASIF(dataDevPath); err != nil {
-			logrus.WithError(err).Warnf("failed to detach %q (%q)", dataDevPath, disk)
+			logrus.WithError(err).Warnf("failed to detach %#q (%#q)", dataDevPath, disk)
 		}
 	}()
 
 	instDir := filepath.Dir(disk)
 	mnt := filepath.Join(instDir, filenames.MntDir)
 	if err := os.MkdirAll(mnt, 0o755); err != nil {
-		return fmt.Errorf("failed to create mount point %q: %w", mnt, err)
+		return fmt.Errorf("failed to create mount point %#q: %w", mnt, err)
 	}
 	defer func() {
 		if err := os.Remove(mnt); err != nil {
-			logrus.WithError(err).Warnf("failed to remove mount point %q", mnt)
+			logrus.WithError(err).Warnf("failed to remove mount point %#q", mnt)
 		}
 	}()
 	return writeGuestFiles(ctx, dataDevPath, mnt)
@@ -91,7 +91,7 @@ func patchFixOwnership(ctx context.Context, disk string) error {
 	dataDevPath := "/dev/" + attached.Data
 	defer func() {
 		if err := asifutil.DetachASIF(dataDevPath); err != nil {
-			logrus.WithError(err).Warnf("failed to detach %q (%q)", dataDevPath, disk)
+			logrus.WithError(err).Warnf("failed to detach %#q (%#q)", dataDevPath, disk)
 		}
 	}()
 
@@ -126,7 +126,7 @@ func writeGuestFiles(ctx context.Context, dataSliceDevice, mnt string) error {
 	}
 	defer func() {
 		if err := osutil.Umount(ctx, mnt); err != nil {
-			logrus.WithError(err).Warnf("failed to unmount %q", mnt)
+			logrus.WithError(err).Warnf("failed to unmount %#q", mnt)
 		}
 	}()
 
@@ -136,7 +136,7 @@ func writeGuestFiles(ctx context.Context, dataSliceDevice, mnt string) error {
 	}
 	for _, file := range filesToTouch {
 		if err := osutil.Touch(file); err != nil {
-			return fmt.Errorf("failed to touch %q: %w", file, err)
+			return fmt.Errorf("failed to touch %#q: %w", file, err)
 		}
 	}
 

--- a/pkg/hostagent/dns/dns_test.go
+++ b/pkg/hostagent/dns/dns_test.go
@@ -177,7 +177,7 @@ func TestDNSRecords(t *testing.T) {
 				return cmp.ResultSuccess
 			}
 			return cmp.ResultFailure(
-				fmt.Sprintf("%q did not match pattern %q", value, pattern))
+				fmt.Sprintf("%#q did not match pattern %#q", value, pattern))
 		}
 	}
 	t.Run("test TXT records", func(t *testing.T) {

--- a/pkg/hostagent/events/watcher.go
+++ b/pkg/hostagent/events/watcher.go
@@ -63,7 +63,7 @@ loop:
 			}
 			var ev Event
 			if err := json.Unmarshal([]byte(line.Text), &ev); err != nil {
-				return fmt.Errorf("failed to unmarshal %q as %T: %w", line.Text, ev, err)
+				return fmt.Errorf("failed to unmarshal %#q as %T: %w", line.Text, ev, err)
 			}
 			logrus.WithField("event", ev).Debugf("received an event")
 			if !begin.IsZero() && ev.Time.Before(begin) {

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -136,7 +136,7 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 	if b, err := os.ReadFile(limaVersionFile); err == nil {
 		limaVersion = strings.TrimSpace(string(b))
 	} else if !errors.Is(err, os.ErrNotExist) {
-		logrus.WithError(err).Warnf("Failed to read %q", limaVersionFile)
+		logrus.WithError(err).Warnf("Failed to read %#q", limaVersionFile)
 	}
 
 	// inst.Config is loaded with FillDefault() already, so no need to care about nil pointers.
@@ -277,7 +277,7 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 
 func writeSSHConfigFile(sshPath, instName, instDir, instSSHAddress string, sshLocalPort int, sshOpts []string) error {
 	if instDir == "" {
-		return fmt.Errorf("directory is unknown for the instance %q", instName)
+		return fmt.Errorf("directory is unknown for the instance %#q", instName)
 	}
 	b := bytes.NewBufferString(`# This SSH config file can be passed to 'ssh -F'.
 # This file is created by Lima, but not used by Lima itself currently.
@@ -508,7 +508,7 @@ func (a *HostAgent) startRoutinesAndWait(ctx context.Context, errCh <-chan error
 	// wait for either the driver to stop or a signal to shut down
 	select {
 	case driverErr := <-errCh:
-		logrus.Infof("Driver stopped due to error: %q", driverErr)
+		logrus.Infof("Driver stopped due to error: %#q", driverErr)
 	case sig := <-a.signalCh:
 		logrus.Infof("Received %s, shutting down the host agent", osutil.SignalName(sig))
 	}
@@ -569,9 +569,9 @@ sudo ln -sf "${SSH_AUTH_SOCK}" /run/host-services/ssh-auth.sock
 sudo chown -R "${USER}" /run/host-services`
 		faDesc := "linking ssh auth socket to static location /run/host-services/ssh-auth.sock"
 		stdout, stderr, err := ssh.ExecuteScript(a.instSSHAddress, a.sshLocalPort, a.sshConfig, faScript, faDesc)
-		logrus.Debugf("stdout=%q, stderr=%q, err=%v", stdout, stderr, err)
+		logrus.Debugf("stdout=%#q, stderr=%#q, err=%v", stdout, stderr, err)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("stdout=%q, stderr=%q: %w", stdout, stderr, err))
+			errs = append(errs, fmt.Errorf("stdout=%#q, stderr=%#q: %w", stdout, stderr, err))
 		}
 	}
 	if *a.instConfig.MountType == limatype.REVSSHFS && !*a.instConfig.Plain {
@@ -598,7 +598,7 @@ sudo chown -R "${USER}" /run/host-services`
 					unlockErrs = append(unlockErrs, inspectErr)
 					continue
 				}
-				logrus.Infof("Unmounting disk %q", disk.Name)
+				logrus.Infof("Unmounting disk %#q", disk.Name)
 				if unlockErr := disk.Unlock(); unlockErr != nil {
 					unlockErrs = append(unlockErrs, unlockErr)
 				}
@@ -896,7 +896,7 @@ func (a *HostAgent) processGuestAgentEvents(ctx context.Context, client *guestag
 	onEvent := func(ev *guestagentapi.Event) {
 		logrus.Debugf("guest agent event: %+v", ev)
 		for _, f := range ev.Errors {
-			logrus.Warnf("received error from the guest: %q", f)
+			logrus.Warnf("received error from the guest: %#q", f)
 		}
 		// History of the default value of useSSHFwd:
 		// - v0.1.0:        true  (effectively)
@@ -907,7 +907,7 @@ func (a *HostAgent) processGuestAgentEvents(ctx context.Context, client *guestag
 		if envVar := os.Getenv("LIMA_SSH_PORT_FORWARDER"); envVar != "" {
 			b, err := strconv.ParseBool(envVar)
 			if err != nil {
-				logrus.WithError(err).Warnf("invalid LIMA_SSH_PORT_FORWARDER value %q", envVar)
+				logrus.WithError(err).Warnf("invalid LIMA_SSH_PORT_FORWARDER value %#q", envVar)
 			} else {
 				useSSHFwd = b
 			}
@@ -944,7 +944,7 @@ func executeSSH(ctx context.Context, sshConfig *ssh.SSHConfig, sshAddress string
 	args = append(args, command...)
 	cmd := exec.CommandContext(ctx, sshConfig.Binary(), args...)
 	if out, err := cmd.Output(); err != nil {
-		return fmt.Errorf("failed to run %v: %q: %w", cmd.Args, string(out), err)
+		return fmt.Errorf("failed to run %v: %#q: %w", cmd.Args, string(out), err)
 	}
 	return nil
 }
@@ -975,54 +975,54 @@ func forwardSSH(ctx context.Context, sshConfig *ssh.SSHConfig, sshAddress string
 		switch verb {
 		case verbForward:
 			if reverse {
-				logrus.Infof("Forwarding %q (host) to %q (guest)", local, remote)
+				logrus.Infof("Forwarding %#q (host) to %#q (guest)", local, remote)
 				if err := executeSSH(ctx, sshConfig, sshAddress, sshPort, "rm", "-f", remote); err != nil {
-					logrus.WithError(err).Warnf("Failed to clean up %q (guest) before setting up forwarding", remote)
+					logrus.WithError(err).Warnf("Failed to clean up %#q (guest) before setting up forwarding", remote)
 				}
 			} else {
-				logrus.Infof("Forwarding %q (guest) to %q (host)", remote, local)
+				logrus.Infof("Forwarding %#q (guest) to %#q (host)", remote, local)
 				if err := os.RemoveAll(local); err != nil {
-					logrus.WithError(err).Warnf("Failed to clean up %q (host) before setting up forwarding", local)
+					logrus.WithError(err).Warnf("Failed to clean up %#q (host) before setting up forwarding", local)
 				}
 			}
 			if err := os.MkdirAll(filepath.Dir(local), 0o750); err != nil {
-				return fmt.Errorf("can't create directory for local socket %q: %w", local, err)
+				return fmt.Errorf("can't create directory for local socket %#q: %w", local, err)
 			}
 		case verbCancel:
 			if reverse {
-				logrus.Infof("Stopping forwarding %q (host) to %q (guest)", local, remote)
+				logrus.Infof("Stopping forwarding %#q (host) to %#q (guest)", local, remote)
 				if err := executeSSH(ctx, sshConfig, sshAddress, sshPort, "rm", "-f", remote); err != nil {
-					logrus.WithError(err).Warnf("Failed to clean up %q (guest) after stopping forwarding", remote)
+					logrus.WithError(err).Warnf("Failed to clean up %#q (guest) after stopping forwarding", remote)
 				}
 			} else {
-				logrus.Infof("Stopping forwarding %q (guest) to %q (host)", remote, local)
+				logrus.Infof("Stopping forwarding %#q (guest) to %#q (host)", remote, local)
 				defer func() {
 					if err := os.RemoveAll(local); err != nil {
-						logrus.WithError(err).Warnf("Failed to clean up %q (host) after stopping forwarding", local)
+						logrus.WithError(err).Warnf("Failed to clean up %#q (host) after stopping forwarding", local)
 					}
 				}()
 			}
 		default:
-			panic(fmt.Errorf("invalid verb %q", verb))
+			panic(fmt.Errorf("invalid verb %#q", verb))
 		}
 	}
 	cmd := exec.CommandContext(ctx, sshConfig.Binary(), args...)
-	logrus.Debugf("Running %q", cmd)
+	logrus.Debugf("Running %#q", cmd)
 	if out, err := cmd.Output(); err != nil {
 		if verb == verbForward && strings.HasPrefix(local, "/") {
 			if reverse {
-				logrus.WithError(err).Warnf("Failed to set up forward from %q (host) to %q (guest)", local, remote)
+				logrus.WithError(err).Warnf("Failed to set up forward from %#q (host) to %#q (guest)", local, remote)
 				if err := executeSSH(ctx, sshConfig, sshAddress, sshPort, "rm", "-f", remote); err != nil {
-					logrus.WithError(err).Warnf("Failed to clean up %q (guest) after forwarding failed", remote)
+					logrus.WithError(err).Warnf("Failed to clean up %#q (guest) after forwarding failed", remote)
 				}
 			} else {
-				logrus.WithError(err).Warnf("Failed to set up forward from %q (guest) to %q (host)", remote, local)
+				logrus.WithError(err).Warnf("Failed to set up forward from %#q (guest) to %#q (host)", remote, local)
 				if removeErr := os.RemoveAll(local); removeErr != nil {
-					logrus.WithError(removeErr).Warnf("Failed to clean up %q (host) after forwarding failed", local)
+					logrus.WithError(removeErr).Warnf("Failed to clean up %#q (host) after forwarding failed", local)
 				}
 			}
 		}
-		return fmt.Errorf("failed to run %v: %q: %w", cmd.Args, string(out), err)
+		return fmt.Errorf("failed to run %v: %#q: %w", cmd.Args, string(out), err)
 	}
 	return nil
 }
@@ -1189,15 +1189,15 @@ func copyToHost(ctx context.Context, sshConfig *ssh.SSHConfig, sshAddress string
 	)
 	logrus.Infof("Copying config from %s to %s", remote, local)
 	if err := os.MkdirAll(filepath.Dir(local), 0o700); err != nil {
-		return fmt.Errorf("can't create directory for local file %q: %w", local, err)
+		return fmt.Errorf("can't create directory for local file %#q: %w", local, err)
 	}
 	cmd := exec.CommandContext(ctx, sshConfig.Binary(), args...)
 	out, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("failed to run %v: %q: %w", cmd.Args, string(out), err)
+		return fmt.Errorf("failed to run %v: %#q: %w", cmd.Args, string(out), err)
 	}
 	if err := os.WriteFile(local, out, 0o600); err != nil {
-		return fmt.Errorf("can't write to local file %q: %w", local, err)
+		return fmt.Errorf("can't write to local file %#q: %w", local, err)
 	}
 	return nil
 }

--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -50,7 +50,7 @@ func (a *HostAgent) setupMount(ctx context.Context, m limatype.Mount) (*mount, e
 	if *m.SSHFS.FollowSymlinks {
 		sshfsOptions += ",follow_symlinks"
 	}
-	logrus.Infof("Mounting %q on %q", m.Location, *m.MountPoint)
+	logrus.Infof("Mounting %#q on %#q", m.Location, *m.MountPoint)
 
 	resolvedLocation := m.Location
 	if runtime.GOOS == "windows" {
@@ -87,22 +87,22 @@ func (a *HostAgent) setupMount(ctx context.Context, m limatype.Mount) (*mount, e
 		rsf.SSHConfig.AdditionalArgs = sshutil.DisableControlMasterOptsFromSSHArgs(rsf.SSHConfig.AdditionalArgs)
 	}
 	if err := rsf.Prepare(); err != nil {
-		return nil, fmt.Errorf("failed to prepare reverse sshfs for %q on %q: %w", resolvedLocation, *m.MountPoint, err)
+		return nil, fmt.Errorf("failed to prepare reverse sshfs for %#q on %#q: %w", resolvedLocation, *m.MountPoint, err)
 	}
 	if err := rsf.Start(); err != nil {
-		logrus.WithError(err).Warnf("failed to mount reverse sshfs for %q on %q, retrying with `-o nonempty`", resolvedLocation, *m.MountPoint)
+		logrus.WithError(err).Warnf("failed to mount reverse sshfs for %#q on %#q, retrying with `-o nonempty`", resolvedLocation, *m.MountPoint)
 		// NOTE: nonempty is not supported for libfuse3: https://github.com/canonical/multipass/issues/1381
 		rsf.SSHFSAdditionalArgs = []string{"-o", "nonempty"}
 		if err := rsf.Start(); err != nil {
-			return nil, fmt.Errorf("failed to mount reverse sshfs for %q on %q: %w", resolvedLocation, *m.MountPoint, err)
+			return nil, fmt.Errorf("failed to mount reverse sshfs for %#q on %#q: %w", resolvedLocation, *m.MountPoint, err)
 		}
 	}
 
 	res := &mount{
 		close: func() error {
-			logrus.Infof("Unmounting %q", resolvedLocation)
+			logrus.Infof("Unmounting %#q", resolvedLocation)
 			if err := rsf.Close(); err != nil {
-				return fmt.Errorf("failed to unmount reverse sshfs for %q on %q: %w", resolvedLocation, *m.MountPoint, err)
+				return fmt.Errorf("failed to unmount reverse sshfs for %#q on %#q: %w", resolvedLocation, *m.MountPoint, err)
 			}
 			return nil
 		},

--- a/pkg/hostagent/port_darwin.go
+++ b/pkg/hostagent/port_darwin.go
@@ -42,7 +42,7 @@ func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, sshAddress string
 	// https://twitter.com/_AkihiroSuda_/status/1403403845842075648
 	//
 	// We use "pseudoloopback" forwarder that listens on 0.0.0.0:80 but rejects connections from non-loopback src IP.
-	logrus.Debugf("using pseudoloopback port forwarder for %q", local)
+	logrus.Debugf("using pseudoloopback port forwarder for %#q", local)
 
 	if verb == verbCancel {
 		plf, ok := pseudoLoopbackForwarders[local]
@@ -54,7 +54,7 @@ func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, sshAddress string
 				return err
 			}
 		} else {
-			logrus.Warnf("forwarding for %q seems already cancelled?", local)
+			logrus.Warnf("forwarding for %#q seems already cancelled?", local)
 		}
 		return nil
 	}
@@ -64,14 +64,14 @@ func forwardTCP(ctx context.Context, sshConfig *ssh.SSHConfig, sshAddress string
 		return err
 	}
 	localUnix := filepath.Join(localUnixDir, "sock")
-	logrus.Debugf("forwarding %q to %q", localUnix, remote)
+	logrus.Debugf("forwarding %#q to %#q", localUnix, remote)
 	if err := forwardSSH(ctx, sshConfig, sshAddress, sshPort, localUnix, remote, verb, false); err != nil {
 		return err
 	}
 	plf, err := newPseudoLoopbackForwarder(localPort, localUnix)
 	if err != nil {
 		if cancelErr := forwardSSH(ctx, sshConfig, sshAddress, sshPort, localUnix, remote, verbCancel, false); cancelErr != nil {
-			logrus.WithError(cancelErr).Warnf("failed to cancel forwarding %q to %q", localUnix, remote)
+			logrus.WithError(cancelErr).Warnf("failed to cancel forwarding %#q to %#q", localUnix, remote)
 		}
 		return err
 	}
@@ -129,12 +129,12 @@ func (plf *pseudoLoopbackForwarder) Serve() error {
 		remoteAddr := ac.RemoteAddr().String() // ip:port
 		remoteAddrIP, _, err := net.SplitHostPort(remoteAddr)
 		if err != nil {
-			logrus.WithError(err).Debugf("pseudoloopback forwarder: rejecting non-loopback remoteAddr %q (unparsable)", remoteAddr)
+			logrus.WithError(err).Debugf("pseudoloopback forwarder: rejecting non-loopback remoteAddr %#q (unparsable)", remoteAddr)
 			ac.Close()
 			continue
 		}
 		if !portfwd.IsLoopback(remoteAddrIP) {
-			logrus.WithError(err).Debugf("pseudoloopback forwarder: rejecting non-loopback remoteAddr %q", remoteAddr)
+			logrus.WithError(err).Debugf("pseudoloopback forwarder: rejecting non-loopback remoteAddr %#q", remoteAddr)
 			ac.Close()
 			continue
 		}

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -25,7 +25,7 @@ func (a *HostAgent) waitForRequirements(label string, requirements []requirement
 	var errs []error
 
 	for i, req := range requirements {
-		logrus.Infof("Waiting for the %s requirement %d of %d: %q", label, i+1, len(requirements), req.description)
+		logrus.Infof("Waiting for the %s requirement %d of %d: %#q", label, i+1, len(requirements), req.description)
 	retryLoop:
 		for j := range retries {
 			err := a.waitForRequirement(req)
@@ -35,11 +35,11 @@ func (a *HostAgent) waitForRequirements(label string, requirements []requirement
 			}
 			if req.fatal {
 				logrus.Infof("No further %s requirements will be checked", label)
-				errs = append(errs, fmt.Errorf("failed to satisfy the %s requirement %d of %d %q: %s; skipping further checks: %w", label, i+1, len(requirements), req.description, req.debugHint, err))
+				errs = append(errs, fmt.Errorf("failed to satisfy the %s requirement %d of %d %#q: %s; skipping further checks: %w", label, i+1, len(requirements), req.description, req.debugHint, err))
 				return errors.Join(errs...)
 			}
 			if j == retries-1 {
-				errs = append(errs, fmt.Errorf("failed to satisfy the %s requirement %d of %d %q: %s: %w", label, i+1, len(requirements), req.description, req.debugHint, err))
+				errs = append(errs, fmt.Errorf("failed to satisfy the %s requirement %d of %d %#q: %s: %w", label, i+1, len(requirements), req.description, req.debugHint, err))
 				break retryLoop
 			}
 			time.Sleep(sleepDuration)
@@ -110,7 +110,7 @@ func (a *HostAgent) bashAvailable() bool {
 }
 
 func (a *HostAgent) waitForRequirement(r requirement) error {
-	logrus.Debugf("executing script %q", r.description)
+	logrus.Debugf("executing script %#q", r.description)
 	script := r.script
 	if a.bashAvailable() {
 		var err error
@@ -140,9 +140,9 @@ func (a *HostAgent) waitForRequirement(r requirement) error {
 		}
 	}
 	stdout, stderr, err := ssh.ExecuteScript(a.instSSHAddress, a.sshLocalPort, sshConfig, script, r.description)
-	logrus.Debugf("stdout=%q, stderr=%q, err=%v", stdout, stderr, err)
+	logrus.Debugf("stdout=%#q, stderr=%#q, err=%v", stdout, stderr, err)
 	if err != nil {
-		return fmt.Errorf("stdout=%q, stderr=%q: %w", stdout, stderr, err)
+		return fmt.Errorf("stdout=%#q, stderr=%#q: %w", stdout, stderr, err)
 	}
 	return nil
 }
@@ -209,7 +209,7 @@ A possible workaround is to run "apt-get install sshfs" in the guest.
 `,
 		})
 		req = append(req, requirement{
-			description: "fuse to \"allow_other\" as user",
+			description: "fuse to allow_other as user",
 			script: `#!/bin/sh
 set -eux
 sudo grep -q ^user_allow_other /etc/fuse*.conf

--- a/pkg/httpclientutil/httpclientutil.go
+++ b/pkg/httpclientutil/httpclientutil.go
@@ -103,7 +103,7 @@ func (e *HTTPStatusError) Error() string {
 			return ej.Message
 		}
 	}
-	return fmt.Sprintf("unexpected HTTP status %s, body=%q", http.StatusText(e.StatusCode), e.Body)
+	return fmt.Sprintf("unexpected HTTP status %s, body=%#q", http.StatusText(e.StatusCode), e.Body)
 }
 
 func Successful(resp *http.Response) error {

--- a/pkg/identifiers/validate.go
+++ b/pkg/identifiers/validate.go
@@ -60,11 +60,11 @@ func Validate(s string) error {
 	}
 
 	if len(s) > maxLength {
-		return fmt.Errorf("identifier %q greater than maximum length (%d characters)", s, maxLength)
+		return fmt.Errorf("identifier %#q greater than maximum length (%d characters)", s, maxLength)
 	}
 
 	if !identifierRe.MatchString(s) {
-		return fmt.Errorf("identifier %q must match %v", s, identifierRe)
+		return fmt.Errorf("identifier %#q must match %v", s, identifierRe)
 	}
 	return nil
 }

--- a/pkg/imgutil/nativeimgutil/asifutil/asif_darwin.go
+++ b/pkg/imgutil/nativeimgutil/asifutil/asif_darwin.go
@@ -21,13 +21,13 @@ import (
 func NewASIF(path string, size int64) error {
 	createArgs := []string{"image", "create", "blank", "--fs", "none", "--format", "ASIF", "--size", strconv.FormatInt(size, 10), path}
 	if err := exec.CommandContext(context.Background(), "diskutil", createArgs...).Run(); err != nil {
-		return fmt.Errorf("failed to create ASIF image %q: %w", path, err)
+		return fmt.Errorf("failed to create ASIF image %#q: %w", path, err)
 	}
 	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 		if _, err2 := os.Stat(path + ".asif"); !errors.Is(err2, os.ErrNotExist) {
 			// diskutil may create the file with .asif suffix
 			if err3 := os.Rename(path+".asif", path); err3 != nil {
-				return fmt.Errorf("failed to rename ASIF image from %q to %q: %w", path+".asif", path, err3)
+				return fmt.Errorf("failed to rename ASIF image from %#q to %#q: %w", path+".asif", path, err3)
 			}
 		}
 	}
@@ -44,13 +44,13 @@ func NewAttachedASIF(path string, size int64) (string, *os.File, error) {
 	attachArgs := []string{"image", "attach", "--noMount", path}
 	out, err := exec.CommandContext(context.Background(), "diskutil", attachArgs...).Output()
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to attach ASIF image %q: %w", path, err)
+		return "", nil, fmt.Errorf("failed to attach ASIF image %#q: %w", path, err)
 	}
 	devicePath := strings.TrimSpace(string(out))
 	f, err := os.OpenFile(devicePath, os.O_RDWR, 0o644)
 	if err != nil {
 		_ = DetachASIF(devicePath)
-		return "", nil, fmt.Errorf("failed to open ASIF device %q: %w", devicePath, err)
+		return "", nil, fmt.Errorf("failed to open ASIF device %#q: %w", devicePath, err)
 	}
 	return devicePath, f, err
 }
@@ -58,7 +58,7 @@ func NewAttachedASIF(path string, size int64) (string, *os.File, error) {
 // DetachASIF detaches the ASIF image device at the specified path.
 func DetachASIF(devicePath string) error {
 	if output, err := exec.CommandContext(context.Background(), "hdiutil", "detach", devicePath).CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to detach ASIF image %q: %w: %s", devicePath, err, output)
+		return fmt.Errorf("failed to detach ASIF image %#q: %w: %s", devicePath, err, output)
 	}
 	return nil
 }
@@ -67,7 +67,7 @@ func DetachASIF(devicePath string) error {
 func ResizeASIF(path string, size int64) error {
 	resizeArgs := []string{"image", "resize", "--size", fmt.Sprintf("%d", size), path}
 	if output, err := exec.CommandContext(context.Background(), "diskutil", resizeArgs...).CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to resize ASIF image %q: %w: %s", path, err, output)
+		return fmt.Errorf("failed to resize ASIF image %#q: %w: %s", path, err, output)
 	}
 	return nil
 }
@@ -139,7 +139,7 @@ func DiskutilImageAttachNoMount(ctx context.Context, disk string) (*AttachedDisk
 		if strings.Contains(stderr.String(), "Resource temporarily unavailable") {
 			errToWrap = ErrResourceTemporarilyUnavailable
 		}
-		return nil, fmt.Errorf("failed to execute %v: %w (stderr: %q)", cmd.Args, errToWrap, stderr.String())
+		return nil, fmt.Errorf("failed to execute %v: %w (stderr: %#q)", cmd.Args, errToWrap, stderr.String())
 	}
 	return parseDiskutilImageAttachOutput(stdout.String())
 }

--- a/pkg/imgutil/nativeimgutil/nativeimgutil.go
+++ b/pkg/imgutil/nativeimgutil/nativeimgutil.go
@@ -54,12 +54,12 @@ func convertTo(destType image.Type, source, dest string, size *int64, allowSourc
 	defer srcF.Close()
 	srcImg, err := qcow2reader.Open(srcF)
 	if err != nil {
-		return fmt.Errorf("failed to detect the format of %q: %w", source, err)
+		return fmt.Errorf("failed to detect the format of %#q: %w", source, err)
 	}
 	if size != nil && *size < srcImg.Size() {
-		return fmt.Errorf("specified size %d is smaller than the original image size (%d) of %q", *size, srcImg.Size(), source)
+		return fmt.Errorf("specified size %d is smaller than the original image size (%d) of %#q", *size, srcImg.Size(), source)
 	}
-	logrus.Infof("Converting %q (%s) to a %s disk %q", source, srcImg.Type(), destType, dest)
+	logrus.Infof("Converting %#q (%s) to a %s disk %#q", source, srcImg.Type(), destType, dest)
 	switch t := srcImg.Type(); t {
 	case raw.Type:
 		if destType == raw.Type {
@@ -75,19 +75,19 @@ func convertTo(destType image.Type, source, dest string, size *int64, allowSourc
 				return fmt.Errorf("unexpected qcow2 image %T", srcImg)
 			}
 			if q.BackingFile != "" {
-				return fmt.Errorf("qcow2 image %q has an unexpected backing file: %q", source, q.BackingFile)
+				return fmt.Errorf("qcow2 image %#q has an unexpected backing file: %#q", source, q.BackingFile)
 			}
 		}
 	case asif.Type:
 		if destType == asif.Type {
 			return convertASIFToASIF(source, dest, size)
 		}
-		return fmt.Errorf("conversion from ASIF to %q is not supported", destType)
+		return fmt.Errorf("conversion from ASIF to %#q is not supported", destType)
 	default:
-		logrus.Warnf("image %q has an unexpected format: %q", source, t)
+		logrus.Warnf("image %#q has an unexpected format: %#q", source, t)
 	}
 	if err = srcImg.Readable(); err != nil {
-		return fmt.Errorf("image %q is not readable: %w", source, err)
+		return fmt.Errorf("image %#q is not readable: %w", source, err)
 	}
 
 	// Create a tmp file because source and dest can be same.
@@ -114,7 +114,7 @@ func convertTo(destType image.Type, source, dest string, size *int64, allowSourc
 		}
 		attachedDevice, destTmpF, err = asifutil.NewAttachedASIF(destTmp, newSize)
 	default:
-		return fmt.Errorf("unsupported target image type: %q", destType)
+		return fmt.Errorf("unsupported target image type: %#q", destType)
 	}
 	if err != nil {
 		return err
@@ -155,7 +155,7 @@ func convertTo(destType image.Type, source, dest string, size *int64, allowSourc
 	if destType == asif.Type {
 		err := asifutil.DetachASIF(attachedDevice)
 		if err != nil {
-			return fmt.Errorf("failed to detach ASIF image %q: %w", attachedDevice, err)
+			return fmt.Errorf("failed to detach ASIF image %#q: %w", attachedDevice, err)
 		}
 	}
 
@@ -170,10 +170,10 @@ func convertRawToRaw(source, dest string, size *int64) error {
 	if source != dest {
 		// continuity attempts clonefile
 		if err := containerdfs.CopyFile(dest, source); err != nil {
-			return fmt.Errorf("failed to copy %q into %q: %w", source, dest, err)
+			return fmt.Errorf("failed to copy %#q into %#q: %w", source, dest, err)
 		}
 		if err := os.Chmod(dest, 0o644); err != nil {
-			return fmt.Errorf("failed to set permissions on %q: %w", dest, err)
+			return fmt.Errorf("failed to set permissions on %#q: %w", dest, err)
 		}
 	}
 	if size != nil {
@@ -194,16 +194,16 @@ func convertRawToRaw(source, dest string, size *int64) error {
 func convertASIFToASIF(source, dest string, size *int64) error {
 	if source != dest {
 		if err := containerdfs.CopyFile(dest, source); err != nil {
-			return fmt.Errorf("failed to copy %q into %q: %w", source, dest, err)
+			return fmt.Errorf("failed to copy %#q into %#q: %w", source, dest, err)
 		}
 		if err := os.Chmod(dest, 0o644); err != nil {
-			return fmt.Errorf("failed to set permissions on %q: %w", dest, err)
+			return fmt.Errorf("failed to set permissions on %#q: %w", dest, err)
 		}
 	}
 	if size != nil {
 		logrus.Infof("Resizing to %s", units.BytesSize(float64(*size)))
 		if err := asifutil.ResizeASIF(dest, *size); err != nil {
-			return fmt.Errorf("failed to resize ASIF image %q: %w", dest, err)
+			return fmt.Errorf("failed to resize ASIF image %#q: %w", dest, err)
 		}
 	}
 	return nil

--- a/pkg/instance/ansible.go
+++ b/pkg/instance/ansible.go
@@ -20,7 +20,7 @@ import (
 func runAnsibleProvision(ctx context.Context, inst *limatype.Instance) error {
 	for _, f := range inst.Config.Provision {
 		if f.Mode == limatype.ProvisionModeAnsible {
-			logrus.Infof("Waiting for ansible playbook %q", f.Playbook)
+			logrus.Infof("Waiting for ansible playbook %#q", f.Playbook)
 			if err := runAnsiblePlaybook(ctx, inst, f.Playbook); err != nil {
 				return err
 			}
@@ -34,7 +34,7 @@ func runAnsiblePlaybook(ctx context.Context, inst *limatype.Instance, playbook s
 	if err != nil {
 		return err
 	}
-	logrus.Debugf("ansible-playbook -i %q %q", inventory, playbook)
+	logrus.Debugf("ansible-playbook -i %#q %#q", inventory, playbook)
 	args := []string{"-i", inventory, playbook}
 	cmd := exec.CommandContext(ctx, "ansible-playbook", args...)
 	cmd.Env = getAnsibleEnvironment(inst)

--- a/pkg/instance/clone.go
+++ b/pkg/instance/clone.go
@@ -31,7 +31,7 @@ func CloneOrRename(ctx context.Context, oldInst *limatype.Instance, newInstName 
 		return nil, errors.New("got empty instName")
 	}
 	if oldInst.Name == newInstName {
-		return nil, fmt.Errorf("new instance name %q must be different from %q", newInstName, oldInst.Name)
+		return nil, fmt.Errorf("new instance name %#q must be different from %#q", newInstName, oldInst.Name)
 	}
 	if oldInst.Status == limatype.StatusRunning {
 		return nil, errors.New("cannot " + verb + " a running instance")
@@ -43,13 +43,13 @@ func CloneOrRename(ctx context.Context, oldInst *limatype.Instance, newInstName 
 	}
 
 	if _, err = os.Stat(newInstDir); !errors.Is(err, fs.ErrNotExist) {
-		return nil, fmt.Errorf("instance %q already exists", newInstName)
+		return nil, fmt.Errorf("instance %#q already exists", newInstName)
 	}
 
 	// the full path of the socket name must be less than UNIX_PATH_MAX chars.
 	maxSockName := filepath.Join(newInstDir, filenames.LongestSock)
 	if len(maxSockName) >= osutil.UnixPathMax {
-		return nil, fmt.Errorf("instance name %q too long: %q must be less than UNIX_PATH_MAX=%d characters, but is %d",
+		return nil, fmt.Errorf("instance name %#q too long: %#q must be less than UNIX_PATH_MAX=%d characters, but is %d",
 			newInstName, maxSockName, osutil.UnixPathMax, len(maxSockName))
 	}
 

--- a/pkg/instance/create.go
+++ b/pkg/instance/create.go
@@ -37,11 +37,11 @@ func Create(ctx context.Context, instName string, instConfig []byte, saveBrokenY
 	// the full path of the socket name must be less than UNIX_PATH_MAX chars.
 	maxSockName := filepath.Join(instDir, filenames.LongestSock)
 	if len(maxSockName) >= osutil.UnixPathMax {
-		return nil, fmt.Errorf("instance name %q too long: %q must be less than UNIX_PATH_MAX=%d characters, but is %d",
+		return nil, fmt.Errorf("instance name %#q too long: %#q must be less than UNIX_PATH_MAX=%d characters, but is %d",
 			instName, maxSockName, osutil.UnixPathMax, len(maxSockName))
 	}
 	if _, err := os.Stat(instDir); !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("instance %q already exists (%q)", instName, instDir)
+		return nil, fmt.Errorf("instance %#q already exists (%#q)", instName, instDir)
 	}
 	// limayaml.Load() needs to pass the store file path to limayaml.FillDefault() to calculate default MAC addresses
 	filePath := filepath.Join(instDir, filenames.LimaYAML)
@@ -50,7 +50,7 @@ func Create(ctx context.Context, instName string, instConfig []byte, saveBrokenY
 		return nil, err
 	}
 	if err := driverutil.ResolveVMType(ctx, loadedInstConfig, filePath); err != nil {
-		return nil, fmt.Errorf("failed to resolve vm for %q: %w", filePath, err)
+		return nil, fmt.Errorf("failed to resolve vm for %#q: %w", filePath, err)
 	}
 	if err := limayaml.Validate(loadedInstConfig, true); err != nil {
 		if !saveBrokenYAML {
@@ -58,9 +58,9 @@ func Create(ctx context.Context, instName string, instConfig []byte, saveBrokenY
 		}
 		rejectedYAML := "lima.REJECTED.yaml"
 		if writeErr := os.WriteFile(rejectedYAML, instConfig, 0o644); writeErr != nil {
-			return nil, fmt.Errorf("the YAML is invalid, attempted to save the buffer as %q but failed: %w: %w", rejectedYAML, writeErr, err)
+			return nil, fmt.Errorf("the YAML is invalid, attempted to save the buffer as %#q but failed: %w: %w", rejectedYAML, writeErr, err)
 		}
-		return nil, fmt.Errorf("the YAML is invalid, saved the buffer as %q: %w", rejectedYAML, err)
+		return nil, fmt.Errorf("the YAML is invalid, saved the buffer as %#q: %w", rejectedYAML, err)
 	}
 	if err := os.MkdirAll(instDir, 0o700); err != nil {
 		return nil, err

--- a/pkg/instance/delete.go
+++ b/pkg/instance/delete.go
@@ -18,18 +18,18 @@ func Delete(ctx context.Context, inst *limatype.Instance, force bool) error {
 		return errors.New("instance is protected to prohibit accidental removal (Hint: use `limactl unprotect`)")
 	}
 	if !force && inst.Status != limatype.StatusStopped {
-		return fmt.Errorf("expected status %q, got %q", limatype.StatusStopped, inst.Status)
+		return fmt.Errorf("expected status %#q, got %#q", limatype.StatusStopped, inst.Status)
 	}
 
 	StopForcibly(inst)
 
 	if len(inst.Errors) == 0 {
 		if err := unregister(ctx, inst); err != nil {
-			return fmt.Errorf("failed to unregister %q: %w", inst.Dir, err)
+			return fmt.Errorf("failed to unregister %#q: %w", inst.Dir, err)
 		}
 	}
 	if err := os.RemoveAll(inst.Dir); err != nil {
-		return fmt.Errorf("failed to remove %q: %w", inst.Dir, err)
+		return fmt.Errorf("failed to remove %#q: %w", inst.Dir, err)
 	}
 
 	return nil

--- a/pkg/instance/restart.go
+++ b/pkg/instance/restart.go
@@ -26,7 +26,7 @@ func Restart(ctx context.Context, inst *limatype.Instance, showProgress bool) er
 
 	// Network reconciliation will be performed by the process launched by the autostart manager
 	if registered, err := autostart.IsRegistered(ctx, inst); err != nil && !errors.Is(err, autostart.ErrNotSupported) {
-		return fmt.Errorf("failed to check if the autostart entry for instance %q is registered: %w", inst.Name, err)
+		return fmt.Errorf("failed to check if the autostart entry for instance %#q is registered: %w", inst.Name, err)
 	} else if !registered {
 		if err := reconcile.Reconcile(ctx, inst.Name); err != nil {
 			return err
@@ -45,7 +45,7 @@ func RestartForcibly(ctx context.Context, inst *limatype.Instance, showProgress 
 	StopForcibly(inst)
 
 	if registered, err := autostart.IsRegistered(ctx, inst); err != nil && !errors.Is(err, autostart.ErrNotSupported) {
-		return fmt.Errorf("failed to check if the autostart entry for instance %q is registered: %w", inst.Name, err)
+		return fmt.Errorf("failed to check if the autostart entry for instance %#q is registered: %w", inst.Name, err)
 	} else if !registered {
 		if err := reconcile.Reconcile(ctx, inst.Name); err != nil {
 			return err

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -168,9 +168,9 @@ func Prepare(ctx context.Context, inst *limatype.Instance, guestAgent string) (*
 func StartWithPaths(ctx context.Context, inst *limatype.Instance, launchHostAgentForeground, showProgress bool, limactl, guestAgent string) error {
 	haPIDPath := filepath.Join(inst.Dir, filenames.HostAgentPID)
 	if _, err := os.Stat(haPIDPath); !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("instance %q seems running (hint: remove %q if the instance is not actually running)", inst.Name, haPIDPath)
+		return fmt.Errorf("instance %#q seems running (hint: remove %#q if the instance is not actually running)", inst.Name, haPIDPath)
 	}
-	logrus.Infof("Starting the instance %q with %s VM driver %q", inst.Name, registry.CheckInternalOrExternal(inst.VMType), inst.VMType)
+	logrus.Infof("Starting the instance %#q with %s VM driver %#q", inst.Name, registry.CheckInternalOrExternal(inst.VMType), inst.VMType)
 
 	haSockPath := filepath.Join(inst.Dir, filenames.HostAgentSock)
 
@@ -296,7 +296,7 @@ func waitHostAgentStart(_ context.Context, haPIDPath, haStderrPath string) error
 			return nil
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("hostagent (%q) did not start up in %v (hint: see %q)", haPIDPath, deadlineDuration, haStderrPath)
+			return fmt.Errorf("hostagent (%#q) did not start up in %v (hint: see %#q)", haPIDPath, deadlineDuration, haStderrPath)
 		}
 	}
 }
@@ -340,12 +340,12 @@ func watchHostAgentEvents(ctx context.Context, inst *limatype.Instance, haStdout
 			logrus.Errorf("%+v", ev.Status.Errors)
 		}
 		if ev.Status.Exiting {
-			err = fmt.Errorf("exiting, status=%+v (hint: see %q)", ev.Status, haStderrPath)
+			err = fmt.Errorf("exiting, status=%+v (hint: see %#q)", ev.Status, haStderrPath)
 			return true
 		} else if ev.Status.Running {
 			receivedRunningEvent = true
 			if ev.Status.Degraded {
-				logrus.Warnf("DEGRADED. The VM seems running, but file sharing and port forwarding may not work. (hint: see %q)", haStderrPath)
+				logrus.Warnf("DEGRADED. The VM seems running, but file sharing and port forwarding may not work. (hint: see %#q)", haStderrPath)
 				err = fmt.Errorf("degraded, status=%+v", ev.Status)
 				return true
 			}
@@ -361,7 +361,7 @@ func watchHostAgentEvents(ctx context.Context, inst *limatype.Instance, haStdout
 
 			if !isLaunchingShell(ctx) {
 				if *inst.Config.Plain {
-					logrus.Infof("READY. Run `ssh -F %q %s` to open the shell.", inst.SSHConfigFile, inst.Hostname)
+					logrus.Infof("READY. Run `ssh -F %#q %s` to open the shell.", inst.SSHConfigFile, inst.Hostname)
 				} else {
 					logrus.Infof("READY. Run `%s` to open the shell.", LimactlShellCmd(inst.Name))
 				}
@@ -382,7 +382,7 @@ func watchHostAgentEvents(ctx context.Context, inst *limatype.Instance, haStdout
 	}
 
 	if !receivedRunningEvent {
-		return errors.New("did not receive an event with the \"running\" status")
+		return errors.New("did not receive an event with the `running` status")
 	}
 
 	return nil
@@ -444,7 +444,7 @@ func ShowMessage(inst *limatype.Instance) error {
 		return err
 	}
 	scanner := bufio.NewScanner(&b)
-	logrus.Infof("Message from the instance %q:", inst.Name)
+	logrus.Infof("Message from the instance %#q:", inst.Name)
 	for scanner.Scan() {
 		// Avoid prepending logrus "INFO" header, for ease of copy pasting
 		fmt.Fprintln(logrus.StandardLogger().Out, scanner.Text())

--- a/pkg/instance/stop.go
+++ b/pkg/instance/stop.go
@@ -30,7 +30,7 @@ func StopGracefully(ctx context.Context, inst *limatype.Instance, isRestart bool
 			logrus.Warn("The instance is not running, continuing with the restart")
 			return nil
 		}
-		return fmt.Errorf("expected status %q, got %q (maybe use `limactl stop -f`?)", limatype.StatusRunning, inst.Status)
+		return fmt.Errorf("expected status %#q, got %#q (maybe use `limactl stop -f`?)", limatype.StatusRunning, inst.Status)
 	}
 
 	begin := time.Now() // used for logrus propagation
@@ -77,7 +77,7 @@ func waitForHostAgentTermination(ctx context.Context, inst *limatype.Instance, b
 	}
 
 	if !receivedExitingEvent {
-		return errors.New("did not receive an event with the \"exiting\" status")
+		return errors.New("did not receive an event with the `exiting` status")
 	}
 
 	return nil
@@ -136,11 +136,11 @@ func StopForcibly(inst *limatype.Instance) {
 		diskName := d.Name
 		disk, err := store.InspectDisk(diskName, d.FSType)
 		if err != nil {
-			logrus.Warnf("Disk %q does not exist", diskName)
+			logrus.Warnf("Disk %#q does not exist", diskName)
 			continue
 		}
 		if err := disk.Unlock(); err != nil {
-			logrus.Warnf("Failed to unlock disk %q. To use, run `limactl disk unlock %v`", diskName, diskName)
+			logrus.Warnf("Failed to unlock disk %#q. To use, run `limactl disk unlock %v`", diskName, diskName)
 		}
 	}
 
@@ -154,7 +154,7 @@ func StopForcibly(inst *limatype.Instance) {
 	}
 
 	globPatterns := strings.ReplaceAll(strings.Join(filenames.TmpFileSuffixes, " "), ".", "*.")
-	logrus.Infof("Removing %s under %q", globPatterns, inst.Dir)
+	logrus.Infof("Removing %s under %#q", globPatterns, inst.Dir)
 
 	fi, err := os.ReadDir(inst.Dir)
 	if err != nil {
@@ -165,7 +165,7 @@ func StopForcibly(inst *limatype.Instance) {
 		path := filepath.Join(inst.Dir, f.Name())
 		for _, suffix := range filenames.TmpFileSuffixes {
 			if strings.HasSuffix(path, suffix) {
-				logrus.Infof("Removing %q", path)
+				logrus.Infof("Removing %#q", path)
 				if err := os.Remove(path); err != nil {
 					if errors.Is(err, os.ErrNotExist) {
 						logrus.Debug(err.Error())

--- a/pkg/iso9660util/joliet.go
+++ b/pkg/iso9660util/joliet.go
@@ -49,7 +49,7 @@ func writeJoliet(isoPath, label string, layout []Entry) error {
 	logrus.Debugf("Executing %v", cmd.Args)
 	b, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to run %v: %w (output=%q)", cmd.Args, err, string(b))
+		return fmt.Errorf("failed to run %v: %w (output=%#q)", cmd.Args, err, string(b))
 	}
 	return nil
 }

--- a/pkg/limactlutil/limactlutil.go
+++ b/pkg/limactlutil/limactlutil.go
@@ -28,7 +28,7 @@ func Inspect(ctx context.Context, limactl, instName string) (*limatype.Instance,
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("failed to run %v: stdout=%q, stderr=%q: %w", cmd.Args, stdout.String(), stderr.String(), err)
+		return nil, fmt.Errorf("failed to run %v: stdout=%#q, stderr=%#q: %w", cmd.Args, stdout.String(), stderr.String(), err)
 	}
 	var inst limatype.Instance
 	if err := json.Unmarshal(stdout.Bytes(), &inst); err != nil {

--- a/pkg/limainfo/limainfo.go
+++ b/pkg/limainfo/limainfo.go
@@ -111,9 +111,9 @@ func New(ctx context.Context) (*LimaInfo, error) {
 			bin, err := usrlocal.GuestAgentBinary(os, arch)
 			if err != nil {
 				if errors.Is(err, fs.ErrNotExist) {
-					logrus.WithError(err).Debugf("Failed to resolve the guest agent binary for %q-%q", os, arch)
+					logrus.WithError(err).Debugf("Failed to resolve the guest agent binary for %#q-%#q", os, arch)
 				} else {
-					logrus.WithError(err).Warnf("Failed to resolve the guest agent binary for %q-%q", os, arch)
+					logrus.WithError(err).Warnf("Failed to resolve the guest agent binary for %#q-%#q", os, arch)
 				}
 				continue
 			}

--- a/pkg/limatmpl/abs.go
+++ b/pkg/limatmpl/abs.go
@@ -127,9 +127,9 @@ func absPath(locator, basePath string) (string, error) {
 		case basePath == "-":
 			return "", errors.New("can't use relative paths when reading template from STDIN")
 		case strings.Contains(locator, "../"):
-			return "", fmt.Errorf("relative locator path %q must not contain '../' segments", locator)
+			return "", fmt.Errorf("relative locator path %#q must not contain '../' segments", locator)
 		case volumeLen != 0:
-			return "", fmt.Errorf("relative locator path %q must not include a volume name", locator)
+			return "", fmt.Errorf("relative locator path %#q must not include a volume name", locator)
 		}
 		u, err = url.Parse(basePath)
 		if err != nil {

--- a/pkg/limatmpl/embed.go
+++ b/pkg/limatmpl/embed.go
@@ -45,7 +45,7 @@ func (tmpl *Template) Embed(ctx context.Context, embedAll, defaultBase bool) err
 }
 
 func (tmpl *Template) embedAllBases(ctx context.Context, embedAll, defaultBase bool, seen map[string]bool) error {
-	logrus.Debugf("Embedding templates into %q", tmpl.Locator)
+	logrus.Debugf("Embedding templates into %#q", tmpl.Locator)
 	if defaultBase {
 		configDir, err := dirnames.LimaConfigDir()
 		if err != nil {
@@ -73,7 +73,7 @@ func (tmpl *Template) embedAllBases(ctx context.Context, embedAll, defaultBase b
 		}
 		baseLocator := tmpl.Config.Base[0]
 		if baseLocator.Digest != nil {
-			return fmt.Errorf("base %q in %q has specified a digest; digest support is not yet implemented", baseLocator.URL, tmpl.Locator)
+			return fmt.Errorf("base %#q in %#q has specified a digest; digest support is not yet implemented", baseLocator.URL, tmpl.Locator)
 		}
 		isTemplate, _ := SeemsTemplateURL(baseLocator.URL)
 		if isTemplate && !embedAll {
@@ -81,7 +81,7 @@ func (tmpl *Template) embedAllBases(ctx context.Context, embedAll, defaultBase b
 			for i := 1; i < len(tmpl.Config.Base); i++ {
 				isTemplate, _ = SeemsTemplateURL(tmpl.Config.Base[i].URL)
 				if !isTemplate {
-					return fmt.Errorf("cannot embed template %q after not embedding %q", tmpl.Config.Base[i].URL, baseLocator.URL)
+					return fmt.Errorf("cannot embed template %#q after not embedding %#q", tmpl.Config.Base[i].URL, baseLocator.URL)
 				}
 			}
 			break
@@ -89,7 +89,7 @@ func (tmpl *Template) embedAllBases(ctx context.Context, embedAll, defaultBase b
 		}
 
 		if seen[baseLocator.URL] {
-			return fmt.Errorf("base template loop detected: template %q already included", baseLocator.URL)
+			return fmt.Errorf("base template loop detected: template %#q already included", baseLocator.URL)
 		}
 		seen[baseLocator.URL] = true
 
@@ -102,13 +102,13 @@ func (tmpl *Template) embedAllBases(ctx context.Context, embedAll, defaultBase b
 		return err
 	}
 	if len(tmpl.Bytes) > yBytesLimit {
-		return fmt.Errorf("template %q embedding exceeded the size limit (%d bytes)", tmpl.Locator, yBytesLimit)
+		return fmt.Errorf("template %#q embedding exceeded the size limit (%d bytes)", tmpl.Locator, yBytesLimit)
 	}
 	return nil
 }
 
 func (tmpl *Template) embedBase(ctx context.Context, baseLocator limatype.LocatorWithDigest, embedAll bool, seen map[string]bool) error {
-	logrus.Debugf("Embedding base %q in template %q", baseLocator.URL, tmpl.Locator)
+	logrus.Debugf("Embedding base %#q in template %#q", baseLocator.URL, tmpl.Locator)
 	if err := tmpl.Unmarshal(); err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func (tmpl *Template) embedBase(ctx context.Context, baseLocator limatype.Locato
 		return err
 	}
 	if len(tmpl.Bytes) > yBytesLimit {
-		return fmt.Errorf("template %q embedding exceeded the size limit (%d bytes)", tmpl.Locator, yBytesLimit)
+		return fmt.Errorf("template %#q embedding exceeded the size limit (%d bytes)", tmpl.Locator, yBytesLimit)
 	}
 	return nil
 }
@@ -568,7 +568,7 @@ func encodeScriptReason(script string) string {
 	line := 1
 	for i, r := range script {
 		if !(unicode.IsPrint(r) || r == '\n') {
-			return fmt.Sprintf("unprintable character %q at offset %d", r, i)
+			return fmt.Sprintf("unprintable character %#q at offset %d", r, i)
 		}
 		// maxLineLength includes final newline
 		if i-start >= maxLineLength {
@@ -612,7 +612,7 @@ func binaryString(s string) string {
 func (tmpl *Template) updateScript(field string, idx int, newName, script, file string) {
 	tag := ""
 	if reason := encodeScriptReason(script); reason != "" {
-		logrus.Infof("File %q is being base64 encoded: %s", file, reason)
+		logrus.Infof("File %#q is being base64 encoded: %s", file, reason)
 		script = binaryString(script)
 		tag = "!!binary"
 	}

--- a/pkg/limatmpl/github.go
+++ b/pkg/limatmpl/github.go
@@ -35,7 +35,7 @@ func transformGitHubURL(ctx context.Context, input string) (string, error) {
 	}
 	org := parts[0]
 	if org == "" {
-		return "", fmt.Errorf("github: URL must contain at least an ORG, got %q", input)
+		return "", fmt.Errorf("github: URL must contain at least an ORG, got %#q", input)
 	}
 	// If REPO is omitted (github:ORG or github:ORG//PATH), default it to ORG
 	repo := cmp.Or(parts[1], org)
@@ -150,14 +150,14 @@ func resolveGitHubSymlink(ctx context.Context, org, repo, branch, filePath, orig
 		}
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("file %q not found or inaccessible: status %d", resp.Request.URL, resp.StatusCode)
+		return "", fmt.Errorf("file %#q not found or inaccessible: status %d", resp.Request.URL, resp.StatusCode)
 	}
 
 	// Read first 1KB to check the file content
 	buf := make([]byte, 1024)
 	n, err := resp.Body.Read(buf)
 	if err != nil && !errors.Is(err, io.EOF) {
-		return "", fmt.Errorf("failed to read %q content: %w", resp.Request.URL, err)
+		return "", fmt.Errorf("failed to read %#q content: %w", resp.Request.URL, err)
 	}
 	content := string(buf[:n])
 
@@ -184,11 +184,11 @@ func resolveGitHubRedirect(ctx context.Context, org, repo, defaultBranch, filePa
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("file %q not found or inaccessible: status %d", resp.Request.URL, resp.StatusCode)
+		return "", fmt.Errorf("file %#q not found or inaccessible: status %d", resp.Request.URL, resp.StatusCode)
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to read %q content: %w", resp.Request.URL, err)
+		return "", fmt.Errorf("failed to read %#q content: %w", resp.Request.URL, err)
 	}
 	return validateGitHubRedirect(string(body), org, origBranch, resp.Request.URL.String())
 }
@@ -198,10 +198,10 @@ func validateGitHubRedirect(body, org, origBranch, url string) (string, error) {
 	redirect = strings.TrimSpace(redirect)
 
 	if !strings.HasPrefix(redirect, "github:"+org+"/") {
-		return "", fmt.Errorf(`redirect %q is not a "github:%s" URL (from %q)`, redirect, org, url)
+		return "", fmt.Errorf("redirect %#q is not a `github:%s` URL (from %#q)", redirect, org, url)
 	}
 	if strings.ContainsRune(redirect, '@') {
-		return "", fmt.Errorf("redirect %q must not include a branch/tag/sha (from %q)", redirect, url)
+		return "", fmt.Errorf("redirect %#q must not include a branch/tag/sha (from %#q)", redirect, url)
 	}
 	// If the origBranch is empty, then we need to look up the default branch in the redirect
 	if origBranch != "" {

--- a/pkg/limatmpl/locator.go
+++ b/pkg/limatmpl/locator.go
@@ -47,7 +47,7 @@ func Read(ctx context.Context, name, locator string) (*Template, error) {
 	isTemplateURL, templateName := SeemsTemplateURL(locator)
 	switch {
 	case isTemplateURL:
-		logrus.Debugf("interpreting argument %q as a template name %q", locator, templateName)
+		logrus.Debugf("interpreting argument %#q as a template name %#q", locator, templateName)
 		if tmpl.Name == "" {
 			// e.g., templateName = "deprecated/centos-7.yaml" , tmpl.Name = "centos-7"
 			tmpl.Name, err = InstNameFromYAMLPath(templateName)
@@ -66,7 +66,7 @@ func Read(ctx context.Context, name, locator string) (*Template, error) {
 				return nil, err
 			}
 		}
-		logrus.Debugf("interpreting argument %q as a http url for instance %q", locator, tmpl.Name)
+		logrus.Debugf("interpreting argument %#q as a http url for instance %#q", locator, tmpl.Name)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, locator, http.NoBody)
 		if err != nil {
 			return nil, err
@@ -87,10 +87,10 @@ func Read(ctx context.Context, name, locator string) (*Template, error) {
 				return nil, err
 			}
 		}
-		logrus.Debugf("interpreting argument %q as a file URL for instance %q", locator, tmpl.Name)
+		logrus.Debugf("interpreting argument %#q as a file URL for instance %#q", locator, tmpl.Name)
 		filePath := strings.TrimPrefix(locator, "file://")
 		if !filepath.IsAbs(filePath) {
-			return nil, fmt.Errorf("file URL %q is not an absolute path", locator)
+			return nil, fmt.Errorf("file URL %#q is not an absolute path", locator)
 		}
 		r, err := os.Open(filePath)
 		if err != nil {
@@ -113,7 +113,7 @@ func Read(ctx context.Context, name, locator string) (*Template, error) {
 				return nil, err
 			}
 		}
-		logrus.Debugf("interpreting argument %q as a file path for instance %q", locator, tmpl.Name)
+		logrus.Debugf("interpreting argument %#q as a file path for instance %#q", locator, tmpl.Name)
 		if locator, err = filepath.Abs(locator); err != nil {
 			return nil, err
 		}
@@ -202,7 +202,7 @@ func imageTemplate(tmpl *Template, locator string) bool {
 	}
 	if imageOS == "" {
 		imageOS = limatype.LINUX
-		logrus.Debugf("cannot determine image OS from URL %q; assuming %q", locator, imageOS)
+		logrus.Debugf("cannot determine image OS from URL %#q; assuming %#q", locator, imageOS)
 	}
 
 	var imageArch limatype.Arch
@@ -219,7 +219,7 @@ func imageTemplate(tmpl *Template, locator string) bool {
 			// Other architectures were never supported for macOS guests
 		} else {
 			imageArch = limatype.NewArch(runtime.GOARCH)
-			logrus.Warnf("cannot determine image arch from URL %q; assuming %q", locator, imageArch)
+			logrus.Warnf("cannot determine image arch from URL %#q; assuming %#q", locator, imageArch)
 		}
 	}
 
@@ -331,7 +331,7 @@ func InstNameFromYAMLPath(yamlPath string) (string, error) {
 	// "." is allowed in instance names, but replaced to "-" for hostnames.
 	// e.g., yaml: "ubuntu-24.04.yaml" , instance name: "ubuntu-24.04", hostname: "lima-ubuntu-24-04"
 	if err := identifiers.Validate(s); err != nil {
-		return "", fmt.Errorf("filename %q is invalid: %w", yamlPath, err)
+		return "", fmt.Errorf("filename %#q is invalid: %w", yamlPath, err)
 	}
 	return s, nil
 }
@@ -348,7 +348,7 @@ func transformCustomURL(ctx context.Context, locator string) (string, error) {
 		}
 		// Fix malformed "template:" URLs.
 		newLocator := "template:" + path.Join(u.Host, u.Path)
-		logrus.Warnf("Template locator %q should be written %q since Lima v2.0", locator, newLocator)
+		logrus.Warnf("Template locator %#q should be written %#q since Lima v2.0", locator, newLocator)
 		return newLocator, nil
 	}
 
@@ -380,10 +380,10 @@ func transformCustomURL(ctx context.Context, locator string) (string, error) {
 		if errors.As(err, &exitErr) {
 			stderrMsg := string(exitErr.Stderr)
 			if stderrMsg != "" {
-				return "", fmt.Errorf("command %q failed: %s", cmd.String(), strings.TrimSpace(stderrMsg))
+				return "", fmt.Errorf("command %#q failed: %s", cmd.String(), strings.TrimSpace(stderrMsg))
 			}
 		}
-		return "", fmt.Errorf("command %q failed: %w", cmd.String(), err)
+		return "", fmt.Errorf("command %#q failed: %w", cmd.String(), err)
 	}
 	return strings.TrimSpace(string(stdout)), nil
 }
@@ -408,8 +408,8 @@ func TransformCustomURL(ctx context.Context, locator string) (string, error) {
 			}
 			return newLocator, nil
 		}
-		logrus.Debugf("Locator %q replaced with %q", locator, newLocator)
+		logrus.Debugf("Locator %#q replaced with %#q", locator, newLocator)
 		locator = newLocator
 	}
-	return "", fmt.Errorf("custom locator %q has a redirect loop", origLocator)
+	return "", fmt.Errorf("custom locator %#q has a redirect loop", origLocator)
 }

--- a/pkg/limatype/dirnames/dirnames.go
+++ b/pkg/limatype/dirnames/dirnames.go
@@ -36,7 +36,7 @@ func LimaDir() (string, error) {
 	}
 	realdir, err := filepath.EvalSymlinks(dir)
 	if err != nil {
-		return "", fmt.Errorf("cannot evaluate symlinks in %q: %w", dir, err)
+		return "", fmt.Errorf("cannot evaluate symlinks in %#q: %w", dir, err)
 	}
 	return realdir, nil
 }
@@ -95,11 +95,11 @@ func InstanceDir(name string) (string, error) {
 // be a valid identifier, and not end in .yml or .yaml (case insensitively).
 func ValidateInstName(name string) error {
 	if err := identifiers.Validate(name); err != nil {
-		return fmt.Errorf("instance name %q is not a valid identifier: %w", name, err)
+		return fmt.Errorf("instance name %#q is not a valid identifier: %w", name, err)
 	}
 	lower := strings.ToLower(name)
 	if strings.HasSuffix(lower, ".yml") || strings.HasSuffix(lower, ".yaml") {
-		return fmt.Errorf("instance name %q must not end with .yml or .yaml suffix", name)
+		return fmt.Errorf("instance name %#q must not end with .yml or .yaml suffix", name)
 	}
 	return nil
 }


### PR DESCRIPTION
Change %q in logs and errors to %#q and update the codes so that backticks are used everywhere in logs and errors. (all files in the following directories) .

- `pkg/guestagent`
- `pkg/guestpatch`
- `pkg/hostagent`
- `pkg/httpclientutil`
- `pkg/identifiers`
- `pkg/imgutil`
- `pkg/instance`
- `pkg/iso9660util`
- `pkg/limactlutil`
- `pkg/limainfo`
- `pkg/limatmpl`
- `pkg/limatype`

Related issue: #4898 
This PR is a continuation of the work from #4909 and #5017 .