### PR TITLE
fix: disable user containerd by default for non-Linux guests

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -528,10 +528,9 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 		y.Containerd.User = o.Containerd.User
 	}
 	if y.Containerd.User == nil {
-		switch *y.Arch {
-		case limatype.X8664, limatype.AARCH64:
+		if *y.OS == limatype.LINUX && (*y.Arch == limatype.X8664 || *y.Arch == limatype.AARCH64) {
 			y.Containerd.User = ptr.Of(true)
-		default:
+		} else {
 			y.Containerd.User = ptr.Of(false)
 		}
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -726,6 +726,35 @@ func TestContainerdDefault(t *testing.T) {
 	assert.Assert(t, len(archives) > 0)
 }
 
+func TestContainerdUserDefaultDependsOnGuestOS(t *testing.T) {
+	tests := []struct {
+		name string
+		os   limatype.OS
+		arch limatype.Arch
+		want bool
+	}{
+		{name: "linux x86_64", os: limatype.LINUX, arch: limatype.X8664, want: true},
+		{name: "linux aarch64", os: limatype.LINUX, arch: limatype.AARCH64, want: true},
+		{name: "linux riscv64", os: limatype.LINUX, arch: limatype.RISCV64, want: false},
+		{name: "darwin x86_64", os: limatype.DARWIN, arch: limatype.X8664, want: false},
+		{name: "darwin aarch64", os: limatype.DARWIN, arch: limatype.AARCH64, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			y := limatype.LimaYAML{
+				OS:   ptr.Of(tt.os),
+				Arch: ptr.Of(tt.arch),
+			}
+
+			FillDefault(t.Context(), &y, &limatype.LimaYAML{}, &limatype.LimaYAML{}, "", false)
+
+			assert.Assert(t, y.Containerd.User != nil)
+			assert.Equal(t, *y.Containerd.User, tt.want)
+		})
+	}
+}
+
 func TestStaticPortForwarding(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
﻿Fixes #5037.

`containerd.user` was defaulted from the guest architecture only, so macOS guests on `x86_64` or `aarch64` enabled user containerd and pulled the nerdctl archive even though containerd/nerdctl are Linux guest functionality.

This keeps the existing default for Linux guests on `x86_64` and `aarch64`, but defaults `containerd.user` to `false` for non-Linux guests.

I also added a small table test for the defaulting behavior across Linux and Darwin guests.

Local check:

- `git diff --check`

I could not run `go test` locally because this Windows environment does not have the Go toolchain installed.
