### PR TITLE
feat: allow opting out of passwordless sudo

### DIFF
--- a/hack/bats/tests/passwordless-sudo.bats
+++ b/hack/bats/tests/passwordless-sudo.bats
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load "../helpers/load"
+CUSTOM_INSTANCE="test-passwordlessSudo"
+local_setup_file() {
+	limactl delete -f "${CUSTOM_INSTANCE}" 2>/dev/null || true
+	limactl start --name="${CUSTOM_INSTANCE}" --tty=false \
+		--set '.user.passwordlessSudo = false' \
+		--plain \
+		template:default
+}
+
+local_teardown_file() {
+	limactl delete -f "${CUSTOM_INSTANCE}"
+}
+
+@test "passwordlessSudo: false - sudo without password fails" {
+	run -1 limactl shell "${CUSTOM_INSTANCE}" -- sudo -n true
+}
+
+@test "passwordlessSudo: false - password file exists with correct permissions" {
+	limactl shell "${CUSTOM_INSTANCE}" -- bash -c 'stat ~/password'
+	run -0 limactl shell "${CUSTOM_INSTANCE}" -- bash -c 'stat -c "%a" ~/password'
+	assert_output "600"
+}
+
+@test "passwordlessSudo: false - generated password authenticates sudo" {
+	limactl shell "${CUSTOM_INSTANCE}" -- bash -c 'echo "$(cat ~/password)" | sudo -S true'
+}
+
+@test "passwordlessSudo: false - password file is not regenerated on reboot" {
+	original=$(limactl shell "${CUSTOM_INSTANCE}" -- bash -c 'cat ~/password')
+
+	limactl stop "${CUSTOM_INSTANCE}"
+	limactl start --tty=false "${CUSTOM_INSTANCE}"
+
+	run -0 limactl shell "${CUSTOM_INSTANCE}" -- bash -c 'cat ~/password'
+	assert_output "${original}"
+}
+
+@test "passwordlessSudo: false - deleted password file is not regenerated" {
+	limactl shell "${CUSTOM_INSTANCE}" -- bash -c 'rm -f ~/password'
+	limactl stop "${CUSTOM_INSTANCE}"
+	limactl start --tty=false "${CUSTOM_INSTANCE}"
+	run -1 limactl shell "${CUSTOM_INSTANCE}" -- bash -c 'test -f ~/password'
+}

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.sh
@@ -203,6 +203,41 @@ if [ -d "${LIMA_CIDATA_MNT}"/provision.user ]; then
 	done
 fi
 
+if [ "${UNAME}" != "Darwin" ] && [ "${LIMA_CIDATA_PASSWORDLESS_SUDO}" != "1" ]; then
+	if [ ! -f "${LIMA_CIDATA_HOME}/.lima-password-set" ]; then
+		PASSWORD=$(head -c 8 /dev/urandom | od -An -tx1 | tr -d ' \n')
+		if command -v chpasswd >/dev/null 2>&1; then
+			if ! echo "${LIMA_CIDATA_USER}:${PASSWORD}" | chpasswd; then
+				WARNING "failed to set password via chpasswd"
+				PASSWORD=""
+				CODE=1
+			fi
+		elif command -v pw >/dev/null 2>&1; then
+			if ! echo "${PASSWORD}" | pw usermod "${LIMA_CIDATA_USER}" -h 0; then
+				WARNING "failed to set password via pw"
+				PASSWORD=""
+				CODE=1
+			fi
+		else
+			WARNING "no supported tool to set password found"
+			PASSWORD=""
+			CODE=1
+		fi
+		if [ -n "${PASSWORD}" ]; then
+			(umask 077 && : >"${LIMA_CIDATA_HOME}/password")
+			chown "${LIMA_CIDATA_USER}:${LIMA_CIDATA_USER}" "${LIMA_CIDATA_HOME}/password" || {
+				WARNING "failed to chown ${LIMA_CIDATA_HOME}/password"
+				CODE=1
+			}
+			echo "${PASSWORD}" >"${LIMA_CIDATA_HOME}/password"
+			touch "${LIMA_CIDATA_HOME}/.lima-password-set"
+			chown "${LIMA_CIDATA_USER}:${LIMA_CIDATA_USER}" "${LIMA_CIDATA_HOME}/.lima-password-set" || {
+				WARNING "failed to chown ${LIMA_CIDATA_HOME}/.lima-password-set"
+				CODE=1
+			}
+		fi
+	fi
+fi
 # Signal that provisioning is done. The instance ID changes on every boot,
 # so any value from a previous boot cycle will be different.
 echo "${LIMA_CIDATA_IID}" >"${RUN}/lima-boot-done"

