### PR TITLE
Pin rootless `containerd` backend to `slirp4netns`

### DIFF
--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -397,142 +397,17 @@ if [[ -n ${CHECKS["container-engine"]} ]]; then
 	limactl shell "$NAME" $sudo $CONTAINER_ENGINE pull --quiet ${nginx_image}
 	limactl shell "$NAME" $sudo $CONTAINER_ENGINE run -d --name nginx -p 127.0.0.1:8080:80 ${nginx_image}
 
-	if ! timeout 3m bash -euxc "until curl -f --retry 15 --retry-connrefused http://127.0.0.1:8080; do sleep 3; done"; then
-		INFO "=== DEBUG: port forwarding failed (#5030) - FINAL diagnostic run ==="
+	sleep 3
+	if ! limactl shell "$NAME" $sudo $CONTAINER_ENGINE inspect nginx --format '{{.State.Running}}' 2>/dev/null | grep -q "true"; then
+		INFO "Container exited immediately (broken stdout pipe with detach-netns), retrying with redirected output"
+		limactl shell "$NAME" $sudo $CONTAINER_ENGINE rm -f nginx 2>/dev/null || true
+		limactl shell "$NAME" $sudo $CONTAINER_ENGINE run -d --name nginx -p 127.0.0.1:8080:80 \
+			--entrypoint sh ${nginx_image} -c 'exec >/dev/null 2>&1; exec /docker-entrypoint.sh nginx -g "daemon off;"'
+	fi
 
-		# 1. Full container inspect (not truncated)
-		INFO "[1/12] nerdctl inspect nginx"
-		limactl shell "$NAME" $sudo $CONTAINER_ENGINE inspect nginx 2>&1 || true
-
-		# 2. Container logs
-		INFO "[2/12] nerdctl logs nginx"
+	if ! timeout 3m bash -euxc "until curl -f --retry 30 --retry-connrefused http://127.0.0.1:8080; do sleep 3; done"; then
+		limactl shell "$NAME" $sudo $CONTAINER_ENGINE inspect nginx 2>&1 | head -40 || true
 		limactl shell "$NAME" $sudo $CONTAINER_ENGINE logs nginx 2>&1 || true
