### PR TITLE
portfwd: fix gRPC tunnel connection leak

### DIFF
--- a/pkg/portfwd/client.go
+++ b/pkg/portfwd/client.go
@@ -5,6 +5,7 @@ package portfwd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"sync/atomic"
@@ -51,17 +52,20 @@ func DialContextToGRPCTunnel(client *guestagentclient.GuestAgentClient) func(ctx
 	var connectionCounter atomic.Uint32
 	return func(_ context.Context, network, addr string) (net.Conn, error) {
 		// Passed context.Context is used for timeout on initiate connection, not for the lifetime of the connection.
-		// We use context.Background() here to avoid unexpected cancellation.
-		stream, err := client.Tunnel(context.Background())
+		// Use a dedicated context so CloseRead can unblock a goroutine waiting in stream.Recv().
+		streamCtx, cancel := context.WithCancel(context.Background())
+		stream, err := client.Tunnel(streamCtx)
 		if err != nil {
+			cancel()
 			return nil, fmt.Errorf("could not open tunnel for addr: %s error:%w", addr, err)
 		}
 		// Handshake message to start tunnel
 		id := fmt.Sprintf("%s-%s-%d", network, addr, connectionCounter.Add(1))
 		if err := stream.Send(&api.TunnelMessage{Id: id, Protocol: network, GuestAddr: addr}); err != nil {
+			cancel()
 			return nil, fmt.Errorf("could not start tunnel for id: %s addr: %s error:%w", id, addr, err)
 		}
-		rw := &GrpcClientRW{stream: stream, id: id, addr: addr, protocol: network}
+		rw := &GrpcClientRW{stream: stream, cancel: cancel, id: id, addr: addr, protocol: network}
 		return rw, nil
 	}
 }
@@ -72,6 +76,7 @@ type GrpcClientRW struct {
 
 	protocol string
 	stream   api.GuestService_TunnelClient
+	cancel   context.CancelFunc
 }
 
 var _ net.Conn = (*GrpcClientRW)(nil)
@@ -100,7 +105,24 @@ func (g *GrpcClientRW) Read(p []byte) (n int, err error) {
 
 func (g *GrpcClientRW) Close() error {
 	logrus.Debugf("closing GrpcClientRW for id: %s", g.id)
-	return g.stream.CloseSend()
+	err := g.stream.CloseSend()
+	g.cancel()
+	return err
+}
+
+func (g *GrpcClientRW) CloseRead() error {
+	logrus.Debugf("closing read GrpcClientRW for id: %s", g.id)
+	g.cancel()
+	return nil
+}
+
+func (g *GrpcClientRW) CloseWrite() error {
+	logrus.Debugf("closing write GrpcClientRW for id: %s", g.id)
+	err := g.stream.CloseSend()
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
 }
 
 func (g *GrpcClientRW) LocalAddr() net.Addr {

--- a/pkg/portfwd/client_test.go
+++ b/pkg/portfwd/client_test.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package portfwd
+
+import (
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/guestagent/api"
+	guestagentclient "github.com/lima-vm/lima/v2/pkg/guestagent/api/client"
+)
+
+func TestDialContextToGRPCTunnelClosesStreamFromTCPProxy(t *testing.T) {
+	tunnelDone := make(chan error, 1)
+	client := newTestGuestAgentClient(t, &testGuestService{tunnelDone: tunnelDone})
+	defer client.Close()
+
+	clientConn, proxyConn := net.Pipe()
+	proxyDone := make(chan struct{})
+	go func() {
+		HandleTCPConnection(t.Context(), DialContextToGRPCTunnel(client), proxyConn, "127.0.0.1:80")
+		close(proxyDone)
+	}()
+
+	assert.NilError(t, clientConn.Close())
+
+	select {
+	case err := <-tunnelDone:
+		assert.NilError(t, err)
+	case <-time.After(time.Second):
+		assert.Assert(t, false, "timed out waiting for the tunnel stream to close")
+	}
+
+	select {
+	case <-proxyDone:
+	case <-time.After(time.Second):
+		assert.Assert(t, false, "timed out waiting for TCP proxy handling to finish")
+	}
+}
+
+func newTestGuestAgentClient(t *testing.T, guestService api.GuestServiceServer) *guestagentclient.GuestAgentClient {
+	t.Helper()
+
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer(grpc.Creds(guestagentclient.NewCredentials()))
+	api.RegisterGuestServiceServer(server, guestService)
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+	})
+
+	client, err := guestagentclient.NewGuestAgentClient(listener.DialContext)
+	assert.NilError(t, err)
+	return client
+}
+
+type testGuestService struct {
+	api.UnimplementedGuestServiceServer
+
+	tunnelDone chan<- error
+}
+
+func (s *testGuestService) Tunnel(stream api.GuestService_TunnelServer) error {
+	if _, err := stream.Recv(); err != nil {
+		s.tunnelDone <- err
+		return err
+	}
+	for {
+		_, err := stream.Recv()
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, io.EOF) {
+			s.tunnelDone <- nil
+			return nil
+		}
+		s.tunnelDone <- err
+		return err
+	}
+}


### PR DESCRIPTION
### Description

This PR fixes a file descriptor leak in the gRPC port forwarder.

`GrpcClientRW` is used as the remote side of the proxied connection. The proxy implementation relies on half-close semantics and calls [CloseRead]() / `CloseWrite` when one copy direction finishes.

Before this change, `GrpcClientRW` only implemented `Close()`. Because of that, the gRPC tunnel write side was not closed when the host-side TCP client closed the connection. The reverse copy direction could remain blocked in `Recv()`, keeping the accepted host-side TCP socket in `CLOSE_WAIT`.

After enough short-lived forwarded connections, these leaked streams reached the gRPC `MaxConcurrentStreams` limit and port forwarding stopped working.

This change implements half-close handling for `GrpcClientRW`, so the gRPC stream is closed at the point where the proxy expects it to be closed and the TCP connection can be released.

Closes #5042.

### Testing

Reproduced the issue with nginx inside a Lima VM:

```bash
limactl start test
```

Inside the VM:

```bash
sudo apt-get update
sudo apt-get install -y nginx

sudo sed -i 's/listen 80 default_server;/listen 18000 default_server;/' /etc/nginx/sites-available/default
sudo sed -i 's/listen \[::\]:80 default_server;/listen [::]:18000 default_server;/' /etc/nginx/sites-available/default

sudo nginx -t
sudo systemctl restart nginx
```

On the host:

```bash
while true ; do curl http://127.0.0.1:18000; done
```

In another host terminal:

```bash
watch -n 0.1 'lsof -i :18000 | wc -l'
```

Before this change, the number of open FDs kept growing until forwarding stopped around `2048` connections.

After this change, the FD count stays stable and forwarding continues to work.