### PR TITLE
fix: reject parent directory template locators

### DIFF
--- a/pkg/limatmpl/abs.go
+++ b/pkg/limatmpl/abs.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/lima-vm/lima/v2/pkg/localpathutil"
@@ -126,7 +127,7 @@ func absPath(locator, basePath string) (string, error) {
 			return "", errors.New("basePath is empty")
 		case basePath == "-":
 			return "", errors.New("can't use relative paths when reading template from STDIN")
-		case strings.Contains(locator, "../"):
+		case containsParentDir(locator):
 			return "", fmt.Errorf("relative locator path %q must not contain '../' segments", locator)
 		case volumeLen != 0:
 			return "", fmt.Errorf("relative locator path %q must not include a volume name", locator)
@@ -145,4 +146,10 @@ func absPath(locator, basePath string) (string, error) {
 		locator = filepath.Join(basePath, locator)
 	}
 	return withVolume(locator)
+}
+
+func containsParentDir(locator string) bool {
+	return slices.Contains(strings.FieldsFunc(locator, func(r rune) bool {
+		return r == '/' || (runtime.GOOS == "windows" && r == '\\')
+	}), "..")
 }

--- a/pkg/limatmpl/abs_test.go
+++ b/pkg/limatmpl/abs_test.go
@@ -249,6 +249,11 @@ func TestAbsPath(t *testing.T) {
 		assert.ErrorContains(t, err, "'../'")
 	})
 
+	t.Run("Relative parent directory locator must be underneath the basePath", func(t *testing.T) {
+		_, err = absPath("..", volume+"/root")
+		assert.ErrorContains(t, err, "'../'")
+	})
+
 	t.Run("locator must not be empty", func(t *testing.T) {
 		_, err = absPath("", "foo")
 		assert.ErrorContains(t, err, "locator is empty")


### PR DESCRIPTION
It fixes tiny edge case

`base: ..` slipped past the parent-dir check because it only looked for `../`. That lets `limactl template copy` absolutize it to the parent of the template dir.

Repro on main:
```bash
tmpdir=$(mktemp -d)
printf "base: ..\n" > "$tmpdir/template.yaml"
limactl template copy "$tmpdir/template.yaml" -
```

This prints a parent path instead of rejecting it. now it errors, same vibe as `../base.yaml`.

Tests:
```bash
go test ./...
```