### PR TITLE
fix: append %r to ControlPath to prevent SSH session reuse across users

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -327,9 +327,8 @@ func removeOptsFromSSHArgs(sshArgs []string, removeOpts ...string) []string {
 
 // IsControlMasterExisting returns true if the control socket file exists.
 func IsControlMasterExisting(instDir string) bool {
-	controlSock := filepath.Join(instDir, filenames.SSHSock)
-	_, err := os.Stat(controlSock)
-	return err == nil
+	matches, err := filepath.Glob(filepath.Join(instDir, filenames.SSHSock) + "*")
+	return err == nil && len(matches) > 0
 }
 
 // SSHOpts adds the following options to CommonOptions: User, ControlMaster, ControlPath, ControlPersist.
@@ -342,13 +341,13 @@ func SSHOpts(ctx context.Context, sshExe SSHExe, instDir, username string, useDo
 	if err != nil {
 		return nil, err
 	}
-	controlPath := fmt.Sprintf(`ControlPath="%s"`, controlSock)
+	controlPath := fmt.Sprintf(`ControlPath="%s.%%r"`, controlSock)
 	if runtime.GOOS == "windows" {
 		controlSock, err = ioutilx.WindowsSubsystemPath(ctx, controlSock)
 		if err != nil {
 			return nil, err
 		}
-		controlPath = fmt.Sprintf(`ControlPath='%s'`, controlSock)
+		controlPath = fmt.Sprintf(`ControlPath='%s.%%r'`, controlSock)
 	}
 	opts = append(opts,
 		fmt.Sprintf("User=%s", username), // guest and host have the same username, but we should specify the username explicitly (#85)


### PR DESCRIPTION
## Problem

When connecting to a Lima instance as different users via SSH, the second user silently reuses the first user's ControlMaster session. This is because `ControlPath` does not include the remote username (`%r`), so all users share the same socket file.

**Reproduction:**
```
ssh firstuser@lima-MACHINE   # connects, creates socket at ssh.sock
ssh seconduser@lima-MACHINE  # reuses firstuser's socket -> whoami returns "firstuser"
```

## Fix

Append `.%r` (SSH escape for remote username) to the `ControlPath` template in `SSHOpts()`. This causes SSH to create separate control sockets per user (e.g., `ssh.sock.firstuser`, `ssh.sock.seconduser`).

Also update `IsControlMasterExisting()` to use `filepath.Glob` instead of exact `os.Stat`, so it finds any socket variant (`ssh.sock.*`).

The `filenames.LongestSock` constant already accounts for a 16-char suffix on the socket name, which is sufficient for the `%r` expansion in typical usage.

**Changes:** 1 file, +4/-5 lines.

Fixes #5062
