### PR TITLE
fix(networks): fail fast when socket_vmnet daemon does not start

### DIFF
--- a/pkg/networks/reconcile/reconcile.go
+++ b/pkg/networks/reconcile/reconcile.go
@@ -6,6 +6,7 @@ package reconcile
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -112,20 +113,22 @@ func makeVarRun(ctx context.Context, cfg *networks.Config) error {
 	return nil
 }
 
-func startDaemon(ctx context.Context, cfg *networks.Config, name, daemon string) error {
+// startDaemon starts the daemon process and returns its running *exec.Cmd so the
+// caller can wait on the process while polling for its PID file.
+func startDaemon(ctx context.Context, cfg *networks.Config, name, daemon string) (*exec.Cmd, error) {
 	if err := makeVarRun(ctx, cfg); err != nil {
-		return err
+		return nil, err
 	}
 	networksDir, err := dirnames.LimaNetworksDir()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := os.MkdirAll(networksDir, 0o755); err != nil {
-		return err
+		return nil, err
 	}
 	user, err := cfg.User(daemon)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	args := []string{"--user", user.User, "--group", user.Group, "--non-interactive"}
@@ -138,26 +141,32 @@ func startDaemon(ctx context.Context, cfg *networks.Config, name, daemon string)
 	stdoutPath := cfg.LogFile(name, daemon, "stdout")
 	stderrPath := cfg.LogFile(name, daemon, "stderr")
 	if err := os.RemoveAll(stdoutPath); err != nil {
-		return err
+		return nil, err
 	}
 	if err := os.RemoveAll(stderrPath); err != nil {
-		return err
+		return nil, err
 	}
 
-	cmd.Stdout, err = os.Create(stdoutPath)
+	stdoutFile, err := os.Create(stdoutPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	cmd.Stderr, err = os.Create(stderrPath)
+	// The child inherits its own dup of the descriptor at Start, so we can close our
+	// copy when startDaemon returns; this avoids leaking a descriptor on every retry.
+	defer stdoutFile.Close()
+	stderrFile, err := os.Create(stderrPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	defer stderrFile.Close()
+	cmd.Stdout = stdoutFile
+	cmd.Stderr = stderrFile
 
 	logrus.Debugf("Starting %#q daemon for %#q network: %v", daemon, name, cmd.Args)
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to run %v: %w (Hint: check %#q, %#q)", cmd.Args, err, stdoutPath, stderrPath)
+		return nil, fmt.Errorf("failed to run %v: %w (Hint: check %#q, %#q)", cmd.Args, err, stdoutPath, stderrPath)
 	}
-	return nil
+	return cmd, nil
 }
 
 var validation struct {
@@ -212,12 +221,138 @@ func startNetwork(ctx context.Context, cfg *networks.Config, name string) error 
 		pid, _ := store.ReadPIDFile(cfg.PIDFile(name, daemon))
 		if pid == 0 {
 			logrus.Infof("Starting %s daemon for %#q network", daemon, name)
-			if err := startDaemon(ctx, cfg, name, daemon); err != nil {
+			if err := startDaemonWithRetry(ctx, cfg, name, daemon); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+// daemonStuckError reports that the daemon process is still running but never wrote
+// its PID file within the timeout. Unlike an early exit (the transient XPC race we
+// retry for), this points at a different problem and is not retried.
+type daemonStuckError struct {
+	timeout time.Duration
+}
+
+func (e *daemonStuckError) Error() string {
+	return fmt.Sprintf("did not write its PID file within %s but is still running", e.timeout)
+}
+
+// startDaemonWithRetry starts the daemon and waits for it to come up, retrying with
+// exponential backoff. socket_vmnet can fail transiently at boot when
+// com.apple.NetworkSharing has not yet registered its XPC endpoint (VMNET_FAILURE);
+// in that case the process exits before writing its PID file and we retry. A process
+// that keeps running without writing its PID file, or a failure from startDaemon
+// itself, is not transient and is returned immediately.
+func startDaemonWithRetry(ctx context.Context, cfg *networks.Config, name, daemon string) error {
+	const (
+		maxAttempts = 5
+		// startTimeout is deliberately generous: socket_vmnet writes its PID file
+		// promptly on success, so reaching this while the process is still alive
+		// indicates a problem other than the transient startup race.
+		startTimeout = 30 * time.Second
+	)
+	pidFile := cfg.PIDFile(name, daemon)
+	stderrLog := cfg.LogFile(name, daemon, "stderr")
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 {
+			backoff := time.Duration(1<<uint(attempt-2)) * time.Second // 1s, 2s, 4s, 8s
+			logrus.Infof("Retrying %s daemon for %#q network (attempt %d/%d, waiting %s): %v",
+				daemon, name, attempt, maxAttempts, backoff, lastErr)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+		cmd, err := startDaemon(ctx, cfg, name, daemon)
+		if err != nil {
+			return err // infrastructure failure (sudo/exec) — not transient
+		}
+		err = waitForDaemon(ctx, cmd, pidFile, startTimeout)
+		if err == nil {
+			return nil
+		}
+		// A stuck (still-running) daemon is not the transient race; stop and surface stderr.
+		var stuck *daemonStuckError
+		if errors.As(err, &stuck) {
+			return fmt.Errorf("%s daemon for %#q network %w%s", daemon, name, err, stderrHint(stderrLog))
+		}
+		lastErr = err // process exited — retry
+	}
+	return fmt.Errorf("%s daemon for %#q network failed to start after %d attempts: %w%s",
+		daemon, name, maxAttempts, lastErr, stderrHint(stderrLog))
+}
+
+// waitForDaemon waits until the daemon writes its PID file (success), exits (returns
+// the exit error so the caller can retry), or stays alive past timeout without a PID
+// file (returns *daemonStuckError). A stuck or cancelled process is killed and reaped.
+func waitForDaemon(ctx context.Context, cmd *exec.Cmd, pidFile string, timeout time.Duration) error {
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		ready, err := pidFileWritten(pidFile)
+		if err != nil {
+			_ = cmd.Process.Kill()
+			<-waitCh
+			return err
+		}
+		if ready {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			_ = cmd.Process.Kill()
+			<-waitCh
+			return ctx.Err()
+		case waitErr := <-waitCh:
+			// Process exited. If it managed to write the PID file first, treat as success;
+			// otherwise this is the transient VMNET_FAILURE case — signal a retry, keeping
+			// the exit error so the cause survives even when stderr is empty.
+			ready, err := pidFileWritten(pidFile)
+			if err != nil {
+				return err
+			}
+			if ready {
+				return nil
+			}
+			return fmt.Errorf("daemon exited before writing its PID file: %w", waitErr)
+		case <-timer.C:
+			_ = cmd.Process.Kill()
+			<-waitCh
+			return &daemonStuckError{timeout: timeout}
+		case <-ticker.C:
+			// re-check the PID file on the next loop iteration
+		}
+	}
+}
+
+// pidFileWritten reports whether the daemon has written a valid PID file. A read
+// error (e.g. a corrupt or unreadable PID file) is non-transient and is returned so
+// the caller can fail fast rather than mistake it for a daemon that is slow to start.
+func pidFileWritten(pidFile string) (bool, error) {
+	pid, err := store.ReadPIDFile(pidFile)
+	if err != nil {
+		return false, fmt.Errorf("failed to read PID file %#q: %w", pidFile, err)
+	}
+	return pid != 0, nil
+}
+
+// stderrHint returns the daemon's stderr (or a pointer to the log) to append to errors.
+func stderrHint(stderrLog string) string {
+	if b, err := os.ReadFile(stderrLog); err == nil && len(b) > 0 {
+		return fmt.Sprintf(" (stderr: %s)", strings.TrimSpace(string(b)))
+	}
+	return fmt.Sprintf(" (check %#q)", stderrLog)
 }
 
 func stopNetwork(ctx context.Context, cfg *networks.Config, name string) error {

--- a/pkg/networks/reconcile/reconcile.go
+++ b/pkg/networks/reconcile/reconcile.go
@@ -240,12 +240,30 @@ func (e *daemonStuckError) Error() string {
 	return fmt.Sprintf("did not write its PID file within %s but is still running", e.timeout)
 }
 
+// daemonExitedError reports that the daemon process exited before writing its PID
+// file. This is the transient VMNET_FAILURE startup race that startDaemonWithRetry
+// retries for. err is the process's exit error, which may be nil when the daemon
+// exited cleanly (status 0) without writing a PID file.
+type daemonExitedError struct {
+	err error
+}
+
+func (e *daemonExitedError) Error() string {
+	if e.err == nil {
+		return "daemon exited before writing its PID file"
+	}
+	return fmt.Sprintf("daemon exited before writing its PID file: %v", e.err)
+}
+
+func (e *daemonExitedError) Unwrap() error { return e.err }
+
 // startDaemonWithRetry starts the daemon and waits for it to come up, retrying with
 // exponential backoff. socket_vmnet can fail transiently at boot when
 // com.apple.NetworkSharing has not yet registered its XPC endpoint (VMNET_FAILURE);
-// in that case the process exits before writing its PID file and we retry. A process
-// that keeps running without writing its PID file, or a failure from startDaemon
-// itself, is not transient and is returned immediately.
+// in that case the process exits before writing its PID file and we retry. Every
+// other failure — a process that keeps running without writing its PID file, a
+// failure from startDaemon itself, an unreadable PID file, or context cancellation —
+// is not transient and is returned immediately.
 func startDaemonWithRetry(ctx context.Context, cfg *networks.Config, name, daemon string) error {
 	const (
 		maxAttempts = 5
@@ -276,20 +294,28 @@ func startDaemonWithRetry(ctx context.Context, cfg *networks.Config, name, daemo
 		if err == nil {
 			return nil
 		}
-		// A stuck (still-running) daemon is not the transient race; stop and surface stderr.
-		var stuck *daemonStuckError
-		if errors.As(err, &stuck) {
-			return fmt.Errorf("%s daemon for %#q network %w%s", daemon, name, err, stderrHint(stderrLog))
+		// Only an early exit (the transient XPC race) is retried; everything else
+		// is surfaced immediately.
+		var exited *daemonExitedError
+		if !errors.As(err, &exited) {
+			// A stuck (still-running) daemon gets its stderr appended; PID-read and
+			// context errors propagate as-is.
+			var stuck *daemonStuckError
+			if errors.As(err, &stuck) {
+				return fmt.Errorf("%s daemon for %#q network %w%s", daemon, name, err, stderrHint(stderrLog))
+			}
+			return err
 		}
-		lastErr = err // process exited — retry
+		lastErr = err // process exited early — retry
 	}
 	return fmt.Errorf("%s daemon for %#q network failed to start after %d attempts: %w%s",
 		daemon, name, maxAttempts, lastErr, stderrHint(stderrLog))
 }
 
-// waitForDaemon waits until the daemon writes its PID file (success), exits (returns
-// the exit error so the caller can retry), or stays alive past timeout without a PID
-// file (returns *daemonStuckError). A stuck or cancelled process is killed and reaped.
+// waitForDaemon waits until the daemon writes its PID file (success), exits without
+// one (returns *daemonExitedError so the caller can retry), or stays alive past
+// timeout without a PID file (returns *daemonStuckError). A stuck or cancelled
+// process is killed and reaped.
 func waitForDaemon(ctx context.Context, cmd *exec.Cmd, pidFile string, timeout time.Duration) error {
 	waitCh := make(chan error, 1)
 	go func() { waitCh <- cmd.Wait() }()
@@ -317,7 +343,9 @@ func waitForDaemon(ctx context.Context, cmd *exec.Cmd, pidFile string, timeout t
 		case waitErr := <-waitCh:
 			// Process exited. If it managed to write the PID file first, treat as success;
 			// otherwise this is the transient VMNET_FAILURE case — signal a retry, keeping
-			// the exit error so the cause survives even when stderr is empty.
+			// the exit error so the cause survives even when stderr is empty. waitErr may be
+			// nil (clean exit without a PID file); daemonExitedError renders that without a
+			// dangling %!w(<nil>).
 			ready, err := pidFileWritten(pidFile)
 			if err != nil {
 				return err
@@ -325,7 +353,7 @@ func waitForDaemon(ctx context.Context, cmd *exec.Cmd, pidFile string, timeout t
 			if ready {
 				return nil
 			}
-			return fmt.Errorf("daemon exited before writing its PID file: %w", waitErr)
+			return &daemonExitedError{err: waitErr}
 		case <-timer.C:
 			_ = cmd.Process.Kill()
 			<-waitCh


### PR DESCRIPTION
## Problem

`startDaemon()` launches socket_vmnet and returns immediately without verifying the process stayed alive. If `vmnet_start_interface` returns `VMNET_FAILURE` — for example because the `com.apple.NetworkSharing` XPC Mach port is not yet registered at early boot — socket_vmnet exits silently. Lima then starts the VM anyway and blocks indefinitely waiting for SSH that will never arrive, with no indication of what went wrong.

This is especially likely when using `limactl autostart enable --condition=boot` (#4984), where Lima starts before all XPC services are guaranteed to be registered.

## Fix

Add `waitForDaemon()`, called in `startNetwork()` immediately after `startDaemon()`. socket_vmnet writes its PID file only after `vmnet_start_interface` succeeds, so the presence of that file is a reliable indicator of successful startup.

- **Transient early exit** (the `VMNET_FAILURE` race): the daemon exits before writing its PID file, so Lima retries with exponential backoff (1/2/4/8s, up to 5 attempts).
- **Stuck process**: if the daemon instead stays alive past a generous timeout (30s) without writing its PID file, that points at a different problem, so Lima fails fast and surfaces the daemon's stderr rather than hanging:

```
socket_vmnet daemon for "bridged" network did not write its PID file within 30s but is still running (stderr: ...)
```

- **Non-transient failure** (an unreadable PID file, a cancelled context, or a failure from `startDaemon` itself such as sudo/exec): returned immediately, without retrying.

## Effect on other use cases

- **Normal startup:** socket_vmnet writes its PID file within ~1s. No user-visible change.
- **Already running (pid != 0):** `startDaemon` is skipped entirely; `waitForDaemon` is never called.
- **Linux / non-darwin:** Early return before this code path. No change.
- **Usernet networking:** Separate code path. No change.
- **QEMU + socket_vmnet:** Same improvement — not VZ-specific.

Ref: #5074 (XPC timing), #4984 (LaunchDaemon boot condition)

Signed-off-by: Robert Esker <resker@gmail.com>
