### PR TITLE
vz: reconnect socket_vmnet on bridge failure

### DIFF
--- a/pkg/driver/vz/network_darwin.go
+++ b/pkg/driver/vz/network_darwin.go
@@ -42,181 +42,268 @@ func PassFDToUnix(unixSock string) (*os.File, error) {
 	return client, nil
 }
 
-func dialQemuConn(ctx context.Context, unixSock string) (*qemuPacketConn, error) {
-	var dialer net.Dialer
-	conn, err := dialer.DialContext(ctx, "unix", unixSock)
-	if err != nil {
-		return nil, err
-	}
-	return &qemuPacketConn{Conn: conn}, nil
-}
-
 // DialQemu support connecting to QEMU supported network stack via unix socket.
 // Returns os.File, connected dgram connection to be used for vz.
 func DialQemu(ctx context.Context, unixSock string) (*os.File, error) {
-	qemuConn, err := dialQemuConn(ctx, unixSock)
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(ctx, "unix", unixSock)
 	if err != nil {
 		return nil, err
 	}
 
 	server, client, err := createSockPair()
 	if err != nil {
+		conn.Close()
 		return nil, err
 	}
 	dgramConn, err := net.FileConn(server)
 	if err != nil {
+		conn.Close()
 		return nil, err
 	}
 	vzConn := &packetConn{Conn: dgramConn}
 
-	go forwardPackets(ctx, unixSock, qemuConn, vzConn)
+	fwdCtx, fwdCancel := context.WithCancel(ctx)
+	qemuConn := newQemuPacketConn(fwdCtx, unixSock, conn)
+
+	go forwardPackets(fwdCancel, qemuConn, vzConn)
 
 	return client, nil
 }
 
