### PR TITLE
cidata: skip set-name for slirp NIC to fix ubuntu-26.04 first-boot delay

### DIFF
--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -229,7 +229,7 @@ if [[ -n ${CHECKS["proxy-settings"]} ]]; then
 	got=$(limactl shell "$NAME" env | grep FTP_PROXY)
 	# Expected: FTP_PROXY is set in addition to ftp_proxy, localhost is replaced
 	# by the gateway address, and the value is set immediately without a restart
-	gatewayIp=$(limactl shell "$NAME" ip route show 0.0.0.0/0 dev eth0 | cut -d\  -f3)
+	gatewayIp=$(limactl shell "$NAME" ip route show 0.0.0.0/0 | awk '{print $3; exit}')
 	expected="FTP_PROXY=http://${gatewayIp}:2121"
 	INFO "FTP_PROXY: expected=${expected} got=${got}"
 	if [ "$got" != "$expected" ]; then

--- a/pkg/cidata/cidata.TEMPLATE.d/network-config
+++ b/pkg/cidata/cidata.TEMPLATE.d/network-config
@@ -5,9 +5,6 @@ ethernets:
     match:
       macaddress: '{{$nw.MACAddress}}'
     dhcp4: true
-    {{- if eq $nw.Interface $.SlirpNICName }}
-    optional: true
-    {{- end }}
     set-name: {{$nw.Interface}}
     dhcp4-overrides:
       route-metric: {{$nw.Metric}}

--- a/pkg/cidata/cidata.TEMPLATE.d/network-config
+++ b/pkg/cidata/cidata.TEMPLATE.d/network-config
@@ -5,6 +5,9 @@ ethernets:
     match:
       macaddress: '{{$nw.MACAddress}}'
     dhcp4: true
+    {{- if eq $nw.Interface $.SlirpNICName }}
+    optional: true
+    {{- end }}
     set-name: {{$nw.Interface}}
     dhcp4-overrides:
       route-metric: {{$nw.Metric}}


### PR DESCRIPTION
## What This PR Changes

Skips `set-name` for Lima's built-in slirp NIC in the `network-config` cloud-init template. Also removes a hardcoded `eth0` interface name from the proxy-settings check in `hack/test-templates.sh`.

## Linked Issue

Closes #4792

## How I Tested This

Verified the template renders correctly (unit tests pass). End-to-end boot test on a fresh `template:ubuntu-26.04` instance is required to confirm the 2-minute delay is gone — I don't have an environment to run that locally