### PR TITLE
MountTag hashing using ":" instead of "\0" separator

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -95,7 +95,7 @@ func MACAddress(uniqueID string) string {
 // MountTag generates a stable mount tag from location and mountPoint.
 // Both paths are hashed to handle the same location mounted to multiple mount points.
 func MountTag(location, mountPoint string) string {
-	sha := sha256.Sum256([]byte(location + "\x00" + mountPoint))
+	sha := sha256.Sum256([]byte(location + ":" + mountPoint))
 	return fmt.Sprintf("lima-%x", sha[0:8])
 }
 


### PR DESCRIPTION
Using \0 as a separator makes the hash hard to reproduce in environments that do not allow NUL bytes in strings. This affects, for example, NixOS configurations that generate filesystem mount definitions directly rather than using cloud-init (https://github.com/ciderale/nixos-lima/blob/general-update/modules/lima_mounts.nix#L12). While ":" is a valid file path character, I don't think that this change may cause a problem in practice for the hashed mount tag.