--- a/pkg/cidata/cidata.TEMPLATE.d/lima.env
+++ b/pkg/cidata/cidata.TEMPLATE.d/lima.env
@@ -76,3 +76,8 @@ LIMA_CIDATA_NO_CLOUD_INIT=1
 {{- else}}
 LIMA_CIDATA_NO_CLOUD_INIT=
 {{- end}}
+{{- if .PasswordlessSudo}}
+LIMA_CIDATA_PASSWORDLESS_SUDO=1
+{{- else}}
+LIMA_CIDATA_PASSWORDLESS_SUDO=
+{{- end}}

--- a/pkg/cidata/cidata.TEMPLATE.d/user-data
+++ b/pkg/cidata/cidata.TEMPLATE.d/user-data
@@ -55,6 +55,7 @@ users:
     {{/* (Why doesn't macOS VM support graceful shutdown?) */}}
     sudo: ALL=(ALL) NOPASSWD:/sbin/shutdown -h now
 {{- else }}
+    {{- if .PasswordlessSudo }}
     sudo: ALL=(ALL) NOPASSWD:ALL
     {{- if eq .OS "FreeBSD" }}
     groups:
@@ -62,6 +63,15 @@ users:
     doas: permit nopass :wheel
     {{- end}}
     lock_passwd: true
