### PR TITLE
feat(screenshot): add limactl screenshot command for VZ GUI VMs

### DIFF
--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -199,6 +199,7 @@ func newApp() *cobra.Command {
 		newGenDocCommand(),
 		newGenSchemaCommand(),
 		newSnapshotCommand(),
+		newScreenshotCommand(),
 		newProtectCommand(),
 		newUnprotectCommand(),
 		newTunnelCommand(),

--- a/cmd/limactl/screenshot.go
+++ b/cmd/limactl/screenshot.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/v2/pkg/hostagent/api/client"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/store"
+)
+
+func newScreenshotCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "screenshot INSTANCE",
+		Short:   "Capture a screenshot of the VM display",
+		Args:    WrapArgsError(cobra.ExactArgs(1)),
+		RunE:    screenshotAction,
+		GroupID: advancedCommand,
+	}
+	cmd.Flags().StringP("output", "o", "", "Output path; extension must be .png or .bmp (default: INSTANCE-screenshot.png)")
+	return cmd
+}
+
+func screenshotAction(cmd *cobra.Command, args []string) error {
+	instName := args[0]
+
+	ctx := cmd.Context()
+	inst, err := store.Inspect(ctx, instName)
+	if err != nil {
+		return err
+	}
+	if inst.Status != limatype.StatusRunning {
+		return fmt.Errorf("instance %q is not running (status: %s)", instName, inst.Status)
+	}
+
+	outputPath, _ := cmd.Flags().GetString("output")
+	if outputPath == "" {
+		outputPath = instName + "-screenshot.png"
+	}
+
+	var format string
+	switch strings.ToLower(filepath.Ext(outputPath)) {
+	case ".png":
+		format = "png"
+	case ".bmp":
+		format = "bmp"
+	default:
+		return fmt.Errorf("unsupported output extension %q: must be .png or .bmp", filepath.Ext(outputPath))
+	}
+
+	haSock := filepath.Join(inst.Dir, filenames.HostAgentSock)
+	haClient, err := client.NewHostAgentClient(haSock)
+	if err != nil {
+		return fmt.Errorf("failed to connect to hostagent: %w", err)
+	}
+
+	data, err := haClient.Screenshot(ctx, format)
+	if err != nil {
+		return fmt.Errorf("screenshot failed: %w", err)
+	}
+
+	if err := os.WriteFile(outputPath, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write %q: %w", outputPath, err)
+	}
+	logrus.Infof("Screenshot saved to %q (%d bytes)", outputPath, len(data))
+	return nil
+}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -5,15 +5,28 @@ package driver
 
 import (
 	"context"
+	"errors"
 	"net"
 
 	"github.com/lima-vm/lima/v2/pkg/hostagent/events"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 )
 
+// ErrDriverNotScreenshotter is returned when the active driver does not implement Screenshotter.
+var ErrDriverNotScreenshotter = errors.New("driver does not support screenshots")
+
+// ErrNoDisplay is returned when the VM has no display configured.
+var ErrNoDisplay = errors.New("no display configured")
+
 // VsockEventEmitter is an optional interface for drivers to emit vsock events.
 type VsockEventEmitter interface {
 	SetVsockEventCallback(callback func(*events.VsockEvent))
+}
+
+// Screenshotter is an optional interface for drivers that can capture the VM display.
+// format is "png" or "bmp"; an empty string defaults to "png".
+type Screenshotter interface {
+	CaptureScreenshot(format string) ([]byte, error)
 }
 
 // Lifecycle defines basic lifecycle operations.

