### PR TITLE
limayaml: do not default containerd.user=true on non-Linux guests

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -528,10 +528,17 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 		y.Containerd.User = o.Containerd.User
 	}
 	if y.Containerd.User == nil {
-		switch *y.Arch {
-		case limatype.X8664, limatype.AARCH64:
-			y.Containerd.User = ptr.Of(true)
-		default:
+		// nerdctl is a Linux-only container runtime; only default
+		// containerd.user=true when the guest OS is Linux. Otherwise
+		// downloading the nerdctl archive (~250 MiB) is wasted I/O.
+		if *y.OS == limatype.LINUX {
+			switch *y.Arch {
+			case limatype.X8664, limatype.AARCH64:
+				y.Containerd.User = ptr.Of(true)
+			default:
+				y.Containerd.User = ptr.Of(false)
+			}
+		} else {
 			y.Containerd.User = ptr.Of(false)
 		}
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -887,3 +887,54 @@ func TestMountTagDuplicateLocation(t *testing.T) {
 	tag2 := MountTag(location, "/mnt/home-writable")
 	assert.Assert(t, tag1 != tag2)
 }
+
+// TestContainerdUserDefaultPerOS verifies that FillDefault only enables
+// containerd.user=true on Linux guests. nerdctl is a Linux-only runtime,
+// so non-Linux guests (Darwin, FreeBSD) must default to false regardless
+// of the host architecture. Regression test for issue #5037.
+func TestContainerdUserDefaultPerOS(t *testing.T) {
+	cases := []struct {
+		os   limatype.OS
+		arch limatype.Arch
+		want bool
+	}{
+		{limatype.LINUX, limatype.X8664, true},
+		{limatype.LINUX, limatype.AARCH64, true},
+		{limatype.LINUX, limatype.RISCV64, false},
+		{limatype.LINUX, limatype.ARMV7L, false},
+		{limatype.DARWIN, limatype.AARCH64, false},
+		{limatype.DARWIN, limatype.X8664, false},
+		{limatype.FREEBSD, limatype.X8664, false},
+		{limatype.FREEBSD, limatype.AARCH64, false},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%s/%s", tc.os, tc.arch), func(t *testing.T) {
+			y := limatype.LimaYAML{
+				OS:   ptr.Of(tc.os),
+				Arch: ptr.Of(tc.arch),
+			}
+			var d, o limatype.LimaYAML
+			FillDefault(t.Context(), &y, &d, &o, "", false)
+			assert.Assert(t, y.Containerd.User != nil, "Containerd.User must be set after FillDefault")
+			assert.Equal(t, *y.Containerd.User, tc.want,
+				"Containerd.User default for OS=%s Arch=%s", tc.os, tc.arch)
+		})
+	}
+}
+
+// TestContainerdUserExplicitOverride verifies FillDefault respects an
+// explicit containerd.user=true value even on non-Linux guests.
+func TestContainerdUserExplicitOverride(t *testing.T) {
+	y := limatype.LimaYAML{
+		OS:   ptr.Of(limatype.DARWIN),
+		Arch: ptr.Of(limatype.AARCH64),
+		Containerd: limatype.Containerd{
+			User: ptr.Of(true),
+		},
+	}
+	var d, o limatype.LimaYAML
+	FillDefault(t.Context(), &y, &d, &o, "", false)
+	assert.Assert(t, y.Containerd.User != nil)
+	assert.Equal(t, *y.Containerd.User, true,
+		"explicit Containerd.User=true must be preserved on non-Linux guests")
+}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -889,7 +889,7 @@ func TestMountTagDuplicateLocation(t *testing.T) {
 }
 
 // TestContainerdUserDefaultPerOS verifies that FillDefault only enables
-// containerd.user=true on Linux guests. nerdctl is a Linux-only runtime,
+// containerd.user=true on Linux guests for x86_64 and aarch64. nerdctl is a Linux-only runtime,
 // so non-Linux guests (Darwin, FreeBSD) must default to false regardless
 // of the host architecture. Regression test for issue #5037.
 func TestContainerdUserDefaultPerOS(t *testing.T) {

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -187,7 +187,7 @@ containerd:
   # 🟢 Builtin default: false
   system: null
   # Enable user-scoped (aka rootless) containerd and its dependencies
-  # 🟢 Builtin default: true (for x86_64 and aarch64)
+  # 🟢 Builtin default: true for Linux x86_64 and aarch64 guests, false otherwise
   user: null
 #  # Override containerd archive
 #  # 🟢 Builtin default: hard-coded URL with hard-coded digest (see the output of `limactl info | jq .defaultTemplate.containerd.archives`)


### PR DESCRIPTION
## What

`FillDefault` in `pkg/limayaml/defaults.go` enabled `containerd.user=true` whenever the guest architecture was `x86_64` or `aarch64`, with no check on the guest OS. macOS (`os: Darwin`) and FreeBSD guests therefore defaulted to `containerd.user=true` even though nerdctl is a Linux-only runtime, causing the ~250 MiB nerdctl archive to be downloaded unnecessarily.

## How

Gate the `true` default on `*y.OS == limatype.LINUX`:

```go
if y.Containerd.User == nil {
    if *y.OS == limatype.LINUX {
        switch *y.Arch {
        case limatype.X8664, limatype.AARCH64:
            y.Containerd.User = ptr.Of(true)
        default:
            y.Containerd.User = ptr.Of(false)
        }
    } else {
        y.Containerd.User = ptr.Of(false)
    }
}
```

`y.OS` is already resolved earlier in `FillDefault` (line 157 via `ResolveOS`), so dereferencing is safe.

## Behavior

- Linux + x86_64 / aarch64 → `true` (unchanged)
- Linux + riscv64 / armv7l / ppc64le / s390x → `false` (unchanged)
- Darwin + any arch → `false` (was `true` for x86_64 / aarch64; this is the fix)
- FreeBSD + any arch → `false` (was `true` for x86_64 / aarch64; this is the fix)
- Explicit `containerd.user: true` in user YAML → preserved (override path runs before this block)

## Tests

- `TestContainerdUserDefaultPerOS` — table-driven test covering Linux/Darwin/FreeBSD across `x86_64`, `aarch64`, `riscv64`, `armv7l`.
- `TestContainerdUserExplicitOverride` — verifies an explicit `containerd.user: true` is preserved on a Darwin guest.

Existing `TestFillDefault` already pins Linux + host arch and continues to pass.

```
ok  github.com/lima-vm/lima/v2/pkg/limayaml  0.342s
```

Fixes #5037