### PR TITLE
refactor: enable usestdlibvars linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
   - unconvert
   - unused
   - usetesting
+  - usestdlibvars
   - whitespace
   settings:
     depguard:
@@ -133,6 +134,10 @@ linters:
       - -ST1000
       - -ST1001  # duplicates revive.dot-imports
       - -ST1022
+    usestdlibvars:
+      http-method: false
+      time-date-month: true
+      time-layout: true
     usetesting:
       os-temp-dir: true
       context-background: true

--- a/cmd/limactl/watch.go
+++ b/cmd/limactl/watch.go
@@ -238,11 +238,11 @@ func isInstanceDir(path string) bool {
 }
 
 func printStatus(out io.Writer, msg string) {
-	fmt.Fprintf(out, "%s %s\n", time.Now().Format("2006-01-02 15:04:05"), msg)
+	fmt.Fprintf(out, "%s %s\n", time.Now().Format(time.DateTime), msg)
 }
 
 func printHumanReadableEvent(out io.Writer, instName string, ev events.Event) {
-	timestamp := ev.Time.Format("2006-01-02 15:04:05")
+	timestamp := ev.Time.Format(time.DateTime)
 
 	printEvent := func(msg string) {
 		fmt.Fprintf(out, "%s %s | %s\n", timestamp, instName, msg)

--- a/pkg/plist/plist_test.go
+++ b/pkg/plist/plist_test.go
@@ -73,7 +73,7 @@ func TestUnmarshalPlist(t *testing.T) {
 								" intKey with\n\t\t\tspaces": {Integer: ptr.Of(int64(43))},
 								"intKeyZero":                 {Integer: ptr.Of(int64(0))},
 								"dataKey":                    {Data: []byte("hello")},
-								"dateKey":                    {Date: ptr.Of(time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC))},
+								"dateKey":                    {Date: ptr.Of(time.Date(2020, time.January, 2, 3, 4, 5, 0, time.UTC))},
 								"trueKey":                    {Boolean: ptr.Of(true)},
 								"falseKey":                   {Boolean: ptr.Of(false)},
 								"realKey":                    {Real: ptr.Of(3.14)},


### PR DESCRIPTION
https://golangci-lint.run/docs/linters/configuration/#usestdlibvars