### PR TITLE
restart: accept editflags to modify configuration before restarting

### DIFF
--- a/cmd/limactl/restart.go
+++ b/cmd/limactl/restart.go
@@ -4,10 +4,22 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/lima-vm/lima/v2/cmd/limactl/editflags"
+	"github.com/lima-vm/lima/v2/pkg/driverutil"
 	"github.com/lima-vm/lima/v2/pkg/instance"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/limayaml"
 	"github.com/lima-vm/lima/v2/pkg/store"
+	"github.com/lima-vm/lima/v2/pkg/yqutil"
 )
 
 func newRestartCommand() *cobra.Command {
@@ -22,6 +34,7 @@ func newRestartCommand() *cobra.Command {
 
 	restartCmd.Flags().BoolP("force", "f", false, "Force stop and restart the instance")
 	restartCmd.Flags().Bool("progress", false, "Show provision script progress by tailing cloud-init logs")
+	editflags.RegisterEdit(restartCmd, "")
 	return restartCmd
 }
 
@@ -37,19 +50,70 @@ func restartAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	force, err := cmd.Flags().GetBool("force")
+	flags := cmd.Flags()
+	force, err := flags.GetBool("force")
 	if err != nil {
 		return err
 	}
-	progress, err := cmd.Flags().GetBool("progress")
+	progress, err := flags.GetBool("progress")
 	if err != nil {
 		return err
+	}
+
+	filePath := filepath.Join(inst.Dir, filenames.LimaYAML)
+	yContent, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	var params map[string]string
+	if flags.Changed("param") {
+		var y limatype.LimaYAML
+		if err := limayaml.Unmarshal(yContent, &y, filePath); err != nil {
+			return err
+		}
+		params = y.Param
+	}
+
+	yqExprs, err := editflags.YQExpressions(flags, false, params)
+	if err != nil {
+		return err
+	}
+
+	if len(yqExprs) > 0 {
+		yq := yqutil.Join(yqExprs)
+		yBytes, err := yqutil.EvaluateExpression(ctx, yq, yContent)
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(yBytes, yContent) {
+			y, err := limayaml.LoadWithWarnings(ctx, yBytes, filePath)
+			if err != nil {
+				return err
+			}
+			if err := driverutil.ResolveVMType(ctx, y, filePath); err != nil {
+				return fmt.Errorf("failed to resolve vm for %#q: %w", filePath, err)
+			}
+			if err := limayaml.Validate(y, true); err != nil {
+				return saveRejectedYAML(yBytes, err)
+			}
+			if err := limayaml.ValidateAgainstLatestConfig(ctx, yBytes, yContent); err != nil {
+				return saveRejectedYAML(yBytes, err)
+			}
+			if err := os.WriteFile(filePath, yBytes, 0o644); err != nil {
+				return err
+			}
+			logrus.Infof("Instance %#q configuration edited", inst.Name)
+			inst, err = store.Inspect(ctx, instName)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	if force {
 		return instance.RestartForcibly(ctx, inst, progress)
 	}
-
 	return instance.Restart(ctx, inst, progress)
 }
 


### PR DESCRIPTION
Fixes #4249

## Changes

`limactl restart` now accepts all editflags (the same flags available on `limactl edit`), so you can atomically edit and restart an instance in one command:

```console
# Change memory to 8 GiB and restart
limactl restart --memory=8 myinstance

# Change CPUs and restart forcibly
limactl restart --force --cpus=4 myinstance

# Use raw yq expression and restart
limactl restart --set '.ssh.localPort = 60023' myinstance
```

## Implementation

When any editflag is provided, `restartAction` reads the current `lima.yaml`, applies the yq expressions, validates the result (same pipeline as `limactl edit`), and writes the updated config — all before stopping the instance. This ensures validation errors are caught before any disruptive stop. Then the normal stop+start flow runs via `instance.Restart` / `instance.RestartForcibly`.

If no editflags are provided, behavior is identical to before.

## Testing

- `go build ./cmd/limactl/` passes
- `go test ./cmd/limactl/...` passes
- `golangci-lint run ./cmd/limactl/...` reports 0 issues