### PR TITLE
feat: add support for Windows VM configuration via autounattend templates.

### DIFF
--- a/cmd/limactl/tab_completion.go
+++ b/cmd/limactl/tab_completion.go
@@ -85,7 +85,7 @@ var setFlagEnumValues = map[string][]string{
 		limatype.QEMU, limatype.VZ, limatype.WSL2,
 	},
 	".os": {
-		limatype.LINUX, limatype.DARWIN, limatype.FREEBSD,
+		limatype.LINUX, limatype.DARWIN, limatype.FREEBSD, limatype.WINDOWS,
 	},
 	".arch": {
 		limatype.X8664, limatype.AARCH64, limatype.ARMV7L,

--- a/pkg/cidata/cidata.TEMPLATE.d.Windows.amd64/autounattend.xml
+++ b/pkg/cidata/cidata.TEMPLATE.d.Windows.amd64/autounattend.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>3</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>4</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassCPUCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>5</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassStorageCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <FullName>{{.User}}</FullName>
+        <Organization>Lima</Organization>
+        <ProductKey>
+          <WillShowUI>Never</WillShowUI>
+        </ProductKey>
+      </UserData>
+      <DiskConfiguration>
+        <Disk wcm:action="add">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Type>EFI</Type>
+              <Size>100</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>MSR</Type>
+              <Size>16</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>3</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionID>1</PartitionID>
+              <Label>System</Label>
+              <Format>FAT32</Format>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionID>2</PartitionID>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>3</Order>
+              <PartitionID>3</PartitionID>
+              <Label>Windows</Label>
+              <Format>NTFS</Format>
+              <Letter>C</Letter>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/IMAGE/INDEX</Key>
+              <Value>6</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>3</PartitionID>
+          </InstallTo>
+          <InstallToAvailablePartition>false</InstallToAvailablePartition>
+        </OSImage>
+      </ImageInstall>
+    </component>
+  </settings>
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <ComputerName>{{.WindowsComputerName}}</ComputerName>
+      <TimeZone>{{.TimeZone}}</TimeZone>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>3</ProtectYourPC>
+      </OOBE>
+      <UserAccounts>
+        <LocalAccounts>
+          <LocalAccount wcm:action="add">
+            <Name>{{.User}}</Name>
+            <DisplayName>{{.User}}</DisplayName>
+            <Group>Administrators</Group>
+            <Password>
+              <Value></Value>
+              <PlainText>true</PlainText>
+            </Password>
+          </LocalAccount>
+        </LocalAccounts>
+      </UserAccounts>
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Username>{{.User}}</Username>
+        <Password>
+          <Value></Value>
+          <PlainText>true</PlainText>
+        </Password>
+        <LogonCount>3</LogonCount>
+      </AutoLogon>
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <CommandLine>powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0"</CommandLine>
+          <Description>Install OpenSSH Server</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <CommandLine>powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Start-Service sshd; Set-Service -Name sshd -StartupType Automatic"</CommandLine>
+          <Description>Start OpenSSH Server</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>3</Order>
+          <CommandLine>powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$sshDir = 'C:\ProgramData\ssh'; New-Item -Path $sshDir -ItemType Directory -Force; $keys = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{.WindowsSSHPubKeysBase64}}')); Set-Content -Path (Join-Path $sshDir 'administrators_authorized_keys') -Value $keys -NoNewline; icacls (Join-Path $sshDir 'administrators_authorized_keys') /inheritance:r /grant 'SYSTEM:(F)' /grant 'Administrators:(F)'"</CommandLine>
+          <Description>Install SSH authorized keys</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>4</Order>
+          <CommandLine>powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$cfg = 'C:\ProgramData\ssh\sshd_config'; Add-Content $cfg 'Match Group administrators'; Add-Content $cfg '  AuthorizedKeysFile C:/ProgramData/ssh/administrators_authorized_keys'; Restart-Service sshd"</CommandLine>
+          <Description>Configure administrator SSH keys</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>5</Order>
+          <CommandLine>powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "New-NetFirewallRule -Name 'OpenSSH-Server' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22"</CommandLine>
+          <Description>Allow SSH through firewall</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>6</Order>
+          <CommandLine>reg.exe add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoAdminLogon /t REG_SZ /d 0 /f</CommandLine>
+          <Description>Disable automatic logon</Description>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+  </settings>
+</unattend>