+    {{- else }}
+    sudo: ALL=(ALL) ALL
+    {{- if eq .OS "FreeBSD" }}
+    groups:
+    - wheel
+    doas: permit :wheel
+    {{- end}}
+    lock_passwd: false
+    {{- end }}
 {{- end }}
 {{- if eq .OS "FreeBSD" }}
     ssh_authorized_keys:

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -136,6 +136,7 @@ func templateArgs(ctx context.Context, bootScripts bool, instDir, name string, i
 		Home:               *instConfig.User.Home,
 		Shell:              *instConfig.User.Shell,
 		UID:                *instConfig.User.UID,
+		PasswordlessSudo:   *instConfig.User.PasswordlessSudo,
 		GuestInstallPrefix: *instConfig.GuestInstallPrefix,
 		UpgradePackages:    *instConfig.UpgradePackages,
 		Containerd:         Containerd{System: *instConfig.Containerd.System, User: *instConfig.Containerd.User, Archive: archive},

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -100,6 +100,7 @@ type TemplateArgs struct {
 	Home                            string // home directory
 	Shell                           string // login shell
 	UID                             uint32
+	PasswordlessSudo                bool
 	SSHPubKeys                      []string
 	Mounts                          []Mount
 	MountType                       string

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -109,11 +109,12 @@ var (
 )
 
 type User struct {
-	Name    *string `yaml:"name,omitempty" json:"name,omitempty" jsonschema:"nullable"`
-	Comment *string `yaml:"comment,omitempty" json:"comment,omitempty" jsonschema:"nullable"`
-	Home    *string `yaml:"home,omitempty" json:"home,omitempty" jsonschema:"nullable"`
-	Shell   *string `yaml:"shell,omitempty" json:"shell,omitempty" jsonschema:"nullable"`
-	UID     *uint32 `yaml:"uid,omitempty" json:"uid,omitempty" jsonschema:"nullable"`
+	Name             *string `yaml:"name,omitempty" json:"name,omitempty" jsonschema:"nullable"`
+	Comment          *string `yaml:"comment,omitempty" json:"comment,omitempty" jsonschema:"nullable"`
+	Home             *string `yaml:"home,omitempty" json:"home,omitempty" jsonschema:"nullable"`
+	Shell            *string `yaml:"shell,omitempty" json:"shell,omitempty" jsonschema:"nullable"`
+	UID              *uint32 `yaml:"uid,omitempty" json:"uid,omitempty" jsonschema:"nullable"`
+	PasswordlessSudo *bool   `yaml:"passwordlessSudo,omitempty" json:"passwordlessSudo,omitempty" jsonschema:"nullable"`
 }
 
 type VMOpts map[VMType]any

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -171,6 +171,9 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 	if y.User.UID == nil {
 		y.User.UID = d.User.UID
 	}
+	if y.User.PasswordlessSudo == nil {
+		y.User.PasswordlessSudo = d.User.PasswordlessSudo
+	}
 	if o.User.Name != nil {
 		y.User.Name = o.User.Name
 	}
@@ -185,6 +188,9 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 	}
 	if o.User.UID != nil {
 		y.User.UID = o.User.UID
+	}
+	if o.User.PasswordlessSudo != nil {
+		y.User.PasswordlessSudo = o.User.PasswordlessSudo
 	}
 	if y.User.Name == nil {
 		y.User.Name = ptr.Of(osutil.LimaUser(ctx, existingLimaVersion, warn, y.OS).Username)
@@ -220,6 +226,15 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 			y.User.UID = ptr.Of(uint32(1000))
 		}
 		// warn = false
+	}
+
+	// fallback to nopasswd
+	if y.User.PasswordlessSudo == nil {
+		if y.OS != nil && *y.OS == limatype.DARWIN {
+			y.User.PasswordlessSudo = ptr.Of(false)
+		} else {
+			y.User.PasswordlessSudo = ptr.Of(true)
+		}
 	}
 	if out, err := executeGuestTemplate(*y.User.Home, instDir, y.User, y.Param); err == nil {
 		y.User.Home = ptr.Of(out.String())

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -116,11 +116,12 @@ func TestFillDefault(t *testing.T) {
 		NestedVirtualization: ptr.Of(false),
 		Plain:                ptr.Of(false),
 		User: limatype.User{
-			Name:    ptr.Of(user.Username),
-			Comment: ptr.Of(user.Name),
-			Home:    ptr.Of(user.HomeDir),
-			Shell:   ptr.Of("/bin/bash"),
-			UID:     ptr.Of(uint32(uid)),
+			Name:             ptr.Of(user.Username),
+			Comment:          ptr.Of(user.Name),
+			Home:             ptr.Of(user.HomeDir),
+			Shell:            ptr.Of("/bin/bash"),
+			UID:              ptr.Of(uint32(uid)),
+			PasswordlessSudo: ptr.Of(true),
 		},
 		TPM: ptr.Of(false),
 	}
@@ -417,11 +418,12 @@ func TestFillDefault(t *testing.T) {
 		},
 		NestedVirtualization: ptr.Of(true),
 		User: limatype.User{
-			Name:    ptr.Of("xxx"),
-			Comment: ptr.Of("Foo Bar"),
-			Home:    ptr.Of("/tmp"),
-			Shell:   ptr.Of("/bin/tcsh"),
-			UID:     ptr.Of(uint32(8080)),
+			Name:             ptr.Of("xxx"),
+			Comment:          ptr.Of("Foo Bar"),
+			Home:             ptr.Of("/tmp"),
+			Shell:            ptr.Of("/bin/tcsh"),
+			UID:              ptr.Of(uint32(8080)),
+			PasswordlessSudo: ptr.Of(false),
 		},
 		VMOpts: limatype.VMOpts{
 			"qemu": map[string]any{
@@ -646,11 +648,12 @@ func TestFillDefault(t *testing.T) {
 		},
 		NestedVirtualization: ptr.Of(false),
 		User: limatype.User{
-			Name:    ptr.Of("foo"),
-			Comment: ptr.Of("foo bar baz"),
-			Home:    ptr.Of("/override"),
-			Shell:   ptr.Of("/bin/sh"),
-			UID:     ptr.Of(uint32(1122)),
+			Name:             ptr.Of("foo"),
+			Comment:          ptr.Of("foo bar baz"),
+			Home:             ptr.Of("/override"),
+			Shell:            ptr.Of("/bin/sh"),
+			UID:              ptr.Of(uint32(1122)),
+			PasswordlessSudo: ptr.Of(true),
 		},
 		VMOpts: limatype.VMOpts{
 			"vz": map[string]any{
@@ -971,7 +974,6 @@ func TestDefaultSelectedImageIsStandard(t *testing.T) {
 	var y limatype.LimaYAML
 	err = Unmarshal(data, &y, "ubuntu-24.04.yaml")
 	assert.NilError(t, err)
-
 	var foundServer, foundMinimal bool
 	for _, img := range y.Images {
 		switch img.Variant {
@@ -984,4 +986,67 @@ func TestDefaultSelectedImageIsStandard(t *testing.T) {
 	}
 	assert.Assert(t, foundServer, "should have found standard/server images")
 	assert.Assert(t, foundMinimal, "should have found minimal images")
+}
+
+func TestFillDefaultUserPasswordlessSudo(t *testing.T) {
+	baseY := func() *limatype.LimaYAML {
+		return &limatype.LimaYAML{
+			OS:   ptr.Of(limatype.LINUX),
+			Arch: ptr.Of(limatype.X8664),
+		}
+	}
+	t.Run("fallback to true", func(t *testing.T) {
+		y, d, o := baseY(), &limatype.LimaYAML{}, &limatype.LimaYAML{}
+		FillDefault(t.Context(), y, d, o, "test.yaml", false)
+		assert.Assert(t, y.User.PasswordlessSudo != nil)
+		assert.Equal(t, *y.User.PasswordlessSudo, true)
+	})
+	t.Run("default propagates", func(t *testing.T) {
+		y, d, o := baseY(), &limatype.LimaYAML{User: limatype.User{PasswordlessSudo: ptr.Of(false)}}, &limatype.LimaYAML{}
+		FillDefault(t.Context(), y, d, o, "test.yaml", false)
+		assert.Equal(t, *y.User.PasswordlessSudo, false)
+	})
+	t.Run("yaml wins over default", func(t *testing.T) {
+		y, d, o := baseY(), &limatype.LimaYAML{User: limatype.User{PasswordlessSudo: ptr.Of(true)}}, &limatype.LimaYAML{}
+		y.User.PasswordlessSudo = ptr.Of(false)
+		FillDefault(t.Context(), y, d, o, "test.yaml", false)
+		assert.Equal(t, *y.User.PasswordlessSudo, false)
+	})
+	t.Run("override wins", func(t *testing.T) {
+		y, d, o := baseY(), &limatype.LimaYAML{}, &limatype.LimaYAML{User: limatype.User{PasswordlessSudo: ptr.Of(false)}}
+		y.User.PasswordlessSudo = ptr.Of(true)
+		FillDefault(t.Context(), y, d, o, "test.yaml", false)
+		assert.Equal(t, *y.User.PasswordlessSudo, false)
+	})
+}
+
+func TestValidatePasswordlessSudoRequiresPlain(t *testing.T) {
+	y, d, o := &limatype.LimaYAML{}, &limatype.LimaYAML{}, &limatype.LimaYAML{}
+	FillDefault(t.Context(), y, d, o, "test.yaml", false)
+	y.Images = []limatype.Image{
+		{
+			File: limatype.File{
+				Location: "https://example.com/dummy.img",
+				Arch:     limatype.X8664,
+			},
+		},
+	}
+	y.User.PasswordlessSudo = ptr.Of(false)
+	y.Plain = ptr.Of(false) // plain is false, which violates the GHSA constraint
+	err := Validate(y, false)
+	assert.ErrorContains(t, err, "`user.passwordlessSudo: false` requires `plain: true`")
+	y.Plain = ptr.Of(true)
+	errValid := Validate(y, false)
+	assert.NilError(t, errValid)
+}
+
+func TestValidatePasswordlessSudoFalseNoPlainRequiredOnMacOS(t *testing.T) {
+	y, d, o := &limatype.LimaYAML{}, &limatype.LimaYAML{}, &limatype.LimaYAML{}
+	y.OS = ptr.Of(limatype.DARWIN)
+	FillDefault(t.Context(), y, d, o, "test.yaml", false)
+	y.Images = []limatype.Image{
+		{File: limatype.File{Location: "https://example.com/dummy.img", Arch: limatype.AARCH64}},
+	}
+	err := Validate(y, false)
+	assert.NilError(t, err)
 }

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -424,6 +424,25 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 			}
 		}
 	}
+
+	// passwordlessSudo: true is not supported on macOS guests yet (lock_passwd unimplemented,
+	// account creation requires a password, and the same account backs the GUI session)
+	if y.OS != nil && *y.OS == limatype.DARWIN &&
+		y.User.PasswordlessSudo != nil && *y.User.PasswordlessSudo {
+		errs = errors.Join(errs, errors.New("`user.passwordlessSudo: true` is not supported on macOS guests"))
+	}
+	if y.VMType != nil && *y.VMType == limatype.WSL2 &&
+		y.User.PasswordlessSudo != nil && !*y.User.PasswordlessSudo {
+		errs = errors.Join(errs, errors.New("`user.passwordlessSudo: false` is not supported on WSL2 guest"))
+	}
+	// GHSA-2j9v-p4xj-cjw2 constraint: require plain mode when passwordless sudo is disabled
+	if y.User.PasswordlessSudo != nil && !*y.User.PasswordlessSudo {
+		if y.OS == nil || *y.OS != limatype.DARWIN {
+			if y.Plain == nil || !*y.Plain {
+				errs = errors.Join(errs, errors.New("`user.passwordlessSudo: false` requires `plain: true`"))
+			}
+		}
+	}
 	if y.Plain != nil && *y.Plain {
 		const portRangeWarnThreshold = 10
 		for i, rule := range y.PortForwards {
@@ -662,6 +681,14 @@ func warnExperimental(y *limatype.LimaYAML) {
 	}
 	if y.MountInotify != nil && *y.MountInotify {
 		logrus.Warn("`mountInotify` is experimental")
+	}
+	if y.User.PasswordlessSudo != nil && !*y.User.PasswordlessSudo {
+		if y.OS == nil || *y.OS != limatype.DARWIN {
+			logrus.Warn("`user.passwordlessSudo: false` is experimental")
+		}
+	}
+	if y.User.PasswordlessSudo != nil && !*y.User.PasswordlessSudo && len(y.Param) > 0 {
+		logrus.Warn("`param` still relies on sudo internally, it may not work as expected when `user.passwordlessSudo: false` is set")
 	}
 }
 

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -374,6 +374,12 @@ user:
   # The shell must already exist in the guest image.
   # 🟢 Builtin default: "/bin/bash" (Linux), "/bin/zsh" (macOS), "/bin/sh" (FreeBSD), "cmd.exe" (Windows)
   shell: null
+  # EXPERIMENTAL
+  # If false, a secure 16-character random password will be generated inside
+  # the guest on first boot and saved to `~/password` (with 0600 permissions).
+  # The user should manually rotate this password after the initial login.
+  # 🟢 Builtin default: true (false for macOS)
+  passwordlessSudo: null
 
 vmOpts:
   qemu:

--- a/website/content/en/docs/config/sudo.md
+++ b/website/content/en/docs/config/sudo.md
@@ -1,0 +1,26 @@
+---
+title: Sudo
+weight: 40
+---
+
+| ⚡ Requirement | Lima >= 2.2 |
+|---------------|-------------|
+
+By default, the guest user has passwordless sudo (`NOPASSWD:ALL`).
+
+The password is only generated once, on first boot. If you manually change the
+password and remove `~/password`, it will **not** be regenerated on subsequent
+boots, the file is purely informational for the initial login.
+
+```yaml
+user:
+  passwordlessSudo: false
+```
+
+## Caveats
+
+- Requires `plain: true` on non-macOS guests ([GHSA-2j9v-p4xj-cjw2](https://github.com/lima-vm/lima/security/advisories/GHSA-2j9v-p4xj-cjw2)): the guest agent's Unix socket tunneling is disabled until it can safely refuse privileged socket tunneling with passwordless sudo off.
+- Only applies to cloud-init provisioned guests (QEMU/vz). Setting `user.passwordlessSudo: false` on WSL2 (Windows) guests returns a validation error, as WSL2 does not support this configuration as of now.
+- The guest user is already a member of the `adm` and `systemd-journal` groups, which grants passive read access to `/var/log/*` and the full system journal independent of sudo.
+- `param` still relies on sudo internally (`param.env` is read via `sudo cat` inside the guest), so it may not work as expected when `user.passwordlessSudo: false` is set. A warning is printed in this case.
+- **macOS**: not configurable. Password-required sudo is always on (except `/sbin/shutdown -h now`), matching the built-in [macOS guest](/docs/usage/guests/macos/) behavior. Setting `user.passwordlessSudo: true` on a macOS guest returns a validation error.

--- a/website/content/en/docs/releases/experimental.md
+++ b/website/content/en/docs/releases/experimental.md
@@ -13,6 +13,7 @@ The following features are experimental and subject to change:
 - `audio.device` and `audio.interface`
 - `mountInotify: true`
 - `tpm: true`
+- `user.passwordlessSudo` (See [Sudo](../config/sudo))
 - `External drivers`: building and using drivers as separate executables (see [Virtual Machine Drivers](../dev/drivers))
 - [`vmType: krunkit`](../config/vmtype/krunkit.md)
 - [`github` URL scheme](../templates/github.md): referencing templates on GitHub with `github:` URLs

--- a/website/content/en/docs/usage/guests/macos.md
+++ b/website/content/en/docs/usage/guests/macos.md
@@ -30,7 +30,7 @@ limactl shell macos cat /Users/${USER}.guest/password
 
 ## Difference from Linux guests
 - Password login is enabled
-- Password-less sudo is disabled, except for `/sbin/shutdown -h now`
+- Password-less sudo is disabled, except for `/sbin/shutdown -h now` (see [Sudo](/docs/config/sudo/) — this is not currently configurable on macOS)
 - Several features are not implemented yet. See [Caveats](#caveats) below.
 
 ## Caveats


### PR DESCRIPTION
Fixes #4594 

Adds `user.passwordlessSudo` (default `true`, unchanged behavior). When set to `false`, the guest user gets `sudo: ALL=(ALL) ALL` with `lock_passwd: false` instead of `NOPASSWD:ALL`. A random password is generated on first boot via `boot.sh` using `/dev/urandom`, applied via `chpasswd`, and saved to `~/password` in the guest (`0600`).

 This PR is the final piece of a series of prerequisite PRs needed to safely remove `NOPASSWD:ALL`:
 - #5135 — drop `sudo grep` for `fuse*.conf` check (notification file approach)
 - #5147  — drop sudo for non-privileged files in `copyToHost`
 - #5157   — move `/run/host-services` `mkdir`/`chown` to boot script

 **Design notes:**
 - Password is stored guest-side at `~/password`, consistent with macOS guest convention in `macos-26.yaml`
 - Nothing password-related is written to the cidata ISO, avoiding the plaintext visibility concern in #4593
 - `plain: true` is required when `passwordlessSudo: false` as an interim constraint per [GHSA-2j9v-p4xj-cjw2](https://github.com/lima-vm/lima/security/advisories/GHSA-2j9v-p4xj-cjw2), until guestagent's Unix socket tunneling refusal is implemented

 **Known limitations / follow-ups:**
 - [ ] Only applies to cloud-init provisioned guests (QEMU/vz). WSL2 instances ignore `passwordlessSudo`.
 - [ ] `param.env` sudo dependency pending #4593 direction
 - [ ] Proper guestagent Unix socket tunneling refusal when `passwordlessSudo: false` (currently enforced via `plain: true`)
 - [ ] No CLI to retrieve the password, users must `cat ~/password` from inside the guest
 - [ ] Security Constraint: Enforces plain: true when passwordlessSudo: false is set. This mitigates GHSA-2j9v-p4xj-cjw2 by disabling the guestagent (and its Unix socket tunneling) until the guestagent is refactored to refuse socket tunneling safely.
