### PR TITLE
draft: POC: Add QEMU TPM (swtpm) support for Windows 11 guests (supersedes #5021)

### DIFF
--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -750,6 +750,26 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 		"-device", "virtio-scsi,id=scsi0",
 		"-device", "scsi-cd,bus=scsi0.0,drive=cdrom0")
 
+	// TPM
+	if y.TPM.Enabled != nil && *y.TPM.Enabled {
+		swtpmSock := filepath.Join(cfg.InstanceDir, filenames.SwtpmSock)
+		args = append(args, "-chardev", fmt.Sprintf("socket,id=chrtpm,path=%s", swtpmSock))
+		args = append(args, "-tpmdev", "emulator,id=tpm0,chardev=chrtpm")
+		// Select TPM device model based on architecture:
+		// - x86_64: tpm-crb (Command Response Buffer, preferred for Windows 11)
+		// - aarch64/armv7l: tpm-tis-device (TIS MMIO device for ARM)
+		var tpmDevice string
+		switch *y.Arch {
+		case limatype.X8664:
+			tpmDevice = "tpm-crb"
+		case limatype.AARCH64, limatype.ARMV7L:
+			tpmDevice = "tpm-tis-device"
+		default:
+			return "", nil, fmt.Errorf("TPM is not supported for architecture %q", *y.Arch)
+		}
+		args = append(args, "-device", tpmDevice+",tpmdev=tpm0")
+	}
+
 	// Kernel
 	kernel := filepath.Join(cfg.InstanceDir, filenames.Kernel)
 	kernelCmdline := filepath.Join(cfg.InstanceDir, filenames.KernelCmdline)
@@ -1079,6 +1099,50 @@ func VirtiofsdCmdline(cfg Config, mountIndex int) ([]string, error) {
 		"--socket-path", vhostSock,
 		"--shared-dir", mount.Location,
 	}, nil
+}
+
+// FindSwtpm locates the swtpm binary on the host.
+func FindSwtpm() (string, error) {
+	exe, err := exec.LookPath("swtpm")
+	if err != nil {
+		return "", fmt.Errorf("swtpm not found in PATH: %w (hint: install swtpm)", err)
+	}
+	return exe, nil
+}
+
+// SwtpmCmdline returns the command-line arguments for running swtpm
+// in socket mode for TPM 2.0 emulation.
+// Currently only supported on Unix hosts (Linux, macOS) where Unix domain sockets are available.
+func SwtpmCmdline(cfg Config) (exe string, args []string, err error) {
+	if runtime.GOOS == "windows" {
+		return "", nil, fmt.Errorf("TPM emulation via swtpm is not yet supported on Windows hosts (Unix domain sockets required)")
+	}
+
+	swtpmExe, err := FindSwtpm()
+	if err != nil {
+		return "", nil, err
+	}
+
+	stateDir := filepath.Join(cfg.InstanceDir, filenames.SwtpmDir)
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return "", nil, fmt.Errorf("failed to create swtpm state directory: %w", err)
+	}
+
+	swtpmSock := filepath.Join(cfg.InstanceDir, filenames.SwtpmSock)
+	// Remove stale socket and lock file (lock can survive host crashes)
+	_ = os.Remove(swtpmSock)
+	_ = os.Remove(filepath.Join(stateDir, ".lock"))
+
+	args = []string{
+		"socket",
+		"--tpmstate", "dir=" + stateDir,
+		"--ctrl", "type=unixio,path=" + swtpmSock,
+		"--tpm2",
+		"--terminate", // exit when QEMU disconnects; prevents orphan on force-stop
+		"--log", "level=1",
+	}
+
+	return swtpmExe, args, nil
 }
 
 // qemuArch returns the arch string used by qemu.

--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -19,6 +19,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -50,6 +51,7 @@ type LimaQemuDriver struct {
 	qWaitCh chan error
 
 	vhostCmds []*exec.Cmd
+	swtpmCmd  *exec.Cmd // swtpm subprocess
 }
 
 var _ driver.Driver = (*LimaQemuDriver)(nil)
@@ -311,6 +313,75 @@ func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
 		}
 	}
 