--- a/pkg/cidata/cidata.TEMPLATE.d.Windows.arm64/autounattend.xml
+++ b/pkg/cidata/cidata.TEMPLATE.d.Windows.arm64/autounattend.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>3</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>4</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassCPUCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>5</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassStorageCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <FullName>{{.User}}</FullName>
+        <Organization>Lima</Organization>
+        <ProductKey>
+          <WillShowUI>Never</WillShowUI>
+        </ProductKey>
+      </UserData>
+      <DiskConfiguration>
+        <Disk wcm:action="add">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Type>EFI</Type>
+              <Size>260</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>MSR</Type>
+              <Size>16</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>3</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionID>1</PartitionID>
+              <Label>System</Label>
+              <Format>FAT32</Format>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionID>2</PartitionID>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>3</Order>
+              <PartitionID>3</PartitionID>
+              <Label>Windows</Label>
+              <Format>NTFS</Format>
+              <Letter>C</Letter>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/IMAGE/INDEX</Key>
+              <Value>3</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>3</PartitionID>
+          </InstallTo>
+          <InstallToAvailablePartition>false</InstallToAvailablePartition>
+        </OSImage>
+      </ImageInstall>
+    </component>
+  </settings>
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <ComputerName>{{.WindowsComputerName}}</ComputerName>
+      <TimeZone>{{.TimeZone}}</TimeZone>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>3</ProtectYourPC>
+      </OOBE>
+      <UserAccounts>
+        <LocalAccounts>
+          <LocalAccount wcm:action="add">
+            <Name>{{.User}}</Name>
+            <DisplayName>{{.User}}</DisplayName>
+            <Group>Administrators</Group>
+            <Password>
+              <Value></Value>
+              <PlainText>true</PlainText>
+            </Password>
+          </LocalAccount>
+        </LocalAccounts>
+      </UserAccounts>
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Username>{{.User}}</Username>
+        <Password>
+          <Value></Value>
+          <PlainText>true</PlainText>
+        </Password>
+        <LogonCount>3</LogonCount>
+      </AutoLogon>
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <CommandLine>powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0"</CommandLine>
+          <Description>Install OpenSSH Server</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <CommandLine>powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Start-Service sshd; Set-Service -Name sshd -StartupType Automatic"</CommandLine>
+          <Description>Start OpenSSH Server</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>3</Order>
+          <CommandLine>powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$sshDir = 'C:\ProgramData\ssh'; New-Item -Path $sshDir -ItemType Directory -Force; $keys = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{.WindowsSSHPubKeysBase64}}')); Set-Content -Path (Join-Path $sshDir 'administrators_authorized_keys') -Value $keys -NoNewline; icacls (Join-Path $sshDir 'administrators_authorized_keys') /inheritance:r /grant 'SYSTEM:(F)' /grant 'Administrators:(F)'"</CommandLine>
+          <Description>Install SSH authorized keys</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>4</Order>
+          <CommandLine>powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$cfg = 'C:\ProgramData\ssh\sshd_config'; Add-Content $cfg 'Match Group administrators'; Add-Content $cfg '  AuthorizedKeysFile C:/ProgramData/ssh/administrators_authorized_keys'; Restart-Service sshd"</CommandLine>
+          <Description>Configure administrator SSH keys</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>5</Order>
+          <CommandLine>powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "New-NetFirewallRule -Name 'OpenSSH-Server' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22"</CommandLine>
+          <Description>Allow SSH through firewall</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>6</Order>
+          <CommandLine>reg.exe add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoAdminLogon /t REG_SZ /d 0 /f</CommandLine>
+          <Description>Disable automatic logon</Description>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+  </settings>
+</unattend>

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -4,8 +4,10 @@
 package cidata
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -150,6 +152,9 @@ func templateArgs(ctx context.Context, bootScripts bool, instDir, name string, i
 		NoCloudInit:    noCloudInit,
 		Param:          instConfig.Param,
 	}
+	if args.OS == limatype.WINDOWS {
+		args.WindowsComputerName = windowsComputerName(args.Hostname)
+	}
 
 	firstUsernetIndex := limayaml.FirstUsernetIndex(instConfig)
 	var subnet net.IP