-// forwardPackets relays packets between vzConn and qemuConn, reconnecting the
-// qemuConn (socket_vmnet) side on failure. vzConn is bound to
-// Virtualization.framework at VM creation and cannot be replaced; only qemuConn
-// is re-dialed on reconnect.
-func forwardPackets(ctx context.Context, unixSock string, qemuConn *qemuPacketConn, vzConn *packetConn) {
-	defer vzConn.Close()
+// forwardPackets relays packets between vzConn and qemuConn. Reconnection of
+// the qemuConn side is handled internally by qemuPacketConn; this function
+// just runs io.Copy in both directions until a fatal error occurs.
+func forwardPackets(cancel context.CancelFunc, qemuConn *qemuPacketConn, vzConn *packetConn) {
+	done := make(chan struct{}, 2)
 
+	go func() {
+		io.Copy(qemuConn, vzConn)
+		done <- struct{}{}
+	}()
+
+	go func() {
+		io.Copy(vzConn, qemuConn)
+		done <- struct{}{}
+	}()
+
+	<-done
+	if !qemuConn.done() {
+		logrus.Error("VZ network socket error, packet forwarding stopped permanently")
+	}
+	cancel()
+	vzConn.Close()
+	qemuConn.Close()
+	<-done
+}
+
+// qemuPacketConn relays length-prefixed Ethernet frames over a unix stream
+// socket to socket_vmnet, reconnecting automatically on connection failure.
+type qemuPacketConn struct {
+	mu        sync.Mutex
+	cond      *sync.Cond
+	conn      net.Conn
+	gen       uint64
+	reconnect chan uint64
+	ctx       context.Context
+	sock      string
+}
+
+func newQemuPacketConn(ctx context.Context, sock string, conn net.Conn) *qemuPacketConn {
+	c := &qemuPacketConn{
+		conn:      conn,
+		reconnect: make(chan uint64, 1),
+		ctx:       ctx,
+		sock:      sock,
+	}
+	c.cond = sync.NewCond(&c.mu)
+	go c.reconnectLoop()
+	go func() {
+		<-ctx.Done()
+		c.cond.Broadcast()
+	}()
+	return c
+}
+
+// getConn returns the current connection and its generation. Blocks while a
+// reconnect is in progress. Returns ok=false on shutdown.
+func (c *qemuPacketConn) getConn() (conn net.Conn, gen uint64, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for c.conn == nil {
+		if c.ctx.Err() != nil {
+			return nil, c.gen, false
+		}
+		c.cond.Wait()
+	}
+	return c.conn, c.gen, true
+}
+
+// waitReconnect signals the reconnect goroutine and blocks until a new
+// connection is available. Returns false on shutdown.
+func (c *qemuPacketConn) waitReconnect(gen uint64) bool {
+	select {
+	case c.reconnect <- gen:
+	default:
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for c.gen == gen {
+		if c.ctx.Err() != nil {
+			return false
+		}
+		c.cond.Wait()
+	}
+	return c.conn != nil
+}
+
+func (c *qemuPacketConn) reconnectLoop() {
 	const (
 		initialBackoff = 100 * time.Millisecond
 		maxBackoff     = 2 * time.Second
 	)
 
 	for {
-		fatal := forwardUntilError(qemuConn, vzConn)
-		if fatal {
-			logrus.Error("VZ network socket error, packet forwarding stopped permanently")
+		select {
+		case <-c.ctx.Done():
+			c.shutdown()
 			return
-		}
-
-		logrus.Warn("VMNET connection lost, reconnecting")
-
-		backoff := initialBackoff
-		for {
-			if ctx.Err() != nil {
-				return
-			}
-
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(backoff):
-			}
-
-			var err error
-			qemuConn, err = dialQemuConn(ctx, unixSock)
-			if err != nil {
-				logrus.WithError(err).Debug("Failed to reconnect to VMNET")
-				backoff *= 2
-				if backoff > maxBackoff {
-					backoff = maxBackoff
-				}
+		case failedGen := <-c.reconnect:
+			c.mu.Lock()
+			if c.gen != failedGen {
+				c.mu.Unlock()
 				continue
 			}
+			old := c.conn
+			c.conn = nil
+			c.mu.Unlock()
 
-			logrus.Info("VMNET connection re-established, resuming packet forwarding")
-			break
-		}
-	}
-}
+			if old != nil {
+				old.Close()
+			}
 
-// forwardUntilError forwards packets between qemuConn and vzConn until an error
-// occurs. Returns true if the error is fatal (vzConn failure), false if
-// recoverable (qemuConn failure). Always closes qemuConn before returning.
-// The goroutine blocked on vzConn.Read may not unblock until the guest sends
-// its next packet (ARP, NDP, DHCP — typically within seconds).
-func forwardUntilError(qemuConn *qemuPacketConn, vzConn *packetConn) bool {
-	errCh := make(chan bool, 2)
+			logrus.Warn("VMNET connection lost, reconnecting")
 
-	var wg sync.WaitGroup
-	wg.Add(2)
+			var dialer net.Dialer
+			backoff := initialBackoff
+			for {
+				select {
+				case <-c.ctx.Done():
+					c.shutdown()
+					return
+				case <-time.After(backoff):
+				}
 
-	// VZ → VMNET: reads vzConn, writes qemuConn
-	go func() {
-		defer wg.Done()
-		readErr, _ := copyPackets(qemuConn, vzConn)
-		errCh <- readErr // readErr=true → vzConn read failed (fatal)
-	}()
+				conn, err := dialer.DialContext(c.ctx, "unix", c.sock)
+				if err != nil {
+					logrus.WithError(err).Debug("Failed to reconnect to VMNET")
+					backoff *= 2
+					if backoff > maxBackoff {
+						backoff = maxBackoff
+					}
+					continue
+				}
 
-	// VMNET → VZ: reads qemuConn, writes vzConn
-	go func() {
-		defer wg.Done()
-		readErr, _ := copyPackets(vzConn, qemuConn)
-		errCh <- !readErr // !readErr → vzConn write failed (fatal)
-	}()
+				if c.ctx.Err() != nil {
+					conn.Close()
+					c.shutdown()
+					return
+				}
 
-	first := <-errCh
-	qemuConn.Close()
-	wg.Wait()
-	second := <-errCh
+				c.mu.Lock()
+				c.conn = conn
+				c.gen++
+				c.cond.Broadcast()
+				c.mu.Unlock()
 
-	return first || second
-}
-
-// maxPacketSize is the maximum Ethernet frame (1514) plus 4-byte QEMU length
-// prefix. Used for relay buffers and as a sanity check on incoming frames.
-const maxPacketSize = 1518
-
-// copyPackets is like io.Copy but reports whether the error was a read error
-// (true) or write error (false), so the caller can distinguish fatal (vzConn)
-// from recoverable (qemuConn) failures.
-func copyPackets(dst io.Writer, src io.Reader) (readErr bool, err error) {
-	buf := make([]byte, maxPacketSize)
-	for {
-		nr, er := src.Read(buf)
-		if nr > 0 {
-			if _, ew := dst.Write(buf[:nr]); ew != nil {
-				return false, ew
+				logrus.Info("VMNET connection re-established")
+				break
 			}
 		}
-		if er != nil {
-			return true, er
+	}
+}
+
+func (c *qemuPacketConn) done() bool {
+	return c.ctx.Err() != nil
+}
+
+func (c *qemuPacketConn) shutdown() {
+	c.mu.Lock()
+	if c.conn != nil {
+		c.conn.Close()
+	}
+	c.conn = nil
+	c.gen++
+	c.cond.Broadcast()
+	c.mu.Unlock()
+}
+
+func (c *qemuPacketConn) Read(b []byte) (int, error) {
+	for {
+		conn, gen, ok := c.getConn()
+		if !ok {
+			return 0, c.ctx.Err()
+		}
+		n, err := readPacket(conn, b)
+		if err == nil {
+			return n, nil
+		}
+		if !c.waitReconnect(gen) {
+			return 0, err
 		}
 	}
 }
 
-// qemuPacketConn converts raw network packet to a QEMU supported network packet.
-type qemuPacketConn struct {
-	net.Conn
+func (c *qemuPacketConn) Write(b []byte) (int, error) {
+	for {
+		conn, gen, ok := c.getConn()
+		if !ok {
+			return 0, c.ctx.Err()
+		}
+		err := writePacket(conn, b)
+		if err == nil {
+			return len(b), nil
+		}
+		if !c.waitReconnect(gen) {
+			return 0, err
+		}
+	}
 }
 
-// Read reads a QEMU packet and returns the contained raw packet.  Returns (len,
-// nil) if a packet was read, and (0, err) on error. Errors means the protocol
-// is broken and the socket must be closed.
-func (c *qemuPacketConn) Read(b []byte) (n int, err error) {
+func (c *qemuPacketConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.conn != nil {
+		err := c.conn.Close()
+		c.conn = nil
+		return err
+	}
+	return nil
+}
+
+func readPacket(conn net.Conn, b []byte) (int, error) {
 	var size uint32
-	if err := binary.Read(c.Conn, binary.BigEndian, &size); err != nil {
-		// Likely connection closed by peer.
+	if err := binary.Read(conn, binary.BigEndian, &size); err != nil {
 		return 0, err
 	}
 	if size > uint32(len(b)) {
 		return 0, fmt.Errorf("packet size %d exceeds buffer %d", size, len(b))
 	}
-	return io.ReadFull(c.Conn, b[:size])
+	return io.ReadFull(conn, b[:size])
 }
 
-// Write writes a QEMU packet containing the raw packet. Returns (len(b), nil)
-// if a packet was written, and (0, err) if a packet was not fully written.
-// Errors means the protocol is broken and the socket must be closed.
-func (c *qemuPacketConn) Write(b []byte) (int, error) {
-	size := len(b)
-	header := uint32(size)
-	if err := binary.Write(c.Conn, binary.BigEndian, header); err != nil {
-		return 0, err
+func writePacket(conn net.Conn, b []byte) error {
+	if err := binary.Write(conn, binary.BigEndian, uint32(len(b))); err != nil {
+		return err
 	}
-
 	for len(b) != 0 {
-		n, err := c.Conn.Write(b)
+		n, err := conn.Write(b)
 		if err != nil {
-			return 0, err
+			return err
 		}
 		b = b[n:]
 	}
-	return size, nil
+	return nil
 }
 
 // Testing show that retries are very rare (e.g 24 of 62,499,008 packets) and

--- a/pkg/driver/vz/network_darwin.go
+++ b/pkg/driver/vz/network_darwin.go
@@ -9,8 +9,8 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
-	"math"
 	"net"
 	"os"
 	"sync"
@@ -75,21 +75,15 @@ func DialQemu(ctx context.Context, unixSock string) (*os.File, error) {
 }
 
 // forwardPackets relays packets between vzConn and qemuConn, reconnecting the
-// qemuConn (socket_vmnet) side on failure. vzConn is the local end of a DGRAM
-// socketpair whose other end is bound to Virtualization.framework at VM creation
-// and cannot be changed. Only qemuConn is replaced on reconnect.
-//
-// During reconnect, packets from the guest buffer in the socketpair kernel buffer
-// (4MB). If the buffer fills, the guest gets ENOBUFS (packet drops), which is
-// normal for a brief network interruption and recovered by TCP retransmit / ARP
-// retry. Packets from the network side are lost while disconnected.
+// qemuConn (socket_vmnet) side on failure. vzConn is bound to
+// Virtualization.framework at VM creation and cannot be replaced; only qemuConn
+// is re-dialed on reconnect.
 func forwardPackets(ctx context.Context, unixSock string, qemuConn *qemuPacketConn, vzConn *packetConn) {
 	defer vzConn.Close()
 
 	const (
 		initialBackoff = 100 * time.Millisecond
-		maxBackoff     = 30 * time.Second
-		backoffFactor  = 2.0
+		maxBackoff     = 2 * time.Second
 	)
 
 	for {
@@ -99,15 +93,13 @@ func forwardPackets(ctx context.Context, unixSock string, qemuConn *qemuPacketCo
 			return
 		}
 
+		logrus.Warn("VMNET connection lost, reconnecting")
+
 		backoff := initialBackoff
 		for {
-			select {
-			case <-ctx.Done():
+			if ctx.Err() != nil {
 				return
-			default:
 			}
-
-			logrus.Warnf("VMNET connection lost, reconnecting in %v", backoff)
 
 			select {
 			case <-ctx.Done():
@@ -118,8 +110,11 @@ func forwardPackets(ctx context.Context, unixSock string, qemuConn *qemuPacketCo
 			var err error
 			qemuConn, err = dialQemuConn(ctx, unixSock)
 			if err != nil {
-				logrus.WithError(err).Warn("Failed to reconnect to VMNET")
-				backoff = time.Duration(math.Min(float64(backoff)*backoffFactor, float64(maxBackoff)))
+				logrus.WithError(err).Debug("Failed to reconnect to VMNET")
+				backoff *= 2
+				if backoff > maxBackoff {
+					backoff = maxBackoff
+				}
 				continue
 			}
 
@@ -132,16 +127,8 @@ func forwardPackets(ctx context.Context, unixSock string, qemuConn *qemuPacketCo
 // forwardUntilError forwards packets between qemuConn and vzConn until an error
 // occurs. Returns true if the error is fatal (vzConn failure), false if
 // recoverable (qemuConn failure). Always closes qemuConn before returning.
-//
-// Teardown: closing qemuConn forces the goroutine blocked on qemuConn I/O to
-// exit immediately. The goroutine blocked on vzConn.Read may not unblock until
-// the guest sends its next packet, since vzConn must stay open for reuse across
-// reconnects. In practice guests generate periodic traffic (ARP, NDP, DHCP)
-// within seconds. An interruptible copy or read-deadline approach was considered
-// but rejected: SetReadDeadline on the DGRAM vzConn would need to be armed and
-// disarmed on every reconnect cycle and risks false-positive timeouts during
-// normal forwarding. Waiting for the next guest packet is simpler and adds no
-// overhead to the normal forwarding path.
+// The goroutine blocked on vzConn.Read may not unblock until the guest sends
+// its next packet (ARP, NDP, DHCP — typically within seconds).
 func forwardUntilError(qemuConn *qemuPacketConn, vzConn *packetConn) bool {
 	errCh := make(chan bool, 2)
 
@@ -170,15 +157,15 @@ func forwardUntilError(qemuConn *qemuPacketConn, vzConn *packetConn) bool {
 	return first || second
 }
 
-// copyPackets copies packets from src to dst, returning whether the error was a
-// read error (true) or write error (false). This is used instead of io.Copy
-// because io.Copy does not distinguish read errors from write errors, and the
-// reconnect logic needs that distinction: a qemuConn (socket_vmnet) error is
-// recoverable via reconnect, while a vzConn (VZ socketpair) error is fatal.
-// The copy loop is the same read-buf-write-buf loop io.Copy uses (neither
-// qemuPacketConn nor packetConn implements ReaderFrom/WriterTo).
+// maxPacketSize is the maximum Ethernet frame (1514) plus 4-byte QEMU length
+// prefix. Used for relay buffers and as a sanity check on incoming frames.
+const maxPacketSize = 1518
+
+// copyPackets is like io.Copy but reports whether the error was a read error
+// (true) or write error (false), so the caller can distinguish fatal (vzConn)
+// from recoverable (qemuConn) failures.
 func copyPackets(dst io.Writer, src io.Reader) (readErr bool, err error) {
-	buf := make([]byte, 32*1024)
+	buf := make([]byte, maxPacketSize)
 	for {
 		nr, er := src.Read(buf)
 		if nr > 0 {
@@ -205,6 +192,9 @@ func (c *qemuPacketConn) Read(b []byte) (n int, err error) {
 	if err := binary.Read(c.Conn, binary.BigEndian, &size); err != nil {
 		// Likely connection closed by peer.
 		return 0, err
+	}
+	if size > uint32(len(b)) {
+		return 0, fmt.Errorf("packet size %d exceeds buffer %d", size, len(b))
 	}
 	return io.ReadFull(c.Conn, b[:size])
 }

--- a/pkg/driver/vz/network_darwin.go
+++ b/pkg/driver/vz/network_darwin.go
@@ -78,12 +78,12 @@ func forwardPackets(cancel context.CancelFunc, qemuConn *qemuPacketConn, vzConn 
 	done := make(chan struct{}, 2)
 
 	go func() {
-		io.Copy(qemuConn, vzConn)
+		_, _ = io.Copy(qemuConn, vzConn)
 		done <- struct{}{}
 	}()
 
 	go func() {
-		io.Copy(vzConn, qemuConn)
+		_, _ = io.Copy(vzConn, qemuConn)
 		done <- struct{}{}
 	}()
 

--- a/pkg/driver/vz/network_darwin.go
+++ b/pkg/driver/vz/network_darwin.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"math"
 	"net"
 	"os"
 	"sync"
@@ -41,15 +42,22 @@ func PassFDToUnix(unixSock string) (*os.File, error) {
 	return client, nil
 }
 
-// DialQemu support connecting to QEMU supported network stack via unix socket.
-// Returns os.File, connected dgram connection to be used for vz.
-func DialQemu(ctx context.Context, unixSock string) (*os.File, error) {
+func dialQemuConn(ctx context.Context, unixSock string) (*qemuPacketConn, error) {
 	var dialer net.Dialer
-	unixConn, err := dialer.DialContext(ctx, "unix", unixSock)
+	conn, err := dialer.DialContext(ctx, "unix", unixSock)
 	if err != nil {
 		return nil, err
 	}
-	qemuConn := &qemuPacketConn{Conn: unixConn}
+	return &qemuPacketConn{Conn: conn}, nil
+}
+
+// DialQemu support connecting to QEMU supported network stack via unix socket.
+// Returns os.File, connected dgram connection to be used for vz.
+func DialQemu(ctx context.Context, unixSock string) (*os.File, error) {
+	qemuConn, err := dialQemuConn(ctx, unixSock)
+	if err != nil {
+		return nil, err
+	}
 
 	server, client, err := createSockPair()
 	if err != nil {
@@ -61,33 +69,127 @@ func DialQemu(ctx context.Context, unixSock string) (*os.File, error) {
 	}
 	vzConn := &packetConn{Conn: dgramConn}
 
-	go forwardPackets(qemuConn, vzConn)
+	go forwardPackets(ctx, unixSock, qemuConn, vzConn)
 
 	return client, nil
 }
 
-func forwardPackets(qemuConn *qemuPacketConn, vzConn *packetConn) {
-	defer qemuConn.Close()
+// forwardPackets relays packets between vzConn and qemuConn, reconnecting the
+// qemuConn (socket_vmnet) side on failure. vzConn is the local end of a DGRAM
+// socketpair whose other end is bound to Virtualization.framework at VM creation
+// and cannot be changed. Only qemuConn is replaced on reconnect.
+//
+// During reconnect, packets from the guest buffer in the socketpair kernel buffer
+// (4MB). If the buffer fills, the guest gets ENOBUFS (packet drops), which is
+// normal for a brief network interruption and recovered by TCP retransmit / ARP
+// retry. Packets from the network side are lost while disconnected.
+func forwardPackets(ctx context.Context, unixSock string, qemuConn *qemuPacketConn, vzConn *packetConn) {
 	defer vzConn.Close()
+
+	const (
+		initialBackoff = 100 * time.Millisecond
+		maxBackoff     = 30 * time.Second
+		backoffFactor  = 2.0
+	)
+
+	for {
+		fatal := forwardUntilError(qemuConn, vzConn)
+		if fatal {
+			logrus.Error("VZ network socket error, packet forwarding stopped permanently")
+			return
+		}
+
+		backoff := initialBackoff
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			logrus.Warnf("VMNET connection lost, reconnecting in %v", backoff)
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+
+			var err error
+			qemuConn, err = dialQemuConn(ctx, unixSock)
+			if err != nil {
+				logrus.WithError(err).Warn("Failed to reconnect to VMNET")
+				backoff = time.Duration(math.Min(float64(backoff)*backoffFactor, float64(maxBackoff)))
+				continue
+			}
+
+			logrus.Info("VMNET connection re-established, resuming packet forwarding")
+			break
+		}
+	}
+}
+
+// forwardUntilError forwards packets between qemuConn and vzConn until an error
+// occurs. Returns true if the error is fatal (vzConn failure), false if
+// recoverable (qemuConn failure). Always closes qemuConn before returning.
+//
+// Teardown: closing qemuConn forces the goroutine blocked on qemuConn I/O to
+// exit immediately. The goroutine blocked on vzConn.Read may not unblock until
+// the guest sends its next packet, since vzConn must stay open for reuse across
+// reconnects. In practice guests generate periodic traffic (ARP, NDP, DHCP)
+// within seconds. An interruptible copy or read-deadline approach was considered
+// but rejected: SetReadDeadline on the DGRAM vzConn would need to be armed and
+// disarmed on every reconnect cycle and risks false-positive timeouts during
+// normal forwarding. Waiting for the next guest packet is simpler and adds no
+// overhead to the normal forwarding path.
+func forwardUntilError(qemuConn *qemuPacketConn, vzConn *packetConn) bool {
+	errCh := make(chan bool, 2)
 
 	var wg sync.WaitGroup
 	wg.Add(2)
 
+	// VZ → VMNET: reads vzConn, writes qemuConn
 	go func() {
 		defer wg.Done()
-		if _, err := io.Copy(qemuConn, vzConn); err != nil {
-			logrus.Errorf("Failed to forward packets from VZ to VMNET: %s", err)
-		}
+		readErr, _ := copyPackets(qemuConn, vzConn)
+		errCh <- readErr // readErr=true → vzConn read failed (fatal)
 	}()
 
+	// VMNET → VZ: reads qemuConn, writes vzConn
 	go func() {
 		defer wg.Done()
-		if _, err := io.Copy(vzConn, qemuConn); err != nil {
-			logrus.Errorf("Failed to forward packets from VMNET to VZ: %s", err)
-		}
+		readErr, _ := copyPackets(vzConn, qemuConn)
+		errCh <- !readErr // !readErr → vzConn write failed (fatal)
 	}()
 
+	first := <-errCh
+	qemuConn.Close()
 	wg.Wait()
+	second := <-errCh
+
+	return first || second
+}
+
+// copyPackets copies packets from src to dst, returning whether the error was a
+// read error (true) or write error (false). This is used instead of io.Copy
+// because io.Copy does not distinguish read errors from write errors, and the
+// reconnect logic needs that distinction: a qemuConn (socket_vmnet) error is
+// recoverable via reconnect, while a vzConn (VZ socketpair) error is fatal.
+// The copy loop is the same read-buf-write-buf loop io.Copy uses (neither
+// qemuPacketConn nor packetConn implements ReaderFrom/WriterTo).
+func copyPackets(dst io.Writer, src io.Reader) (readErr bool, err error) {
+	buf := make([]byte, 32*1024)
+	for {
+		nr, er := src.Read(buf)
+		if nr > 0 {
+			if _, ew := dst.Write(buf[:nr]); ew != nil {
+				return false, ew
+			}
+		}
+		if er != nil {
+			return true, er
+		}
+	}
 }
 
 // qemuPacketConn converts raw network packet to a QEMU supported network packet.

--- a/pkg/driver/vz/network_darwin_test.go
+++ b/pkg/driver/vz/network_darwin_test.go
@@ -8,7 +8,6 @@ package vz
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"net"
 	"path/filepath"
 	"testing"
@@ -38,9 +37,11 @@ func TestDialQemu(t *testing.T) {
 	}()
 
 	// Connect to the fake vmnet server.
-	client, err := DialQemu(t.Context(), listener.Addr().String())
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	client, err := DialQemu(ctx, listener.Addr().String())
 	assert.NilError(t, err)
-	t.Log("Connected to fake vment server")
+	t.Log("Connected to fake vmnet server")
 
 	dgramConn, err := net.FileConn(client)
 	assert.NilError(t, err)
@@ -66,20 +67,11 @@ func TestDialQemu(t *testing.T) {
 			}
 		}
 		t.Logf("Sent %d data packets", packetsCount)
-
-		// quit packet format:
-		//     0-4:     "quit"
-		copy(buf[:4], "quit")
-		if _, err := vzConn.Write(buf[:4]); err != nil {
-			errc <- err
-			return
-		}
-
 		errc <- nil
 		t.Log("Sender finished")
 	}()
 
-	// Read and verify packets to the server.
+	// Read and verify echoed packets.
 
 	buf := make([]byte, vmnetMaxPacketSize)
 
@@ -98,9 +90,12 @@ func TestDialQemu(t *testing.T) {
 	}
 	t.Logf("Received and verified %d data packets", packetsCount)
 
+	// Cancel forwarding context before the server closes, so the
+	// reconnect goroutine doesn't fire on the server's close.
+	cancel()
+
 	for range 2 {
-		err := <-errc
-		assert.NilError(t, err)
+		<-errc
 	}
 }
 
@@ -158,12 +153,6 @@ func TestForwardPacketsReconnect(t *testing.T) {
 		server2Done <- serveOneClient(listener)
 	}()
 
-	// Dummy packet to unblock the VZ→VMNET goroutine blocked on vzConn.Read.
-	dummy := make([]byte, 4)
-	binary.BigEndian.PutUint32(dummy, 0xFFFFFFFF)
-	_, err = vzClient.Write(dummy)
-	assert.NilError(t, err)
-
 	// Wait for reconnect (100ms backoff + dial).
 	time.Sleep(300 * time.Millisecond)
 
@@ -173,37 +162,33 @@ func TestForwardPacketsReconnect(t *testing.T) {
 	}
 	t.Log("Second connection: 10 packets verified after reconnect")
 
+	// Stop forwarding before the second server closes.
+	cancel()
+
 	// Clean up second server.
-	_, err = vzClient.Write(quit)
-	assert.NilError(t, err)
-	assert.NilError(t, <-server2Done)
+	<-server2Done
 }
 
-// serveOneClient accepts one client and echo back received packets until a
+// serveOneClient accepts one client and echoes back received packets until a
 // "quit" packet is sent.
 func serveOneClient(listener *net.UnixListener) error {
 	conn, err := listener.Accept()
 	if err != nil {
 		return err
 	}
-	qemuConn := qemuPacketConn{Conn: conn}
-	defer qemuConn.Close()
+	defer conn.Close()
 
 	buf := make([]byte, vmnetMaxPacketSize)
 	for {
-		nr, err := qemuConn.Read(buf)
+		nr, err := readPacket(conn, buf)
 		if err != nil {
 			return err
 		}
 		if string(buf[:4]) == "quit" {
 			return nil
 		}
-		nw, err := qemuConn.Write(buf[:nr])
-		if err != nil {
+		if err := writePacket(conn, buf[:nr]); err != nil {
 			return err
-		}
-		if nw != nr {
-			return fmt.Errorf("incomplete write: expected: %d, wrote: %d", nr, nw)
 		}
 	}
 }

--- a/pkg/driver/vz/network_darwin_test.go
+++ b/pkg/driver/vz/network_darwin_test.go
@@ -6,11 +6,13 @@
 package vz
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"net"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 )
@@ -100,6 +102,83 @@ func TestDialQemu(t *testing.T) {
 		err := <-errc
 		assert.NilError(t, err)
 	}
+}
+
+func TestForwardPacketsReconnect(t *testing.T) {
+	listener, err := listenUnix(t.TempDir())
+	assert.NilError(t, err)
+	defer listener.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// Start first fake vmnet server.
+	server1Done := make(chan error, 1)
+	go func() {
+		server1Done <- serveOneClient(listener)
+	}()
+
+	client, err := DialQemu(ctx, listener.Addr().String())
+	assert.NilError(t, err)
+
+	dgramConn, err := net.FileConn(client)
+	assert.NilError(t, err)
+	vzClient := packetConn{Conn: dgramConn}
+	defer vzClient.Close()
+
+	sendRecv := func(seq uint32) {
+		t.Helper()
+		buf := make([]byte, vmnetMaxPacketSize)
+		binary.BigEndian.PutUint32(buf, seq)
+		_, err := vzClient.Write(buf)
+		assert.NilError(t, err)
+		n, err := vzClient.Read(buf)
+		assert.NilError(t, err)
+		assert.Assert(t, n >= 4)
+		assert.Equal(t, binary.BigEndian.Uint32(buf[:4]), seq)
+	}
+
+	// Verify packets through first connection.
+	for i := range 10 {
+		sendRecv(uint32(i))
+	}
+	t.Log("First connection: 10 packets verified")
+
+	// Tell first server to quit, closing its connection.
+	quit := make([]byte, 4)
+	copy(quit, "quit")
+	_, err = vzClient.Write(quit)
+	assert.NilError(t, err)
+	assert.NilError(t, <-server1Done)
+	t.Log("First server closed")
+
+	// Start second fake vmnet server for the reconnect.
+	server2Done := make(chan error, 1)
+	go func() {
+		server2Done <- serveOneClient(listener)
+	}()
+
+	// Send a sacrificial packet to unblock the VZ→VMNET goroutine that may
+	// be blocked reading from vzConn. This packet will be lost during the
+	// reconnect window — expected behavior.
+	sacrificial := make([]byte, 4)
+	binary.BigEndian.PutUint32(sacrificial, 0xFFFFFFFF)
+	_, err = vzClient.Write(sacrificial)
+	assert.NilError(t, err)
+
+	// Wait for reconnect (100ms backoff + dial).
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify packets through second connection.
+	for i := 10; i < 20; i++ {
+		sendRecv(uint32(i))
+	}
+	t.Log("Second connection: 10 packets verified after reconnect")
+
+	// Clean up second server.
+	_, err = vzClient.Write(quit)
+	assert.NilError(t, err)
+	assert.NilError(t, <-server2Done)
 }
 
 // serveOneClient accepts one client and echo back received packets until a

--- a/pkg/driver/vz/network_darwin_test.go
+++ b/pkg/driver/vz/network_darwin_test.go
@@ -158,12 +158,10 @@ func TestForwardPacketsReconnect(t *testing.T) {
 		server2Done <- serveOneClient(listener)
 	}()
 
-	// Send a sacrificial packet to unblock the VZ→VMNET goroutine that may
-	// be blocked reading from vzConn. This packet will be lost during the
-	// reconnect window — expected behavior.
-	sacrificial := make([]byte, 4)
-	binary.BigEndian.PutUint32(sacrificial, 0xFFFFFFFF)
-	_, err = vzClient.Write(sacrificial)
+	// Dummy packet to unblock the VZ→VMNET goroutine blocked on vzConn.Read.
+	dummy := make([]byte, 4)
+	binary.BigEndian.PutUint32(dummy, 0xFFFFFFFF)
+	_, err = vzClient.Write(dummy)
 	assert.NilError(t, err)
 
 	// Wait for reconnect (100ms backoff + dial).


### PR DESCRIPTION
## Summary

- Add reconnect logic to VZ network forwarding for socket_vmnet connection failures
- On error, the socket_vmnet connection is re-established with exponential backoff (100ms–30s) while keeping the VZ DGRAM socketpair alive
- Replaces `io.Copy` with `copyPackets()` that distinguishes read vs write errors for fatal/recoverable classification

## Motivation

When the socket_vmnet daemon restarts or the UNIX socket connection breaks, `forwardPackets()` exits permanently and VM networking is dead until a full VM restart. The VZ-side socketpair (bound to `VZFileHandleNetworkDeviceAttachment` at VM creation) cannot be replaced, but the socket_vmnet connection is stateless and can be re-dialed.

Fixes #3020

## Performance

Tested on macOS 26 (Apple M1, VZ backend, 1GbE NIC). 3-run averages for each variant:

| | Baseline (2.1.1) | Patched (32K buf) | Patched (64K buf) |
|---|---|---|---|
| Throughput (VM → LAN host) | 944 Mbits/sec | 944 Mbits/sec | 944 Mbits/sec |
| Throughput (VM → macOS host, loopback) | 2.16 Gbits/sec | 2.18 Gbits/sec | 2.15 Gbits/sec |
| limactl CPU during iperf3 (VM → LAN) | ~40% | ~41% | ~42% |
| limactl CPU during iperf3 (loopback) | ~145% | ~145% | ~140% |
| Ping latency (100 pings) | 0.67ms | 0.86ms | 0.98ms |

No measurable throughput or CPU impact. Buffer size (32K matching io.Copy vs 64K) makes no difference on DGRAM sockets where each read returns one packet.

## Reconnect behavior

Tested by killing socket_vmnet (SIGKILL) and immediately restarting:

- Lima detects connection loss within one packet relay cycle
- Exponential backoff: 100ms → 200ms → 400ms → ... → 30s max
- socket_vmnet handles stale socket files on restart (no manual cleanup needed)
- With immediate daemon restart: **zero packet loss**, reconnect in <100ms
- With delayed restart: packets buffer in socketpair kernel buffer (4MB), full recovery when daemon returns
- Docker containers and k3s agent survive the outage

### Goroutine teardown tradeoff

Closing the socket_vmnet connection unblocks the goroutine doing socket_vmnet I/O immediately. The goroutine blocked on `vzConn.Read()` waits until the guest sends its next packet (ARP, NDP, DHCP — typically within seconds). `SetReadDeadline` was considered but rejected: arming/disarming deadlines on the DGRAM socket across reconnect cycles adds complexity and risks false-positive timeouts during normal forwarding.

## Test plan

- [x] Unit tests pass (`TestDialQemu`, `TestForwardPacketsReconnect`)
- [x] `TestForwardPacketsReconnect`: kills fake server, verifies reconnect to new server, packets resume
- [x] No regression in normal operation (ping, iperf3, docker, k3s)
- [x] Throughput benchmarked before/after (iperf3, 3 runs averaged, 3 variants)
- [x] Reconnect tested: SIGKILL socket_vmnet + immediate restart (2 runs, 0% packet loss)
- [x] Reconnect tested: SIGKILL socket_vmnet + delayed restart (backoff to 30s, full recovery)
- [x] Docker containers survive outage
- [x] k3s agent survives outage
- [ ] Soak testing on production host