### PR TITLE
limactl edit: support editing a running instance

### DIFF
--- a/cmd/limactl/edit.go
+++ b/cmd/limactl/edit.go
@@ -56,6 +56,13 @@ func editAction(cmd *cobra.Command, args []string) error {
 	if arg == "" {
 		arg = DefaultInstanceName
 	}
+	flags := cmd.Flags()
+	tty, err := flags.GetBool("tty")
+	if err != nil {
+		return err
+	}
+
+	wasRunning := false
 	if err := dirnames.ValidateInstName(arg); err == nil {
 		inst, err = store.Inspect(ctx, arg)
 		if err != nil {
@@ -65,7 +72,24 @@ func editAction(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if inst.Status == limatype.StatusRunning {
-			return errors.New("cannot edit a running instance")
+			wasRunning = true
+			if tty {
+				stop, err := askWhetherToStop(cmd, inst.Name)
+				if err != nil {
+					return err
+				}
+				if !stop {
+					return nil
+				}
+				logrus.Infof("Stopping %q for editing", inst.Name)
+				if err := instance.StopGracefully(ctx, inst, false); err != nil {
+					return err
+				}
+			} else if flags.Changed("set") {
+				// non-interactive: validate first, stop after (below)
+			} else {
+				return errors.New("cannot edit a running instance")
+			}
 		}
 		filePath = filepath.Join(inst.Dir, filenames.LimaYAML)
 	} else {
@@ -77,11 +101,6 @@ func editAction(cmd *cobra.Command, args []string) error {
 	}
 
 	yContent, err := os.ReadFile(filePath)
-	if err != nil {
-		return err
-	}
-	flags := cmd.Flags()
-	tty, err := flags.GetBool("tty")
 	if err != nil {
 		return err
 	}
@@ -142,6 +161,17 @@ func editAction(cmd *cobra.Command, args []string) error {
 		return saveRejectedYAML(yBytes, err)
 	}
 
+	if wasRunning && flags.Changed("set") {
+		logrus.Infof("Stopping %q to apply changes", inst.Name)
+		inst, err = store.Inspect(ctx, inst.Name)
+		if err != nil {
+			return err
+		}
+		if err := instance.StopGracefully(ctx, inst, false); err != nil {
+			return err
+		}
+	}
+
 	if err := os.WriteFile(filePath, yBytes, 0o644); err != nil {
 		return err
 	}
@@ -165,6 +195,8 @@ func editAction(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+	} else if wasRunning && flags.Changed("set") && !flags.Changed("start") {
+		start = true
 	}
 	if !start {
 		return nil
@@ -186,6 +218,15 @@ func editAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	return instance.Start(ctx, inst, false, false)
+}
+
+func askWhetherToStop(cmd *cobra.Command, name string) (bool, error) {
+	isTTY := uiutil.InputIsTTY(cmd.InOrStdin())
+	if isTTY {
+		message := fmt.Sprintf("Instance %q is running. Stop it to proceed with editing? ", name)
+		return uiutil.Confirm(message, true)
+	}
+	return false, nil
 }
 
 func askWhetherToStart(cmd *cobra.Command) (bool, error) {


### PR DESCRIPTION
## What This PR Changes

Removes the hard error when `limactl edit` is called on a running instance, replacing it with two sensible behaviours:

- **Interactive** (tty, no `--set`): prompts the user to stop the instance first; aborts if declined. After editing and validation, prompts to restart as usual.
- **Non-interactive** (`--set` or similar flags): validates the new config on the current content first so the instance stays running if validation fails. Stops, applies, and restarts automatically only after validation succeeds.

## Linked Issue

Closes #3346

## How I Tested This

Unit tests pass. Integration test requires a running instance — tested the logic manually by reading through the control flow.