### PR TITLE
pkg/downloader: logging nit

### DIFF
--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -558,7 +558,7 @@ func decompressLocal(ctx context.Context, decompressCmd, dst, src, ext, descript
 		if description == "" {
 			description = filepath.Base(src)
 		}
-		logrus.Infof("Decompressing %s\n", description)
+		logrus.Infof("Decompressing %s", description)
 	}
 	bar.Start()
 	err = cmd.Run()


### PR DESCRIPTION
When commit 9ed9bbc1 changed fmt.Printf to logrus.Infof, it forgot to remove "\n" from the message. This is not shown with the default test log format, but it is visible in json output, e.g.:

> {"level":"info","msg":"Decompressing data\n","time":"2026-05-27T01:39:52-07:00"}

Remove "\n".