@@ -189,6 +194,9 @@ func templateArgs(ctx context.Context, bootScripts bool, instDir, name string, i
 	}
 	for _, f := range pubKeys {
 		args.SSHPubKeys = append(args.SSHPubKeys, f.Content)
+	}
+	if args.OS == limatype.WINDOWS {
+		args.WindowsSSHPubKeysBase64 = base64.StdEncoding.EncodeToString([]byte(strings.Join(args.SSHPubKeys, "\r\n")))
 	}
 
 	var fstype string
@@ -359,6 +367,10 @@ func templateArgs(ctx context.Context, bootScripts bool, instDir, name string, i
 }
 
 func GenerateCloudConfig(ctx context.Context, instDir, name string, instConfig *limatype.LimaYAML) error {
+	if instConfig.OS != nil && *instConfig.OS == limatype.WINDOWS {
+		os.Remove(filepath.Join(instDir, filenames.CloudConfig)) // delete existing
+		return nil
+	}
 	args, err := templateArgs(ctx, false, instDir, name, instConfig, 0, 0, 0, "", false, false, false)
 	if err != nil {
 		return err
@@ -387,6 +399,14 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 	args, err := templateArgs(ctx, true, instDir, name, instConfig, udpDNSLocalPort, tcpDNSLocalPort, vsockPort, virtioPort, noCloudInit, rosettaEnabled, rosettaBinFmt)
 	if err != nil {
 		return "", err
+	}
+
+	if *instConfig.OS == limatype.WINDOWS {
+		winArch := "amd64"
+		if instConfig.Arch != nil && *instConfig.Arch == limatype.AARCH64 {
+			winArch = "arm64"
+		}
+		return generateWindowsISO(args, instDir, winArch)
 	}
 
 	if err := ValidateTemplateArgs(args); err != nil {
@@ -503,6 +523,54 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 		iso9660Options = append(iso9660Options, iso9660util.WithJoliet())
 	}
 	return args.IID, iso9660util.Write(filepath.Join(instDir, filenames.CIDataISO), "cidata", layout, iso9660Options...)
+}
+
+func generateWindowsISO(args *TemplateArgs, instDir, arch string) (string, error) {
+	xmlBytes, err := ExecuteTemplateAutounattend(args, arch)
+	if err != nil {
+		return "", fmt.Errorf("failed to render autounattend.xml: %w", err)
+	}
+
+	layout := []iso9660util.Entry{
+		{
+			Path:   "autounattend.xml",
+			Reader: bytes.NewReader(xmlBytes),
+		},
+	}
+
+	isoPath := filepath.Join(instDir, filenames.CIDataISO)
+	return args.IID, iso9660util.Write(isoPath, "autounattend", layout, iso9660util.WithJoliet())
+}
+
+func windowsComputerName(hostname string) string {
+	name := strings.Builder{}
+	for _, r := range strings.ToUpper(hostname) {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-':
+			name.WriteRune(r)
+		}
+		if name.Len() == 15 {
+			break
+		}
+	}
+	s := strings.Trim(name.String(), "-")
+	if s == "" {
+		return "LIMA-WINDOWS"
+	}
+	allDigits := true
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			allDigits = false
+			break
+		}
+	}
+	if allDigits {
+		s = "LIMA-" + s
+		if len(s) > 15 {
+			s = s[:15]
+		}
+	}
+	return s
 }
 
 func removeControlChars(s string) string {

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -22,6 +22,16 @@ var templateFS embed.FS
 
 const templateFSRoot = "cidata.TEMPLATE.d"
 
+//go:embed cidata.TEMPLATE.d.Windows.amd64
+var windowsAmd64TemplateFS embed.FS
+
+const windowsAmd64TemplateFSRoot = "cidata.TEMPLATE.d.Windows.amd64"
+
+//go:embed cidata.TEMPLATE.d.Windows.arm64
+var windowsArm64TemplateFS embed.FS
+
+const windowsArm64TemplateFSRoot = "cidata.TEMPLATE.d.Windows.arm64"
+
 type CACerts struct {
 	RemoveDefaults *bool
 	Trusted        []Cert
@@ -117,6 +127,8 @@ type TemplateArgs struct {
 	Plain                           bool
 	TimeZone                        string
 	NoCloudInit                     bool
+	WindowsComputerName             string
+	WindowsSSHPubKeysBase64         string
 }
 
 func ValidateTemplateArgs(args *TemplateArgs) error {
@@ -204,4 +216,27 @@ func ExecuteTemplateCIDataISO(args *TemplateArgs) ([]iso9660util.Entry, error) {
 	}
 
 	return layout, nil
+}
+
+// ExecuteTemplateAutounattend renders the Windows autounattend.xml template.
+func ExecuteTemplateAutounattend(args *TemplateArgs, arch string) ([]byte, error) {
+	var templateFS embed.FS
+	var root string
+	switch arch {
+	case "amd64":
+		templateFS = windowsAmd64TemplateFS
+		root = windowsAmd64TemplateFSRoot
+	case "arm64":
+		templateFS = windowsArm64TemplateFS
+		root = windowsArm64TemplateFSRoot
+	default:
+		return nil, fmt.Errorf("unsupported Windows arch %q", arch)
+	}
+
+	xmlTemplate, err := templateFS.ReadFile(path.Join(root, "autounattend.xml"))
+	if err != nil {
+		return nil, err
+	}
+
+	return textutil.ExecuteTemplate(string(xmlTemplate), args)
 }

--- a/pkg/cidata/template_test.go
+++ b/pkg/cidata/template_test.go
@@ -4,6 +4,8 @@
 package cidata
 
 import (
+	"encoding/base64"
+	"encoding/xml"
 	"io"
 	"strings"
 	"testing"
@@ -166,5 +168,33 @@ func TestTemplate9p(t *testing.T) {
 			// mounted at boot
 			assert.Assert(t, strings.Contains(string(b), "mounts:"))
 		}
+	}
+}
+
+func TestAutounattend(t *testing.T) {
+	key := "ssh-rsa dummy foo@example.com"
+	args := &TemplateArgs{
+		Name:                    "default",
+		User:                    "lima",
+		TimeZone:                "UTC",
+		WindowsComputerName:     "LIMA-DEFAULT",
+		SSHPubKeys:              []string{key},
+		WindowsSSHPubKeysBase64: base64.StdEncoding.EncodeToString([]byte(key)),
+	}
+	for _, arch := range []string{"amd64", "arm64"} {
+		t.Run(arch, func(t *testing.T) {
+			output, err := ExecuteTemplateAutounattend(args, arch)
+			assert.NilError(t, err)
+
+			assert.Assert(t, xml.Unmarshal(output, new(any)) == nil, "output is not valid XML")
+			s := string(output)
+			assert.Assert(t, strings.Contains(s, "Microsoft-Windows-Setup"), "missing disk/install component")
+			assert.Assert(t, strings.Contains(s, "Microsoft-Windows-Shell-Setup"), "missing shell setup component")
+			assert.Assert(t, strings.Contains(s, "OpenSSH.Server"), "missing OpenSSH server capability")
+			assert.Assert(t, strings.Contains(s, "administrators_authorized_keys"), "missing SSH authorized_keys setup")
+			assert.Assert(t, strings.Contains(s, args.WindowsSSHPubKeysBase64), "missing SSH public key payload")
+			assert.Assert(t, !strings.Contains(s, "PLACEHOLDER"), "must not contain placeholder SSH keys")
+			assert.Assert(t, !strings.Contains(s, "ProductKey>VK7JG"), "must not contain generic product keys")
+		})
 	}
 }

--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -397,6 +397,51 @@ func qemuMachine(arch limatype.Arch) string {
 	return "virt"
 }
 
+func appendWindowsDrives(args []string, arch limatype.Arch, diskPath, isoPath, cidataISOPath string, isoPresent bool) []string {
+	switch arch {
+	case limatype.AARCH64:
+		args = append(args, "-device", "qemu-xhci,id=usb-win")
+		if osutil.FileExists(diskPath) {
+			args = append(args,
+				"-drive", fmt.Sprintf("file=%s,if=none,discard=on,id=boot-disk", diskPath),
+				"-device", "nvme,serial=lima0,drive=boot-disk,bootindex=1")
+		}
+		if isoPresent {
+			args = appendArgsIfNoConflict(args, "-boot", "order=d,splash-time=0,menu=on")
+			args = append(args,
+				"-drive", fmt.Sprintf("file=%s,if=none,format=raw,media=cdrom,readonly=on,id=install-cdrom", isoPath),
+				"-device", "usb-storage,bus=usb-win.0,drive=install-cdrom,bootindex=2")
+		} else {
+			args = appendArgsIfNoConflict(args, "-boot", "order=c,splash-time=0,menu=on")
+		}
+		args = append(args,
+			"-drive", "id=autounattend,if=none,format=raw,readonly=on,file="+cidataISOPath,
+			"-device", "usb-storage,bus=usb-win.0,drive=autounattend",
+			"-device", "usb-kbd,bus=usb-win.0",
+			"-device", "usb-tablet,bus=usb-win.0",
+			"-device", "ramfb")
+	default:
+		args = append(args, "-device", "ich9-ahci,id=sata")
+		if osutil.FileExists(diskPath) {
+			args = append(args,
+				"-drive", fmt.Sprintf("file=%s,if=none,discard=on,id=boot-disk", diskPath),
+				"-device", "ide-hd,bus=sata.0,drive=boot-disk,bootindex=1")
+		}
+		if isoPresent {
+			args = appendArgsIfNoConflict(args, "-boot", "order=d,splash-time=0,menu=on")
+			args = append(args,
+				"-drive", fmt.Sprintf("file=%s,if=none,format=raw,media=cdrom,readonly=on,id=install-cdrom", isoPath),
+				"-device", "ide-cd,bus=sata.1,drive=install-cdrom,bootindex=2")
+		} else {
+			args = appendArgsIfNoConflict(args, "-boot", "order=c,splash-time=0,menu=on")
+		}
+		args = append(args,
+			"-drive", "id=autounattend,if=none,format=raw,readonly=on,file="+cidataISOPath,
+			"-device", "ide-cd,bus=sata.2,drive=autounattend")
+	}
+	return args
+}
+
 // audioDevice returns the default audio device.
 func audioDevice() string {
 	switch runtime.GOOS {
@@ -725,7 +770,9 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	}
 
 	isoPresent := osutil.FileExists(isoPath)
-	if osutil.FileExists(diskPath) {
+	if *y.OS == limatype.WINDOWS {
+		args = appendWindowsDrives(args, *y.Arch, diskPath, isoPath, filepath.Join(cfg.InstanceDir, filenames.CIDataISO), isoPresent)
+	} else if osutil.FileExists(diskPath) {
 		if isoPresent {
 			args = append(args, "-drive", fmt.Sprintf("file=%s,if=virtio,discard=on", diskPath))
 		} else {
@@ -734,7 +781,8 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 			args = append(args, "-device", fmt.Sprintf("%s,drive=boot-disk,bootindex=1", virtioBlk))
 		}
 	}
-	if isoPresent {
+	if *y.OS == limatype.WINDOWS {
+	} else if isoPresent {
 		args = appendArgsIfNoConflict(args, "-boot", "order=d,splash-time=0,menu=on")
 		args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,media=cdrom,readonly=on", isoPath))
 	} else {
@@ -744,11 +792,12 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 		args = append(args, "-drive", fmt.Sprintf("file=%s,if=virtio,discard=on", extraDisk))
 	}
 
-	// cloud-init
-	args = append(args,
-		"-drive", "id=cdrom0,if=none,format=raw,readonly=on,file="+filepath.Join(cfg.InstanceDir, filenames.CIDataISO),
-		"-device", "virtio-scsi,id=scsi0",
-		"-device", "scsi-cd,bus=scsi0.0,drive=cdrom0")
+	if *y.OS != limatype.WINDOWS {
+		args = append(args,
+			"-drive", "id=cdrom0,if=none,format=raw,readonly=on,file="+filepath.Join(cfg.InstanceDir, filenames.CIDataISO),
+			"-device", "virtio-scsi,id=scsi0",
+			"-device", "scsi-cd,bus=scsi0.0,drive=cdrom0")
+	}
 
 	// Kernel
 	kernel := filepath.Join(cfg.InstanceDir, filenames.Kernel)

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -80,6 +80,7 @@ const (
 	LINUX   OS = "Linux"
 	DARWIN  OS = "Darwin"
 	FREEBSD OS = "FreeBSD"
+	WINDOWS OS = "Windows"
 
 	X8664   Arch = "x86_64"
 	AARCH64 Arch = "aarch64"
@@ -99,7 +100,7 @@ const (
 )
 
 var (
-	OSTypes    = []OS{LINUX, DARWIN, FREEBSD}
+	OSTypes    = []OS{LINUX, DARWIN, FREEBSD, WINDOWS}
 	ArchTypes  = []Arch{X8664, AARCH64, ARMV7L, PPC64LE, RISCV64, S390X}
 	MountTypes = []MountType{REVSSHFS, NINEP, VIRTIOFS, WSLMount}
 	VMTypes    = []VMType{QEMU, VZ, WSL2}
@@ -348,6 +349,8 @@ func NewOS(osname string) OS {
 		return LINUX
 	case "darwin":
 		return DARWIN
+	case "windows":
+		return WINDOWS
 	default:
 		logrus.Warnf("Unknown os: %s", osname)
 		return osname

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -694,9 +694,9 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 		if mount.MountPoint == nil {
 			mountLocation := mount.Location
 			if runtime.GOOS == "windows" {
-				var err error
-				mountLocation, err = ioutilx.WindowsSubsystemPath(ctx, mountLocation)
-				if err != nil {
+				if mountLocationSub, err := ioutilx.WindowsSubsystemPath(ctx, mountLocation); err == nil {
+					mountLocation = mountLocationSub
+				} else {
 					logrus.WithError(err).Warnf("Couldn't convert location %#q into mount target", mount.Location)
 				}
 			}

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -50,7 +50,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 	}
 
 	switch *y.OS {
-	case limatype.LINUX, limatype.DARWIN, limatype.FREEBSD:
+	case limatype.LINUX, limatype.DARWIN, limatype.FREEBSD, limatype.WINDOWS:
 	default:
 		errs = errors.Join(errs, fmt.Errorf("field `os` must be one of %#q; got %#q", limatype.OSTypes, *y.OS))
 	}

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -369,7 +369,7 @@ provision:
 	err = Validate(y, false)
 	t.Logf("Validation errors: %v", err)
 
-	assert.Error(t, err, "field `os` must be one of [`Linux` `Darwin` `FreeBSD`]; got `windows`\n"+
+	assert.Error(t, err, "field `os` must be one of [`Linux` `Darwin` `FreeBSD` `Windows`]; got `windows`\n"+
 		"field `arch` must be one of [x86_64 aarch64 armv7l ppc64le riscv64 s390x]; got `unsupported_arch`\n"+
 		"field `images` must be set\n"+
 		"field `provision[0].mode` must one of `system`, `user`, `boot`, `data`, `dependency`, `ansible`, or `yq`\n"+


### PR DESCRIPTION
# Description

This PR adds Windows VM support in Lima for both `amd64` and `arm64`.

Lima can now automatically install and configure Windows using generated `autounattend.xml` files, removing the need for manual setup.

---

# What's Included

* Added Windows as a supported OS type
* Updated YAML validation and CLI completion support
* Added `autounattend.xml` templates for:

  * amd64
  * arm64
* Added `generateWindowsISO()` for Windows CIData ISO generation
* Added tests for template rendering and SSH key injection

---

# Design Decisions

## arm64 Storage

arm64 uses NVMe instead of VirtIO because Windows ARM already includes native NVMe drivers.

## Product Keys

Removed hardcoded product keys to avoid licensing issues.

## SSH Setup

OpenSSH Server is automatically installed and started during setup, allowing Lima to connect automatically after installation.

---

# Testing

Both architectures were tested successfully with fully unattended installation.

## amd64

* Tested with Windows 10 ISOs
* Uses `q35` machine type

## arm64

* Tested with Windows 11 ARM64 ISOs
* Added QEMU device mappings for:

  * NVMe
  * USB keyboard/tablet
  * ramfb

---

# Local Validation

```bash
go test -v ./pkg/cidata
```

Verifies correct template rendering.

```bash
limactl validate
```

Confirms Windows `lima.yaml` profiles are parsed correctly.

<img width="881" height="343" alt="Screenshot 2026-06-04 000334" src="https://github.com/user-attachments/assets/95d23cbc-7c0f-40d5-9c8f-fcaea822e2bf" />
<img width="1071" height="111" alt="Screenshot 2026-06-04 000732" src="https://github.com/user-attachments/assets/05255cf2-855b-4f8e-9ef4-ca51b07bed94" />