--- a/pkg/driver/vz/screenshot_darwin.go
+++ b/pkg/driver/vz/screenshot_darwin.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin && !no_vz
+
+package vz
+
+/*
+#cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
+#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework AppKit -framework CoreGraphics -framework ImageIO
+#include <stdlib.h>
+#include <string.h>
+#include <dispatch/dispatch.h>
+#include <AppKit/AppKit.h>
+#include <CoreGraphics/CoreGraphics.h>
+#include <ImageIO/ImageIO.h>
+
+static void freeCString(char *s) { free(s); }
+
+// captureWindowImageBytes captures the frontmost non-panel on-screen window of
+// the current process, encodes it using the given ImageIO UTI, and returns a
+// malloc'd buffer. The caller must free() the returned pointer.
+static void *captureWindowImageBytes(int *outLen, const char *uti) {
+    __block void *result = NULL;
+    __block int resultLen = 0;
+
+    NSString *utiStr = [NSString stringWithUTF8String:uti];
+
+    // dispatch_sync to the main queue is required for window server access.
+    // CaptureScreenshot is always called from a Go goroutine, which is never
+    // the main thread, so no deadlock is possible in normal Lima operation.
+    // The isMainThread guard is a safety net for unexpected call paths.
+    void (^captureBlock)(void) = ^{
+        NSWindow *target = nil;
+        for (NSWindow *w in [NSApplication sharedApplication].windows) {
+            if ([w isKindOfClass:[NSPanel class]]) continue;
+            if (!w.isVisible) continue;
+            target = w;
+            break;
+        }
+        if (!target) return;
+
+        CGWindowID wid = (CGWindowID)[target windowNumber];
+        CGImageRef img = CGWindowListCreateImage(
+            CGRectNull,
+            kCGWindowListOptionIncludingWindow,
+            wid,
+            kCGWindowImageBoundsIgnoreFraming | kCGWindowImageShouldBeOpaque
+        );
+        if (!img) return;
+
+        NSMutableData *data = [NSMutableData data];
+        CGImageDestinationRef dst = CGImageDestinationCreateWithData(
+            (__bridge CFMutableDataRef)data,
+            (__bridge CFStringRef)utiStr,
+            1, NULL
+        );
+        if (!dst) {
+            CGImageRelease(img);
+            return;
+        }
+        CGImageDestinationAddImage(dst, img, NULL);
+        bool ok = CGImageDestinationFinalize(dst);
+        CFRelease(dst);
+        CGImageRelease(img);
+        if (!ok) return;
+
+        resultLen = (int)data.length;
+        result = malloc(resultLen);
+        memcpy(result, data.bytes, resultLen);
+    };
+
+    if ([NSThread isMainThread]) {
+        captureBlock();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), captureBlock);
+    }
+
+    *outLen = resultLen;
+    return result;
+}
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/lima-vm/lima/v2/pkg/driver"
+)
+
+// CaptureScreenshot captures the VM display window.
+// format is "png" or "bmp"; anything else defaults to PNG.
+// Implements driver.Screenshotter. Requires the GUI app bundle to be running.
+func (l *LimaVzDriver) CaptureScreenshot(format string) ([]byte, error) {
+	if !l.canRunGUI() {
+		return nil, fmt.Errorf("%w (set video.display to \"default\" or \"vz\" to enable screenshots)", driver.ErrNoDisplay)
+	}
+	uti := "public.png"
+	if format == "bmp" {
+		uti = "com.microsoft.bmp"
+	}
+	cuti := C.CString(uti)
+	defer C.freeCString(cuti)
+	var outLen C.int
+	ptr := C.captureWindowImageBytes(&outLen, cuti)
+	if ptr == nil || outLen == 0 {
+		return nil, errors.New("screenshot capture returned no data; GUI window may not be visible")
+	}
+	defer C.free(ptr)
+	return C.GoBytes(ptr, outLen), nil
+}

--- a/pkg/hostagent/api/client/client.go
+++ b/pkg/hostagent/api/client/client.go
@@ -9,8 +9,11 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/lima-vm/lima/v2/pkg/hostagent/api"
 	"github.com/lima-vm/lima/v2/pkg/httpclientutil"
@@ -19,6 +22,8 @@ import (
 type HostAgentClient interface {
 	HTTPClient() *http.Client
 	Info(context.Context) (*api.Info, error)
+	// Screenshot captures the VM display. format is "png" or "bmp" (default "png").
+	Screenshot(context.Context, string) ([]byte, error)
 }
 
 // NewHostAgentClient creates a client.
@@ -64,4 +69,42 @@ func (c *client) Info(ctx context.Context) (*api.Info, error) {
 		return nil, err
 	}
 	return &info, nil
+}
+
+func (c *client) Screenshot(ctx context.Context, format string) ([]byte, error) {
+	if format == "" {
+		format = "png"
+	}
+	if format != "png" && format != "bmp" {
+		return nil, fmt.Errorf("unsupported format %q: must be png or bmp", format)
+	}
+	params := url.Values{"format": {format}}
+	u := fmt.Sprintf("http://%s/%s/screenshot?%s", c.dummyHost, c.version, params.Encode())
+	resp, err := httpclientutil.Get(ctx, c.HTTPClient(), u)
+	if err != nil {
+		var httpErr *httpclientutil.HTTPStatusError
+		if errors.As(err, &httpErr) {
+			switch httpErr.StatusCode {
+			case http.StatusNotFound:
+				return nil, errors.New("hostagent does not support screenshot — restart the instance to pick up the latest hostagent binary")
+			case http.StatusNotImplemented:
+				// httpErr.Error() extracts ErrorJSON.Message from the body, which
+				// includes the driver name set by the hostagent.
+				return nil, httpErr
+			case http.StatusUnprocessableEntity:
+				return nil, errors.New("VM has no display configured — set video.display (e.g., \"default\") in the instance config")
+			}
+		}
+		return nil, err
+	}
+	defer resp.Body.Close()
+	const maxScreenshotSize = 32 << 20 // 32 MB
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxScreenshotSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxScreenshotSize {
+		return nil, fmt.Errorf("screenshot response exceeds %d MB limit", maxScreenshotSize>>20)
+	}
+	return data, nil
 }

--- a/pkg/hostagent/api/server/server.go
+++ b/pkg/hostagent/api/server/server.go
@@ -6,8 +6,12 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 
+	"github.com/lima-vm/lima/v2/pkg/driver"
 	"github.com/lima-vm/lima/v2/pkg/hostagent"
 	"github.com/lima-vm/lima/v2/pkg/httputil"
 )
@@ -17,8 +21,9 @@ type Backend struct {
 }
 
 func (b *Backend) onError(w http.ResponseWriter, err error, ec int) {
-	w.WriteHeader(ec)
+	// Set headers before WriteHeader — calling WriteHeader flushes headers.
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(ec)
 	// err may potentially contain credential info (in a future version),
 	// but it is safe to return the err to the client, because we do not expose the socket to the internet
 	e := httputil.ErrorJSON{
@@ -53,6 +58,47 @@ func (b *Backend) GetInfo(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(m)
 }
 
+// GetScreenshot is the handler for GET /v1/screenshot.
+func (b *Backend) GetScreenshot(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	ctx := r.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	format := strings.ToLower(r.URL.Query().Get("format"))
+	if format == "" {
+		format = "png"
+	}
+	if format != "png" && format != "bmp" {
+		b.onError(w, fmt.Errorf("unsupported format %q: must be png or bmp", format), http.StatusBadRequest)
+		return
+	}
+	data, err := b.Agent.Screenshot(ctx, format)
+	if err != nil {
+		ec := http.StatusInternalServerError
+		switch {
+		case errors.Is(err, driver.ErrDriverNotScreenshotter):
+			ec = http.StatusNotImplemented
+		case errors.Is(err, driver.ErrNoDisplay):
+			ec = http.StatusUnprocessableEntity
+		}
+		b.onError(w, err, ec)
+		return
+	}
+	ct := "image/png"
+	if format == "bmp" {
+		ct = "image/bmp"
+	}
+	w.Header().Set("Content-Type", ct)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
 func AddRoutes(r *http.ServeMux, b *Backend) {
 	r.Handle("/v1/info", http.HandlerFunc(b.GetInfo))
+	r.Handle("/v1/screenshot", http.HandlerFunc(b.GetScreenshot))
 }

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -526,6 +526,19 @@ func (a *HostAgent) startRoutinesAndWait(ctx context.Context, errCh <-chan error
 	return a.driver.Stop(ctx)
 }
 
+func (a *HostAgent) Screenshot(ctx context.Context, format string) ([]byte, error) {
+	// ConfiguredDriver wraps the concrete driver; unwrap to reach optional interfaces.
+	inner := a.driver
+	if cd, ok := a.driver.(*driver.ConfiguredDriver); ok {
+		inner = cd.Driver
+	}
+	s, ok := inner.(driver.Screenshotter)
+	if !ok {
+		return nil, fmt.Errorf("driver %q: %w", a.driver.Info(ctx).Name, driver.ErrDriverNotScreenshotter)
+	}
+	return s.CaptureScreenshot(format)
+}
+
 func (a *HostAgent) Info(_ context.Context) (*hostagentapi.Info, error) {
 	info := &hostagentapi.Info{
 		AutoStartedIdentifier: autostart.AutoStartedIdentifier(),


### PR DESCRIPTION
This PR implments a screenshot command for the VZ driver. It sounds like adding a QEMU version could follow on. 

Adds `limactl screenshot <instance>` — captures the current display of
a running VZ VM and saves it to an image file on the host.

## Usage

```
limactl screenshot myvm                    # saves myvm-screenshot.png
limactl screenshot myvm --output foo.png   # custom path
limactl screenshot myvm --output foo.bmp   # BMP format
```

## Scope and limitations

VZ driver only, macOS host only. Requires `video.display: vz` or
`video.display: default` and the Lima.app GUI window must be on screen.
QEMU instances and headless VZ instances return a clear error rather
than failing silently.

## Implementation

- New optional `Screenshotter` interface in the driver layer — same
  pattern as existing optional interfaces. Only VZ implements it now;
  afbjorklund noted QEMU's `screendump` HMP command could follow once
  the interface is settled.
- New `GET /v1/screenshot` endpoint on the hostagent HTTP API,
  consistent with `/v1/info`.
- New `Screenshot` method on the hostagent client with typed HTTP
  error handling (404/501/422).
- New `limactl screenshot` subcommand (`//go:build darwin`).

Also fixes a pre-existing bug in `server.go` `onError`: `WriteHeader`
was called before `w.Header().Set(...)`, silently dropping the
Content-Type on error responses.

Closes #5094

Note: I am using Claude Code with Sonnet 4.6 (default) to assist with this work.