### PR TITLE
fix(darwin): pin main goroutine to OS thread 0 for VZ GUI

### DIFF
--- a/cmd/limactl/main_darwin_gui.go
+++ b/cmd/limactl/main_darwin_gui.go
@@ -1,0 +1,16 @@
+//go:build darwin
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "runtime"
+
+func init() {
+	// Lock the main goroutine to the initial process thread before main() runs.
+	// VZVirtualMachineView requires GUI operations on the initial thread; without
+	// this, Go's scheduler may migrate the goroutine before hostagent starts.
+	// Assumes no other package init() triggers a scheduling point before this runs.
+	runtime.LockOSThread()
+}


### PR DESCRIPTION
VZVirtualMachineView requires GUI operations to run on the process main
thread. limactl already calls runtime.LockOSThread() in hostagentAction,
but that runs too late: by the time cobra dispatches the hostagent
subcommand, Go's scheduler has already migrated the main goroutine to a
worker thread. On macOS 26 this causes a SIGTRAP when the VZ driver calls
startVirtualMachineWindow.

Adding runtime.LockOSThread() to an init() function ensures the main
goroutine is pinned to thread 0 before main() runs. The build tag
restricts the file to darwin; Linux and Windows are unaffected.

Tested on macOS 26.5 (25F71), Apple Silicon, with Lima 2.1.2-beta.0:
fresh macOS 26 guest install from IPSW and start of an existing macOS 26
VM with video.display: default both complete without SIGTRAP.

Assisted-by: Commercial LLM tooling

Fixes #4743