### PR TITLE
feat(autostart): add --keep-alive flag to limactl autostart enable

### DIFF
--- a/cmd/limactl/autostart.go
+++ b/cmd/limactl/autostart.go
@@ -34,6 +34,10 @@ func newAutostartEnableCommand() *cobra.Command {
 		"user", "",
 		"macOS username to run the instance as when --condition=boot (default: $USER)",
 	)
+	flags.Bool(
+		"keep-alive", true,
+		"Restart the instance automatically if the host agent exits unexpectedly",
+	)
 	return cmd
 }
 

--- a/cmd/limactl/autostart_darwin.go
+++ b/cmd/limactl/autostart_darwin.go
@@ -20,7 +20,12 @@ import (
 )
 
 func autostartEnableAction(cmd *cobra.Command, args []string) error {
-	condition, err := cmd.Flags().GetString("condition")
+	flags := cmd.Flags()
+	condition, err := flags.GetString("condition")
+	if err != nil {
+		return err
+	}
+	keepAlive, err := flags.GetBool("keep-alive")
 	if err != nil {
 		return err
 	}
@@ -36,12 +41,13 @@ func autostartEnableAction(cmd *cobra.Command, args []string) error {
 
 	switch condition {
 	case "login":
-		if err := autostart.RegisterToStartAtLogin(ctx, inst); err != nil {
+		mgr := autostart.ManagerWith(keepAlive)
+		if err := mgr.RegisterToStartAtLogin(ctx, inst); err != nil {
 			return fmt.Errorf("failed to register instance %#q to start at login: %w", inst.Name, err)
 		}
 		logrus.Infof("Instance %#q registered to start at login", inst.Name)
 	case "boot":
-		userName, err := cmd.Flags().GetString("user")
+		userName, err := flags.GetString("user")
 		if err != nil {
 			return err
 		}
@@ -51,7 +57,7 @@ func autostartEnableAction(cmd *cobra.Command, args []string) error {
 		if userName == "" {
 			return errors.New("could not determine user; pass --user")
 		}
-		return daemonInstall(ctx, inst.Name, inst.Dir, userName)
+		return daemonInstall(ctx, inst.Name, inst.Dir, userName, keepAlive)
 	default:
 		return fmt.Errorf("unknown condition %q: must be \"login\" or \"boot\"", condition)
 	}
@@ -89,18 +95,22 @@ func autostartDisableAction(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func daemonInstall(ctx context.Context, instName, workDir, userName string) error {
+func daemonInstall(ctx context.Context, instName, workDir, userName string, keepAlive bool) error {
 	selfExe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("could not determine limactl path: %w", err)
 	}
 
-	content, err := textutil.ExecuteTemplate(launchd.DaemonTemplate, map[string]string{
+	vars := map[string]string{
 		"Binary":   selfExe,
 		"Instance": instName,
 		"WorkDir":  workDir,
 		"UserName": userName,
-	})
+	}
+	if keepAlive {
+		vars["KeepAlive"] = "true"
+	}
+	content, err := textutil.ExecuteTemplate(launchd.DaemonTemplate, vars)
 	if err != nil {
 		return fmt.Errorf("failed to render daemon plist: %w", err)
 	}

--- a/cmd/limactl/autostart_others.go
+++ b/cmd/limactl/autostart_others.go
@@ -35,7 +35,12 @@ func autostartEnableAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := autostart.RegisterToStartAtLogin(ctx, inst); err != nil {
+	keepAlive, err := cmd.Flags().GetBool("keep-alive")
+	if err != nil {
+		return err
+	}
+	mgr := autostart.ManagerWith(keepAlive)
+	if err := mgr.RegisterToStartAtLogin(ctx, inst); err != nil {
 		return fmt.Errorf("failed to register instance %#q to start at login: %w", inst.Name, err)
 	}
 	logrus.Infof("Instance %#q registered to start at login", inst.Name)

--- a/pkg/autostart/autostart_test.go
+++ b/pkg/autostart/autostart_test.go
@@ -22,10 +22,24 @@ var (
 		requestStart:          launchd.RequestStart,
 		requestStop:           launchd.RequestStop,
 	}
+	LaunchdKeepAlive = &TemplateFileBasedManager{
+		filePath:              launchd.GetPlistPath,
+		template:              launchd.Template,
+		enabler:               launchd.EnableDisableService,
+		autoStartedIdentifier: launchd.AutoStartedServiceName,
+		requestStart:          launchd.RequestStart,
+		requestStop:           launchd.RequestStop,
+		extraTemplateVars:     map[string]string{"KeepAlive": "true"},
+	}
 	LaunchdDaemon = &TemplateFileBasedManager{
 		filePath:          launchd.GetDaemonPlistPath,
 		template:          launchd.DaemonTemplate,
 		extraTemplateVars: map[string]string{"UserName": "alice"},
+	}
+	LaunchdDaemonKeepAlive = &TemplateFileBasedManager{
+		filePath:          launchd.GetDaemonPlistPath,
+		template:          launchd.DaemonTemplate,
+		extraTemplateVars: map[string]string{"UserName": "alice", "KeepAlive": "true"},
 	}
 	Systemd = &TemplateFileBasedManager{
 		filePath:              systemd.GetUnitPath,
@@ -115,6 +129,88 @@ func TestRenderTemplate(t *testing.T) {
 	</array>
 	<key>RunAtLoad</key>
 	<true/>
+	<key>StandardErrorPath</key>
+	<string>launchd.stderr.log</string>
+	<key>StandardOutPath</key>
+	<string>launchd.stdout.log</string>
+	<key>WorkingDirectory</key>
+	<string>/some/path</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+</dict>
+</plist>
+`,
+			GetExecutable: func() (string, error) {
+				return "/limactl", nil
+			},
+			WorkDir: "/some/path",
+		},
+		{
+			Manager:      LaunchdKeepAlive,
+			Name:         "render darwin launchd plist with keep-alive enabled",
+			InstanceName: "default",
+			Expected: `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>io.lima-vm.autostart.default</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/limactl</string>
+		<string>start</string>
+		<string>default</string>
+		<string>--foreground</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+	<key>StandardErrorPath</key>
+	<string>launchd.stderr.log</string>
+	<key>StandardOutPath</key>
+	<string>launchd.stdout.log</string>
+	<key>WorkingDirectory</key>
+	<string>/some/path</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+</dict>
+</plist>
+`,
+			GetExecutable: func() (string, error) {
+				return "/limactl", nil
+			},
+			WorkDir: "/some/path",
+		},
+		{
+			Manager:      LaunchdDaemonKeepAlive,
+			Name:         "render darwin launchd daemon plist with keep-alive enabled",
+			InstanceName: "k3s",
+			Expected: `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>io.lima-vm.daemon.k3s</string>
+	<key>UserName</key>
+	<string>alice</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/limactl</string>
+		<string>start</string>
+		<string>k3s</string>
+		<string>--foreground</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
 	<key>StandardErrorPath</key>
 	<string>launchd.stderr.log</string>
 	<key>StandardOutPath</key>

--- a/pkg/autostart/autostart_test.go
+++ b/pkg/autostart/autostart_test.go
@@ -34,6 +34,16 @@ var (
 		autoStartedIdentifier: systemd.AutoStartedUnitName,
 		requestStart:          systemd.RequestStart,
 		requestStop:           systemd.RequestStop,
+		extraTemplateVars:     map[string]string{"Restart": "on-failure"},
+	}
+	SystemdNoKeepAlive = &TemplateFileBasedManager{
+		filePath:              systemd.GetUnitPath,
+		template:              systemd.Template,
+		enabler:               systemd.EnableDisableUnit,
+		autoStartedIdentifier: systemd.AutoStartedUnitName,
+		requestStart:          systemd.RequestStart,
+		requestStop:           systemd.RequestStop,
+		extraTemplateVars:     map[string]string{"Restart": "no"},
 	}
 )
 
@@ -135,6 +145,29 @@ WorkingDirectory=%h
 Type=simple
 TimeoutSec=10
 Restart=on-failure
+
+[Install]
+WantedBy=default.target
+`,
+			GetExecutable: func() (string, error) {
+				return "/limactl", nil
+			},
+			WorkDir: "/some/path",
+		},
+		{
+			Manager:      SystemdNoKeepAlive,
+			Name:         "render linux systemd service with keep-alive disabled",
+			InstanceName: "default",
+			Expected: `[Unit]
+Description=Lima - Linux virtual machines, with a focus on running containers.
+Documentation=man:lima(1)
+
+[Service]
+ExecStart=/limactl start %i --foreground
+WorkingDirectory=%h
+Type=simple
+TimeoutSec=10
+Restart=no
 
 [Install]
 WantedBy=default.target

--- a/pkg/autostart/launchd/io.lima-vm.autostart.INSTANCE.plist
+++ b/pkg/autostart/launchd/io.lima-vm.autostart.INSTANCE.plist
@@ -15,7 +15,10 @@
 	<true/>
 {{- if .KeepAlive }}
 	<key>KeepAlive</key>
-	<true/>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
 {{- end }}
 	<key>StandardErrorPath</key>
 	<string>launchd.stderr.log</string>

--- a/pkg/autostart/launchd/io.lima-vm.autostart.INSTANCE.plist
+++ b/pkg/autostart/launchd/io.lima-vm.autostart.INSTANCE.plist
@@ -13,9 +13,10 @@
 	</array>
 	<key>RunAtLoad</key>
 	<true/>
-{{ if .KeepAlive }}	<key>KeepAlive</key>
+{{- if .KeepAlive }}
+	<key>KeepAlive</key>
 	<true/>
-{{ end }}
+{{- end }}
 	<key>StandardErrorPath</key>
 	<string>launchd.stderr.log</string>
 	<key>StandardOutPath</key>

--- a/pkg/autostart/launchd/io.lima-vm.autostart.INSTANCE.plist
+++ b/pkg/autostart/launchd/io.lima-vm.autostart.INSTANCE.plist
@@ -13,6 +13,9 @@
 	</array>
 	<key>RunAtLoad</key>
 	<true/>
+{{ if .KeepAlive }}	<key>KeepAlive</key>
+	<true/>
+{{ end }}
 	<key>StandardErrorPath</key>
 	<string>launchd.stderr.log</string>
 	<key>StandardOutPath</key>

--- a/pkg/autostart/launchd/io.lima-vm.daemon.INSTANCE.plist
+++ b/pkg/autostart/launchd/io.lima-vm.daemon.INSTANCE.plist
@@ -15,6 +15,9 @@
 	</array>
 	<key>RunAtLoad</key>
 	<true/>
+{{ if .KeepAlive }}	<key>KeepAlive</key>
+	<true/>
+{{ end }}
 	<key>StandardErrorPath</key>
 	<string>launchd.stderr.log</string>
 	<key>StandardOutPath</key>

--- a/pkg/autostart/launchd/io.lima-vm.daemon.INSTANCE.plist
+++ b/pkg/autostart/launchd/io.lima-vm.daemon.INSTANCE.plist
@@ -17,7 +17,10 @@
 	<true/>
 {{- if .KeepAlive }}
 	<key>KeepAlive</key>
-	<true/>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
 {{- end }}
 	<key>StandardErrorPath</key>
 	<string>launchd.stderr.log</string>

--- a/pkg/autostart/launchd/io.lima-vm.daemon.INSTANCE.plist
+++ b/pkg/autostart/launchd/io.lima-vm.daemon.INSTANCE.plist
@@ -15,9 +15,10 @@
 	</array>
 	<key>RunAtLoad</key>
 	<true/>
-{{ if .KeepAlive }}	<key>KeepAlive</key>
+{{- if .KeepAlive }}
+	<key>KeepAlive</key>
 	<true/>
-{{ end }}
+{{- end }}
 	<key>StandardErrorPath</key>
 	<string>launchd.stderr.log</string>
 	<key>StandardOutPath</key>

--- a/pkg/autostart/managers_darwin.go
+++ b/pkg/autostart/managers_darwin.go
@@ -7,6 +7,15 @@ import "github.com/lima-vm/lima/v2/pkg/autostart/launchd"
 
 // Manager returns the autostart manager for Darwin.
 func Manager() autoStartManager {
+	return ManagerWith(true)
+}
+
+// ManagerWith returns the autostart manager for Darwin with the given options.
+func ManagerWith(keepAlive bool) autoStartManager {
+	extra := map[string]string{}
+	if keepAlive {
+		extra["KeepAlive"] = "true"
+	}
 	return &TemplateFileBasedManager{
 		filePath:              launchd.GetPlistPath,
 		template:              launchd.Template,
@@ -14,6 +23,7 @@ func Manager() autoStartManager {
 		autoStartedIdentifier: launchd.AutoStartedServiceName,
 		requestStart:          launchd.RequestStart,
 		requestStop:           launchd.RequestStop,
+		extraTemplateVars:     extra,
 	}
 }
 

--- a/pkg/autostart/managers_linux.go
+++ b/pkg/autostart/managers_linux.go
@@ -10,25 +10,29 @@ func DaemonManager(_ string) autoStartManager {
 	return &notSupportedManager{}
 }
 
-// ManagerWith returns the autostart manager for Linux.
-// The keepAlive parameter is accepted for API compatibility but ignored;
-// systemd restart behavior is configured separately via the unit file.
-func ManagerWith(_ bool) autoStartManager {
-	return Manager()
+// Manager returns the autostart manager for Linux, with keep-alive enabled by default.
+func Manager() autoStartManager {
+	return ManagerWith(true)
 }
 
-// Manager returns the autostart manager for Linux.
-func Manager() autoStartManager {
-	if systemd.IsRunningSystemd() {
-		return &TemplateFileBasedManager{
-			filePath:              systemd.GetUnitPath,
-			template:              systemd.Template,
-			enabler:               systemd.EnableDisableUnit,
-			autoStartedIdentifier: systemd.AutoStartedUnitName,
-			requestStart:          systemd.RequestStart,
-			requestStop:           systemd.RequestStop,
-		}
+// ManagerWith returns the autostart manager for Linux. keepAlive controls the systemd
+// unit's Restart= directive: on-failure when enabled, no when disabled.
+func ManagerWith(keepAlive bool) autoStartManager {
+	if !systemd.IsRunningSystemd() {
+		// TODO: add support for non-systemd Linux distros
+		return &notSupportedManager{}
 	}
-	// TODO: add support for non-systemd Linux distros
-	return &notSupportedManager{}
+	restart := "on-failure"
+	if !keepAlive {
+		restart = "no"
+	}
+	return &TemplateFileBasedManager{
+		filePath:              systemd.GetUnitPath,
+		template:              systemd.Template,
+		enabler:               systemd.EnableDisableUnit,
+		autoStartedIdentifier: systemd.AutoStartedUnitName,
+		requestStart:          systemd.RequestStart,
+		requestStop:           systemd.RequestStop,
+		extraTemplateVars:     map[string]string{"Restart": restart},
+	}
 }

--- a/pkg/autostart/managers_linux.go
+++ b/pkg/autostart/managers_linux.go
@@ -10,6 +10,13 @@ func DaemonManager(_ string) autoStartManager {
 	return &notSupportedManager{}
 }
 
+// ManagerWith returns the autostart manager for Linux.
+// The keepAlive parameter is accepted for API compatibility but ignored;
+// systemd restart behavior is configured separately via the unit file.
+func ManagerWith(_ bool) autoStartManager {
+	return Manager()
+}
+
 // Manager returns the autostart manager for Linux.
 func Manager() autoStartManager {
 	if systemd.IsRunningSystemd() {

--- a/pkg/autostart/managers_others.go
+++ b/pkg/autostart/managers_others.go
@@ -14,3 +14,8 @@ func Manager() autoStartManager {
 func DaemonManager(_ string) autoStartManager {
 	return &notSupportedManager{}
 }
+
+// ManagerWith is not supported on this OS.
+func ManagerWith(_ bool) autoStartManager {
+	return &notSupportedManager{}
+}

--- a/pkg/autostart/systemd/lima-vm@INSTANCE.service
+++ b/pkg/autostart/systemd/lima-vm@INSTANCE.service
@@ -7,7 +7,7 @@ ExecStart={{.Binary}} start %i --foreground
 WorkingDirectory=%h
 Type=simple
 TimeoutSec=10
-Restart=on-failure
+Restart={{.Restart}}
 
 [Install]
 WantedBy=default.target

--- a/website/content/en/docs/usage/autostart.md
+++ b/website/content/en/docs/usage/autostart.md
@@ -58,8 +58,8 @@ limactl autostart enable --keep-alive=false default
 ```
 
 This applies to both `--condition=login` (macOS LaunchAgent) and
-`--condition=boot` (macOS LaunchDaemon). On Linux, restart behavior is
-configured separately in the systemd unit file.
+`--condition=boot` (macOS LaunchDaemon). On Linux, the systemd unit always
+uses `Restart=on-failure`, so keep-alive is always enabled regardless of the flag.
 
 ## Lima < 2.2
 

--- a/website/content/en/docs/usage/autostart.md
+++ b/website/content/en/docs/usage/autostart.md
@@ -58,8 +58,8 @@ limactl autostart enable --keep-alive=false default
 ```
 
 This applies to both `--condition=login` (macOS LaunchAgent) and
-`--condition=boot` (macOS LaunchDaemon). On Linux, the systemd unit always
-uses `Restart=on-failure`, so keep-alive is always enabled regardless of the flag.
+`--condition=boot` (macOS LaunchDaemon). On Linux, the flag sets the systemd unit's
+`Restart=` directive: `on-failure` when enabled (the default), or `no` when disabled.
 
 ## Lima < 2.2
 

--- a/website/content/en/docs/usage/autostart.md
+++ b/website/content/en/docs/usage/autostart.md
@@ -48,6 +48,19 @@ The `--user` flag specifies which macOS user the instance runs as (default:
 `$USER`). The plist is installed to
 `/Library/LaunchDaemons/io.lima-vm.daemon.<instance>.plist`.
 
+## Keep-alive behavior
+
+By default (`--keep-alive=true`), launchd will automatically restart the Lima
+host agent if it exits unexpectedly. To disable this:
+
+```bash
+limactl autostart enable --keep-alive=false default
+```
+
+This applies to both `--condition=login` (macOS LaunchAgent) and
+`--condition=boot` (macOS LaunchDaemon). On Linux, restart behavior is
+configured separately in the systemd unit file.
+
 ## Lima < 2.2
 
 Use `limactl start-at-login` (equivalent to `limactl autostart enable --condition=login`):


### PR DESCRIPTION
Depends on #4984.

## Summary

- Adds `--keep-alive` (default: `true`) to `limactl autostart enable` for both LaunchAgent and LaunchDaemon plist templates
- When enabled, launchd restarts the Lima host agent automatically if it exits unexpectedly, preventing instances from remaining in a `Broken` state until the next login or reboot
- The flag is accepted on all platforms:
  - **macOS:** the `KeepAlive` stanza is rendered as a dict with `SuccessfulExit=false`, so launchd restarts the agent only on an unexpected (non-zero) exit — a clean `limactl stop` stays stopped.
  - **Linux:** the flag sets the systemd unit's `Restart=` directive (`on-failure` when enabled, `no` when disabled).

## Testing

- Manually tested on Apple Silicon Mac (macOS 26, arm64)
- Confirmed launchd restarts the agent after a simulated crash with `--keep-alive=true`
- Confirmed no restart with `--keep-alive=false`
- Template-render unit tests cover the keep-alive-enabled LaunchAgent and LaunchDaemon plists

Closes #4992

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have signed off all commits per the DCO.