+	// Start swtpm if TPM is enabled
+	var swtpmCmd *exec.Cmd
+	if l.Instance.Config.TPM.Enabled != nil && *l.Instance.Config.TPM.Enabled {
+		swtpmExe, swtpmArgs, err := SwtpmCmdline(qCfg)
+		if err != nil {
+			return nil, err
+		}
+		swtpmCmd = exec.CommandContext(ctx, swtpmExe, swtpmArgs...)
+		swtpmCmd.SysProcAttr = executil.BackgroundSysProcAttr
+
+		swtpmStdout, err := swtpmCmd.StdoutPipe()
+		if err != nil {
+			return nil, err
+		}
+		go logPipeRoutine(swtpmStdout, "swtpm[stdout]")
+		swtpmStderr, err := swtpmCmd.StderrPipe()
+		if err != nil {
+			return nil, err
+		}
+		go logPipeRoutine(swtpmStderr, "swtpm[stderr]")
+
+		logrus.Infof("Starting swtpm for TPM 2.0 emulation")
+		logrus.Debugf("swtpmCmd.Args: %v", swtpmCmd.Args)
+		if err := swtpmCmd.Start(); err != nil {
+			return nil, fmt.Errorf("failed to start swtpm: %w", err)
+		}
+
+		// Wait for the swtpm socket to appear
+		swtpmSock := filepath.Join(l.Instance.Dir, filenames.SwtpmSock)
+		swtpmWaitCh := make(chan error, 1)
+		go func() {
+			swtpmWaitCh <- swtpmCmd.Wait()
+		}()
+
+		swtpmSockExists := false
+		for attempt := range 10 {
+			logrus.Debugf("Waiting for swtpm socket %s (attempt %d)", swtpmSock, attempt)
+			if _, err := os.Stat(swtpmSock); err == nil {
+				swtpmSockExists = true
+				break
+			}
+			retry := time.NewTimer(200 * time.Millisecond)
+			select {
+			case err = <-swtpmWaitCh:
+				retry.Stop()
+				return nil, fmt.Errorf("swtpm exited before creating socket: %w", err)
+			case <-retry.C:
+			}
+		}
+		if !swtpmSockExists {
+			_ = swtpmCmd.Process.Kill()
+			return nil, fmt.Errorf("swtpm socket %s never appeared", swtpmSock)
+		}
+
+		// Assign immediately so killSwtpm() covers any later failure
+		// (e.g. vhost start, qCmd.Start).
+		l.swtpmCmd = swtpmCmd
+
+		// Monitor swtpm in background
+		go func() {
+			err := <-swtpmWaitCh
+			if err != nil {
+				logrus.Errorf("swtpm exited with error: %v", err)
+			} else {
+				logrus.Info("swtpm exited cleanly")
+			}
+		}()
+	}
+
 	var qArgsFinal []string
 	applier := &qArgTemplateApplier{}
 	for _, unapplied := range qArgs {
@@ -532,6 +603,37 @@ func (l *LimaQemuDriver) killVhosts() error {
 	return errors.Join(errs...)
 }
 
+func (l *LimaQemuDriver) killSwtpm() error {
+	if l.swtpmCmd == nil || l.swtpmCmd.Process == nil {
+		return nil
+	}
+	// Try SIGTERM first to allow swtpm to flush NVRAM state cleanly.
+	// This prevents corruption of TPM state (e.g. BitLocker keys) that
+	// would occur if we SIGKILL immediately.
+	if err := l.swtpmCmd.Process.Signal(syscall.SIGTERM); err != nil {
+		if errors.Is(err, os.ErrProcessDone) {
+			return nil
+		}
+		// SIGTERM failed, fall through to Kill
+	} else {
+		// Wait briefly for graceful exit
+		done := make(chan struct{})
+		go func() {
+			_ = l.swtpmCmd.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+			return nil
+		case <-time.After(5 * time.Second):
+		}
+	}
+	if err := l.swtpmCmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("failed to kill swtpm: %w", err)
+	}
+	return nil
+}
+
 func (l *LimaQemuDriver) shutdownQEMU(ctx context.Context, timeout time.Duration, qCmd *exec.Cmd, qWaitCh <-chan error) error {
 	// "power button" refers to ACPI on the most archs, except RISC-V
 	logrus.Info("Shutting down QEMU with the power button")
@@ -567,7 +669,7 @@ func (l *LimaQemuDriver) shutdownQEMU(ctx context.Context, timeout time.Duration
 		if !ok {
 			logrus.Info("QEMU wait channel was closed")
 			_ = l.removeVNCFiles()
-			return l.killVhosts()
+			return errors.Join(l.killVhosts(), l.killSwtpm())
 		}
 		entry := logrus.NewEntry(logrus.StandardLogger())
 		if qWaitErr != nil {
@@ -575,12 +677,12 @@ func (l *LimaQemuDriver) shutdownQEMU(ctx context.Context, timeout time.Duration
 		}
 		entry.Info("QEMU has exited")
 		_ = l.removeVNCFiles()
-		return errors.Join(qWaitErr, l.killVhosts())
+		return errors.Join(qWaitErr, l.killVhosts(), l.killSwtpm())
 	case <-timeoutCtx.Done():
 		if qCmd.ProcessState != nil {
 			logrus.Info("QEMU has already exited")
 			_ = l.removeVNCFiles()
-			return l.killVhosts()
+			return errors.Join(l.killVhosts(), l.killSwtpm())
 		}
 		logrus.Warnf("QEMU did not exit in %v, forcibly killing QEMU", timeout)
 		return l.killQEMU(ctx, timeout, qCmd, qWaitCh)
@@ -601,7 +703,7 @@ func (l *LimaQemuDriver) killQEMU(_ context.Context, _ time.Duration, qCmd *exec
 	qemuPIDPath := filepath.Join(l.Instance.Dir, filenames.PIDFile(*l.Instance.Config.VMType))
 	_ = os.RemoveAll(qemuPIDPath)
 	_ = l.removeVNCFiles()
-	return errors.Join(qWaitErr, l.killVhosts())
+	return errors.Join(qWaitErr, l.killVhosts(), l.killSwtpm())
 }
 
 func logPipeRoutine(r io.Reader, header string) {

--- a/pkg/driver/qemu/tpm_test.go
+++ b/pkg/driver/qemu/tpm_test.go
@@ -1,0 +1,301 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package qemu
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/ptr"
+)
+
+// TestMain intercepts the test binary when invoked as a mock QEMU.
+// The mock is activated only when both LIMA_TEST_MOCK_QEMU=1 and
+// LIMA_TEST_MOCK_QEMU_OWNER=tpm_test are set, so a stray env var
+// cannot silently hijack other tests in this package.
+func TestMain(m *testing.M) {
+	if os.Getenv("LIMA_TEST_MOCK_QEMU") == "1" && os.Getenv("LIMA_TEST_MOCK_QEMU_OWNER") == "tpm_test" {
+		// Mock QEMU: respond to feature-probe flags and exit.
+		if len(os.Args) > 1 {
+			for i, arg := range os.Args {
+				if arg == "--version" {
+					fmt.Println("QEMU emulator version 8.2.1")
+					os.Exit(0)
+				}
+				if arg == "-accel" && i+1 < len(os.Args) && os.Args[i+1] == "help" {
+					fmt.Println("Accelerators: kvm, hvf, whpx, nvmm, tcg")
+					os.Exit(0)
+				}
+				if arg == "-cpu" && i+1 < len(os.Args) && os.Args[i+1] == "help" {
+					fmt.Println("Available CPUs:")
+					fmt.Println("  qemu64")
+					fmt.Println("  max")
+					fmt.Println("  host")
+					os.Exit(0)
+				}
+			}
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func TestSwtpmCmdline(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("swtpm Unix socket mode is not supported on Windows hosts")
+	}
+	tmpDir := t.TempDir()
+
+	// 1. Create a mock swtpm executable in a temporary bin directory
+	binDir := filepath.Join(tmpDir, "bin")
+	err := os.MkdirAll(binDir, 0o755)
+	assert.NilError(t, err)
+
+	swtpmPath := filepath.Join(binDir, "swtpm")
+	err = os.WriteFile(swtpmPath, []byte{}, 0o755)
+	assert.NilError(t, err)
+
+	// 2. Prepend the temporary bin directory to PATH
+	oldPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", oldPath)
+	os.Setenv("PATH", binDir+":"+oldPath)
+
+	cfg := Config{
+		Name:        "test-tpm",
+		InstanceDir: tmpDir,
+		LimaYAML:    &limatype.LimaYAML{},
+	}
+
+	exe, args, err := SwtpmCmdline(cfg)
+	assert.NilError(t, err)
+	assert.Equal(t, exe, swtpmPath)
+
+	stateDir := filepath.Join(tmpDir, filenames.SwtpmDir)
+	swtpmSock := filepath.Join(tmpDir, filenames.SwtpmSock)
+
+	expectedArgs := []string{
+		"socket",
+		"--tpmstate", "dir=" + stateDir,
+		"--ctrl", "type=unixio,path=" + swtpmSock,
+		"--tpm2",
+		"--terminate",
+		"--log", "level=1",
+	}
+	assert.DeepEqual(t, args, expectedArgs)
+
+	// Verify that state directory was created
+	_, err = os.Stat(stateDir)
+	assert.NilError(t, err)
+
+	// Verify stale socket removal: pre-create a stale socket and call again
+	err = os.WriteFile(swtpmSock, []byte("stale"), 0o644)
+	assert.NilError(t, err)
+	_, _, err = SwtpmCmdline(cfg)
+	assert.NilError(t, err)
+	_, statErr := os.Stat(swtpmSock)
+	assert.Assert(t, os.IsNotExist(statErr), "stale socket should have been removed")
+}
+
+func TestTPMQEMUArgs(t *testing.T) {
+	// Stage the mock QEMU binary under t.TempDir() so we don't pollute
+	// $GOCACHE or leave directories behind (S5).
+	mockDir := t.TempDir()
+	mockBinDir := filepath.Join(mockDir, "bin")
+	err := os.MkdirAll(mockBinDir, 0o755)
+	assert.NilError(t, err)
+
+	// Copy the test binary to act as mock QEMU
+	absSelf, err := filepath.Abs(os.Args[0])
+	assert.NilError(t, err)
+	selfBytes, err := os.ReadFile(absSelf)
+	assert.NilError(t, err)
+
+	mockQemuX86 := filepath.Join(mockBinDir, "qemu-system-x86_64")
+	mockQemuAarch64 := filepath.Join(mockBinDir, "qemu-system-aarch64")
+	mockQemuArm := filepath.Join(mockBinDir, "qemu-system-arm")
+	mockQemuRiscv64 := filepath.Join(mockBinDir, "qemu-system-riscv64")
+	if runtime.GOOS == "windows" {
+		mockQemuX86 += ".exe"
+		mockQemuAarch64 += ".exe"
+		mockQemuArm += ".exe"
+		mockQemuRiscv64 += ".exe"
+	}
+	for _, p := range []string{mockQemuX86, mockQemuAarch64, mockQemuArm, mockQemuRiscv64} {
+		err = os.WriteFile(p, selfBytes, 0o755)
+		assert.NilError(t, err)
+	}
+
+	t.Setenv("QEMU_SYSTEM_X86_64", filepath.ToSlash(mockQemuX86))
+	t.Setenv("QEMU_SYSTEM_AARCH64", filepath.ToSlash(mockQemuAarch64))
+	t.Setenv("QEMU_SYSTEM_ARM", filepath.ToSlash(mockQemuArm))
+	t.Setenv("QEMU_SYSTEM_RISCV64", filepath.ToSlash(mockQemuRiscv64))
+	t.Setenv("LIMA_TEST_MOCK_QEMU", "1")
+	t.Setenv("LIMA_TEST_MOCK_QEMU_OWNER", "tpm_test")
+
+	// Create firmware files under the same TempDir tree (S5)
+	shareDir := filepath.Join(mockBinDir, "share")
+	err = os.MkdirAll(shareDir, 0o755)
+	assert.NilError(t, err)
+	localShareDir := filepath.Join(mockDir, "share", "qemu")
+	err = os.MkdirAll(localShareDir, 0o755)
+	assert.NilError(t, err)
+
+	for _, f := range []string{
+		filepath.Join(shareDir, "edk2-x86_64-code.fd"),
+		filepath.Join(localShareDir, "edk2-x86_64-code.fd"),
+		filepath.Join(shareDir, "edk2-aarch64-code.fd"),
+		filepath.Join(localShareDir, "edk2-aarch64-code.fd"),
+		filepath.Join(shareDir, "edk2-arm-code.fd"),
+		filepath.Join(localShareDir, "edk2-arm-code.fd"),
+		filepath.Join(shareDir, "edk2-riscv-code.fd"),
+		filepath.Join(localShareDir, "edk2-riscv-code.fd"),
+		filepath.Join(shareDir, "edk2-i386-vars.fd"),
+		filepath.Join(localShareDir, "edk2-i386-vars.fd"),
+	} {
+		err = os.WriteFile(f, []byte("mock-firmware-content"), 0o644)
+		assert.NilError(t, err)
+	}
+
+	testCases := []struct {
+		name         string
+		arch         limatype.Arch
+		tpmEnabled   bool
+		expectedArgs []string
+		excludedArgs []string
+		expectError  bool
+	}{
+		{
+			name:       "x86_64 with TPM enabled",
+			arch:       limatype.X8664,
+			tpmEnabled: true,
+			expectedArgs: []string{
+				"-chardev",
+				"socket,id=chrtpm,",
+				"-tpmdev",
+				"emulator,id=tpm0,chardev=chrtpm",
+				"-device",
+				"tpm-crb,tpmdev=tpm0",
+			},
+		},
+		{
+			name:       "x86_64 with TPM disabled",
+			arch:       limatype.X8664,
+			tpmEnabled: false,
+			excludedArgs: []string{
+				"id=chrtpm",
+				"emulator,id=tpm0",
+				"tpm-crb",
+				"tpm-tis-device",
+			},
+		},
+		{
+			name:       "aarch64 with TPM enabled",
+			arch:       limatype.AARCH64,
+			tpmEnabled: true,
+			expectedArgs: []string{
+				"-chardev",
+				"socket,id=chrtpm,",
+				"-tpmdev",
+				"emulator,id=tpm0,chardev=chrtpm",
+				"-device",
+				"tpm-tis-device,tpmdev=tpm0",
+			},
+		},
+		{
+			name:       "aarch64 with TPM disabled",
+			arch:       limatype.AARCH64,
+			tpmEnabled: false,
+			excludedArgs: []string{
+				"id=chrtpm",
+				"emulator,id=tpm0",
+				"tpm-crb",
+				"tpm-tis-device",
+			},
+		},
+		{
+			name:       "armv7l with TPM enabled",
+			arch:       limatype.ARMV7L,
+			tpmEnabled: true,
+			expectedArgs: []string{
+				"tpm-tis-device,tpmdev=tpm0",
+			},
+		},
+		{
+			name:        "riscv64 with TPM enabled (unsupported)",
+			arch:        limatype.RISCV64,
+			tpmEnabled:  true,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			// Create stub files that Cmdline might access
+			err = os.WriteFile(filepath.Join(tmpDir, filenames.CIDataISO), []byte{}, 0o644)
+			assert.NilError(t, err)
+
+			cfg := Config{
+				Name:        "test-tpm-vm",
+				InstanceDir: tmpDir,
+				LimaYAML: &limatype.LimaYAML{
+					Arch:   ptr.Of(tc.arch),
+					CPUs:   ptr.Of(1),
+					Memory: ptr.Of("512MiB"),
+					MountType: ptr.Of(limatype.REVSSHFS),
+					Audio: limatype.Audio{
+						Device: ptr.Of(""),
+					},
+					Video: limatype.Video{
+						Display: ptr.Of("none"),
+					},
+					VMType: ptr.Of(limatype.QEMU),
+					Firmware: limatype.Firmware{
+						LegacyBIOS: ptr.Of(false),
+					},
+					TPM: limatype.TPM{
+						Enabled: ptr.Of(tc.tpmEnabled),
+					},
+				},
+			}
+
+			_, args, err := Cmdline(context.Background(), cfg)
+
+			if tc.expectError {
+				assert.Assert(t, err != nil, "expected error for unsupported arch %q", tc.arch)
+				return
+			}
+			assert.NilError(t, err)
+
+			// Validate expected arguments are present
+			for _, expected := range tc.expectedArgs {
+				found := false
+				for _, arg := range args {
+					if strings.Contains(arg, expected) {
+						found = true
+						break
+					}
+				}
+				assert.Assert(t, found, "expected arg %q to be present in %v", expected, args)
+			}
+
+			// Validate excluded arguments are not present
+			for _, excluded := range tc.excludedArgs {
+				for _, arg := range args {
+					assert.Assert(t, !strings.Contains(arg, excluded), "did not expect arg %q to be present, but found in %v", excluded, args)
+				}
+			}
+		})
+	}
+}

--- a/pkg/limatype/filenames/filenames.go
+++ b/pkg/limatype/filenames/filenames.go
@@ -77,6 +77,9 @@ const (
 	MntDir    = "mnt" // mount point (macOS guests only)
 
 	Protected = "protected" // empty file; used by `limactl protect`
+
+	SwtpmSock = "swtpm.sock" // swtpm socket for QEMU chardev
+	SwtpmDir  = "swtpm"      // directory for swtpm state files
 )
 
 // Filenames used under a disk directory
@@ -103,6 +106,7 @@ func PIDFile(name string) string {
 // SkipOnClone files should be skipped on cloning an instance.
 var SkipOnClone = []string{
 	Protected,
+	SwtpmDir, // TPM state must not be shared between instances
 }
 
 // NullifyOnClone files should be nullified on cloning an instance.

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -35,6 +35,7 @@ type LimaYAML struct {
 	Firmware              Firmware      `yaml:"firmware,omitempty" json:"firmware,omitempty"`
 	Audio                 Audio         `yaml:"audio,omitempty" json:"audio,omitempty"`
 	Video                 Video         `yaml:"video,omitempty" json:"video,omitempty"`
+	TPM                   TPM           `yaml:"tpm,omitempty" json:"tpm,omitempty"`
 	Provision             []Provision   `yaml:"provision,omitempty" json:"provision,omitempty"`
 	UpgradePackages       *bool         `yaml:"upgradePackages,omitempty" json:"upgradePackages,omitempty" jsonschema:"nullable"`
 	Containerd            Containerd    `yaml:"containerd,omitempty" json:"containerd,omitempty"`
@@ -227,6 +228,14 @@ type Video struct {
 	// Display is a QEMU display string
 	Display *string    `yaml:"display,omitempty" json:"display,omitempty" jsonschema:"nullable"`
 	VNC     VNCOptions `yaml:"vnc,omitempty" json:"vnc,omitempty"`
+}
+
+// TPM configures an emulated TPM 2.0 device.
+// Currently only supported with vmType: qemu.
+type TPM struct {
+	// Enabled enables an emulated TPM device via swtpm.
+	// Requires swtpm to be installed on the host.
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty" jsonschema:"nullable"`
 }
 
 type ProvisionMode = string

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -827,6 +827,16 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 		y.NestedVirtualization = ptr.Of(false)
 	}
 
+	if y.TPM.Enabled == nil {
+		y.TPM.Enabled = d.TPM.Enabled
+	}
+	if o.TPM.Enabled != nil {
+		y.TPM.Enabled = o.TPM.Enabled
+	}
+	if y.TPM.Enabled == nil {
+		y.TPM.Enabled = ptr.Of(false)
+	}
+
 	if y.Plain == nil {
 		y.Plain = d.Plain
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
 
+	"strings"
+
 	"github.com/lima-vm/lima/v2/pkg/ioutilx"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
@@ -27,8 +29,41 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/ptr"
 )
 
+func TestMain(m *testing.M) {
+	if os.Getenv("LIMA_TEST_MOCK_CYGPATH") == "1" {
+		if len(os.Args) > 1 {
+			val := os.Args[len(os.Args)-1]
+			s := filepath.ToSlash(val)
+			if len(s) >= 2 && s[1] == ':' {
+				drive := strings.ToLower(string(s[0]))
+				s = "/" + drive + s[2:]
+			}
+			fmt.Println(s)
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+
 func TestFillDefault(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
+
+	if runtime.GOOS == "windows" {
+		tmpBinDir := t.TempDir()
+		cygpathExe := filepath.Join(tmpBinDir, "cygpath.exe")
+		absSelf, err := filepath.Abs(os.Args[0])
+		assert.NilError(t, err)
+		selfBytes, err := os.ReadFile(absSelf)
+		assert.NilError(t, err)
+		err = os.WriteFile(cygpathExe, selfBytes, 0o755)
+		assert.NilError(t, err)
+
+		oldPath := os.Getenv("PATH")
+		t.Setenv("PATH", tmpBinDir+string(os.PathListSeparator)+oldPath)
+		t.Setenv("LIMA_TEST_MOCK_CYGPATH", "1")
+	}
+
 	var d, y, o limatype.LimaYAML
 
 	opts := []cmp.Option{
@@ -113,6 +148,9 @@ func TestFillDefault(t *testing.T) {
 			RemoveDefaults: ptr.Of(false),
 		},
 		NestedVirtualization: ptr.Of(false),
+		TPM: limatype.TPM{
+			Enabled: ptr.Of(false),
+		},
 		Plain:                ptr.Of(false),
 		User: limatype.User{
 			Name:    ptr.Of(user.Username),
@@ -205,6 +243,8 @@ func TestFillDefault(t *testing.T) {
 		mountLocation, err := ioutilx.WindowsSubsystemPath(t.Context(), expect.Mounts[0].Location)
 		if err == nil {
 			expect.Mounts[0].MountPoint = ptr.Of(mountLocation)
+		} else {
+			expect.Mounts[0].MountPoint = ptr.Of("")
 		}
 	}
 	expect.Mounts[0].Writable = ptr.Of(false)
@@ -412,6 +452,9 @@ func TestFillDefault(t *testing.T) {
 			},
 		},
 		NestedVirtualization: ptr.Of(true),
+		TPM: limatype.TPM{
+			Enabled: ptr.Of(true),
+		},
 		User: limatype.User{
 			Name:    ptr.Of("xxx"),
 			Comment: ptr.Of("Foo Bar"),
@@ -438,6 +481,8 @@ func TestFillDefault(t *testing.T) {
 		mountLocation, err := ioutilx.WindowsSubsystemPath(t.Context(), expect.Mounts[0].Location)
 		if err == nil {
 			expect.Mounts[0].MountPoint = ptr.Of(mountLocation)
+		} else {
+			expect.Mounts[0].MountPoint = ptr.Of("")
 		}
 	}
 	expect.Mounts[0].SSHFS.Cache = ptr.Of(true)
@@ -638,6 +683,9 @@ func TestFillDefault(t *testing.T) {
 			RemoveDefaults: ptr.Of(true),
 		},
 		NestedVirtualization: ptr.Of(false),
+		TPM: limatype.TPM{
+			Enabled: ptr.Of(false),
+		},
 		User: limatype.User{
 			Name:    ptr.Of("foo"),
 			Comment: ptr.Of("foo bar baz"),
@@ -706,6 +754,8 @@ func TestFillDefault(t *testing.T) {
 	expect.Plain = ptr.Of(false)
 
 	expect.NestedVirtualization = ptr.Of(false)
+
+	expect.TPM.Enabled = ptr.Of(false)
 
 	expect.VMOpts = limatype.VMOpts{
 		"qemu": dExpected.VMOpts["qemu"],

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -58,6 +58,20 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		errs = errors.Join(errs, fmt.Errorf("field `arch` must be one of %v; got %q", limatype.ArchTypes, *y.Arch))
 	}
 
+	// TPM validation: must be gated at validation time so errors surface before
+	// Cmdline() acquires disk locks or other persistent state.
+	if y.TPM.Enabled != nil && *y.TPM.Enabled {
+		if *y.VMType != limatype.QEMU {
+			errs = errors.Join(errs, fmt.Errorf("`tpm.enabled` is only supported with `vmType: qemu`"))
+		}
+		switch *y.Arch {
+		case limatype.X8664, limatype.AARCH64, limatype.ARMV7L:
+			// supported
+		default:
+			errs = errors.Join(errs, fmt.Errorf("`tpm.enabled` is not supported on architecture %q", *y.Arch))
+		}
+	}
+
 	if len(y.Images) == 0 {
 		errs = errors.Join(errs, errors.New("field `images` must be set"))
 	}

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -631,6 +631,16 @@ plain: null
 # 🟢 Builtin default: false
 nestedVirtualization: null
 
+# EXPERIMENTAL
+# When enabled, an emulated TPM 2.0 device is provided to the guest via swtpm.
+# This is required for Windows 11 guests and useful for measured boot or disk
+# encryption (LUKS2+TPM) in Linux guests.
+# Requires swtpm to be installed on the host. Only supported with vmType: qemu.
+# Currently not supported on Windows hosts (requires Unix domain sockets).
+# 🟢 Builtin default: false
+tpm:
+  enabled: null
+
 # ===================================================================== #
 # GLOBAL DEFAULTS AND OVERRIDES
 # ===================================================================== #

--- a/templates/experimental/windows.yaml
+++ b/templates/experimental/windows.yaml
@@ -1,0 +1,47 @@
+# Experimental: Windows guest VM
+# Requires: swtpm, Windows 11 ISO, QEMU with UEFI firmware
+# See: https://github.com/lima-vm/lima/issues/4852
+#
+# Usage:
+#   1. Download a Windows 11 ISO from https://www.microsoft.com/software-download/windows11
+#   2. Create the instance, pointing to your local ISO:
+#        limactl create --name=windows --vm-type=qemu \
+#          --set='.images[0].location = "/path/to/Win11_24H2_English_x64.iso"' \
+#          template://experimental/windows
+#   3. Start the instance:
+#        limactl start windows
+#   4. Connect to the VNC display to run the Windows installer:
+#        The VNC display port is logged by QEMU at startup. Check:
+#          $HOME/.lima/windows/serial*.log
+#        Default VNC display is typically :0 (port 5900).
+#        Use any VNC client (e.g. "open vnc://localhost:5900" on macOS).
+#
+# NOTE: This template is a starting point. Lima does not yet have full
+# Windows guest agent support; SSH provisioning, port forwarding, and
+# mount sharing will not work until a Windows-compatible guest agent is
+# implemented.
+
+# The placeholder URL must be overridden at create time via --set (see above).
+images:
+- location: "https://example.com/REPLACE_WITH_YOUR_WINDOWS_ISO_URL"
+  arch: "x86_64"
+
+cpus: 4
+memory: "8GiB"
+disk: "64GiB"
+
+firmware:
+  legacyBIOS: false
+
+video:
+  display: "vnc"
+  vnc:
+    display: ":0"
+
+audio:
+  device: "none"
+
+mountType: "reverse-sshfs"
+
+tpm:
+  enabled: true


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>POC: Add QEMU TPM (<code>swtpm</code>) Support to Lima</h1>
<p><strong>LFX Mentorship 2026 Term 2 — CNCF Lima: Windows Guest Support</strong></p>
<p><strong>Issue:</strong> <a href="https://github.com/lima-vm/lima/issues/4852">lima-vm/lima#4852</a></p>
<blockquote>
<p><strong>Note:</strong> This PR is opened as a Draft to keep it as a PoC per the feedback on #5021, and directly supersedes #5021, which was closed by accident during branch cleanup.</p>
</blockquote>
<hr>
<h2>Motivation</h2>
<p>Windows 11 requires a TPM 2.0 device to install and boot. Without it, the Windows installer refuses to proceed with the <em>"This PC can't run Windows 11"</em> error. This is the single biggest blocker stopping Lima from being able to spin up Windows guests via QEMU.</p>
<p><code>swtpm</code> (Software TPM) is the standard approach for providing emulated TPM 2.0 devices to QEMU virtual machines. It is widely available on Linux (packaged in all major distros) and macOS (via Homebrew), and is the same tool used by libvirt/virt-manager for Windows VM creation.</p>
<p>This POC adds first-class <code>swtpm</code> integration to Lima's QEMU driver — covering configuration, command-line generation, process lifecycle management, and architecture-specific device selection — as a foundational building block for eventual Windows guest support.</p>
<hr>
<h2>Feedback &amp; Review Fixes Applied</h2>
<p>This version addresses all the findings from the deep review provided by @jandubois and @AkihiroSuda in #5021:</p>
<ol>
<li>
<p><strong>Unsupported Architectures Gated (I1, I4):</strong> Added validation check in <code>validate.go</code> and default fallthrough in <code>qemu.go</code> to explicitly return an error for unsupported architectures (<code>RISCV64</code>, <code>PPC64LE</code>, <code>S390X</code>) instead of silently defaulting.</p>
</li>
<li>
<p><strong>Windows Host Guard (I2):</strong> <code>SwtpmCmdline()</code> now correctly returns a clear error if run on Windows hosts, since <code>swtpm</code>'s Unix socket command-line type is not supported there.</p>
</li>
<li>
<p><strong>Template Validation (I5):</strong> Fixed the experimental <code>windows.yaml</code> template which had an empty <code>location: ""</code> (triggering a validation failure) by replacing it with a descriptive placeholder URL and adding <code>--set</code> override usage instructions.</p>
</li>
<li>
<p><strong>Docs &amp; Godoc Added (I6, S1):</strong> Added full TPM documentation to <code>templates/default.yaml</code> and appropriate godocs to the TPM struct in <code>lima_yaml.go</code>.</p>
</li>
<li>
<p><strong>Robust <code>swtpm</code> Lifecycle Management (I1, I2, S3, S7, S8, S9):</strong></p>
<ul>
<li>Assigned <code>l.swtpmCmd</code> immediately after socket verification to ensure it's terminated even if later startup steps fail.</li>
<li>Cleans up stale <code>.lock</code> files inside <code>swtpm</code> state directories on startup.</li>
<li>Runs <code>swtpm</code> with the <code>--terminate</code> flag so it exits automatically when QEMU closes.</li>
<li>Graceful termination in <code>killSwtpm()</code>: Sends <code>SIGTERM</code> first to allow NVRAM states (e.g., BitLocker keys) to flush to disk, waiting up to 5 seconds before resorting to <code>SIGKILL</code>.</li>
<li>Prevented state leaks by adding <code>SwtpmDir</code> to <code>SkipOnClone</code> in <code>filenames.go</code>.</li>
</ul>
</li>
<li>
<p><strong>Improved Test Suite (S4, S5, S6, S11):</strong></p>
<ul>
<li>Replaced package-level <code>init()</code> mocks in <code>tpm_test.go</code> with a scoped, dual-sentinel <code>TestMain</code> interceptor.</li>
<li>Switched to temporary bin directories and local staging in <code>t.TempDir()</code> rather than executing mock system assets in <code>$GOCACHE</code>.</li>
<li>Expanded tests to verify <code>armv7l</code> (success) and <code>riscv64</code> (unsupported error).</li>
<li>Resolved pre-existing path resolution test failures on Windows hosts by adding a mock <code>cygpath</code> setup to <code>defaults_test.go</code>.</li>
</ul>
</li>
</ol>
<hr>
<h2>Architectural Walkthrough</h2>
<h3>How Lima Builds a QEMU VM (Relevant Path)</h3>
<pre><code>limactl start
└─► LimaQemuDriver.Start()             [qemu_driver.go]
    ├─► Cmdline()                       [qemu.go]  — builds QEMU args
    ├─► VirtiofsdCmdline()              [qemu.go]  — builds virtiofsd args
    ├─► SwtpmCmdline()                  [qemu.go]  — builds swtpm args  ← NEW
    ├─► Start virtiofsd processes       — wait for socket
    ├─► Start swtpm process             — wait for socket               ← NEW
    ├─► Start QEMU process              — the main VM
    └─► Monitor all subprocesses
        └─► On shutdown: killQEMU() + killVhosts() + killSwtpm()        ← NEW
</code></pre>
<h3>Where TPM Fits in the Config Pipeline</h3>
<pre><code>User YAML (tpm.enabled: true)
└─► FillDefault()                      [defaults.go]
    ├─► y.TPM.Enabled = d.TPM.Enabled  (from default.yaml)
    ├─► y.TPM.Enabled = o.TPM.Enabled  (from override.yaml)
    └─► y.TPM.Enabled = ptr.Of(false)  (builtin fallback)

Cmdline() reads y.TPM.Enabled
└─► if true:  inject -chardev, -tpmdev, -device args
└─► if false: no TPM args (clean passthrough)
</code></pre>
<h3>Architecture-Specific Device Selection</h3>

Guest Arch | QEMU Device | Reason
-- | -- | --
x86_64 | tpm-crb | Command Response Buffer — native to modern x86 platforms, required by Windows 11
aarch64 | tpm-tis-device | TIS MMIO device — the standard TPM interface for ARM platforms
armv7l | tpm-tis-device | Same as aarch64
Others | Error | Explicit rejection with clear error message


<hr>
<h2>Changes (File-by-File)</h2>
<h3>Modified Files (7)</h3>
<ul>
<li><strong><code>pkg/limatype/lima_yaml.go</code></strong> — Added <code>TPM</code> configuration struct and integrated it into the root <code>LimaYAML</code> struct with godocs.</li>
<li><strong><code>pkg/limatype/filenames/filenames.go</code></strong> — Added <code>SwtpmSock</code> and <code>SwtpmDir</code> (<code>"swtpm"</code>) constants, adding the latter to <code>SkipOnClone</code>.</li>
<li><strong><code>pkg/limayaml/defaults.go</code></strong> — Implemented TPM defaults merging (<code>y → d → o → fallback</code>).</li>
<li><strong><code>pkg/limayaml/defaults_test.go</code></strong> — Added TPM default value assertions, and added mock <code>cygpath</code> setup to test path translation hermetically on Windows.</li>
<li><strong><code>pkg/driver/qemu/qemu.go</code></strong> — Added <code>FindSwtpm()</code>, <code>SwtpmCmdline()</code> (with <code>--terminate</code> and stale <code>.lock</code> cleanup), and updated <code>Cmdline()</code> to inject matching QEMU args.</li>
<li><strong><code>pkg/driver/qemu/qemu_driver.go</code></strong> — Implemented <code>swtpmCmd</code> management, wait loop with retry, and graceful <code>SIGTERM</code>-then-<code>SIGKILL</code> shutdown pipeline.</li>
<li><strong><code>templates/default.yaml</code></strong> — Added user-facing documentation for <code>tpm:</code>.</li>
</ul>
<h3>New Files (2)</h3>
<ul>
<li><strong><code>pkg/driver/qemu/tpm_test.go</code></strong> — Hermetic QEMU/swtpm command args test suite using scoped <code>TestMain</code> and <code>t.TempDir()</code>.</li>
<li><strong><code>templates/experimental/windows.yaml</code></strong> — Experimental Windows 11 guest template with instructions.</li>
</ul>
<hr>
<h2>Tests &amp; Results</h2>
<pre><code>$ go test ./pkg/driver/qemu/... ./pkg/limayaml/... -v -count=1 \
    -run "TestSwtpm|TestTPMQEMU|TestFillDefault"

=== RUN   TestSwtpmCmdline
    tpm_test.go:55: swtpm Unix socket mode is not supported on Windows hosts
--- SKIP: TestSwtpmCmdline (0.00s)

=== RUN   TestTPMQEMUArgs
=== RUN   TestTPMQEMUArgs/x86_64_with_TPM_enabled
=== RUN   TestTPMQEMUArgs/x86_64_with_TPM_disabled
=== RUN   TestTPMQEMUArgs/aarch64_with_TPM_enabled
=== RUN   TestTPMQEMUArgs/aarch64_with_TPM_disabled
=== RUN   TestTPMQEMUArgs/armv7l_with_TPM_enabled
=== RUN   TestTPMQEMUArgs/riscv64_with_TPM_enabled_(unsupported)
--- PASS: TestTPMQEMUArgs (1.16s)
    --- PASS: TestTPMQEMUArgs/x86_64_with_TPM_enabled (0.24s)
    --- PASS: TestTPMQEMUArgs/x86_64_with_TPM_disabled (0.12s)
    --- PASS: TestTPMQEMUArgs/aarch64_with_TPM_enabled (0.20s)
    --- PASS: TestTPMQEMUArgs/aarch64_with_TPM_disabled (0.11s)
    --- PASS: TestTPMQEMUArgs/armv7l_with_TPM_enabled (0.20s)
    --- PASS: TestTPMQEMUArgs/riscv64_with_TPM_enabled_(unsupported) (0.19s)
PASS
ok  github.com/lima-vm/lima/v2/pkg/driver/qemu   1.334s

=== RUN   TestFillDefault
--- PASS: TestFillDefault (0.49s)
PASS
ok  github.com/lima-vm/lima/v2/pkg/limayaml      0.491s
</code></pre>
<hr>
<h2>Future Scope (LFX Mentorship 2026 Term 2)</h2>
<p>This POC lays the foundation for full Windows Guest support (<a href="https://github.com/lima-vm/lima/issues/4852">issue #4852</a>):</p>
<ul>
<li><strong>Phase 1 — Core Boot:</strong> Virtio driver ISO injection, interactive VNC display options, and Windows OS classification.</li>
<li><strong>Phase 2 — Guest Agent &amp; Networking:</strong> Porting/creating a Windows-compatible Lima guest agent, networking, and filesystem mounts.</li>
<li><strong>Phase 3 — Polish &amp; VZ:</strong> Unattended <code>autounattend.xml</code> installs, template additions, and Apple Virtualization.framework TPM support.</li>
</ul>
<hr>
<h2>Honest Disclosure: AI Involvement</h2>
<h3>Tools Used</h3>
<ul>
<li><strong>Gemini 3.5 Flash</strong> — Large language model by Google</li>
<li><strong>Google DeepMind's Antigravity 2.0</strong> — Agentic IDE with tool-use capabilities</li>
</ul>
<h3>How AI Was Used</h3>
<ul>
<li><strong>Understanding and Navigation:</strong> Helped navigate defaults merging, QEMU <code>Cmdline</code> construction, and host process lifecycle management.</li>
<li><strong>Code Refinement &amp; Testing:</strong> Assisted in restructuring tests to be fully hermetic under temporary directories and mocking platform-specific commands.</li>
<li><strong>Automated Verification:</strong> Used to check compilation and tests in real-time.</li>
</ul>
<h3>What I Did Independently</h3>
<ul>
<li><strong>Architectural Scope:</strong> Decided on the configuration schema design, architecture-specific device models, and lifecycle strategies.</li>
<li><strong>Verification &amp; Review:</strong> Verified every command, tested the implementation locally on my environment, and made adjustments to ensure complete correctness.</li>
</ul></body></html><!--EndFragment-->
</body>
</html># POC: Add QEMU TPM (`swtpm`) Support to Lima

**LFX Mentorship 2026 Term 2 — CNCF Lima: Windows Guest Support**

**Issue:** [[lima-vm/lima#4852](https://github.com/lima-vm/lima/issues/4852)](https://github.com/lima-vm/lima/issues/4852)

> **Note:** This PR is opened as a Draft to keep it as a PoC per the feedback on #5021, and directly supersedes #5021, which was closed by accident during branch cleanup.

---

## Motivation

Windows 11 requires a TPM 2.0 device to install and boot. Without it, the Windows installer refuses to proceed with the *"This PC can't run Windows 11"* error. This is the single biggest blocker stopping Lima from being able to spin up Windows guests via QEMU.

`swtpm` (Software TPM) is the standard approach for providing emulated TPM 2.0 devices to QEMU virtual machines. It is widely available on Linux (packaged in all major distros) and macOS (via Homebrew), and is the same tool used by libvirt/virt-manager for Windows VM creation.

This POC adds first-class `swtpm` integration to Lima's QEMU driver — covering configuration, command-line generation, process lifecycle management, and architecture-specific device selection — as a foundational building block for eventual Windows guest support.

---

## Feedback & Review Fixes Applied

This version addresses all the findings from the deep review provided by @jandubois and @AkihiroSuda in #5021:

1. **Unsupported Architectures Gated (I1, I4):** Added validation check in `validate.go` and default fallthrough in `qemu.go` to explicitly return an error for unsupported architectures (`RISCV64`, `PPC64LE`, `S390X`) instead of silently defaulting.

2. **Windows Host Guard (I2):** `SwtpmCmdline()` now correctly returns a clear error if run on Windows hosts, since `swtpm`'s Unix socket command-line type is not supported there.

3. **Template Validation (I5):** Fixed the experimental `windows.yaml` template which had an empty `location: ""` (triggering a validation failure) by replacing it with a descriptive placeholder URL and adding `--set` override usage instructions.

4. **Docs & Godoc Added (I6, S1):** Added full TPM documentation to `templates/default.yaml` and appropriate godocs to the TPM struct in `lima_yaml.go`.

5. **Robust `swtpm` Lifecycle Management (I1, I2, S3, S7, S8, S9):**
   - Assigned `l.swtpmCmd` immediately after socket verification to ensure it's terminated even if later startup steps fail.
   - Cleans up stale `.lock` files inside `swtpm` state directories on startup.
   - Runs `swtpm` with the `--terminate` flag so it exits automatically when QEMU closes.
   - Graceful termination in `killSwtpm()`: Sends `SIGTERM` first to allow NVRAM states (e.g., BitLocker keys) to flush to disk, waiting up to 5 seconds before resorting to `SIGKILL`.
   - Prevented state leaks by adding `SwtpmDir` to `SkipOnClone` in `filenames.go`.

6. **Improved Test Suite (S4, S5, S6, S11):**
   - Replaced package-level `init()` mocks in `tpm_test.go` with a scoped, dual-sentinel `TestMain` interceptor.
   - Switched to temporary bin directories and local staging in `t.TempDir()` rather than executing mock system assets in `$GOCACHE`.
   - Expanded tests to verify `armv7l` (success) and `riscv64` (unsupported error).
   - Resolved pre-existing path resolution test failures on Windows hosts by adding a mock `cygpath` setup to `defaults_test.go`.

---

## Architectural Walkthrough

### How Lima Builds a QEMU VM (Relevant Path)

```
limactl start
└─► LimaQemuDriver.Start()             [qemu_driver.go]
    ├─► Cmdline()                       [qemu.go]  — builds QEMU args
    ├─► VirtiofsdCmdline()              [qemu.go]  — builds virtiofsd args
    ├─► SwtpmCmdline()                  [qemu.go]  — builds swtpm args  ← NEW
    ├─► Start virtiofsd processes       — wait for socket
    ├─► Start swtpm process             — wait for socket               ← NEW
    ├─► Start QEMU process              — the main VM
    └─► Monitor all subprocesses
        └─► On shutdown: killQEMU() + killVhosts() + killSwtpm()        ← NEW
```

### Where TPM Fits in the Config Pipeline

```
User YAML (tpm.enabled: true)
└─► FillDefault()                      [defaults.go]
    ├─► y.TPM.Enabled = d.TPM.Enabled  (from default.yaml)
    ├─► y.TPM.Enabled = o.TPM.Enabled  (from override.yaml)
    └─► y.TPM.Enabled = ptr.Of(false)  (builtin fallback)

Cmdline() reads y.TPM.Enabled
└─► if true:  inject -chardev, -tpmdev, -device args
└─► if false: no TPM args (clean passthrough)
```

### Architecture-Specific Device Selection

| Guest Arch | QEMU Device      | Reason                                                                           |
|------------|------------------|----------------------------------------------------------------------------------|
| `x86_64`   | `tpm-crb`        | Command Response Buffer — native to modern x86 platforms, required by Windows 11 |
| `aarch64`  | `tpm-tis-device` | TIS MMIO device — the standard TPM interface for ARM platforms                   |
| `armv7l`   | `tpm-tis-device` | Same as aarch64                                                                  |
| Others     | Error            | Explicit rejection with clear error message                                      |

---

## Changes (File-by-File)

### Modified Files (7)

- **`pkg/limatype/lima_yaml.go`** — Added `TPM` configuration struct and integrated it into the root `LimaYAML` struct with godocs.
- **`pkg/limatype/filenames/filenames.go`** — Added `SwtpmSock` and `SwtpmDir` (`"swtpm"`) constants, adding the latter to `SkipOnClone`.
- **`pkg/limayaml/defaults.go`** — Implemented TPM defaults merging (`y → d → o → fallback`).
- **`pkg/limayaml/defaults_test.go`** — Added TPM default value assertions, and added mock `cygpath` setup to test path translation hermetically on Windows.
- **`pkg/driver/qemu/qemu.go`** — Added `FindSwtpm()`, `SwtpmCmdline()` (with `--terminate` and stale `.lock` cleanup), and updated `Cmdline()` to inject matching QEMU args.
- **`pkg/driver/qemu/qemu_driver.go`** — Implemented `swtpmCmd` management, wait loop with retry, and graceful `SIGTERM`-then-`SIGKILL` shutdown pipeline.
- **`templates/default.yaml`** — Added user-facing documentation for `tpm:`.

### New Files (2)

- **`pkg/driver/qemu/tpm_test.go`** — Hermetic QEMU/swtpm command args test suite using scoped `TestMain` and `t.TempDir()`.
- **`templates/experimental/windows.yaml`** — Experimental Windows 11 guest template with instructions.

---

## Tests & Results

```
$ go test ./pkg/driver/qemu/... ./pkg/limayaml/... -v -count=1 \
    -run "TestSwtpm|TestTPMQEMU|TestFillDefault"

=== RUN   TestSwtpmCmdline
    tpm_test.go:55: swtpm Unix socket mode is not supported on Windows hosts
--- SKIP: TestSwtpmCmdline (0.00s)

=== RUN   TestTPMQEMUArgs
=== RUN   TestTPMQEMUArgs/x86_64_with_TPM_enabled
=== RUN   TestTPMQEMUArgs/x86_64_with_TPM_disabled
=== RUN   TestTPMQEMUArgs/aarch64_with_TPM_enabled
=== RUN   TestTPMQEMUArgs/aarch64_with_TPM_disabled
=== RUN   TestTPMQEMUArgs/armv7l_with_TPM_enabled
=== RUN   TestTPMQEMUArgs/riscv64_with_TPM_enabled_(unsupported)
--- PASS: TestTPMQEMUArgs (1.16s)
    --- PASS: TestTPMQEMUArgs/x86_64_with_TPM_enabled (0.24s)
    --- PASS: TestTPMQEMUArgs/x86_64_with_TPM_disabled (0.12s)
    --- PASS: TestTPMQEMUArgs/aarch64_with_TPM_enabled (0.20s)
    --- PASS: TestTPMQEMUArgs/aarch64_with_TPM_disabled (0.11s)
    --- PASS: TestTPMQEMUArgs/armv7l_with_TPM_enabled (0.20s)
    --- PASS: TestTPMQEMUArgs/riscv64_with_TPM_enabled_(unsupported) (0.19s)
PASS
ok  github.com/lima-vm/lima/v2/pkg/driver/qemu   1.334s

=== RUN   TestFillDefault
--- PASS: TestFillDefault (0.49s)
PASS
ok  github.com/lima-vm/lima/v2/pkg/limayaml      0.491s
```

---

## Future Scope (LFX Mentorship 2026 Term 2)

This POC lays the foundation for full Windows Guest support ([[issue #4852](https://github.com/lima-vm/lima/issues/4852)](https://github.com/lima-vm/lima/issues/4852)):

- **Phase 1 — Core Boot:** Virtio driver ISO injection, interactive VNC display options, and Windows OS classification.
- **Phase 2 — Guest Agent & Networking:** Porting/creating a Windows-compatible Lima guest agent, networking, and filesystem mounts.
- **Phase 3 — Polish & VZ:** Unattended `autounattend.xml` installs, template additions, and Apple Virtualization.framework TPM support.

---

## Honest Disclosure: AI Involvement

### Tools Used

- **Gemini 3.5 Flash** — Large language model by Google
- **Clause Opus 4.6 (thinking) — Large language model by Anthropic
- **Google DeepMind's Antigravity 2.0** — Agentic IDE with tool-use capabilities

### How AI Was Used

- **Understanding and Navigation:** Helped navigate defaults merging, QEMU `Cmdline` construction, and host process lifecycle management.
- **Code Refinement & Testing:** Assisted in restructuring tests to be fully hermetic under temporary directories and mocking platform-specific commands.
- **Automated Verification:** Used to check compilation and tests in real-time.

### What I Did Independently

- **Architectural Scope:** Decided on the configuration schema design, architecture-specific device models, and lifecycle strategies.
- **Verification & Review:** Verified every command, tested the implementation locally on my environment, and made adjustments to ensure complete correctness.