### PR TITLE
feat(vz): set descriptive window title for VZ VMs using the graphical display

### DIFF
--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -468,7 +468,8 @@ func (l *LimaVzDriver) canRunGUI() bool {
 
 func (l *LimaVzDriver) RunGUI(_ context.Context) error {
 	if l.canRunGUI() {
-		return l.machine.StartGraphicApplication(1920, 1200)
+		title := fmt.Sprintf("Lima: %s", l.Instance.Name)
+		return l.machine.StartGraphicApplication(1920, 1200, vz.WithWindowTitle(title))
 	}
 	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "vz", *l.Instance.Config.Video.Display)
 }


### PR DESCRIPTION
Let's label the VZ GUI windows so it's easy to tell which window each VM is using.

StartGraphicApplication accepts a vz.WithWindowTitle option via the
Code-Hex/vz library. This passes a title of the form "Lima: <name>
(<arch>)" so users can identify which VM owns a given window at a
glance — useful when running multiple VMs simultaneously.

Tested on macOS 26.5 (25F71), Apple Silicon, with a Linux guest
(video.display: vz) and a macOS 26 guest (video.display: default).

Assisted-by: Commercial LLM Tooling