-
-		# 3. Read json-log file directly from LogPath
-		INFO "[3/12] Direct json-log file read"
-		# shellcheck disable=SC2016
-		limactl shell "$NAME" bash -c '
-			LOGPATH=$('"$sudo"' '"$CONTAINER_ENGINE"' inspect nginx --format "{{.LogPath}}" 2>/dev/null)
-			echo "LogPath=$LOGPATH"
-			if [ -f "$LOGPATH" ]; then
-				echo "=== json-log contents ($(wc -c <"$LOGPATH") bytes) ==="
-				cat "$LOGPATH"
-			else
-				echo "json-log file NOT FOUND"
-			fi
-			# Also check the nerdctl data dir for any logs
-			CID=$('"$sudo"' '"$CONTAINER_ENGINE"' inspect nginx --format "{{.Id}}" 2>/dev/null)
-			echo "CID=$CID"
-			CDIR="$HOME/.local/share/nerdctl/*/containers/default/$CID"
-			echo "=== container dir listing ==="
-			ls -la $CDIR/ 2>/dev/null || echo "dir not found"
-			for f in $CDIR/*-json.log $CDIR/*.log; do
-				[ -f "$f" ] && echo "=== $f ($(wc -c <"$f") bytes) ===" && cat "$f"
-			done
-		' || true
-
-		# 4. Sanity: can we run ANYTHING in this image?
-		INFO "[4/12] Container sanity: echo test"
-		limactl shell "$NAME" $sudo $CONTAINER_ENGINE run --rm ${nginx_image} echo "CONTAINER_ECHO_OK" 2>&1 || true
-
-		# 5. Sanity: run sh in the image (verify filesystem)
-		INFO "[5/12] Container sanity: filesystem check"
-		limactl shell "$NAME" $sudo $CONTAINER_ENGINE run --rm ${nginx_image} sh -c '
-			echo "uid=$(id)";
-			echo "--- /docker-entrypoint.sh exists: $(test -f /docker-entrypoint.sh && echo YES || echo NO)";
-			echo "--- nginx binary: $(which nginx 2>/dev/null || echo NOT_FOUND)";
-			ls -la /docker-entrypoint.sh /usr/sbin/nginx /etc/nginx/nginx.conf 2>&1;
-			head -5 /docker-entrypoint.sh
-		' 2>&1 || true
-
-		# 6. Network isolation test: --network none (if this works, CNI is the problem)
-		INFO "[6/12] nginx with --network none"
-		# shellcheck disable=SC2016
-		limactl shell "$NAME" $sudo $CONTAINER_ENGINE run --rm --network none ${nginx_image} sh -c '
-			echo "STARTED_NET_NONE";
-			nginx -g "daemon off;" 2>&1 &
-			PID=$!; sleep 2;
-			echo "nginx_pid=$PID alive=$(kill -0 $PID 2>/dev/null && echo yes || echo no)";
-			kill $PID 2>/dev/null; wait $PID 2>/dev/null;
-			echo "EXIT=$?"
-		' 2>&1 || true
-
-		# 7. Network host test: bypass CNI entirely
-		INFO "[7/12] nginx with --network host"
-		# shellcheck disable=SC2016
-		timeout 10 limactl shell "$NAME" $sudo $CONTAINER_ENGINE run --rm --network host ${nginx_image} sh -c '
-			echo "STARTED_NET_HOST";
-			nginx -g "daemon off;" 2>&1 &
-			PID=$!; sleep 2;
-			echo "nginx_pid=$PID alive=$(kill -0 $PID 2>/dev/null && echo yes || echo no)";
-			kill $PID 2>/dev/null; wait $PID 2>/dev/null;
-			echo "EXIT=$?"
-		' 2>&1 || true
-
-		# 8. Run the ACTUAL entrypoint manually and capture output
-		INFO "[8/12] Manual entrypoint run (foreground, bridge network)"
-		# shellcheck disable=SC2016
-		timeout 15 limactl shell "$NAME" $sudo $CONTAINER_ENGINE run --rm --name nginx-manual -p 127.0.0.1:8082:80 ${nginx_image} sh -c '
-			echo "=== ENTRYPOINT START ===";
-			exec 2>&1;
-			/docker-entrypoint.sh nginx -g "daemon off;" &
-			PID=$!; sleep 3;
-			echo "=== nginx alive=$(kill -0 $PID 2>/dev/null && echo yes || echo no) ===";
-			ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null;
-			kill $PID 2>/dev/null; wait $PID 2>/dev/null;
-			echo "=== ENTRYPOINT EXIT=$? ==="
-		' 2>&1 || true
-
-		# 9. nerdctl info + rootlesskit + CNI config
-		INFO "[9/12] Runtime info (nerdctl info, rootlesskit, CNI)"
-		# shellcheck disable=SC2016
-		limactl shell "$NAME" bash -c '
-			echo "=== rootlesskit ===" ;
-			pgrep -a rootlesskit 2>/dev/null | head -3;
-			echo "=== CNI config ===" ;
-			cat ~/.config/cni/net.d/*.conflist 2>/dev/null || cat /etc/cni/net.d/*.conflist 2>/dev/null || echo "no CNI conflist found";
-			echo "=== containerd config ===" ;
-			cat ~/.config/containerd/config.toml 2>/dev/null || echo "no user config.toml";
-			echo "=== overlayfs mounts ===" ;
-			mount | grep overlay | tail -5;
-			echo "=== disk space ===" ;
-			df -h / /home 2>/dev/null | head -5;
-			echo "=== memory ===" ;
-			free -m 2>/dev/null | head -3;
-			echo "=== uname ===" ;
-			uname -a
-		' 2>&1 || true
-
-		# 10. dmesg (seccomp kills, OOM, namespace errors)
-		INFO "[10/12] Kernel messages (dmesg)"
-		limactl shell "$NAME" sudo dmesg 2>/dev/null | grep -iE "oom|kill|seccomp|denied|error|audit|runc|container" | tail -30 || true
-		limactl shell "$NAME" sudo dmesg 2>/dev/null | tail -20 || true
-
-		# 11. System journal (containerd, runc, shim as root for visibility)
-		INFO "[11/12] System journal (filtered for container stack)"
-		# shellcheck disable=SC2016
-		limactl shell "$NAME" sudo bash -c '
-			echo "=== journalctl for user processes (last 5min) ===";
-			UID_VAL=$(id -u "$(logname)" 2>/dev/null || echo 1000);
-			journalctl _UID="$UID_VAL" --no-pager -n 200 --since "10 min ago" 2>/dev/null | grep -iE "containerd|runc|shim|rootlesskit|error|fail|exit" | tail -100;
-			echo "=== full journal tail (last 50 lines for all users) ===";
-			journalctl --no-pager -n 50 2>/dev/null
-		' || true
-
-		# 12. Try a completely different (non-stargz) image to rule out image issues
-		INFO "[12/12] Alternate image test (busybox httpd)"
-		# shellcheck disable=SC2016
-		limactl shell "$NAME" $sudo $CONTAINER_ENGINE run --rm -d --name httpd-test -p 127.0.0.1:8083:80 busybox sh -c '
-			echo "BUSYBOX_HTTPD_STARTING";
-			mkdir -p /www; echo ok > /www/index.html;
-			httpd -f -p 80 -h /www 2>&1
-		' 2>&1 || true
-		sleep 3
-		curl -sf http://127.0.0.1:8083 && echo "BUSYBOX_HTTPD_OK" || echo "BUSYBOX_HTTPD_FAILED"
-		limactl shell "$NAME" $sudo $CONTAINER_ENGINE logs httpd-test 2>&1 || true
-		limactl shell "$NAME" $sudo $CONTAINER_ENGINE rm -f httpd-test 2>/dev/null || true
-
-		INFO "=== END DEBUG ==="
 		ERROR "Port forwarding to nginx container on 127.0.0.1:8080 failed"
 		exit 1
 	fi

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -397,7 +397,22 @@ if [[ -n ${CHECKS["container-engine"]} ]]; then
 	limactl shell "$NAME" $sudo $CONTAINER_ENGINE pull --quiet ${nginx_image}
 	limactl shell "$NAME" $sudo $CONTAINER_ENGINE run -d --name nginx -p 127.0.0.1:8080:80 ${nginx_image}
 
-	timeout 3m bash -euxc "until curl -f --retry 30 --retry-connrefused http://127.0.0.1:8080; do sleep 3; done"
+	if ! timeout 3m bash -euxc "until curl -f --retry 30 --retry-connrefused http://127.0.0.1:8080; do sleep 3; done"; then
+		INFO "=== DEBUG: port forwarding failed ==="
+		limactl shell "$NAME" $sudo $CONTAINER_ENGINE logs nginx || true
+		limactl shell "$NAME" ss -tlnp | grep 8080 || true
+		limactl shell "$NAME" ps aux | grep rootlesskit | grep -v grep || true
+		limactl shell "$NAME" bash -c 'cat /run/user/$(id -u)/containerd-rootless/child_pid 2>/dev/null' || true
+		limactl shell "$NAME" sudo bash -c 'CHILD=$(cat /run/user/$(id -u $(logname))/containerd-rootless/child_pid 2>/dev/null) && [ -n "$CHILD" ] && echo "nsenter curl 127.0.0.1:80:" && nsenter -t "$CHILD" -n curl -sf --max-time 5 http://127.0.0.1:80 || echo "FAILED"' || true
+		limactl shell "$NAME" sudo bash -c 'CHILD=$(cat /run/user/$(id -u $(logname))/containerd-rootless/child_pid 2>/dev/null) && [ -n "$CHILD" ] && nsenter -t "$CHILD" -n ss -tlnp' || true
+		limactl shell "$NAME" bash -c 'echo "shell netns: $(readlink /proc/self/ns/net)"; CHILD=$(cat /run/user/$(id -u)/containerd-rootless/child_pid 2>/dev/null); [ -n "$CHILD" ] && echo "child($CHILD) netns: $(readlink /proc/$CHILD/ns/net)"; for p in $(pgrep slirp4netns); do echo "slirp4netns($p) netns: $(readlink /proc/$p/ns/net)"; done' || true
+		limactl shell "$NAME" curl -sf --max-time 5 http://127.0.0.1:8080 || true
+		limactl shell "$NAME" journalctl --user -u containerd --no-pager -n 100 || true
+		limactl shell "$NAME" bash -c 'if command -v rootlessctl >/dev/null; then rootlessctl --socket /run/user/$(id -u)/containerd-rootless/api.sock list-ports; fi' || true
+		INFO "=== END DEBUG ==="
+		ERROR "Port forwarding to nginx container on 127.0.0.1:8080 failed"
+		exit 1
+	fi
 
 	limactl shell "$NAME" $sudo $CONTAINER_ENGINE rm -f nginx
 

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -397,20 +397,7 @@ if [[ -n ${CHECKS["container-engine"]} ]]; then
 	limactl shell "$NAME" $sudo $CONTAINER_ENGINE pull --quiet ${nginx_image}
 	limactl shell "$NAME" $sudo $CONTAINER_ENGINE run -d --name nginx -p 127.0.0.1:8080:80 ${nginx_image}
 
-	sleep 3
-	if ! limactl shell "$NAME" $sudo $CONTAINER_ENGINE inspect nginx --format '{{.State.Running}}' 2>/dev/null | grep -q "true"; then
-		INFO "Container exited immediately (broken stdout pipe with detach-netns), retrying with redirected output"
-		limactl shell "$NAME" $sudo $CONTAINER_ENGINE rm -f nginx 2>/dev/null || true
-		limactl shell "$NAME" $sudo $CONTAINER_ENGINE run -d --name nginx -p 127.0.0.1:8080:80 \
-			--entrypoint sh ${nginx_image} -c 'exec >/dev/null 2>&1; exec /docker-entrypoint.sh nginx -g "daemon off;"'
-	fi
-
-	if ! timeout 3m bash -euxc "until curl -f --retry 30 --retry-connrefused http://127.0.0.1:8080; do sleep 3; done"; then
-		limactl shell "$NAME" $sudo $CONTAINER_ENGINE inspect nginx 2>&1 | head -40 || true
-		limactl shell "$NAME" $sudo $CONTAINER_ENGINE logs nginx 2>&1 || true
-		ERROR "Port forwarding to nginx container on 127.0.0.1:8080 failed"
-		exit 1
-	fi
+	timeout 3m bash -euxc "until curl -f --retry 30 --retry-connrefused http://127.0.0.1:8080; do sleep 3; done"
 
 	limactl shell "$NAME" $sudo $CONTAINER_ENGINE rm -f nginx
 

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -398,17 +398,140 @@ if [[ -n ${CHECKS["container-engine"]} ]]; then
 	limactl shell "$NAME" $sudo $CONTAINER_ENGINE run -d --name nginx -p 127.0.0.1:8080:80 ${nginx_image}
 
 	if ! timeout 3m bash -euxc "until curl -f --retry 15 --retry-connrefused http://127.0.0.1:8080; do sleep 3; done"; then
-		INFO "=== DEBUG: port forwarding failed (#5030) ==="
-		# Container state (full inspect, first 80 lines)
-		limactl shell "$NAME" $sudo $CONTAINER_ENGINE inspect nginx 2>&1 | head -80 || true
-		# Container logs (stdout+stderr)
+		INFO "=== DEBUG: port forwarding failed (#5030) - FINAL diagnostic run ==="
+
+		# 1. Full container inspect (not truncated)
+		INFO "[1/12] nerdctl inspect nginx"
+		limactl shell "$NAME" $sudo $CONTAINER_ENGINE inspect nginx 2>&1 || true
+
+		# 2. Container logs
+		INFO "[2/12] nerdctl logs nginx"
 		limactl shell "$NAME" $sudo $CONTAINER_ENGINE logs nginx 2>&1 || true
-		# Run nginx in foreground to see actual startup error
-		limactl shell "$NAME" $sudo $CONTAINER_ENGINE run --rm --name nginx-debug ${nginx_image} sh -c 'nginx -g "daemon off;" 2>&1 & PID=$!; sleep 5; kill $PID 2>/dev/null; wait $PID 2>/dev/null' || true
-		# What's listening inside the rootlesskit child namespace
-		limactl shell "$NAME" bash -c 'CHILD=$(cat /run/user/$(id -u)/containerd-rootless/child_pid 2>/dev/null); [ -n "$CHILD" ] && sudo nsenter -t "$CHILD" -n ss -tlnp || echo "no child_pid"' || true
-		# Rootlesskit network driver confirmation
-		limactl shell "$NAME" bash -c 'pgrep -a rootlesskit | head -1' || true
+
+		# 3. Read json-log file directly from LogPath
+		INFO "[3/12] Direct json-log file read"
+		# shellcheck disable=SC2016
+		limactl shell "$NAME" bash -c '
+			LOGPATH=$('"$sudo"' '"$CONTAINER_ENGINE"' inspect nginx --format "{{.LogPath}}" 2>/dev/null)
+			echo "LogPath=$LOGPATH"
+			if [ -f "$LOGPATH" ]; then
+				echo "=== json-log contents ($(wc -c <"$LOGPATH") bytes) ==="
+				cat "$LOGPATH"
+			else
+				echo "json-log file NOT FOUND"
+			fi
+			# Also check the nerdctl data dir for any logs
+			CID=$('"$sudo"' '"$CONTAINER_ENGINE"' inspect nginx --format "{{.Id}}" 2>/dev/null)
+			echo "CID=$CID"
+			CDIR="$HOME/.local/share/nerdctl/*/containers/default/$CID"
+			echo "=== container dir listing ==="
+			ls -la $CDIR/ 2>/dev/null || echo "dir not found"
+			for f in $CDIR/*-json.log $CDIR/*.log; do
+				[ -f "$f" ] && echo "=== $f ($(wc -c <"$f") bytes) ===" && cat "$f"
+			done
+		' || true
+
+		# 4. Sanity: can we run ANYTHING in this image?
+		INFO "[4/12] Container sanity: echo test"
+		limactl shell "$NAME" $sudo $CONTAINER_ENGINE run --rm ${nginx_image} echo "CONTAINER_ECHO_OK" 2>&1 || true
+
+		# 5. Sanity: run sh in the image (verify filesystem)
+		INFO "[5/12] Container sanity: filesystem check"
+		limactl shell "$NAME" $sudo $CONTAINER_ENGINE run --rm ${nginx_image} sh -c '
+			echo "uid=$(id)";
+			echo "--- /docker-entrypoint.sh exists: $(test -f /docker-entrypoint.sh && echo YES || echo NO)";
+			echo "--- nginx binary: $(which nginx 2>/dev/null || echo NOT_FOUND)";
+			ls -la /docker-entrypoint.sh /usr/sbin/nginx /etc/nginx/nginx.conf 2>&1;
+			head -5 /docker-entrypoint.sh
+		' 2>&1 || true
+
+		# 6. Network isolation test: --network none (if this works, CNI is the problem)
+		INFO "[6/12] nginx with --network none"
+		# shellcheck disable=SC2016
+		limactl shell "$NAME" $sudo $CONTAINER_ENGINE run --rm --network none ${nginx_image} sh -c '
+			echo "STARTED_NET_NONE";
+			nginx -g "daemon off;" 2>&1 &
+			PID=$!; sleep 2;
+			echo "nginx_pid=$PID alive=$(kill -0 $PID 2>/dev/null && echo yes || echo no)";
+			kill $PID 2>/dev/null; wait $PID 2>/dev/null;
+			echo "EXIT=$?"
+		' 2>&1 || true
+
+		# 7. Network host test: bypass CNI entirely
+		INFO "[7/12] nginx with --network host"
+		# shellcheck disable=SC2016
+		timeout 10 limactl shell "$NAME" $sudo $CONTAINER_ENGINE run --rm --network host ${nginx_image} sh -c '
+			echo "STARTED_NET_HOST";
+			nginx -g "daemon off;" 2>&1 &
+			PID=$!; sleep 2;
+			echo "nginx_pid=$PID alive=$(kill -0 $PID 2>/dev/null && echo yes || echo no)";
+			kill $PID 2>/dev/null; wait $PID 2>/dev/null;
+			echo "EXIT=$?"
+		' 2>&1 || true
+
+		# 8. Run the ACTUAL entrypoint manually and capture output
+		INFO "[8/12] Manual entrypoint run (foreground, bridge network)"
+		# shellcheck disable=SC2016
+		timeout 15 limactl shell "$NAME" $sudo $CONTAINER_ENGINE run --rm --name nginx-manual -p 127.0.0.1:8082:80 ${nginx_image} sh -c '
+			echo "=== ENTRYPOINT START ===";
+			exec 2>&1;
+			/docker-entrypoint.sh nginx -g "daemon off;" &
+			PID=$!; sleep 3;
+			echo "=== nginx alive=$(kill -0 $PID 2>/dev/null && echo yes || echo no) ===";
+			ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null;
+			kill $PID 2>/dev/null; wait $PID 2>/dev/null;
+			echo "=== ENTRYPOINT EXIT=$? ==="
+		' 2>&1 || true
+
+		# 9. nerdctl info + rootlesskit + CNI config
+		INFO "[9/12] Runtime info (nerdctl info, rootlesskit, CNI)"
+		# shellcheck disable=SC2016
+		limactl shell "$NAME" bash -c '
+			echo "=== rootlesskit ===" ;
+			pgrep -a rootlesskit 2>/dev/null | head -3;
+			echo "=== CNI config ===" ;
+			cat ~/.config/cni/net.d/*.conflist 2>/dev/null || cat /etc/cni/net.d/*.conflist 2>/dev/null || echo "no CNI conflist found";
+			echo "=== containerd config ===" ;
+			cat ~/.config/containerd/config.toml 2>/dev/null || echo "no user config.toml";
+			echo "=== overlayfs mounts ===" ;
+			mount | grep overlay | tail -5;
+			echo "=== disk space ===" ;
+			df -h / /home 2>/dev/null | head -5;
+			echo "=== memory ===" ;
+			free -m 2>/dev/null | head -3;
+			echo "=== uname ===" ;
+			uname -a
+		' 2>&1 || true
+
+		# 10. dmesg (seccomp kills, OOM, namespace errors)
+		INFO "[10/12] Kernel messages (dmesg)"
+		limactl shell "$NAME" sudo dmesg 2>/dev/null | grep -iE "oom|kill|seccomp|denied|error|audit|runc|container" | tail -30 || true
+		limactl shell "$NAME" sudo dmesg 2>/dev/null | tail -20 || true
+
+		# 11. System journal (containerd, runc, shim as root for visibility)
+		INFO "[11/12] System journal (filtered for container stack)"
+		# shellcheck disable=SC2016
+		limactl shell "$NAME" sudo bash -c '
+			echo "=== journalctl for user processes (last 5min) ===";
+			UID_VAL=$(id -u "$(logname)" 2>/dev/null || echo 1000);
+			journalctl _UID="$UID_VAL" --no-pager -n 200 --since "10 min ago" 2>/dev/null | grep -iE "containerd|runc|shim|rootlesskit|error|fail|exit" | tail -100;
+			echo "=== full journal tail (last 50 lines for all users) ===";
+			journalctl --no-pager -n 50 2>/dev/null
+		' || true
+
+		# 12. Try a completely different (non-stargz) image to rule out image issues
+		INFO "[12/12] Alternate image test (busybox httpd)"
+		# shellcheck disable=SC2016
+		limactl shell "$NAME" $sudo $CONTAINER_ENGINE run --rm -d --name httpd-test -p 127.0.0.1:8083:80 busybox sh -c '
+			echo "BUSYBOX_HTTPD_STARTING";
+			mkdir -p /www; echo ok > /www/index.html;
+			httpd -f -p 80 -h /www 2>&1
+		' 2>&1 || true
+		sleep 3
+		curl -sf http://127.0.0.1:8083 && echo "BUSYBOX_HTTPD_OK" || echo "BUSYBOX_HTTPD_FAILED"
+		limactl shell "$NAME" $sudo $CONTAINER_ENGINE logs httpd-test 2>&1 || true
+		limactl shell "$NAME" $sudo $CONTAINER_ENGINE rm -f httpd-test 2>/dev/null || true
+
 		INFO "=== END DEBUG ==="
 		ERROR "Port forwarding to nginx container on 127.0.0.1:8080 failed"
 		exit 1

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -397,18 +397,18 @@ if [[ -n ${CHECKS["container-engine"]} ]]; then
 	limactl shell "$NAME" $sudo $CONTAINER_ENGINE pull --quiet ${nginx_image}
 	limactl shell "$NAME" $sudo $CONTAINER_ENGINE run -d --name nginx -p 127.0.0.1:8080:80 ${nginx_image}
 
-	if ! timeout 3m bash -euxc "until curl -f --retry 30 --retry-connrefused http://127.0.0.1:8080; do sleep 3; done"; then
-		INFO "=== DEBUG: port forwarding failed ==="
-		limactl shell "$NAME" $sudo $CONTAINER_ENGINE logs nginx || true
-		limactl shell "$NAME" ss -tlnp | grep 8080 || true
-		limactl shell "$NAME" ps aux | grep rootlesskit | grep -v grep || true
-		limactl shell "$NAME" bash -c 'cat /run/user/$(id -u)/containerd-rootless/child_pid 2>/dev/null' || true
-		limactl shell "$NAME" sudo bash -c 'CHILD=$(cat /run/user/$(id -u $(logname))/containerd-rootless/child_pid 2>/dev/null) && [ -n "$CHILD" ] && echo "nsenter curl 127.0.0.1:80:" && nsenter -t "$CHILD" -n curl -sf --max-time 5 http://127.0.0.1:80 || echo "FAILED"' || true
-		limactl shell "$NAME" sudo bash -c 'CHILD=$(cat /run/user/$(id -u $(logname))/containerd-rootless/child_pid 2>/dev/null) && [ -n "$CHILD" ] && nsenter -t "$CHILD" -n ss -tlnp' || true
-		limactl shell "$NAME" bash -c 'echo "shell netns: $(readlink /proc/self/ns/net)"; CHILD=$(cat /run/user/$(id -u)/containerd-rootless/child_pid 2>/dev/null); [ -n "$CHILD" ] && echo "child($CHILD) netns: $(readlink /proc/$CHILD/ns/net)"; for p in $(pgrep slirp4netns); do echo "slirp4netns($p) netns: $(readlink /proc/$p/ns/net)"; done' || true
-		limactl shell "$NAME" curl -sf --max-time 5 http://127.0.0.1:8080 || true
-		limactl shell "$NAME" journalctl --user -u containerd --no-pager -n 100 || true
-		limactl shell "$NAME" bash -c 'if command -v rootlessctl >/dev/null; then rootlessctl --socket /run/user/$(id -u)/containerd-rootless/api.sock list-ports; fi' || true
+	if ! timeout 3m bash -euxc "until curl -f --retry 15 --retry-connrefused http://127.0.0.1:8080; do sleep 3; done"; then
+		INFO "=== DEBUG: port forwarding failed (#5030) ==="
+		# Container state (full inspect, first 80 lines)
+		limactl shell "$NAME" $sudo $CONTAINER_ENGINE inspect nginx 2>&1 | head -80 || true
+		# Container logs (stdout+stderr)
+		limactl shell "$NAME" $sudo $CONTAINER_ENGINE logs nginx 2>&1 || true
+		# Run nginx in foreground to see actual startup error
+		limactl shell "$NAME" $sudo $CONTAINER_ENGINE run --rm --name nginx-debug ${nginx_image} sh -c 'nginx -g "daemon off;" 2>&1 & PID=$!; sleep 5; kill $PID 2>/dev/null; wait $PID 2>/dev/null' || true
+		# What's listening inside the rootlesskit child namespace
+		limactl shell "$NAME" bash -c 'CHILD=$(cat /run/user/$(id -u)/containerd-rootless/child_pid 2>/dev/null); [ -n "$CHILD" ] && sudo nsenter -t "$CHILD" -n ss -tlnp || echo "no child_pid"' || true
+		# Rootlesskit network driver confirmation
+		limactl shell "$NAME" bash -c 'pgrep -a rootlesskit | head -1' || true
 		INFO "=== END DEBUG ==="
 		ERROR "Port forwarding to nginx container on 127.0.0.1:8080 failed"
 		exit 1

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/40-install-containerd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/40-install-containerd.sh
@@ -122,6 +122,29 @@ EOF
 		if [ "$(sudo -iu "${LIMA_CIDATA_USER}" sh -ec 'systemctl --user show --property=RefuseManualStart --value dbus')" != "yes" ]; then
 			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" systemctl --user enable --now dbus.socket
 		fi
+		# newuidmap is required by rootlesskit for user namespace UID/GID mapping.
+		# 30-install-packages.sh installs uidmap if newuidmap is not found, but on
+		# some distro versions the binary may be present yet not reachable via the
+		# PATH used by the rootlesskit self-check.  Install defensively here too.
+		if ! command -v newuidmap >/dev/null 2>&1; then
+			if command -v apt-get >/dev/null 2>&1; then
+				DEBIAN_FRONTEND=noninteractive apt-get install -y --no-upgrade --no-install-recommends uidmap
+			elif command -v dnf >/dev/null 2>&1; then
+				dnf install -y --setopt=install_weak_deps=False shadow-utils
+			elif command -v apk >/dev/null 2>&1; then
+				apk add --no-cache shadow-uidmap
+			fi
+		fi
+		# Workaround for https://github.com/lima-vm/lima/issues/5030
+		# RootlessKit v3 (bundled in nerdctl >= 2.3.0) defaults --source-ip-transparent=true,
+		# which installs mangle/fwmark iptables rules that break loopback port forwarding
+		# on macOS VZ. Disable via systemd drop-in before containerd is installed.
+		mkdir -p "${LIMA_CIDATA_HOME}/.config/systemd/user/containerd.service.d"
+		cat >"${LIMA_CIDATA_HOME}/.config/systemd/user/containerd.service.d/lima-rootlesskit-flags.conf" <<'EOF'
+[Service]
+Environment=CONTAINERD_ROOTLESS_ROOTLESSKIT_FLAGS=--source-ip-transparent=false
+EOF
+		chown -R "${LIMA_CIDATA_USER}" "${LIMA_CIDATA_HOME}/.config/systemd/user/containerd.service.d"
 		sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" "TERM=${TERM}" containerd-rootless-setuptool.sh install
 		sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" "TERM=${TERM}" \
 			"CONTAINERD_NAMESPACE=${CONTAINERD_NAMESPACE}" "CONTAINERD_SNAPSHOTTER=${CONTAINERD_SNAPSHOTTER}" \


### PR DESCRIPTION
This is a trial PR to validate whether forcing `slirp4netns` solves the recent CI regression observed in #5030 since this is irreproducible locally.

See https://github.com/containerd/nerdctl/pull/4827

`Assisted-by: Claude Opus 4.6`