### PR TITLE
Secure macOS VZ block-device attachment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -591,8 +591,24 @@ jobs:
         cache: false
     - name: Make
       run: make
+    - name: Install socket_vmnet
+      env:
+        SOCKET_VMNET_VERSION: v1.2.2
+      run: |
+        (
+          cd ~
+          git clone https://github.com/lima-vm/socket_vmnet
+          cd socket_vmnet
+          git checkout $SOCKET_VMNET_VERSION
+          sudo git config --global --add safe.directory /Users/runner/socket_vmnet
+          sudo make PREFIX=/opt/socket_vmnet install
+        )
     - name: Install
-      run: sudo make install
+      run: |
+        sudo install -d -o root -g wheel -m 0755 /opt/lima
+        sudo make PREFIX=/opt/lima install
+        echo /opt/lima/bin >>$GITHUB_PATH
+        /opt/lima/bin/limactl sudoers | sudo tee /etc/sudoers.d/lima
     - name: Cache image used by templates/${{ matrix.template }}
       uses: ./.github/actions/setup_cache_for_template
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -584,6 +584,7 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         persist-credentials: false
+        submodules: true
     - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
       with:
         go-version: stable
@@ -602,6 +603,8 @@ jobs:
       run: brew uninstall --ignore-dependencies --force qemu
     - name: Test
       run: ./hack/test-templates.sh templates/${{ matrix.template }}
+    - name: Run BATS VZ block-device tests
+      run: ./hack/bats/lib/bats-core/bin/bats --timing ./hack/bats/extras/vz-block-device.bats
     - if: failure()
       uses: ./.github/actions/upload_failure_logs_if_exists
       with:

--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -67,6 +67,7 @@ func RegisterEdit(cmd *cobra.Command, commentPrefix string) {
 	flags.Bool("nested-virt", false, commentPrefix+"Enable nested virtualization")
 
 	flags.Bool("rosetta", false, commentPrefix+"Enable Rosetta (for vz instances)")
+	flags.StringSlice("block-device", nil, commentPrefix+"Host block devices to attach on supported backends, e.g. /dev/disk4")
 
 	flags.StringArray("set", []string{}, commentPrefix+"Modify the template inplace, using yq syntax. Can be passed multiple times. See 'limactl help yq-restrictions' for limitations.")
 	flags.StringArray("param", []string{}, commentPrefix+"Set a template parameter, e.g. name=value. Can be passed multiple times.")
@@ -354,6 +355,25 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool, params map[string]stri
 					return nil, err
 				}
 				return []string{fmt.Sprintf(".vmOpts.vz.rosetta.enabled = %v | .vmOpts.vz.rosetta.binfmt = %v", b, b)}, nil
+			},
+			false,
+			false,
+		},
+		{
+			"block-device",
+			func(_ *flag.Flag) ([]string, error) {
+				paths, err := flags.GetStringSlice("block-device")
+				if err != nil {
+					return nil, err
+				}
+				devices := make([]string, len(paths))
+				for i, path := range paths {
+					if path == "" {
+						return nil, errors.New("block device path must not be empty")
+					}
+					devices[i] = strconv.Quote(path)
+				}
+				return []string{fmt.Sprintf(".blockDevices += [%s] | .blockDevices |= unique", strings.Join(devices, ","))}, nil
 			},
 			false,
 			false,

--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -373,7 +373,7 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool, params map[string]stri
 					}
 					devices[i] = strconv.Quote(path)
 				}
-				return []string{fmt.Sprintf(".blockDevices += [%s] | .blockDevices |= unique", strings.Join(devices, ","))}, nil
+				return []string{fmt.Sprintf(".blockDevices = ((.blockDevices // []) + [%s]) | .blockDevices |= unique", strings.Join(devices, ","))}, nil
 			},
 			false,
 			false,

--- a/cmd/limactl/editflags/editflags_test.go
+++ b/cmd/limactl/editflags/editflags_test.go
@@ -11,6 +11,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/lima-vm/lima/v2/pkg/localpathutil"
+	"github.com/lima-vm/lima/v2/pkg/yqutil"
 )
 
 func TestCompleteCPUs(t *testing.T) {
@@ -91,6 +92,28 @@ func TestBuildPortForwardExpression(t *testing.T) {
 				assert.NilError(t, err)
 				assert.Equal(t, tt.expected, result)
 			}
+		})
+	}
+}
+
+func TestBlockDeviceYQExpressionHandlesMissingOrNullBlockDevices(t *testing.T) {
+	cmd := &cobra.Command{}
+	RegisterEdit(cmd, "")
+	assert.NilError(t, cmd.ParseFlags([]string{"--block-device", "/dev/disk4"}))
+	exprs, err := YQExpressions(cmd.Flags(), false, nil)
+	assert.NilError(t, err)
+
+	tests := map[string]string{
+		"missing": "vmType: vz\n",
+		"null":    "vmType: vz\nblockDevices: null\n",
+	}
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Older instance YAML may not have blockDevices yet. Applying the edit
+			// must create a list instead of relying on yq's += behavior for null.
+			out, err := yqutil.EvaluateExpression(t.Context(), yqutil.Join(exprs), []byte(input))
+			assert.NilError(t, err)
+			assert.Equal(t, string(out), "vmType: vz\nblockDevices:\n- /dev/disk4\n")
 		})
 	}
 }
@@ -288,7 +311,7 @@ func TestYQExpressions(t *testing.T) {
 			name:        "block-device",
 			args:        []string{"--block-device", "/dev/disk4", "--block-device", "/dev/rdisk5"},
 			newInstance: false,
-			expected:    []string{`.blockDevices += ["/dev/disk4","/dev/rdisk5"] | .blockDevices |= unique`},
+			expected:    []string{`.blockDevices = ((.blockDevices // []) + ["/dev/disk4","/dev/rdisk5"]) | .blockDevices |= unique`},
 		},
 		{
 			name:        "invalid network",

--- a/cmd/limactl/editflags/editflags_test.go
+++ b/cmd/limactl/editflags/editflags_test.go
@@ -285,6 +285,12 @@ func TestYQExpressions(t *testing.T) {
 			expectError: "template does not define param `missing`",
 		},
 		{
+			name:        "block-device",
+			args:        []string{"--block-device", "/dev/disk4", "--block-device", "/dev/rdisk5"},
+			newInstance: false,
+			expected:    []string{`.blockDevices += ["/dev/disk4","/dev/rdisk5"] | .blockDevices |= unique`},
+		},
+		{
 			name:        "invalid network",
 			args:        []string{"--network", "invalid"},
 			newInstance: true,

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -32,7 +32,7 @@ const (
 )
 
 func main() {
-	if os.Geteuid() == 0 && (len(os.Args) < 2 || os.Args[1] != "generate-doc") {
+	if os.Geteuid() == 0 && (len(os.Args) < 2 || (os.Args[1] != "generate-doc" && !isPrivilegedHelperCommand(os.Args[1]))) {
 		fmt.Fprint(os.Stderr, "limactl: must not run as the root user\n")
 		os.Exit(1)
 	}
@@ -136,6 +136,9 @@ func newApp() *cobra.Command {
 			// allow commands that are used for packaging to run under rosetta to allow cross-architecture builds
 			return errors.New("limactl is running under rosetta, please reinstall lima with native arch")
 		}
+		if isPrivilegedHelperCommand(cmd.Name()) {
+			return nil
+		}
 
 		// Make sure either $HOME or $LIMA_HOME is defined, so we don't need
 		// to check for errors later
@@ -214,6 +217,7 @@ func newApp() *cobra.Command {
 		newWatchCommand(),
 		newYQRestrictionsHelpCommand(),
 	)
+	registerHiddenCommands(rootCmd)
 	addPluginCommands(rootCmd)
 
 	return rootCmd

--- a/cmd/limactl/sudo_open_block_device_command_darwin.go
+++ b/cmd/limactl/sudo_open_block_device_command_darwin.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/v2/pkg/blockdevice"
+)
+
+func isPrivilegedHelperCommand(name string) bool {
+	return name == blockdevice.SudoOpenBlockDeviceCommand
+}
+
+func registerHiddenCommands(rootCmd *cobra.Command) {
+	rootCmd.AddCommand(&cobra.Command{
+		Use:    blockdevice.SudoOpenBlockDeviceCommand,
+		Short:  "Open a host block device via privileged helper",
+		Args:   WrapArgsError(cobra.NoArgs),
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return blockdevice.ServeSudoOpenBlockDevice(cmd.InOrStdin())
+		},
+	})
+}

--- a/cmd/limactl/sudo_open_block_device_command_darwin.go
+++ b/cmd/limactl/sudo_open_block_device_command_darwin.go
@@ -19,10 +19,10 @@ func registerHiddenCommands(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(&cobra.Command{
 		Use:    blockdevice.SudoOpenBlockDeviceCommand,
 		Short:  "Open a host block device via privileged helper",
-		Args:   WrapArgsError(cobra.NoArgs),
+		Args:   WrapArgsError(cobra.ExactArgs(1)),
 		Hidden: true,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return blockdevice.ServeSudoOpenBlockDevice(cmd.InOrStdin())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return blockdevice.ServeSudoOpenBlockDevice(args[0], cmd.InOrStdin())
 		},
 	})
 }

--- a/cmd/limactl/sudo_open_block_device_command_others.go
+++ b/cmd/limactl/sudo_open_block_device_command_others.go
@@ -1,0 +1,14 @@
+//go:build !darwin
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "github.com/spf13/cobra"
+
+func isPrivilegedHelperCommand(string) bool {
+	return false
+}
+
+func registerHiddenCommands(_ *cobra.Command) {}

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -27,7 +27,8 @@ To validate the existing /etc/sudoers.d/lima file:
 $ limactl sudoers --check /etc/sudoers.d/lima
 `,
 		Short: "Generate the content of the /etc/sudoers.d/lima file",
-		Long: fmt.Sprintf(`Generate the content of the /etc/sudoers.d/lima file for enabling vmnet.framework support (socket_vmnet) on macOS.
+		Long: fmt.Sprintf(`Generate the content of the /etc/sudoers.d/lima file for macOS host helpers that require privilege escalation.
+This includes vmnet.framework support (socket_vmnet) and host block-device attachment with --block-device on supported backends.
 The content is written to stdout, NOT to the file.
 This command must not run as the root user.
 See %s for the usage.`, socketVMNetURL),

--- a/cmd/limactl/sudoers.go
+++ b/cmd/limactl/sudoers.go
@@ -28,7 +28,8 @@ $ limactl sudoers --check /etc/sudoers.d/lima
 `,
 		Short: "Generate the content of the /etc/sudoers.d/lima file",
 		Long: fmt.Sprintf(`Generate the content of the /etc/sudoers.d/lima file for macOS host helpers that require privilege escalation.
-This includes vmnet.framework support (socket_vmnet) and host block-device attachment with --block-device on supported backends.
+This includes vmnet.framework support (socket_vmnet). Use --block-device=/dev/rdiskN to also emit opt-in
+host block-device helper entries for the listed devices and current user.
 The content is written to stdout, NOT to the file.
 This command must not run as the root user.
 See %s for the usage.`, socketVMNetURL),
@@ -39,5 +40,7 @@ See %s for the usage.`, socketVMNetURL),
 	cfgFile, _ := networks.ConfigFile()
 	sudoersCommand.Flags().Bool("check", false,
 		fmt.Sprintf("check that the sudoers file is up-to-date with %#q", cfgFile))
+	sudoersCommand.Flags().StringSlice("block-device", nil,
+		"include the macOS VZ host block-device helper for the current user and comma-separated devices")
 	return sudoersCommand
 }

--- a/cmd/limactl/sudoers_darwin.go
+++ b/cmd/limactl/sudoers_darwin.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/lima-vm/lima/v2/pkg/blockdevice"
@@ -27,8 +29,21 @@ func sudoersAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	blockDevices, err := cmd.Flags().GetStringSlice("block-device")
+	if err != nil {
+		return err
+	}
+	includeNetwork := true
+	if err := nwCfg.Validate(); err != nil {
+		if len(blockDevices) == 0 {
+			logrus.Infof("Please check %s for more information.", socketVMNetURL)
+			return err
+		}
+		logrus.WithError(err).Info("Skipping network sudoers entries")
+		includeNetwork = false
+	}
 	if check {
-		return verifySudoAccess(ctx, nwCfg, args, cmd.OutOrStdout())
+		return verifySudoAccess(ctx, nwCfg, args, blockDevices, includeNetwork, cmd.OutOrStdout())
 	}
 	switch len(args) {
 	case 0:
@@ -38,20 +53,34 @@ func sudoersAction(cmd *cobra.Command, args []string) error {
 	default:
 		return fmt.Errorf("unexpected arguments %v", args)
 	}
-	networkSudoers, err := nwCfg.Sudoers()
+	content, err := renderSudoers(nwCfg, blockDevices, includeNetwork)
 	if err != nil {
 		return err
 	}
-	blockDeviceSudoers, err := blockdevice.Sudoers(nwCfg.Group)
-	if err != nil {
-		return err
-	}
-	content := sudoers.AssembleSudoersFragments(networkSudoers, blockDeviceSudoers)
 	fmt.Fprint(cmd.OutOrStdout(), content)
 	return nil
 }
 
-func verifySudoAccess(ctx context.Context, nwCfg networks.Config, args []string, stdout io.Writer) error {
+func renderSudoers(nwCfg networks.Config, blockDevices []string, includeNetwork bool) (string, error) {
+	var networkSudoers string
+	var err error
+	if includeNetwork {
+		networkSudoers, err = nwCfg.Sudoers()
+		if err != nil {
+			return "", err
+		}
+	}
+	var blockDeviceSudoers string
+	if len(blockDevices) > 0 {
+		blockDeviceSudoers, err = blockdevice.Sudoers(blockDevices)
+		if err != nil {
+			return "", err
+		}
+	}
+	return sudoers.AssembleSudoersFragments(networkSudoers, blockDeviceSudoers), nil
+}
+
+func verifySudoAccess(ctx context.Context, nwCfg networks.Config, args, blockDevices []string, includeNetwork bool, stdout io.Writer) error {
 	var file string
 	switch len(args) {
 	case 0:
@@ -65,16 +94,15 @@ func verifySudoAccess(ctx context.Context, nwCfg networks.Config, args []string,
 	default:
 		return errors.New("can check only a single sudoers file")
 	}
-	if err := verifySudoersFile(ctx, nwCfg, file); err != nil {
+	if err := verifySudoersFile(ctx, nwCfg, file, blockDevices, includeNetwork); err != nil {
 		return err
 	}
 	fmt.Fprintf(stdout, "%#q is up-to-date (or sudo doesn't require a password)\n", file)
 	return nil
 }
 
-func verifySudoersFile(ctx context.Context, nwCfg networks.Config, file string) error {
-	hint := fmt.Sprintf("run `%s sudoers >etc_sudoers.d_lima && sudo install -o root etc_sudoers.d_lima %q`)",
-		os.Args[0], file)
+func verifySudoersFile(ctx context.Context, nwCfg networks.Config, file string, blockDevices []string, includeNetwork bool) error {
+	hint := sudoersCheckHint(os.Args[0], file, blockDevices)
 	b, err := os.ReadFile(file)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -86,17 +114,33 @@ func verifySudoersFile(ctx context.Context, nwCfg networks.Config, file string) 
 		}
 		return fmt.Errorf("can't read %q: %w: (Hint: %s)", file, err, hint)
 	}
-	networkSudoers, err := nwCfg.Sudoers()
+	content, err := renderSudoers(nwCfg, blockDevices, includeNetwork)
 	if err != nil {
 		return err
 	}
-	blockDeviceSudoers, err := blockdevice.Sudoers(nwCfg.Group)
-	if err != nil {
-		return err
+	if string(b) == content {
+		return nil
 	}
-	content := sudoers.AssembleSudoersFragments(networkSudoers, blockDeviceSudoers)
-	if string(b) != content {
-		return fmt.Errorf("sudoers file %q is out of sync and must be regenerated (Hint: %s)", file, hint)
+	if len(blockDevices) == 0 {
+		networkSudoers, err := nwCfg.Sudoers()
+		if err != nil {
+			return err
+		}
+		if sudoers.ContainsActiveFragment(string(b), networkSudoers) {
+			return nil
+		}
 	}
-	return nil
+	if len(blockDevices) == 0 {
+		hint += "; include any --block-device entries you still need"
+	}
+	return fmt.Errorf("sudoers file %q is out of sync and must be regenerated (Hint: %s)", file, hint)
+}
+
+func sudoersCheckHint(exe, file string, blockDevices []string) string {
+	sudoersArgs := "sudoers"
+	if len(blockDevices) > 0 {
+		sudoersArgs += " --block-device=" + strings.Join(blockDevices, ",")
+	}
+	return fmt.Sprintf("run `%s %s >etc_sudoers.d_lima && sudo install -o root etc_sudoers.d_lima %q`",
+		exe, sudoersArgs, file)
 }

--- a/cmd/limactl/sudoers_darwin.go
+++ b/cmd/limactl/sudoers_darwin.go
@@ -8,22 +8,19 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/lima-vm/lima/v2/pkg/blockdevice"
 	"github.com/lima-vm/lima/v2/pkg/networks"
+	"github.com/lima-vm/lima/v2/pkg/sudoers"
 )
 
 func sudoersAction(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	nwCfg, err := networks.LoadConfig()
 	if err != nil {
-		return err
-	}
-	// Make sure the current network configuration is secure
-	if err := nwCfg.Validate(); err != nil {
-		logrus.Infof("Please check %s for more information.", socketVMNetURL)
 		return err
 	}
 	check, err := cmd.Flags().GetBool("check")
@@ -41,11 +38,16 @@ func sudoersAction(cmd *cobra.Command, args []string) error {
 	default:
 		return fmt.Errorf("unexpected arguments %v", args)
 	}
-	sudoers, err := networks.Sudoers()
+	networkSudoers, err := nwCfg.Sudoers()
 	if err != nil {
 		return err
 	}
-	fmt.Fprint(cmd.OutOrStdout(), sudoers)
+	blockDeviceSudoers, err := blockdevice.Sudoers(nwCfg.Group)
+	if err != nil {
+		return err
+	}
+	content := sudoers.AssembleSudoersFragments(networkSudoers, blockDeviceSudoers)
+	fmt.Fprint(cmd.OutOrStdout(), content)
 	return nil
 }
 
@@ -63,9 +65,38 @@ func verifySudoAccess(ctx context.Context, nwCfg networks.Config, args []string,
 	default:
 		return errors.New("can check only a single sudoers file")
 	}
-	if err := nwCfg.VerifySudoAccess(ctx, file); err != nil {
+	if err := verifySudoersFile(ctx, nwCfg, file); err != nil {
 		return err
 	}
 	fmt.Fprintf(stdout, "%#q is up-to-date (or sudo doesn't require a password)\n", file)
+	return nil
+}
+
+func verifySudoersFile(ctx context.Context, nwCfg networks.Config, file string) error {
+	hint := fmt.Sprintf("run `%s sudoers >etc_sudoers.d_lima && sudo install -o root etc_sudoers.d_lima %q`)",
+		os.Args[0], file)
+	b, err := os.ReadFile(file)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if err := nwCfg.VerifySudoAccess(ctx, ""); err == nil {
+				if err := sudoers.Run(ctx, "root", "wheel", nil, nil, nil, "", "true"); err == nil {
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("can't read %q: %w: (Hint: %s)", file, err, hint)
+	}
+	networkSudoers, err := nwCfg.Sudoers()
+	if err != nil {
+		return err
+	}
+	blockDeviceSudoers, err := blockdevice.Sudoers(nwCfg.Group)
+	if err != nil {
+		return err
+	}
+	content := sudoers.AssembleSudoersFragments(networkSudoers, blockDeviceSudoers)
+	if string(b) != content {
+		return fmt.Errorf("sudoers file %q is out of sync and must be regenerated (Hint: %s)", file, hint)
+	}
 	return nil
 }

--- a/cmd/limactl/sudoers_darwin_test.go
+++ b/cmd/limactl/sudoers_darwin_test.go
@@ -1,0 +1,72 @@
+//go:build darwin
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/blockdevice"
+	"github.com/lima-vm/lima/v2/pkg/networks"
+)
+
+func TestRenderSudoersOmitsBlockDeviceByDefault(t *testing.T) {
+	content, err := renderSudoers(networks.Config{
+		Paths: networks.Paths{
+			VarRun: "/private/var/run/lima",
+		},
+		Group:    "everyone",
+		Networks: map[string]networks.Network{},
+	}, nil, true)
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(content, "%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: /bin/mkdir -m 775 -p /private/var/run/lima"))
+	assert.Assert(t, !strings.Contains(content, blockdevice.SudoOpenBlockDeviceCommand))
+}
+
+func TestVerifySudoersFileAllowsAdditionalActiveFragments(t *testing.T) {
+	cfg := networks.Config{
+		Paths: networks.Paths{
+			VarRun: "/private/var/run/lima",
+		},
+		Group:    "everyone",
+		Networks: map[string]networks.Network{},
+	}
+	networkSudoers, err := cfg.Sudoers()
+	assert.NilError(t, err)
+
+	file := t.TempDir() + "/lima.sudoers"
+	assert.NilError(t, os.WriteFile(file, []byte(networkSudoers+"alice ALL=(root:wheel) NOPASSWD:NOSETENV: /opt/lima/bin/limactl sudo-open-block-device /dev/rdisk2\n"), 0o600))
+
+	assert.NilError(t, verifySudoersFile(t.Context(), cfg, file, nil, true))
+}
+
+func TestVerifySudoersFileRejectsCommentedNetworkFragment(t *testing.T) {
+	cfg := networks.Config{
+		Paths: networks.Paths{
+			VarRun: "/private/var/run/lima",
+		},
+		Group:    "everyone",
+		Networks: map[string]networks.Network{},
+	}
+	networkSudoers, err := cfg.Sudoers()
+	assert.NilError(t, err)
+
+	file := t.TempDir() + "/lima.sudoers"
+	assert.NilError(t, os.WriteFile(file, []byte("# "+strings.ReplaceAll(networkSudoers, "\n", "\n# ")), 0o600))
+
+	err = verifySudoersFile(t.Context(), cfg, file, nil, true)
+	assert.ErrorContains(t, err, "out of sync")
+}
+
+func TestSudoersCheckHintHasBalancedParentheses(t *testing.T) {
+	hint := sudoersCheckHint("/opt/lima/bin/limactl", "/etc/sudoers.d/lima", []string{"/dev/rdisk2"})
+
+	assert.Equal(t, hint, "run `/opt/lima/bin/limactl sudoers --block-device=/dev/rdisk2 >etc_sudoers.d_lima && sudo install -o root etc_sudoers.d_lima \"/etc/sudoers.d/lima\"`")
+	assert.Assert(t, !strings.HasSuffix(hint, ")"))
+}

--- a/hack/bats/extras/vz-block-device.bats
+++ b/hack/bats/extras/vz-block-device.bats
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load "../helpers/load"
+
+# End-to-end flow:
+# 1. Create a tiny host RAM disk and attach it to a VZ VM as either /dev/diskN or /dev/rdiskN.
+# 2. In the guest, partition it as GPT with an msftdata partition, format it as exFAT, and write test data.
+# 3. Stop the VM, mount the same partition on the macOS host, verify the guest write, and append more data.
+# 4. Start the VM again, verify the host write from the guest, append again, stop the VM, and verify the final
+#    contents from the host once more. This exercises the real guest<->host handoff instead of just local helpers.
+
+configured_block_device=""
+host_disk_device=""
+host_partition=""
+instance_name=""
+
+teardown() {
+	if [[ -n ${instance_name} ]]; then
+		limactl unprotect "${instance_name}" || :
+		limactl delete --force "${instance_name}" || :
+	fi
+	if [[ -n ${host_partition} ]]; then
+		sudo diskutil unmount force "${host_partition}" >/dev/null 2>&1 || :
+	fi
+	if [[ -n ${host_disk_device} ]]; then
+		sudo diskutil unmountDisk force "${host_disk_device}" >/dev/null 2>&1 || :
+		sudo hdiutil detach "${host_disk_device}" -force >/dev/null 2>&1 || :
+	fi
+	configured_block_device=""
+	host_disk_device=""
+	host_partition=""
+	instance_name=""
+}
+
+bats::on_failure() {
+	if [[ -n ${instance_name} ]] && [[ -d ${LIMA_HOME}/${instance_name} ]]; then
+		tail -n 100 "${LIMA_HOME}/${instance_name}"/*.log || :
+		limactl shell "${instance_name}" -- sudo cat /var/log/cloud-init-output.log || :
+	fi
+}
+
+create_ramdisk() {
+	host_disk_device=$(sudo hdiutil attach -nomount ram://65536 | awk 'NR==1 {print $1}')
+	[[ -n ${host_disk_device} ]]
+}
+
+configure_block_device_path() {
+	case "$1" in
+	disk)
+		configured_block_device="${host_disk_device}"
+		;;
+	rdisk)
+		configured_block_device="${host_disk_device/\/dev\/disk/\/dev\/rdisk}"
+		;;
+	*)
+		echo "unknown block device kind: $1" >&2
+		return 1
+		;;
+	esac
+}
+
+start_vz_instance_with_cli_flag() {
+	local extra_args=()
+	if [[ -n ${LIMACTL_CREATE_ARGS:-} ]]; then
+		read -r -a extra_args <<<"${LIMACTL_CREATE_ARGS}"
+	fi
+
+	limactl delete --force "${instance_name}" || :
+	limactl start --tty=false \
+		"${extra_args[@]}" \
+		--vm-type=vz \
+		--block-device "${configured_block_device}" \
+		--name "${instance_name}" \
+		template:default \
+		3>&- 4>&-
+}
+
+start_vz_instance_with_yaml() {
+	local config_file="${BATS_TEST_TMPDIR}/${instance_name}.yaml"
+	local extra_args=()
+	if [[ -n ${LIMACTL_CREATE_ARGS:-} ]]; then
+		read -r -a extra_args <<<"${LIMACTL_CREATE_ARGS}"
+	fi
+
+	cat >"${config_file}" <<EOF
+base: template:default
+vmType: vz
+blockDevices:
+  - ${configured_block_device}
+EOF
+
+	limactl delete --force "${instance_name}" || :
+	limactl start --tty=false \
+		"${extra_args[@]}" \
+		--name "${instance_name}" \
+		"${config_file}" \
+		3>&- 4>&-
+}
+
+format_and_write_from_guest() {
+	local guest_block_device=$1
+	local guest_partition_by_id=$2
+	local volume_label=$3
+	local expected_contents=$4
+
+	limactl shell "${instance_name}" bash -eus -- "${guest_block_device}" "${guest_partition_by_id}" "${volume_label}" "${expected_contents}" <<'EOF'
+guest_block_device="$1"
+guest_partition_by_id="$2"
+volume_label="$3"
+expected_contents="$4"
+guest_partition="$guest_partition_by_id"
+
+if ! command -v mkfs.exfat >/dev/null 2>&1 || ! command -v parted >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y exfatprogs parted
+fi
+
+# macOS only auto-recognizes the guest-created exFAT filesystem after shutdown if the GPT partition type is
+# Microsoft Basic Data rather than the generic Linux filesystem type.
+sudo parted -s "${guest_block_device}" -- mklabel gpt mkpart primary 1MiB 100% set 1 msftdata on
+sudo udevadm settle
+if [ ! -e "${guest_partition}" ]; then
+    # /dev/disk/by-id/...-part1 is the stable path we expect, but udev can lag behind partition creation.
+    # Fall back to the first partition discovered directly from lsblk so the test still validates the same disk.
+    guest_partition="$(lsblk -nrpo PATH "${guest_block_device}" | sed -n '2p')"
+fi
+test -n "${guest_partition}"
+sudo mkfs.exfat -n "${volume_label}" "${guest_partition}"
+sudo mkdir -p /mnt/test
+sudo mount "${guest_partition}" /mnt/test
+printf '%s\n' "${expected_contents}" | sudo tee /mnt/test/test.txt >/dev/null
+sudo sync
+if [ "$(cat /mnt/test/test.txt)" != "${expected_contents}" ]; then
+    exit 1
+fi
+sudo umount /mnt/test
+EOF
+}
+
+append_and_verify_from_guest() {
+	local guest_block_device=$1
+	local guest_partition_by_id=$2
+	local append_line=$3
+	local expected_before=$4
+	local expected_after=$5
+
+	limactl shell "${instance_name}" bash -eus -- "${guest_block_device}" "${guest_partition_by_id}" "${append_line}" "${expected_before}" "${expected_after}" <<'EOF'
+guest_block_device="$1"
+guest_partition_by_id="$2"
+append_line="$3"
+expected_before="$4"
+expected_after="$5"
+guest_partition="$guest_partition_by_id"
+
+if [ ! -e "${guest_partition}" ]; then
+    # After the host mount/unmount handoff, the by-id partition symlink may reappear later than the block device.
+    guest_partition="$(lsblk -nrpo PATH "${guest_block_device}" | sed -n '2p')"
+fi
+test -n "${guest_partition}"
+sudo mkdir -p /mnt/test
+sudo mount "${guest_partition}" /mnt/test
+if [ "$(cat /mnt/test/test.txt)" != "${expected_before}" ]; then
+    exit 1
+fi
+printf '%s\n' "${append_line}" | sudo tee -a /mnt/test/test.txt >/dev/null
+sudo sync
+if [ "$(cat /mnt/test/test.txt)" != "${expected_after}" ]; then
+    exit 1
+fi
+sudo umount /mnt/test
+EOF
+}
+
+mount_and_verify_from_host() {
+	local expected_contents=$1
+
+	# Resolve the host-visible partition that backs the same raw RAM disk after the guest has partitioned it.
+	host_partition="$(diskutil list "${host_disk_device}" | awk '$NF ~ /^disk[0-9]+s[0-9]+$/ {print "/dev/" $NF; exit}')"
+	[[ -n ${host_partition} ]]
+
+	sudo diskutil mount "${host_partition}" >/dev/null
+	local host_mount_point
+	host_mount_point=$(diskutil info -plist "${host_partition}" | plutil -extract MountPoint raw -o - -)
+	[[ -n ${host_mount_point} ]]
+
+	run -0 cat "${host_mount_point}/test.txt"
+	assert_output "${expected_contents}"
+}
+
+append_and_verify_from_host() {
+	local append_line=$1
+	local expected_before=$2
+	local expected_after=$3
+
+	mount_and_verify_from_host "${expected_before}"
+
+	local host_mount_point
+	host_mount_point=$(diskutil info -plist "${host_partition}" | plutil -extract MountPoint raw -o - -)
+	[[ -n ${host_mount_point} ]]
+
+	printf '%s\n' "${append_line}" | sudo tee -a "${host_mount_point}/test.txt" >/dev/null
+	run -0 cat "${host_mount_point}/test.txt"
+	assert_output "${expected_after}"
+}
+
+unmount_host_partition() {
+	[[ -n ${host_partition} ]]
+	sudo diskutil unmount force "${host_partition}"
+	host_partition=""
+}
+
+run_roundtrip_test() {
+	local block_device_kind=$1
+	local start_mode=$2
+	local expected_after_guest_1
+	local expected_after_host_1
+	local expected_after_guest_2
+	local block_device_id
+	local guest_block_device
+	local guest_partition_by_id
+	local volume_label
+
+	[[ $(uname) == "Darwin" ]] || skip "requires macOS host"
+	command -v hdiutil >/dev/null
+	command -v diskutil >/dev/null
+	command -v plutil >/dev/null
+
+	instance_name="vz-block-device-${block_device_kind}"
+	create_ramdisk
+	configure_block_device_path "${block_device_kind}"
+
+	block_device_id=$(basename "${configured_block_device}")
+	guest_block_device="/dev/disk/by-id/virtio-${block_device_id}"
+	guest_partition_by_id="/dev/disk/by-id/virtio-${block_device_id}-part1"
+	volume_label="LIMABD${RANDOM}"
+	expected_after_guest_1="$(printf 'guest-1')"
+	expected_after_host_1="$(printf 'guest-1\nhost-1')"
+	expected_after_guest_2="$(printf 'guest-1\nhost-1\nguest-2')"
+
+	# Cover both user-facing entry points: CLI flag wiring and YAML config wiring.
+	case "${start_mode}" in
+	cli)
+		start_vz_instance_with_cli_flag
+		;;
+	yaml)
+		start_vz_instance_with_yaml
+		;;
+	*)
+		echo "unknown start mode: ${start_mode}" >&2
+		return 1
+		;;
+	esac
+	format_and_write_from_guest "${guest_block_device}" "${guest_partition_by_id}" "${volume_label}" "${expected_after_guest_1}"
+	limactl stop "${instance_name}"
+
+	# The host and guest must not mount the filesystem concurrently; this validates the intended stop/remount handoff.
+	append_and_verify_from_host "host-1" "${expected_after_guest_1}" "${expected_after_host_1}"
+	unmount_host_partition
+
+	limactl start --tty=false "${instance_name}" 3>&- 4>&-
+	append_and_verify_from_guest "${guest_block_device}" "${guest_partition_by_id}" "guest-2" "${expected_after_host_1}" "${expected_after_guest_2}"
+	limactl stop "${instance_name}"
+
+	mount_and_verify_from_host "${expected_after_guest_2}"
+}
+
+@test "VZ block device roundtrip via CLI flag and /dev/diskN" {
+	# /dev/diskN is the documented host-facing path users are most likely to provide.
+	run_roundtrip_test disk cli
+}
+
+@test "VZ block device roundtrip via YAML and /dev/rdiskN" {
+	# /dev/rdiskN exercises the raw-device variant and the YAML blockDevices configuration path in one case.
+	run_roundtrip_test rdisk yaml
+}

--- a/hack/bats/extras/vz-block-device.bats
+++ b/hack/bats/extras/vz-block-device.bats
@@ -60,6 +60,10 @@ configure_block_device_path() {
 	esac
 }
 
+install_block_device_sudoers() {
+	limactl sudoers --block-device="${configured_block_device}" | sudo tee /etc/sudoers.d/lima >/dev/null
+}
+
 start_vz_instance_with_cli_flag() {
 	local extra_args=()
 	if [[ -n ${LIMACTL_CREATE_ARGS:-} ]]; then
@@ -229,6 +233,7 @@ run_roundtrip_test() {
 	instance_name="vz-block-device-${block_device_kind}"
 	create_ramdisk
 	configure_block_device_path "${block_device_kind}"
+	install_block_device_sudoers
 
 	block_device_id=$(basename "${configured_block_device}")
 	guest_block_device="/dev/disk/by-id/virtio-${block_device_id}"

--- a/hack/bats/tests/shell.bats
+++ b/hack/bats/tests/shell.bats
@@ -5,10 +5,6 @@ load "../helpers/load"
 
 INSTANCE=bats-dummy
 
-normalize_stderr_log() {
-    printf '%s\n' "$1" | sed -E 's/^time="[^"]+" //'
-}
-
 @test 'lima stopped lima instance' {
     # check that the "tty" flag is used, also for stdin
     run_e -1 limactl shell --tty=false "$INSTANCE" true </dev/null
@@ -40,10 +36,12 @@ normalize_stderr_log() {
     # --instance should resolve the instance name the same way as the positional arg.
     # Normalize the logrus timestamp because the two invocations may land in different seconds.
     run_e -1 limactl shell --tty=false --instance nonexistent
-    inst_output=$(normalize_stderr_log "$stderr")
+    inst_output=$(sed 's/^time="[^"]*"/time="TIMESTAMP"/' <<<"$stderr")
 
     run_e -1 limactl shell --tty=false nonexistent
-    assert_equal "$inst_output" "$(normalize_stderr_log "$stderr")"
+    pos_output=$(sed 's/^time="[^"]*"/time="TIMESTAMP"/' <<<"$stderr")
+
+    assert_equal "$pos_output" "$inst_output"
 }
 
 @test 'limactl shell --instance with unknown flag errors' {

--- a/hack/bats/tests/shell.bats
+++ b/hack/bats/tests/shell.bats
@@ -5,6 +5,10 @@ load "../helpers/load"
 
 INSTANCE=bats-dummy
 
+normalize_stderr_log() {
+    printf '%s\n' "$1" | sed -E 's/^time="[^"]+" //'
+}
+
 @test 'lima stopped lima instance' {
     # check that the "tty" flag is used, also for stdin
     run_e -1 limactl shell --tty=false "$INSTANCE" true </dev/null
@@ -36,12 +40,10 @@ INSTANCE=bats-dummy
     # --instance should resolve the instance name the same way as the positional arg.
     # Normalize the logrus timestamp because the two invocations may land in different seconds.
     run_e -1 limactl shell --tty=false --instance nonexistent
-    inst_output=$(sed 's/^time="[^"]*"/time="TIMESTAMP"/' <<<"$stderr")
+    inst_output=$(normalize_stderr_log "$stderr")
 
     run_e -1 limactl shell --tty=false nonexistent
-    pos_output=$(sed 's/^time="[^"]*"/time="TIMESTAMP"/' <<<"$stderr")
-
-    assert_equal "$pos_output" "$inst_output"
+    assert_equal "$inst_output" "$(normalize_stderr_log "$stderr")"
 }
 
 @test 'limactl shell --instance with unknown flag errors' {

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -609,7 +609,9 @@ fi
 if [[ -n ${CHECKS["user-v2"]} ]]; then
 	INFO "Testing user-v2 network"
 	secondvm="$NAME-1"
+	limactl delete -f "$secondvm" >/dev/null 2>&1 || true
 	"${LIMACTL_CREATE[@]}" --set ".additionalDisks=null" "$FILE_HOST" --name "$secondvm"
+	defer "limactl delete -f \"$secondvm\" >/dev/null 2>&1 || true"
 	if ! limactl start "$secondvm"; then
 		ERROR "Failed to start \"$secondvm\""
 		diagnose "$secondvm"

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -609,9 +609,7 @@ fi
 if [[ -n ${CHECKS["user-v2"]} ]]; then
 	INFO "Testing user-v2 network"
 	secondvm="$NAME-1"
-	limactl delete -f "$secondvm" >/dev/null 2>&1 || true
 	"${LIMACTL_CREATE[@]}" --set ".additionalDisks=null" "$FILE_HOST" --name "$secondvm"
-	defer "limactl delete -f \"$secondvm\" >/dev/null 2>&1 || true"
 	if ! limactl start "$secondvm"; then
 		ERROR "Failed to start \"$secondvm\""
 		diagnose "$secondvm"

--- a/pkg/blockdevice/block_device_darwin.go
+++ b/pkg/blockdevice/block_device_darwin.go
@@ -1,0 +1,213 @@
+//go:build darwin
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package blockdevice
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/balajiv113/fd"
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/sudoers"
+)
+
+// SudoOpenBlockDeviceCommand is the hidden helper that opens a host block
+// device as root and passes the descriptor back to the unprivileged process.
+const SudoOpenBlockDeviceCommand = "sudo-open-block-device"
+
+// ServeSudoOpenBlockDevice runs inside the short-lived privileged helper
+// process launched via sudo. It receives a JSON request on stdin, opens the
+// requested host device node as root, and sends the resulting file descriptor
+// back to the already-running unprivileged process over a private Unix socket.
+func ServeSudoOpenBlockDevice(r io.Reader) error {
+	var req sudoOpenBlockDeviceRequest
+	if err := json.NewDecoder(r).Decode(&req); err != nil {
+		return fmt.Errorf("failed to decode request: %w", err)
+	}
+	if err := req.validate(); err != nil {
+		return err
+	}
+
+	deviceFile, err := os.OpenFile(req.DevicePath, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open %q: %w", req.DevicePath, err)
+	}
+	defer deviceFile.Close()
+
+	fi, err := deviceFile.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat %q: %w", req.DevicePath, err)
+	}
+	if fi.Mode()&os.ModeDevice == 0 {
+		return fmt.Errorf("%q is not a device node", req.DevicePath)
+	}
+
+	socketAddr, err := net.ResolveUnixAddr("unix", req.SocketPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve socket %q: %w", req.SocketPath, err)
+	}
+	conn, err := net.DialUnix("unix", nil, socketAddr)
+	if err != nil {
+		return fmt.Errorf("failed to connect to socket %q: %w", req.SocketPath, err)
+	}
+	defer conn.Close()
+
+	if err := fd.Put(conn, deviceFile); err != nil {
+		return fmt.Errorf("failed to send file descriptor for %q: %w", req.DevicePath, err)
+	}
+	return nil
+}
+
+// sudoOpenBlockDeviceRequest is the JSON payload sent to the privileged helper.
+// SocketPath is the absolute path to the private Unix socket that the helper
+// must connect back to after opening DevicePath, so it can return the opened
+// file descriptor to the unprivileged caller via SCM_RIGHTS.
+type sudoOpenBlockDeviceRequest struct {
+	DevicePath string `json:"devicePath"`
+	SocketPath string `json:"socketPath"`
+}
+
+// Sudoers returns the sudoers fragment needed to run the hidden block-device
+// helper without prompting.
+func Sudoers(group string) (string, error) {
+	helperArgs, err := sudoOpenBlockDeviceHelperArgs()
+	if err != nil {
+		return "", err
+	}
+	return sudoers.NOPASSWD("%"+group, "root", "wheel", strings.Join(helperArgs, " ")), nil
+}
+
+func (r sudoOpenBlockDeviceRequest) validate() error {
+	if r.DevicePath == "" {
+		return errors.New("devicePath must not be empty")
+	}
+	if !filepath.IsAbs(r.DevicePath) {
+		return fmt.Errorf("devicePath %q must be an absolute path", r.DevicePath)
+	}
+	if filepath.Clean(r.DevicePath) != r.DevicePath {
+		return fmt.Errorf("devicePath %q must be normalized", r.DevicePath)
+	}
+	if !strings.HasPrefix(r.DevicePath, "/dev/") {
+		return fmt.Errorf("devicePath %q must be under /dev", r.DevicePath)
+	}
+
+	if r.SocketPath == "" {
+		return errors.New("socketPath must not be empty")
+	}
+	if !filepath.IsAbs(r.SocketPath) {
+		return fmt.Errorf("socketPath %q must be an absolute path", r.SocketPath)
+	}
+	if filepath.Clean(r.SocketPath) != r.SocketPath {
+		return fmt.Errorf("socketPath %q must be normalized", r.SocketPath)
+	}
+	return nil
+}
+
+func sudoOpenBlockDeviceHelperArgs() ([]string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+	if strings.ContainsAny(exe, " \t\r\n") {
+		return nil, fmt.Errorf("limactl executable path %q contains whitespace and cannot be used in sudoers", exe)
+	}
+	return []string{exe, SudoOpenBlockDeviceCommand}, nil
+}
+
+// Open creates a private Unix socket, asks the privileged helper to open the
+// host device and connect back to that socket, then returns a duplicated
+// descriptor that the caller can retain for as long as needed.
+func Open(ctx context.Context, devicePath, socketPath string) (*os.File, error) {
+	helperArgs, err := sudoOpenBlockDeviceHelperArgs()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.RemoveAll(socketPath); err != nil {
+		return nil, err
+	}
+
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on %q: %w", socketPath, err)
+	}
+	listener.SetUnlinkOnClose(true)
+	defer func() {
+		_ = listener.Close()
+		_ = os.RemoveAll(socketPath)
+	}()
+
+	req := sudoOpenBlockDeviceRequest{
+		DevicePath: devicePath,
+		SocketPath: socketPath,
+	}
+	var stdin bytes.Buffer
+	if err := json.NewEncoder(&stdin).Encode(req); err != nil {
+		return nil, err
+	}
+
+	type receivedFD struct {
+		file *os.File
+		err  error
+	}
+	fdCh := make(chan receivedFD, 1)
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			fdCh <- receivedFD{err: err}
+			return
+		}
+		defer conn.Close()
+
+		files, err := fd.Get(conn, 1, []string{filepath.Base(devicePath)})
+		if err != nil {
+			fdCh <- receivedFD{err: err}
+			return
+		}
+		if len(files) != 1 {
+			for _, file := range files {
+				_ = file.Close()
+			}
+			fdCh <- receivedFD{err: fmt.Errorf("expected 1 file descriptor for %q, got %d", devicePath, len(files))}
+			return
+		}
+		fdCh <- receivedFD{file: files[0]}
+	}()
+
+	var stdout, stderr bytes.Buffer
+	cmd := sudoers.NewCommand(ctx, "root", "wheel", &stdin, &stdout, &stderr, "", helperArgs...)
+	logrus.Debugf("Opening block device %q via sudo helper: %v", devicePath, cmd.Args)
+	if err := cmd.Run(); err != nil {
+		_ = listener.Close()
+		received := <-fdCh
+		if received.file != nil {
+			_ = received.file.Close()
+		}
+		return nil, fmt.Errorf("failed to run %v: stdout=%q, stderr=%q: %w", cmd.Args, stdout.String(), stderr.String(), err)
+	}
+
+	received := <-fdCh
+	if received.err != nil {
+		return nil, fmt.Errorf("failed to receive file descriptor for %q: %w", devicePath, received.err)
+	}
+	dupFD, err := syscall.Dup(int(received.file.Fd()))
+	if err != nil {
+		_ = received.file.Close()
+		return nil, fmt.Errorf("failed to duplicate file descriptor for %q: %w", devicePath, err)
+	}
+	_ = received.file.Close()
+
+	return os.NewFile(uintptr(dupFD), filepath.Base(devicePath)), nil
+}

--- a/pkg/blockdevice/block_device_darwin.go
+++ b/pkg/blockdevice/block_device_darwin.go
@@ -8,19 +8,27 @@ package blockdevice
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"os"
+	"os/user"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
-	"syscall"
+	"time"
 
 	"github.com/balajiv113/fd"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 
+	"github.com/lima-vm/lima/v2/pkg/osutil"
 	"github.com/lima-vm/lima/v2/pkg/sudoers"
 )
 
@@ -28,20 +36,40 @@ import (
 // device as root and passes the descriptor back to the unprivileged process.
 const SudoOpenBlockDeviceCommand = "sudo-open-block-device"
 
+const (
+	blockDeviceNonceHexLen = 64
+	helperReadTimeout      = 30 * time.Second
+)
+
+var (
+	macOSDiskDevicePathRE = regexp.MustCompile(`^/dev/r?disk\d+(s\d+)*$`)
+	nonceRE               = regexp.MustCompile(`^[0-9a-f]{64}$`)
+)
+
 // ServeSudoOpenBlockDevice runs inside the short-lived privileged helper
 // process launched via sudo. It receives a JSON request on stdin, opens the
 // requested host device node as root, and sends the resulting file descriptor
 // back to the already-running unprivileged process over a private Unix socket.
-func ServeSudoOpenBlockDevice(r io.Reader) error {
+func ServeSudoOpenBlockDevice(allowedDevicePath string, r io.Reader) error {
 	var req sudoOpenBlockDeviceRequest
 	if err := json.NewDecoder(r).Decode(&req); err != nil {
 		return fmt.Errorf("failed to decode request: %w", err)
 	}
-	if err := req.validate(); err != nil {
+	if err := req.validateForAllowedDevice(allowedDevicePath); err != nil {
 		return err
 	}
 
-	deviceFile, err := os.OpenFile(req.DevicePath, os.O_RDWR, 0)
+	if err := validateDiskDeviceNode(req.DevicePath); err != nil {
+		return err
+	}
+	originalUID, err := sudoOriginalUID()
+	if err != nil {
+		return err
+	}
+	if err := validatePrivateSocketPath(req.SocketPath, originalUID); err != nil {
+		return err
+	}
+	deviceFile, err := openDiskDeviceNoFollow(req.DevicePath)
 	if err != nil {
 		return fmt.Errorf("failed to open %q: %w", req.DevicePath, err)
 	}
@@ -51,8 +79,8 @@ func ServeSudoOpenBlockDevice(r io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("failed to stat %q: %w", req.DevicePath, err)
 	}
-	if fi.Mode()&os.ModeDevice == 0 {
-		return fmt.Errorf("%q is not a device node", req.DevicePath)
+	if err := validateDiskDeviceMode(req.DevicePath, fi.Mode()); err != nil {
+		return err
 	}
 
 	socketAddr, err := net.ResolveUnixAddr("unix", req.SocketPath)
@@ -65,6 +93,11 @@ func ServeSudoOpenBlockDevice(r io.Reader) error {
 	}
 	defer conn.Close()
 
+	if n, err := io.WriteString(conn, req.Nonce); err != nil {
+		return fmt.Errorf("failed to send authentication nonce: %w", err)
+	} else if n != len(req.Nonce) {
+		return fmt.Errorf("failed to send authentication nonce: %w", io.ErrShortWrite)
+	}
 	if err := fd.Put(conn, deviceFile); err != nil {
 		return fmt.Errorf("failed to send file descriptor for %q: %w", req.DevicePath, err)
 	}
@@ -78,30 +111,59 @@ func ServeSudoOpenBlockDevice(r io.Reader) error {
 type sudoOpenBlockDeviceRequest struct {
 	DevicePath string `json:"devicePath"`
 	SocketPath string `json:"socketPath"`
+	Nonce      string `json:"nonce"`
+}
+
+type receivedFD struct {
+	file *os.File
+	err  error
 }
 
 // Sudoers returns the sudoers fragment needed to run the hidden block-device
-// helper without prompting.
-func Sudoers(group string) (string, error) {
-	helperArgs, err := sudoOpenBlockDeviceHelperArgs()
+// helper without prompting for the current user. The helper is intentionally
+// scoped to a single user instead of the network group, because opening host
+// disks gives direct access to host storage.
+func Sudoers(devicePaths []string) (string, error) {
+	u, err := user.Current()
 	if err != nil {
 		return "", err
 	}
-	return sudoers.NOPASSWD("%"+group, "root", "wheel", strings.Join(helperArgs, " ")), nil
+	return SudoersForUser(u.Username, devicePaths)
+}
+
+func SudoersForUser(userName string, devicePaths []string) (string, error) {
+	if err := validateSudoersUserName(userName); err != nil {
+		return "", err
+	}
+	if len(devicePaths) == 0 {
+		return "", errors.New("at least one block device path is required")
+	}
+	var helperCommands [][]string
+	for _, devicePath := range devicePaths {
+		helperArgs, err := sudoOpenBlockDeviceHelperArgs(devicePath)
+		if err != nil {
+			return "", err
+		}
+		helperCommands = append(helperCommands, helperArgs)
+	}
+	return sudoersForUserAndHelpers(userName, helperCommands...), nil
+}
+
+func sudoersForUserAndHelper(userName string, helperArgs []string) string {
+	return sudoers.NOPASSWD(userName, "root", "wheel", strings.Join(helperArgs, " "))
+}
+
+func sudoersForUserAndHelpers(userName string, helperArgs ...[]string) string {
+	helperCommands := make([]string, 0, len(helperArgs))
+	for _, args := range helperArgs {
+		helperCommands = append(helperCommands, strings.Join(args, " "))
+	}
+	return sudoers.NOPASSWD(userName, "root", "wheel", helperCommands...)
 }
 
 func (r sudoOpenBlockDeviceRequest) validate() error {
-	if r.DevicePath == "" {
-		return errors.New("devicePath must not be empty")
-	}
-	if !filepath.IsAbs(r.DevicePath) {
-		return fmt.Errorf("devicePath %q must be an absolute path", r.DevicePath)
-	}
-	if filepath.Clean(r.DevicePath) != r.DevicePath {
-		return fmt.Errorf("devicePath %q must be normalized", r.DevicePath)
-	}
-	if !strings.HasPrefix(r.DevicePath, "/dev/") {
-		return fmt.Errorf("devicePath %q must be under /dev", r.DevicePath)
+	if err := validateDiskDevicePath(r.DevicePath); err != nil {
+		return err
 	}
 
 	if r.SocketPath == "" {
@@ -113,29 +175,309 @@ func (r sudoOpenBlockDeviceRequest) validate() error {
 	if filepath.Clean(r.SocketPath) != r.SocketPath {
 		return fmt.Errorf("socketPath %q must be normalized", r.SocketPath)
 	}
+	if len(r.SocketPath) >= osutil.UnixPathMax {
+		return fmt.Errorf("socketPath %q must be less than UNIX_PATH_MAX=%d characters, but is %d", r.SocketPath, osutil.UnixPathMax, len(r.SocketPath))
+	}
+	if !nonceRE.MatchString(r.Nonce) {
+		return fmt.Errorf("nonce must be %d lowercase hexadecimal characters", blockDeviceNonceHexLen)
+	}
 	return nil
 }
 
-func sudoOpenBlockDeviceHelperArgs() ([]string, error) {
+func (r sudoOpenBlockDeviceRequest) validateForAllowedDevice(allowedDevicePath string) error {
+	if err := validateDiskDevicePath(allowedDevicePath); err != nil {
+		return fmt.Errorf("allowed devicePath: %w", err)
+	}
+	if err := r.validate(); err != nil {
+		return err
+	}
+	if r.DevicePath != allowedDevicePath {
+		return fmt.Errorf("devicePath %q is not allowed by sudoers entry for %q", r.DevicePath, allowedDevicePath)
+	}
+	return nil
+}
+
+func sudoOpenBlockDeviceHelperArgs(devicePath string) ([]string, error) {
+	if err := validateDiskDevicePath(devicePath); err != nil {
+		return nil, err
+	}
 	exe, err := os.Executable()
 	if err != nil {
 		return nil, err
 	}
-	if strings.ContainsAny(exe, " \t\r\n") {
-		return nil, fmt.Errorf("limactl executable path %q contains whitespace and cannot be used in sudoers", exe)
+	if err := validateSecureHelperPath(exe); err != nil {
+		return nil, err
 	}
-	return []string{exe, SudoOpenBlockDeviceCommand}, nil
+	return []string{exe, SudoOpenBlockDeviceCommand, devicePath}, nil
+}
+
+func validateSudoersUserName(userName string) error {
+	if userName == "" {
+		return errors.New("sudoers user name must not be empty")
+	}
+	if strings.ContainsAny(userName, " \t\r\n,:=\\") {
+		return fmt.Errorf("sudoers user name %q contains unsupported characters", userName)
+	}
+	if strings.HasPrefix(userName, "%") || strings.HasPrefix(userName, "#") {
+		return fmt.Errorf("sudoers user name %q must name a user, not a group or uid", userName)
+	}
+	return nil
+}
+
+func validateDiskDeviceNode(devicePath string) error {
+	if err := validateDiskDevicePath(devicePath); err != nil {
+		return err
+	}
+	fi, err := os.Lstat(devicePath)
+	if err != nil {
+		return fmt.Errorf("failed to lstat %q: %w", devicePath, err)
+	}
+	if fi.Mode()&fs.ModeSymlink != 0 {
+		return fmt.Errorf("%q must not be a symlink", devicePath)
+	}
+	return validateDiskDeviceMode(devicePath, fi.Mode())
+}
+
+func validateDiskDevicePath(devicePath string) error {
+	if devicePath == "" {
+		return errors.New("devicePath must not be empty")
+	}
+	if !filepath.IsAbs(devicePath) {
+		return fmt.Errorf("devicePath %q must be an absolute path", devicePath)
+	}
+	if filepath.Clean(devicePath) != devicePath {
+		return fmt.Errorf("devicePath %q must be normalized", devicePath)
+	}
+	if !macOSDiskDevicePathRE.MatchString(devicePath) {
+		return fmt.Errorf("devicePath %q must be a macOS disk device path like /dev/disk4 or /dev/rdisk4s1", devicePath)
+	}
+	return nil
+}
+
+func validateDiskDeviceFile(devicePath string, file *os.File) error {
+	fi, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat %q: %w", file.Name(), err)
+	}
+	return validateDiskDeviceMode(devicePath, fi.Mode())
+}
+
+func validateDiskDeviceMode(devicePath string, mode os.FileMode) error {
+	if err := validateDiskDevicePath(devicePath); err != nil {
+		return err
+	}
+	if mode&os.ModeDevice == 0 {
+		return fmt.Errorf("%q is not a device node", devicePath)
+	}
+	isRaw := strings.HasPrefix(filepath.Base(devicePath), "rdisk")
+	isChar := mode&os.ModeCharDevice != 0
+	switch {
+	case isRaw && !isChar:
+		return fmt.Errorf("%q must be a raw character disk device", devicePath)
+	case !isRaw && isChar:
+		return fmt.Errorf("%q must be a block disk device", devicePath)
+	}
+	return nil
+}
+
+func sudoOriginalUID() (uint32, error) {
+	sudoUID := os.Getenv("SUDO_UID")
+	if sudoUID == "" {
+		return 0, errors.New("SUDO_UID is not set; privileged helper must be launched by sudo")
+	}
+	uid, err := strconv.ParseUint(sudoUID, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid SUDO_UID %q: %w", sudoUID, err)
+	}
+	return uint32(uid), nil
+}
+
+func validatePrivateSocketPath(socketPath string, ownerUID uint32) error {
+	if socketPath == "" {
+		return errors.New("socketPath must not be empty")
+	}
+	if !filepath.IsAbs(socketPath) {
+		return fmt.Errorf("socketPath %q must be an absolute path", socketPath)
+	}
+	if filepath.Clean(socketPath) != socketPath {
+		return fmt.Errorf("socketPath %q must be normalized", socketPath)
+	}
+	if len(socketPath) >= osutil.UnixPathMax {
+		return fmt.Errorf("socketPath %q must be less than UNIX_PATH_MAX=%d characters, but is %d", socketPath, osutil.UnixPathMax, len(socketPath))
+	}
+	parent := filepath.Dir(socketPath)
+	fi, err := os.Lstat(parent)
+	if err != nil {
+		return fmt.Errorf("failed to lstat socket directory %q: %w", parent, err)
+	}
+	if fi.Mode()&fs.ModeSymlink != 0 {
+		return fmt.Errorf("socket directory %q must not be a symlink", parent)
+	}
+	if !fi.Mode().IsDir() {
+		return fmt.Errorf("socket directory %q is not a directory", parent)
+	}
+	stat, ok := osutil.SysStat(fi)
+	if !ok {
+		return fmt.Errorf("could not retrieve stat buffer for socket directory %q", parent)
+	}
+	if stat.Uid != ownerUID {
+		return fmt.Errorf("socket directory %q is not owned by sudo user uid %d, but by uid %d", parent, ownerUID, stat.Uid)
+	}
+	if fi.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("socket directory %q must not be accessible by group or other users", parent)
+	}
+	return nil
+}
+
+func removeStaleSocket(socketPath string) error {
+	fi, err := os.Lstat(socketPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if fi.Mode()&fs.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to remove socket path %q because it is a symlink", socketPath)
+	}
+	if fi.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("refusing to remove socket path %q because it is not a Unix socket", socketPath)
+	}
+	return os.Remove(socketPath)
+}
+
+func openDiskDeviceNoFollow(devicePath string) (*os.File, error) {
+	openFlags := unix.O_RDWR | unix.O_CLOEXEC | unix.O_NOFOLLOW
+	devFD, err := unix.Open(devicePath, openFlags, 0)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(devFD), filepath.Base(devicePath)), nil
+}
+
+func validateSecureHelperPath(path string) error {
+	root, err := osutil.LookupUser("root")
+	if err != nil {
+		return err
+	}
+	return validateSecurePath(path, root.Uid, root.Gid)
+}
+
+func validateSecurePath(path string, rootUID, rootGID uint32) error {
+	if path == "" {
+		return errors.New("path must not be empty")
+	}
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("path %q is not an absolute path", path)
+	}
+	if strings.ContainsAny(path, " \t\r\n") {
+		return fmt.Errorf("path %q contains whitespace", path)
+	}
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if err := validateSecurePathElement(path, fi, rootUID, rootGID); err != nil {
+		return err
+	}
+	if path != "/" {
+		return validateSecurePath(filepath.Dir(path), rootUID, rootGID)
+	}
+	return nil
+}
+
+func validateSecurePathElement(path string, fi os.FileInfo, rootUID, rootGID uint32) error {
+	file := "file"
+	if fi.Mode().IsDir() {
+		file = "dir"
+	}
+	if fi.Mode()&fs.ModeSymlink != 0 {
+		return fmt.Errorf("%s %q is a symlink", file, path)
+	}
+	stat, ok := osutil.SysStat(fi)
+	if !ok {
+		return fmt.Errorf("could not retrieve stat buffer for %q", path)
+	}
+	if stat.Uid != rootUID {
+		return fmt.Errorf(`%s %q is not owned by root uid %d, but by uid %d`, file, path, rootUID, stat.Uid)
+	}
+	if fi.Mode()&0o20 != 0 && stat.Gid != rootGID {
+		return fmt.Errorf(`%s %q is group-writable and group is not root gid %d, but is gid %d`, file, path, rootGID, stat.Gid)
+	}
+	if fi.Mode()&0o02 != 0 {
+		return fmt.Errorf("%s %q is world-writable", file, path)
+	}
+	return nil
+}
+
+func generateNonce() (string, error) {
+	var b [blockDeviceNonceHexLen / 2]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+func unixPeerUID(conn *net.UnixConn) (uint32, error) {
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+	var uid uint32
+	var sockErr error
+	if err := rawConn.Control(func(fd uintptr) {
+		var cred *unix.Xucred
+		cred, sockErr = unix.GetsockoptXucred(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
+		if sockErr == nil {
+			uid = cred.Uid
+		}
+	}); err != nil {
+		return 0, err
+	}
+	if sockErr != nil {
+		return 0, sockErr
+	}
+	return uid, nil
+}
+
+func validateUnixPeerUID(conn *net.UnixConn, expectedUID uint32) error {
+	uid, err := unixPeerUID(conn)
+	if err != nil {
+		return fmt.Errorf("failed to get Unix socket peer credentials: %w", err)
+	}
+	if uid != expectedUID {
+		return fmt.Errorf("refusing file descriptor from Unix socket peer uid %d; expected uid %d", uid, expectedUID)
+	}
+	return nil
 }
 
 // Open creates a private Unix socket, asks the privileged helper to open the
 // host device and connect back to that socket, then returns a duplicated
 // descriptor that the caller can retain for as long as needed.
 func Open(ctx context.Context, devicePath, socketPath string) (*os.File, error) {
-	helperArgs, err := sudoOpenBlockDeviceHelperArgs()
+	if err := validateDiskDevicePath(devicePath); err != nil {
+		return nil, err
+	}
+	helperArgs, err := sudoOpenBlockDeviceHelperArgs(devicePath)
 	if err != nil {
 		return nil, err
 	}
-	if err := os.RemoveAll(socketPath); err != nil {
+	currentUser, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+	currentUID64, err := strconv.ParseUint(currentUser.Uid, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid current user uid %q: %w", currentUser.Uid, err)
+	}
+	if err := validatePrivateSocketPath(socketPath, uint32(currentUID64)); err != nil {
+		return nil, err
+	}
+	root, err := osutil.LookupUser("root")
+	if err != nil {
+		return nil, err
+	}
+	if err := removeStaleSocket(socketPath); err != nil {
 		return nil, err
 	}
 
@@ -146,44 +488,69 @@ func Open(ctx context.Context, devicePath, socketPath string) (*os.File, error) 
 	listener.SetUnlinkOnClose(true)
 	defer func() {
 		_ = listener.Close()
-		_ = os.RemoveAll(socketPath)
+		_ = os.Remove(socketPath)
 	}()
 
 	req := sudoOpenBlockDeviceRequest{
 		DevicePath: devicePath,
 		SocketPath: socketPath,
 	}
+	req.Nonce, err = generateNonce()
+	if err != nil {
+		return nil, err
+	}
 	var stdin bytes.Buffer
 	if err := json.NewEncoder(&stdin).Encode(req); err != nil {
 		return nil, err
 	}
 
-	type receivedFD struct {
-		file *os.File
-		err  error
-	}
 	fdCh := make(chan receivedFD, 1)
 	go func() {
-		conn, err := listener.AcceptUnix()
-		if err != nil {
-			fdCh <- receivedFD{err: err}
-			return
-		}
-		defer conn.Close()
-
-		files, err := fd.Get(conn, 1, []string{filepath.Base(devicePath)})
-		if err != nil {
-			fdCh <- receivedFD{err: err}
-			return
-		}
-		if len(files) != 1 {
-			for _, file := range files {
-				_ = file.Close()
+		for {
+			conn, err := listener.AcceptUnix()
+			if err != nil {
+				fdCh <- receivedFD{err: err}
+				return
 			}
-			fdCh <- receivedFD{err: fmt.Errorf("expected 1 file descriptor for %q, got %d", devicePath, len(files))}
+			if err := validateUnixPeerUID(conn, root.Uid); err != nil {
+				logrus.WithError(err).Warn("Ignoring unauthenticated block-device helper connection")
+				_ = conn.Close()
+				continue
+			}
+			nonce := make([]byte, len(req.Nonce))
+			_ = conn.SetReadDeadline(time.Now().Add(helperReadTimeout))
+			if _, err := io.ReadFull(conn, nonce); err != nil {
+				_ = conn.Close()
+				fdCh <- receivedFD{err: fmt.Errorf("failed to read authentication nonce: %w", err)}
+				return
+			}
+			if !bytes.Equal(nonce, []byte(req.Nonce)) {
+				_ = conn.Close()
+				fdCh <- receivedFD{err: errors.New("refusing file descriptor from helper with invalid authentication nonce")}
+				return
+			}
+
+			files, err := fd.Get(conn, 1, []string{filepath.Base(devicePath)})
+			_ = conn.Close()
+			if err != nil {
+				fdCh <- receivedFD{err: err}
+				return
+			}
+			if len(files) != 1 {
+				for _, file := range files {
+					_ = file.Close()
+				}
+				fdCh <- receivedFD{err: fmt.Errorf("expected 1 file descriptor for %q, got %d", devicePath, len(files))}
+				return
+			}
+			if err := validateDiskDeviceFile(devicePath, files[0]); err != nil {
+				_ = files[0].Close()
+				fdCh <- receivedFD{err: err}
+				return
+			}
+			fdCh <- receivedFD{file: files[0]}
 			return
 		}
-		fdCh <- receivedFD{file: files[0]}
 	}()
 
 	var stdout, stderr bytes.Buffer
@@ -191,23 +558,60 @@ func Open(ctx context.Context, devicePath, socketPath string) (*os.File, error) 
 	logrus.Debugf("Opening block device %q via sudo helper: %v", devicePath, cmd.Args)
 	if err := cmd.Run(); err != nil {
 		_ = listener.Close()
-		received := <-fdCh
-		if received.file != nil {
-			_ = received.file.Close()
+		// After sudo has failed, do not wait for the helper response: the helper
+		// may never connect back. Only close an fd that has already arrived.
+		if receivedFile := drainReceivedFD(fdCh); receivedFile != nil {
+			_ = receivedFile.Close()
 		}
-		return nil, fmt.Errorf("failed to run %v: stdout=%q, stderr=%q: %w", cmd.Args, stdout.String(), stderr.String(), err)
+		return nil, fmt.Errorf("failed to run %v: stdout=%q, stderr=%q: %w. Hint: run `%s sudoers --block-device=%s` and install the generated file", cmd.Args, stdout.String(), stderr.String(), err, os.Args[0], devicePath)
 	}
 
-	received := <-fdCh
-	if received.err != nil {
-		return nil, fmt.Errorf("failed to receive file descriptor for %q: %w", devicePath, received.err)
-	}
-	dupFD, err := syscall.Dup(int(received.file.Fd()))
+	receivedFile, err := waitForReceivedFD(ctx, fdCh)
 	if err != nil {
-		_ = received.file.Close()
+		if receivedFile := drainReceivedFD(fdCh); receivedFile != nil {
+			_ = receivedFile.Close()
+		}
+		return nil, fmt.Errorf("failed to receive file descriptor for %q: %w", devicePath, err)
+	}
+	defer receivedFile.Close()
+
+	dupFile, err := duplicateFileCloseOnExec(receivedFile, filepath.Base(devicePath))
+	if err != nil {
 		return nil, fmt.Errorf("failed to duplicate file descriptor for %q: %w", devicePath, err)
 	}
-	_ = received.file.Close()
+	return dupFile, nil
+}
 
-	return os.NewFile(uintptr(dupFD), filepath.Base(devicePath)), nil
+// waitForReceivedFD ties fd handoff to the caller context so a helper crash,
+// socket failure, or canceled VM start cannot leave limactl blocked forever.
+func waitForReceivedFD(ctx context.Context, fdCh <-chan receivedFD) (*os.File, error) {
+	select {
+	case received := <-fdCh:
+		if received.err != nil {
+			return nil, received.err
+		}
+		return received.file, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// drainReceivedFD is a non-blocking cleanup path for command failures.
+func drainReceivedFD(fdCh <-chan receivedFD) *os.File {
+	select {
+	case received := <-fdCh:
+		return received.file
+	default:
+		return nil
+	}
+}
+
+// duplicateFileCloseOnExec returns a caller-owned duplicate without allowing
+// the root-opened descriptor to leak into future exec'd child processes.
+func duplicateFileCloseOnExec(file *os.File, name string) (*os.File, error) {
+	dupFD, err := unix.FcntlInt(file.Fd(), unix.F_DUPFD_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(dupFD), name), nil
 }

--- a/pkg/blockdevice/block_device_darwin_test.go
+++ b/pkg/blockdevice/block_device_darwin_test.go
@@ -1,0 +1,83 @@
+//go:build darwin
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package blockdevice
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSudoers(t *testing.T) {
+	sudoers, err := Sudoers("everyone")
+	assert.NilError(t, err)
+	exe, err := os.Executable()
+	assert.NilError(t, err)
+	assert.Equal(t, sudoers, "%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: "+filepath.Clean(exe)+" "+SudoOpenBlockDeviceCommand+"\n")
+}
+
+func TestSudoOpenBlockDeviceRequestValidate(t *testing.T) {
+	valid := sudoOpenBlockDeviceRequest{
+		DevicePath: "/dev/disk4",
+		SocketPath: "/tmp/block-device.0.sock",
+	}
+	assert.NilError(t, valid.validate())
+
+	testCases := []struct {
+		name          string
+		request       sudoOpenBlockDeviceRequest
+		errorContains string
+	}{
+		{
+			name: "empty device path",
+			request: sudoOpenBlockDeviceRequest{
+				SocketPath: valid.SocketPath,
+			},
+			errorContains: "devicePath must not be empty",
+		},
+		{
+			name: "relative device path",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: "disk4",
+				SocketPath: valid.SocketPath,
+			},
+			errorContains: "must be an absolute path",
+		},
+		{
+			name: "non dev device path",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: "/tmp/disk4",
+				SocketPath: valid.SocketPath,
+			},
+			errorContains: "must be under /dev",
+		},
+		{
+			name: "unnormalized socket path",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: valid.DevicePath,
+				SocketPath: "/tmp/../tmp/block-device.0.sock",
+			},
+			errorContains: "socketPath",
+		},
+		{
+			name: "relative socket path",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: valid.DevicePath,
+				SocketPath: "block-device.0.sock",
+			},
+			errorContains: "must be an absolute path",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.request.validate()
+			assert.ErrorContains(t, err, tc.errorContains)
+		})
+	}
+}

--- a/pkg/blockdevice/block_device_darwin_test.go
+++ b/pkg/blockdevice/block_device_darwin_test.go
@@ -6,25 +6,62 @@
 package blockdevice
 
 import (
+	"context"
+	"net"
 	"os"
 	"path/filepath"
+	"strings"
+	"syscall"
 	"testing"
+	"time"
 
+	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/osutil"
 )
 
-func TestSudoers(t *testing.T) {
-	sudoers, err := Sudoers("everyone")
-	assert.NilError(t, err)
-	exe, err := os.Executable()
-	assert.NilError(t, err)
-	assert.Equal(t, sudoers, "%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: "+filepath.Clean(exe)+" "+SudoOpenBlockDeviceCommand+"\n")
+func TestSudoersForUserAndHelper(t *testing.T) {
+	sudoers := sudoersForUserAndHelper("alice", []string{"/usr/local/bin/limactl", SudoOpenBlockDeviceCommand, "/dev/rdisk2"})
+	assert.Equal(t, sudoers, "alice ALL=(root:wheel) NOPASSWD:NOSETENV: /usr/local/bin/limactl "+SudoOpenBlockDeviceCommand+" /dev/rdisk2\n")
+	assert.Assert(t, !contains(sudoers, "%everyone"))
+}
+
+func TestSudoersForUserAndHelpers(t *testing.T) {
+	sudoers := sudoersForUserAndHelpers(
+		"alice",
+		[]string{"/usr/local/bin/limactl", SudoOpenBlockDeviceCommand, "/dev/rdisk2"},
+		[]string{"/usr/local/bin/limactl", SudoOpenBlockDeviceCommand, "/dev/rdisk3"},
+	)
+	assert.Equal(t, sudoers, "alice ALL=(root:wheel) NOPASSWD:NOSETENV: \\\n"+
+		"    /usr/local/bin/limactl "+SudoOpenBlockDeviceCommand+" /dev/rdisk2, \\\n"+
+		"    /usr/local/bin/limactl "+SudoOpenBlockDeviceCommand+" /dev/rdisk3\n")
+}
+
+func TestValidateSudoersUserName(t *testing.T) {
+	assert.NilError(t, validateSudoersUserName("alice"))
+
+	testCases := []string{
+		"",
+		"%everyone",
+		"#501",
+		"alice admin",
+		"alice:admin",
+		"alice=admin",
+		`DOMAIN\alice`,
+	}
+	for _, userName := range testCases {
+		t.Run(userName, func(t *testing.T) {
+			assert.Assert(t, validateSudoersUserName(userName) != nil)
+		})
+	}
 }
 
 func TestSudoOpenBlockDeviceRequestValidate(t *testing.T) {
 	valid := sudoOpenBlockDeviceRequest{
 		DevicePath: "/dev/disk4",
 		SocketPath: "/tmp/block-device.0.sock",
+		Nonce:      strings.Repeat("a", blockDeviceNonceHexLen),
 	}
 	assert.NilError(t, valid.validate())
 
@@ -37,6 +74,7 @@ func TestSudoOpenBlockDeviceRequestValidate(t *testing.T) {
 			name: "empty device path",
 			request: sudoOpenBlockDeviceRequest{
 				SocketPath: valid.SocketPath,
+				Nonce:      valid.Nonce,
 			},
 			errorContains: "devicePath must not be empty",
 		},
@@ -45,22 +83,69 @@ func TestSudoOpenBlockDeviceRequestValidate(t *testing.T) {
 			request: sudoOpenBlockDeviceRequest{
 				DevicePath: "disk4",
 				SocketPath: valid.SocketPath,
+				Nonce:      valid.Nonce,
 			},
 			errorContains: "must be an absolute path",
 		},
 		{
-			name: "non dev device path",
+			name: "raw disk device path",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: "/dev/rdisk4s1",
+				SocketPath: valid.SocketPath,
+				Nonce:      valid.Nonce,
+			},
+		},
+		{
+			name: "non disk device path",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: "/dev/null",
+				SocketPath: valid.SocketPath,
+				Nonce:      valid.Nonce,
+			},
+			errorContains: "must be a macOS disk device path",
+		},
+		{
+			name: "fd device path",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: "/dev/fd/3",
+				SocketPath: valid.SocketPath,
+				Nonce:      valid.Nonce,
+			},
+			errorContains: "must be a macOS disk device path",
+		},
+		{
+			name: "non dev path",
 			request: sudoOpenBlockDeviceRequest{
 				DevicePath: "/tmp/disk4",
 				SocketPath: valid.SocketPath,
+				Nonce:      valid.Nonce,
 			},
-			errorContains: "must be under /dev",
+			errorContains: "must be a macOS disk device path",
+		},
+		{
+			name: "disk path without number",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: "/dev/disk",
+				SocketPath: valid.SocketPath,
+				Nonce:      valid.Nonce,
+			},
+			errorContains: "must be a macOS disk device path",
+		},
+		{
+			name: "disk path with nested suffix",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: "/dev/disk4/secret",
+				SocketPath: valid.SocketPath,
+				Nonce:      valid.Nonce,
+			},
+			errorContains: "must be a macOS disk device path",
 		},
 		{
 			name: "unnormalized socket path",
 			request: sudoOpenBlockDeviceRequest{
 				DevicePath: valid.DevicePath,
 				SocketPath: "/tmp/../tmp/block-device.0.sock",
+				Nonce:      valid.Nonce,
 			},
 			errorContains: "socketPath",
 		},
@@ -69,15 +154,370 @@ func TestSudoOpenBlockDeviceRequestValidate(t *testing.T) {
 			request: sudoOpenBlockDeviceRequest{
 				DevicePath: valid.DevicePath,
 				SocketPath: "block-device.0.sock",
+				Nonce:      valid.Nonce,
 			},
 			errorContains: "must be an absolute path",
+		},
+		{
+			name: "missing nonce",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: valid.DevicePath,
+				SocketPath: valid.SocketPath,
+			},
+			errorContains: "nonce",
+		},
+		{
+			name: "non hex nonce",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: valid.DevicePath,
+				SocketPath: valid.SocketPath,
+				Nonce:      strings.Repeat("g", blockDeviceNonceHexLen),
+			},
+			errorContains: "nonce",
+		},
+		{
+			name: "short nonce",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: valid.DevicePath,
+				SocketPath: valid.SocketPath,
+				Nonce:      strings.Repeat("a", blockDeviceNonceHexLen-1),
+			},
+			errorContains: "nonce",
+		},
+		{
+			name: "socket path too long",
+			request: sudoOpenBlockDeviceRequest{
+				DevicePath: valid.DevicePath,
+				SocketPath: "/tmp/" + strings.Repeat("a", osutil.UnixPathMax),
+				Nonce:      valid.Nonce,
+			},
+			errorContains: "UNIX_PATH_MAX",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.request.validate()
+			if tc.errorContains == "" {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.errorContains)
+			}
+		})
+	}
+}
+
+func TestSudoOpenBlockDeviceRequestValidateForAllowedDevice(t *testing.T) {
+	valid := sudoOpenBlockDeviceRequest{
+		DevicePath: "/dev/rdisk4",
+		SocketPath: "/tmp/block-device.0.sock",
+		Nonce:      strings.Repeat("a", blockDeviceNonceHexLen),
+	}
+
+	assert.NilError(t, valid.validateForAllowedDevice("/dev/rdisk4"))
+
+	err := valid.validateForAllowedDevice("/dev/rdisk5")
+	assert.ErrorContains(t, err, `devicePath "/dev/rdisk4" is not allowed`)
+
+	err = valid.validateForAllowedDevice("/dev/null")
+	assert.ErrorContains(t, err, "allowed devicePath")
+}
+
+func TestServeSudoOpenBlockDeviceRejectsDeviceOutsideAllowlist(t *testing.T) {
+	req := `{"devicePath":"/dev/rdisk4","socketPath":"/tmp/block-device.0.sock","nonce":"` + strings.Repeat("a", blockDeviceNonceHexLen) + `"}`
+
+	err := ServeSudoOpenBlockDevice("/dev/rdisk5", strings.NewReader(req))
+	assert.ErrorContains(t, err, `devicePath "/dev/rdisk4" is not allowed`)
+}
+
+func TestWaitForReceivedFDHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	file, err := waitForReceivedFD(ctx, make(chan receivedFD))
+	assert.Assert(t, file == nil)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDuplicateFilePreservesCloseOnExec(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "fd")
+	assert.NilError(t, err)
+	defer f.Close()
+
+	dup, err := duplicateFileCloseOnExec(f, "fd")
+	assert.NilError(t, err)
+	defer dup.Close()
+
+	flags, err := unix.FcntlInt(dup.Fd(), unix.F_GETFD, 0)
+	assert.NilError(t, err)
+	assert.Assert(t, flags&unix.FD_CLOEXEC != 0)
+}
+
+func TestGenerateNonce(t *testing.T) {
+	nonce1, err := generateNonce()
+	assert.NilError(t, err)
+	nonce2, err := generateNonce()
+	assert.NilError(t, err)
+	assert.Assert(t, nonceRE.MatchString(nonce1))
+	assert.Assert(t, nonceRE.MatchString(nonce2))
+	assert.Assert(t, nonce1 != nonce2)
+}
+
+func TestValidateDiskDeviceMode(t *testing.T) {
+	assert.NilError(t, validateDiskDeviceMode("/dev/disk4", os.ModeDevice))
+	assert.NilError(t, validateDiskDeviceMode("/dev/disk4s1", os.ModeDevice))
+	assert.NilError(t, validateDiskDeviceMode("/dev/disk4s1s1", os.ModeDevice))
+	assert.NilError(t, validateDiskDeviceMode("/dev/rdisk4", os.ModeDevice|os.ModeCharDevice))
+	assert.NilError(t, validateDiskDeviceMode("/dev/rdisk4s1", os.ModeDevice|os.ModeCharDevice))
+	assert.NilError(t, validateDiskDeviceMode("/dev/rdisk4s1s1", os.ModeDevice|os.ModeCharDevice))
+
+	testCases := []struct {
+		name          string
+		path          string
+		mode          os.FileMode
+		errorContains string
+	}{
+		{
+			name:          "regular file",
+			path:          "/dev/disk4",
+			mode:          0o600,
+			errorContains: "not a device node",
+		},
+		{
+			name:          "arbitrary character device",
+			path:          "/dev/null",
+			mode:          os.ModeDevice | os.ModeCharDevice,
+			errorContains: "must be a macOS disk device path",
+		},
+		{
+			name:          "block path is character device",
+			path:          "/dev/disk4",
+			mode:          os.ModeDevice | os.ModeCharDevice,
+			errorContains: "must be a block disk device",
+		},
+		{
+			name:          "raw path is block device",
+			path:          "/dev/rdisk4",
+			mode:          os.ModeDevice,
+			errorContains: "must be a raw character disk device",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDiskDeviceMode(tc.path, tc.mode)
 			assert.ErrorContains(t, err, tc.errorContains)
 		})
 	}
 }
+
+func TestValidateDiskDeviceFileRejectsRegularFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "not-a-disk")
+	assert.NilError(t, err)
+	defer f.Close()
+
+	err = validateDiskDeviceFile("/dev/disk4", f)
+	assert.ErrorContains(t, err, "not a device node")
+}
+
+func TestSudoOriginalUID(t *testing.T) {
+	t.Setenv("SUDO_UID", "501")
+	uid, err := sudoOriginalUID()
+	assert.NilError(t, err)
+	assert.Equal(t, uid, uint32(501))
+
+	t.Setenv("SUDO_UID", "")
+	_, err = sudoOriginalUID()
+	assert.ErrorContains(t, err, "SUDO_UID is not set")
+
+	t.Setenv("SUDO_UID", "not-a-uid")
+	_, err = sudoOriginalUID()
+	assert.ErrorContains(t, err, "invalid SUDO_UID")
+}
+
+func TestValidatePrivateSocketPath(t *testing.T) {
+	privateDir := shortTempDir(t)
+	uid := uint32(os.Getuid())
+
+	assert.NilError(t, validatePrivateSocketPath(filepath.Join(privateDir, "block-device.sock"), uid))
+
+	publicDir := filepath.Join(shortTempDir(t), "public")
+	assert.NilError(t, os.Mkdir(publicDir, 0o755))
+	err := validatePrivateSocketPath(filepath.Join(publicDir, "block-device.sock"), uid)
+	assert.ErrorContains(t, err, "must not be accessible by group or other users")
+
+	err = validatePrivateSocketPath(filepath.Join(privateDir, "block-device.sock"), uid+1)
+	assert.ErrorContains(t, err, "is not owned by sudo user")
+
+	linkParent := filepath.Join(shortTempDir(t), "link")
+	assert.NilError(t, os.Symlink(privateDir, linkParent))
+	err = validatePrivateSocketPath(filepath.Join(linkParent, "block-device.sock"), uid)
+	assert.ErrorContains(t, err, "must not be a symlink")
+
+	fileParent := filepath.Join(shortTempDir(t), "not-dir")
+	assert.NilError(t, os.WriteFile(fileParent, nil, 0o600))
+	err = validatePrivateSocketPath(filepath.Join(fileParent, "block-device.sock"), uid)
+	assert.ErrorContains(t, err, "is not a directory")
+
+	err = validatePrivateSocketPath(filepath.Join(privateDir, strings.Repeat("a", osutil.UnixPathMax)), uid)
+	assert.ErrorContains(t, err, "UNIX_PATH_MAX")
+}
+
+func TestRemoveStaleSocket(t *testing.T) {
+	privateDir := shortTempDir(t)
+
+	missing := filepath.Join(privateDir, "missing.sock")
+	assert.NilError(t, removeStaleSocket(missing))
+
+	socketPath := filepath.Join(privateDir, "stale.sock")
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	assert.NilError(t, err)
+	listener.SetUnlinkOnClose(false)
+	assert.NilError(t, listener.Close())
+	assert.NilError(t, removeStaleSocket(socketPath))
+	_, err = os.Lstat(socketPath)
+	assert.Assert(t, os.IsNotExist(err))
+
+	regularPath := filepath.Join(privateDir, "regular.sock")
+	assert.NilError(t, os.WriteFile(regularPath, nil, 0o600))
+	err = removeStaleSocket(regularPath)
+	assert.ErrorContains(t, err, "not a Unix socket")
+
+	linkPath := filepath.Join(privateDir, "link.sock")
+	assert.NilError(t, os.Symlink(regularPath, linkPath))
+	err = removeStaleSocket(linkPath)
+	assert.ErrorContains(t, err, "symlink")
+}
+
+func TestUnixPeerUID(t *testing.T) {
+	privateDir := shortTempDir(t)
+	socketPath := filepath.Join(privateDir, "peer.sock")
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	assert.NilError(t, err)
+	defer listener.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer conn.Close()
+		errCh <- validateUnixPeerUID(conn, uint32(os.Getuid()))
+	}()
+
+	client, err := net.DialUnix("unix", nil, &net.UnixAddr{Name: socketPath, Net: "unix"})
+	assert.NilError(t, err)
+	defer client.Close()
+	assert.NilError(t, <-errCh)
+}
+
+func TestUnixPeerUIDRejectsUnexpectedUID(t *testing.T) {
+	privateDir := shortTempDir(t)
+	socketPath := filepath.Join(privateDir, "peer.sock")
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	assert.NilError(t, err)
+	defer listener.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer conn.Close()
+		errCh <- validateUnixPeerUID(conn, uint32(os.Getuid()+1))
+	}()
+
+	client, err := net.DialUnix("unix", nil, &net.UnixAddr{Name: socketPath, Net: "unix"})
+	assert.NilError(t, err)
+	defer client.Close()
+	assert.ErrorContains(t, <-errCh, "expected uid")
+}
+
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "lima-bd-test-") //nolint:usetesting // Unix socket paths must stay below macOS UNIX_PATH_MAX.
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	assert.NilError(t, os.Chmod(dir, 0o700))
+	return dir
+}
+
+func TestValidateSecurePathElement(t *testing.T) {
+	const rootUID = 0
+	const rootGID = 0
+
+	assert.NilError(t, validateSecurePathElement("/usr/local/bin/limactl", fakeFileInfo{
+		mode: 0o755,
+		stat: &syscall.Stat_t{Uid: rootUID, Gid: rootGID},
+	}, rootUID, rootGID))
+	assert.NilError(t, validateSecurePathElement("/usr/local/bin", fakeFileInfo{
+		mode: os.ModeDir | 0o775,
+		stat: &syscall.Stat_t{Uid: rootUID, Gid: rootGID},
+	}, rootUID, rootGID))
+
+	testCases := []struct {
+		name          string
+		info          os.FileInfo
+		errorContains string
+	}{
+		{
+			name: "symlink",
+			info: fakeFileInfo{
+				mode: os.ModeSymlink | 0o777,
+				stat: &syscall.Stat_t{Uid: rootUID, Gid: rootGID},
+			},
+			errorContains: "symlink",
+		},
+		{
+			name: "not root owned",
+			info: fakeFileInfo{
+				mode: 0o755,
+				stat: &syscall.Stat_t{Uid: 501, Gid: rootGID},
+			},
+			errorContains: "not owned by root",
+		},
+		{
+			name: "group writable by non-root group",
+			info: fakeFileInfo{
+				mode: 0o775,
+				stat: &syscall.Stat_t{Uid: rootUID, Gid: 20},
+			},
+			errorContains: "group-writable",
+		},
+		{
+			name: "world writable",
+			info: fakeFileInfo{
+				mode: 0o777,
+				stat: &syscall.Stat_t{Uid: rootUID, Gid: rootGID},
+			},
+			errorContains: "world-writable",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSecurePathElement("/usr/local/bin/limactl", tc.info, rootUID, rootGID)
+			assert.ErrorContains(t, err, tc.errorContains)
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return strings.Contains(s, substr)
+}
+
+type fakeFileInfo struct {
+	mode os.FileMode
+	stat any
+}
+
+func (f fakeFileInfo) Name() string       { return "limactl" }
+func (f fakeFileInfo) Size() int64        { return 0 }
+func (f fakeFileInfo) Mode() os.FileMode  { return f.mode }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return f.mode.IsDir() }
+func (f fakeFileInfo) Sys() any           { return f.stat }

--- a/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
@@ -234,6 +234,9 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 	if cfg.MountType != nil && (*cfg.MountType != limatype.VIRTIOFS && *cfg.MountType != limatype.REVSSHFS) {
 		return fmt.Errorf("field `mountType` must be %#q or %#q for krunkit driver, got %#q", limatype.VIRTIOFS, limatype.REVSSHFS, *cfg.MountType)
 	}
+	if len(cfg.BlockDevices) > 0 {
+		return fmt.Errorf("field `blockDevices` is not supported for vmType: %s", vmType)
+	}
 
 	if cfg.TPM != nil && *cfg.TPM {
 		return errors.New("field `tpm` is not supported in krunkit driver")

--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -103,6 +103,9 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 	if err := validateMountType(cfg); err != nil {
 		return err
 	}
+	if len(cfg.BlockDevices) > 0 {
+		return fmt.Errorf("field `blockDevices` is not supported for vmType: %s", limatype.QEMU)
+	}
 
 	for i, nw := range cfg.Networks {
 		if unknown := reflectutil.UnknownNonEmptyFields(nw,

--- a/pkg/driver/qemu/qemu_test.go
+++ b/pkg/driver/qemu/qemu_test.go
@@ -151,3 +151,10 @@ func TestSwtpmCmdline(t *testing.T) {
 	_, err = os.Stat(swtpmSock)
 	assert.ErrorIs(t, err, os.ErrNotExist)
 }
+
+func TestValidateConfigRejectsBlockDevices(t *testing.T) {
+	err := validateConfig(&limatype.LimaYAML{
+		BlockDevices: []string{"/dev/disk4"},
+	})
+	assert.ErrorContains(t, err, "field `blockDevices` is not supported for vmType: qemu")
+}

--- a/pkg/driver/vz/block_device_darwin.go
+++ b/pkg/driver/vz/block_device_darwin.go
@@ -1,0 +1,96 @@
+//go:build darwin && !no_vz
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package vz
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	vzapi "github.com/Code-Hex/vz/v3"
+
+	"github.com/lima-vm/lima/v2/pkg/blockdevice"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+)
+
+// attachHostBlockDevices runs while Lima is building the VZ storage device
+// configuration before the VM boots. For each configured host block device, it
+// obtains a retained descriptor from the privileged helper path, wraps that
+// descriptor in a VZ block-device attachment, and appends it to the VM's
+// storage device list alongside the normal disk image attachments.
+func attachHostBlockDevices(ctx context.Context, inst *limatype.Instance, configurations []vzapi.StorageDeviceConfiguration) ([]vzapi.StorageDeviceConfiguration, error) {
+	if len(inst.Config.BlockDevices) == 0 {
+		return configurations, nil
+	}
+
+	for i, devicePath := range inst.Config.BlockDevices {
+		deviceFile, err := openHostBlockDevice(ctx, inst, devicePath, i)
+		if err != nil {
+			return nil, err
+		}
+		attachment, err := vzapi.NewDiskBlockDeviceStorageDeviceAttachment(deviceFile, false, vzapi.DiskSynchronizationModeFull)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create block device attachment for %q: %w", devicePath, err)
+		}
+		device, err := vzapi.NewVirtioBlockDeviceConfiguration(attachment)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create virtio block device for %q: %w", devicePath, err)
+		}
+		if err := device.SetBlockDeviceIdentifier(guestBlockDeviceIdentifier(devicePath)); err != nil {
+			return nil, fmt.Errorf("failed to set block device identifier for %q: %w", devicePath, err)
+		}
+		configurations = append(configurations, device)
+	}
+	return configurations, nil
+}
+
+// openHostBlockDevice bridges the generic host helper into the VZ lifecycle by
+// choosing a VZ-local socket path and retaining the returned descriptor until
+// the VM stops.
+func openHostBlockDevice(ctx context.Context, inst *limatype.Instance, devicePath string, index int) (*os.File, error) {
+	socketPath := filepath.Join(inst.Dir, fmt.Sprintf("vz-block-device.%d.sock", index))
+	deviceFile, err := blockdevice.Open(ctx, devicePath, socketPath)
+	if err != nil {
+		return nil, err
+	}
+	vmRetainedFileDescriptors = append(vmRetainedFileDescriptors, deviceFile)
+	return deviceFile, nil
+}
+
+// guestBlockDeviceIdentifier derives the VZ block device identifier from the
+// host device basename. This does not force the guest kernel to use a specific
+// /dev node like "/dev/vdb", but it does give the guest a stable identifier
+// value that Linux exposes in predictable places such as /dev/disk/by-id and
+// lsblk SERIAL output.
+func guestBlockDeviceIdentifier(devicePath string) string {
+	base := filepath.Base(devicePath)
+	var b strings.Builder
+	b.Grow(len(base))
+	for _, r := range base {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	id := b.String()
+	if id == "" {
+		id = "block-device"
+	}
+	if len(id) > 20 {
+		id = id[:20]
+	}
+	return id
+}

--- a/pkg/driver/vz/block_device_darwin.go
+++ b/pkg/driver/vz/block_device_darwin.go
@@ -23,13 +23,13 @@ import (
 // obtains a retained descriptor from the privileged helper path, wraps that
 // descriptor in a VZ block-device attachment, and appends it to the VM's
 // storage device list alongside the normal disk image attachments.
-func attachHostBlockDevices(ctx context.Context, inst *limatype.Instance, configurations []vzapi.StorageDeviceConfiguration) ([]vzapi.StorageDeviceConfiguration, error) {
+func attachHostBlockDevices(ctx context.Context, inst *limatype.Instance, configurations []vzapi.StorageDeviceConfiguration, retainedFDs *retainedFileDescriptors) ([]vzapi.StorageDeviceConfiguration, error) {
 	if len(inst.Config.BlockDevices) == 0 {
 		return configurations, nil
 	}
 
 	for i, devicePath := range inst.Config.BlockDevices {
-		deviceFile, err := openHostBlockDevice(ctx, inst, devicePath, i)
+		deviceFile, err := openHostBlockDevice(ctx, inst, devicePath, i, retainedFDs)
 		if err != nil {
 			return nil, err
 		}
@@ -52,13 +52,15 @@ func attachHostBlockDevices(ctx context.Context, inst *limatype.Instance, config
 // openHostBlockDevice bridges the generic host helper into the VZ lifecycle by
 // choosing a VZ-local socket path and retaining the returned descriptor until
 // the VM stops.
-func openHostBlockDevice(ctx context.Context, inst *limatype.Instance, devicePath string, index int) (*os.File, error) {
+func openHostBlockDevice(ctx context.Context, inst *limatype.Instance, devicePath string, index int, retainedFDs *retainedFileDescriptors) (*os.File, error) {
 	socketPath := filepath.Join(inst.Dir, fmt.Sprintf("vz-block-device.%d.sock", index))
 	deviceFile, err := blockdevice.Open(ctx, devicePath, socketPath)
 	if err != nil {
 		return nil, err
 	}
-	vmRetainedFileDescriptors = append(vmRetainedFileDescriptors, deviceFile)
+	if retainedFDs != nil {
+		retainedFDs.Append(deviceFile)
+	}
 	return deviceFile, nil
 }
 

--- a/pkg/driver/vz/block_device_darwin_test.go
+++ b/pkg/driver/vz/block_device_darwin_test.go
@@ -1,0 +1,19 @@
+//go:build darwin && !no_vz
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package vz
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGuestBlockDeviceIdentifier(t *testing.T) {
+	assert.Equal(t, guestBlockDeviceIdentifier("/dev/disk4"), "disk4")
+	assert.Equal(t, guestBlockDeviceIdentifier("/dev/disk@4"), "disk-4")
+	assert.Equal(t, guestBlockDeviceIdentifier("/dev/"+strings.Repeat("a", 64)), strings.Repeat("a", 20))
+}

--- a/pkg/driver/vz/block_device_darwin_test.go
+++ b/pkg/driver/vz/block_device_darwin_test.go
@@ -6,6 +6,7 @@
 package vz
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -16,4 +17,25 @@ func TestGuestBlockDeviceIdentifier(t *testing.T) {
 	assert.Equal(t, guestBlockDeviceIdentifier("/dev/disk4"), "disk4")
 	assert.Equal(t, guestBlockDeviceIdentifier("/dev/disk@4"), "disk-4")
 	assert.Equal(t, guestBlockDeviceIdentifier("/dev/"+strings.Repeat("a", 64)), strings.Repeat("a", 20))
+}
+
+func TestRetainedFileDescriptorsArePerVM(t *testing.T) {
+	first := newRetainedFileDescriptors()
+	second := newRetainedFileDescriptors()
+
+	firstFile, err := os.CreateTemp(t.TempDir(), "first")
+	assert.NilError(t, err)
+	secondFile, err := os.CreateTemp(t.TempDir(), "second")
+	assert.NilError(t, err)
+
+	first.Append(firstFile)
+	second.Append(secondFile)
+	first.CloseAll()
+
+	_, err = secondFile.Stat()
+	assert.NilError(t, err)
+
+	second.CloseAll()
+	_, err = secondFile.Stat()
+	assert.Assert(t, err != nil)
 }

--- a/pkg/driver/vz/external_vz_darwin.go
+++ b/pkg/driver/vz/external_vz_darwin.go
@@ -1,0 +1,8 @@
+//go:build darwin && !no_vz && external_vz
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package vz
+
+const externalVZ = true

--- a/pkg/driver/vz/external_vz_darwin_builtin.go
+++ b/pkg/driver/vz/external_vz_darwin_builtin.go
@@ -1,0 +1,8 @@
+//go:build darwin && !no_vz && !external_vz
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package vz
+
+const externalVZ = false

--- a/pkg/driver/vz/network_darwin.go
+++ b/pkg/driver/vz/network_darwin.go
@@ -21,7 +21,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// PassFDToUnix sends one side of a socketpair to unixSock and returns the other
+// side to the caller. VZ VM setup uses passFDToUnix instead so descriptors that
+// Virtualization.framework keeps using can be retained for exactly one VM.
 func PassFDToUnix(unixSock string) (*os.File, error) {
+	return passFDToUnix(unixSock, processRetainedFDs)
+}
+
+func passFDToUnix(unixSock string, retainedFDs *retainedFileDescriptors) (*os.File, error) {
 	unixAddr, err := net.ResolveUnixAddr("unix", unixSock)
 	if err != nil {
 		return nil, err
@@ -31,7 +38,7 @@ func PassFDToUnix(unixSock string) (*os.File, error) {
 		return nil, err
 	}
 
-	server, client, err := createSockPair()
+	server, client, err := createSockPair(retainedFDs)
 	if err != nil {
 		return nil, err
 	}
@@ -42,9 +49,14 @@ func PassFDToUnix(unixSock string) (*os.File, error) {
 	return client, nil
 }
 
-// DialQemu support connecting to QEMU supported network stack via unix socket.
-// Returns os.File, connected dgram connection to be used for vz.
+// DialQemu connects to a QEMU-compatible network stack via Unix socket and
+// returns a datagram connection file for VZ. VZ VM setup uses dialQemu instead
+// to retain Virtualization.framework-owned descriptors for the VM lifetime.
 func DialQemu(ctx context.Context, unixSock string) (*os.File, error) {
+	return dialQemu(ctx, unixSock, processRetainedFDs)
+}
+
+func dialQemu(ctx context.Context, unixSock string, retainedFDs *retainedFileDescriptors) (*os.File, error) {
 	var dialer net.Dialer
 	unixConn, err := dialer.DialContext(ctx, "unix", unixSock)
 	if err != nil {
@@ -52,7 +64,7 @@ func DialQemu(ctx context.Context, unixSock string) (*os.File, error) {
 	}
 	qemuConn := &qemuPacketConn{Conn: unixConn}
 
-	server, client, err := createSockPair()
+	server, client, err := createSockPair(retainedFDs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/driver/vz/network_darwin_test.go
+++ b/pkg/driver/vz/network_darwin_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/balajiv113/fd"
 	"gotest.tools/v3/assert"
 )
 
@@ -36,7 +37,9 @@ func TestDialQemu(t *testing.T) {
 	}()
 
 	// Connect to the fake vmnet server.
-	client, err := DialQemu(t.Context(), listener.Addr().String())
+	retainedFDs := newRetainedFileDescriptors()
+	defer retainedFDs.CloseAll()
+	client, err := dialQemu(t.Context(), listener.Addr().String(), retainedFDs)
 	assert.NilError(t, err)
 	t.Log("Connected to fake vment server")
 
@@ -100,6 +103,40 @@ func TestDialQemu(t *testing.T) {
 		err := <-errc
 		assert.NilError(t, err)
 	}
+}
+
+func TestPassFDToUnixUsesProcessRetainer(t *testing.T) {
+	processRetainedFDs.CloseAll()
+	t.Cleanup(processRetainedFDs.CloseAll)
+
+	listener, err := listenUnix(t.TempDir())
+	assert.NilError(t, err)
+	defer listener.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer conn.Close()
+		files, err := fd.Get(conn, 1, []string{"server"})
+		for _, file := range files {
+			_ = file.Close()
+		}
+		errCh <- err
+	}()
+
+	client, err := PassFDToUnix(listener.Addr().String())
+	assert.NilError(t, err)
+	assert.NilError(t, <-errCh)
+	assert.Assert(t, client != nil)
+
+	processRetainedFDs.mu.Lock()
+	retained := len(processRetainedFDs.files)
+	processRetainedFDs.mu.Unlock()
+	assert.Equal(t, retained, 2)
 }
 
 // TestQemuPacketConnReadOversize verifies that a packet whose size prefix

--- a/pkg/driver/vz/vm_darwin.go
+++ b/pkg/driver/vz/vm_darwin.go
@@ -52,8 +52,10 @@ type virtualMachineWrapper struct {
 	stopped bool
 }
 
-// Hold all *os.File created via socketpair() so that they won't get garbage collected. f.FD() gets invalid if f gets garbage collected.
-var vmNetworkFiles = make([]*os.File, 1)
+// Hold all *os.File retained by VZ for the VM lifetime so they won't get garbage collected.
+// VZ keeps using the underlying descriptors after configuration is created.
+// For example, block device attachments and network device attachments.
+var vmRetainedFileDescriptors []*os.File
 
 func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int, onVsockEvent func(*events.VsockEvent)) (vm *virtualMachineWrapper, waitSSHLocalPortAccessible <-chan any, errCh chan error, err error) {
 	usernetClient, stopUsernet, err := startUsernet(ctx, inst)
@@ -78,8 +80,8 @@ func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int, onV
 	go func() {
 		// Handle errors via errCh and handle stop vm during context close
 		defer func() {
-			for i := range vmNetworkFiles {
-				vmNetworkFiles[i].Close()
+			for i := range vmRetainedFileDescriptors {
+				_ = vmRetainedFileDescriptors[i].Close()
 			}
 		}()
 		for {
@@ -610,6 +612,11 @@ func attachDisks(ctx context.Context, inst *limatype.Instance, vmConfig *vz.Virt
 		configurations = append(configurations, extraDisk)
 	}
 
+	configurations, err := attachHostBlockDevices(ctx, inst, configurations)
+	if err != nil {
+		return err
+	}
+
 	if err := validateDiskFormat(ciDataPath); err != nil {
 		return err
 	}
@@ -960,7 +967,7 @@ func createSockPair() (server, client *os.File, _ error) {
 	runtime.SetFinalizer(client, func(*os.File) {
 		logrus.Debugf("Client network file GC'ed")
 	})
-	vmNetworkFiles = append(vmNetworkFiles, server, client)
+	vmRetainedFileDescriptors = append(vmRetainedFileDescriptors, server, client)
 	return server, client, nil
 }
 

--- a/pkg/driver/vz/vm_darwin.go
+++ b/pkg/driver/vz/vm_darwin.go
@@ -52,10 +52,34 @@ type virtualMachineWrapper struct {
 	stopped bool
 }
 
-// Hold all *os.File retained by VZ for the VM lifetime so they won't get garbage collected.
-// VZ keeps using the underlying descriptors after configuration is created.
-// For example, block device attachments and network device attachments.
-var vmRetainedFileDescriptors []*os.File
+// retainedFileDescriptors holds descriptors that Virtualization.framework keeps
+// using after VM configuration is created. Keep this per VM so one VM lifecycle
+// cannot leak or close descriptors that belong to another VM in the same process.
+type retainedFileDescriptors struct {
+	mu    sync.Mutex
+	files []*os.File
+}
+
+func newRetainedFileDescriptors() *retainedFileDescriptors {
+	return &retainedFileDescriptors{}
+}
+
+var processRetainedFDs = newRetainedFileDescriptors()
+
+func (r *retainedFileDescriptors) Append(files ...*os.File) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.files = append(r.files, files...)
+}
+
+func (r *retainedFileDescriptors) CloseAll() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, file := range r.files {
+		_ = file.Close()
+	}
+	r.files = nil
+}
 
 func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int, onVsockEvent func(*events.VsockEvent)) (vm *virtualMachineWrapper, waitSSHLocalPortAccessible <-chan any, errCh chan error, err error) {
 	usernetClient, stopUsernet, err := startUsernet(ctx, inst)
@@ -63,7 +87,8 @@ func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int, onV
 		return nil, nil, nil, err
 	}
 
-	machine, err := createVM(ctx, inst)
+	retainedFDs := newRetainedFileDescriptors()
+	machine, err := createVM(ctx, inst, retainedFDs)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -80,9 +105,7 @@ func startVM(ctx context.Context, inst *limatype.Instance, sshLocalPort int, onV
 	go func() {
 		// Handle errors via errCh and handle stop vm during context close
 		defer func() {
-			for i := range vmRetainedFileDescriptors {
-				_ = vmRetainedFileDescriptors[i].Close()
-			}
+			retainedFDs.CloseAll()
 		}()
 		for {
 			select {
@@ -212,7 +235,7 @@ func startUsernet(ctx context.Context, inst *limatype.Instance) (*usernet.Client
 	return usernet.NewClient(endpointSock, subnetIP), cancel, err
 }
 
-func createVM(ctx context.Context, inst *limatype.Instance) (*vz.VirtualMachine, error) {
+func createVM(ctx context.Context, inst *limatype.Instance, retainedFDs *retainedFileDescriptors) (*vz.VirtualMachine, error) {
 	vmConfig, err := createInitialConfig(inst)
 	if err != nil {
 		return nil, err
@@ -226,11 +249,11 @@ func createVM(ctx context.Context, inst *limatype.Instance) (*vz.VirtualMachine,
 		return nil, err
 	}
 
-	if err = attachNetwork(ctx, inst, vmConfig); err != nil {
+	if err = attachNetwork(ctx, inst, vmConfig, retainedFDs); err != nil {
 		return nil, err
 	}
 
-	if err = attachDisks(ctx, inst, vmConfig); err != nil {
+	if err = attachDisks(ctx, inst, vmConfig, retainedFDs); err != nil {
 		return nil, err
 	}
 
@@ -413,7 +436,7 @@ func newVirtioNetworkDeviceConfiguration(attachment vz.NetworkDeviceAttachment, 
 	return networkConfig, nil
 }
 
-func attachNetwork(ctx context.Context, inst *limatype.Instance, vmConfig *vz.VirtualMachineConfiguration) error {
+func attachNetwork(ctx context.Context, inst *limatype.Instance, vmConfig *vz.VirtualMachineConfiguration, retainedFDs *retainedFileDescriptors) error {
 	var configurations []*vz.VirtioNetworkDeviceConfiguration
 
 	// Configure default usernetwork with limayaml.MACAddress(inst.Dir) for eth0 interface
@@ -424,7 +447,7 @@ func attachNetwork(ctx context.Context, inst *limatype.Instance, vmConfig *vz.Vi
 		if err != nil {
 			return err
 		}
-		networkConn, err := PassFDToUnix(vzSock)
+		networkConn, err := passFDToUnix(vzSock, retainedFDs)
 		if err != nil {
 			return err
 		}
@@ -438,7 +461,7 @@ func attachNetwork(ctx context.Context, inst *limatype.Instance, vmConfig *vz.Vi
 		if err != nil {
 			return err
 		}
-		networkConn, err := PassFDToUnix(vzSock)
+		networkConn, err := passFDToUnix(vzSock, retainedFDs)
 		if err != nil {
 			return err
 		}
@@ -477,7 +500,7 @@ func attachNetwork(ctx context.Context, inst *limatype.Instance, vmConfig *vz.Vi
 				if err != nil {
 					return err
 				}
-				clientFile, err := PassFDToUnix(vzSock)
+				clientFile, err := passFDToUnix(vzSock, retainedFDs)
 				if err != nil {
 					return err
 				}
@@ -501,7 +524,7 @@ func attachNetwork(ctx context.Context, inst *limatype.Instance, vmConfig *vz.Vi
 						return err
 					}
 
-					clientFile, err := DialQemu(ctx, sock)
+					clientFile, err := dialQemu(ctx, sock, retainedFDs)
 					if err != nil {
 						return err
 					}
@@ -513,7 +536,7 @@ func attachNetwork(ctx context.Context, inst *limatype.Instance, vmConfig *vz.Vi
 				}
 			}
 		} else if nw.Socket != "" {
-			clientFile, err := DialQemu(ctx, nw.Socket)
+			clientFile, err := dialQemu(ctx, nw.Socket, retainedFDs)
 			if err != nil {
 				return err
 			}
@@ -546,7 +569,7 @@ func validateDiskFormat(diskPath string) error {
 	return nil
 }
 
-func attachDisks(ctx context.Context, inst *limatype.Instance, vmConfig *vz.VirtualMachineConfiguration) error {
+func attachDisks(ctx context.Context, inst *limatype.Instance, vmConfig *vz.VirtualMachineConfiguration, retainedFDs *retainedFileDescriptors) (retErr error) {
 	diskPath := filepath.Join(inst.Dir, filenames.Disk)
 	isoPath := filepath.Join(inst.Dir, filenames.ISO)
 	ciDataPath := filepath.Join(inst.Dir, filenames.CIDataISO)
@@ -582,6 +605,14 @@ func attachDisks(ctx context.Context, inst *limatype.Instance, vmConfig *vz.Virt
 	}
 
 	diskUtil := proxyimgutil.NewDiskUtil(ctx)
+	var lockedDisks []*store.Disk
+	defer func() {
+		if retErr != nil {
+			for _, disk := range lockedDisks {
+				_ = disk.Unlock()
+			}
+		}
+	}()
 
 	for _, d := range inst.Config.AdditionalDisks {
 		diskName := d.Name
@@ -594,6 +625,7 @@ func attachDisks(ctx context.Context, inst *limatype.Instance, vmConfig *vz.Virt
 		if err = disk.LockForInstance(inst.Dir); err != nil {
 			return fmt.Errorf("failed to attach disk %#q: %w", diskName, err)
 		}
+		lockedDisks = append(lockedDisks, disk)
 		extraDiskPath := filepath.Join(disk.Dir, filenames.DataDisk)
 		// ConvertToRaw is a NOP if no conversion is needed
 		logrus.Debugf("Converting extra disk %#q to a raw disk (if it is not a raw)", extraDiskPath)
@@ -612,7 +644,7 @@ func attachDisks(ctx context.Context, inst *limatype.Instance, vmConfig *vz.Virt
 		configurations = append(configurations, extraDisk)
 	}
 
-	configurations, err := attachHostBlockDevices(ctx, inst, configurations)
+	configurations, err := attachHostBlockDevices(ctx, inst, configurations, retainedFDs)
 	if err != nil {
 		return err
 	}
@@ -939,7 +971,7 @@ func getEFI(inst *limatype.Instance) (*vz.EFIVariableStore, error) {
 	return vz.NewEFIVariableStore(efi)
 }
 
-func createSockPair() (server, client *os.File, _ error) {
+func createSockPair(retainedFDs *retainedFileDescriptors) (server, client *os.File, _ error) {
 	pairs, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_DGRAM, 0)
 	if err != nil {
 		return nil, nil, err
@@ -967,7 +999,9 @@ func createSockPair() (server, client *os.File, _ error) {
 	runtime.SetFinalizer(client, func(*os.File) {
 		logrus.Debugf("Client network file GC'ed")
 	})
-	vmRetainedFileDescriptors = append(vmRetainedFileDescriptors, server, client)
+	if retainedFDs != nil {
+		retainedFDs.Append(server, client)
+	}
 	return server, client, nil
 }
 

--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -263,6 +263,9 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 	if cfg == nil {
 		return errors.New("configuration is nil")
 	}
+	if len(cfg.BlockDevices) > 0 && externalVZ {
+		return errors.New("field `blockDevices` is not supported for external VZ driver builds")
+	}
 	macOSProductVersion, err := osutil.ProductVersion()
 	if err != nil {
 		return err

--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -44,6 +44,7 @@ var knownYamlProperties = []string{
 	"AdditionalDisks",
 	"Arch",
 	"Audio",
+	"BlockDevices",
 	"CACertificates",
 	"Containerd",
 	"CopyToHost",
@@ -355,6 +356,9 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 		}
 	default:
 		return fmt.Errorf("field `vmOpts.vz.diskImageFormat` must be %#q or %#q, got %#q", raw.Type, asif.Type, *vzOpts.DiskImageFormat)
+	}
+	if len(cfg.BlockDevices) > 0 && macOSProductVersion.LessThan(*semver.New("14.0.0")) {
+		return fmt.Errorf("field `blockDevices` requires macOS 14 or higher to run, got %q", macOSProductVersion)
 	}
 	return nil
 }

--- a/pkg/driver/vz/vz_driver_external_darwin_test.go
+++ b/pkg/driver/vz/vz_driver_external_darwin_test.go
@@ -1,0 +1,20 @@
+//go:build darwin && !no_vz && external_vz
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package vz
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+)
+
+func TestValidateConfigRejectsBlockDevicesWithExternalVZ(t *testing.T) {
+	cfg := &limatype.LimaYAML{BlockDevices: []string{"/dev/disk4"}}
+	err := validateConfig(cfg)
+	assert.ErrorContains(t, err, "external VZ")
+}

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -25,6 +25,7 @@ import (
 
 var knownYamlProperties = []string{
 	"Arch",
+	"BlockDevices",
 	"Containerd",
 	"CopyToHost",
 	"CPUType",
@@ -101,6 +102,9 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 	}
 	if cfg.MountType != nil && *cfg.MountType != limatype.WSLMount {
 		return fmt.Errorf("field `mountType` must be %#q for WSL2 driver, got %#q", limatype.WSLMount, *cfg.MountType)
+	}
+	if len(cfg.BlockDevices) > 0 {
+		return fmt.Errorf("field `blockDevices` is not supported for vmType: %s", limatype.WSL2)
 	}
 	// TODO: revise this list for WSL2
 	if cfg.VMType != nil {

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -27,6 +27,7 @@ type LimaYAML struct {
 	Memory                *string       `yaml:"memory,omitempty" json:"memory,omitempty" jsonschema:"nullable"` // go-units.RAMInBytes
 	Disk                  *string       `yaml:"disk,omitempty" json:"disk,omitempty" jsonschema:"nullable"`     // go-units.RAMInBytes
 	AdditionalDisks       []Disk        `yaml:"additionalDisks,omitempty" json:"additionalDisks,omitempty" jsonschema:"nullable"`
+	BlockDevices          []string      `yaml:"blockDevices,omitempty" json:"blockDevices,omitempty" jsonschema:"nullable"`
 	Mounts                []Mount       `yaml:"mounts,omitempty" json:"mounts,omitempty"`
 	MountTypesUnsupported []string      `yaml:"mountTypesUnsupported,omitempty" json:"mountTypesUnsupported,omitempty" jsonschema:"nullable"`
 	MountType             *MountType    `yaml:"mountType,omitempty" json:"mountType,omitempty" jsonschema:"nullable"`

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -302,6 +302,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 	}
 
 	y.AdditionalDisks = slices.Concat(o.AdditionalDisks, y.AdditionalDisks, d.AdditionalDisks)
+	y.BlockDevices = slices.Concat(o.BlockDevices, y.BlockDevices, d.BlockDevices)
 
 	if y.Audio.Device == nil {
 		y.Audio.Device = d.Audio.Device

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -772,6 +772,16 @@ func TestContainerdDefault(t *testing.T) {
 	assert.Assert(t, len(archives) > 0)
 }
 
+func TestFillDefaultMergesBlockDevices(t *testing.T) {
+	y := limatype.LimaYAML{BlockDevices: []string{"/dev/disk2"}}
+	d := limatype.LimaYAML{BlockDevices: []string{"/dev/disk3"}}
+	o := limatype.LimaYAML{BlockDevices: []string{"/dev/disk1"}}
+
+	FillDefault(t.Context(), &y, &d, &o, "test.yaml", false)
+
+	assert.DeepEqual(t, y.BlockDevices, []string{"/dev/disk1", "/dev/disk2", "/dev/disk3"})
+}
+
 func TestStaticPortForwarding(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/limayaml/marshal_test.go
+++ b/pkg/limayaml/marshal_test.go
@@ -122,6 +122,18 @@ vmOpts:
 	t.Log(dumpYAML(t, o))
 }
 
+func TestBlockDevices(t *testing.T) {
+	text := `
+blockDevices:
+  - /dev/disk4
+  - /dev/rdisk5
+`
+	var y limatype.LimaYAML
+	err := Unmarshal([]byte(text), &y, "lima.yaml")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, y.BlockDevices, []string{"/dev/disk4", "/dev/rdisk5"})
+}
+
 func TestVMOptsNull(t *testing.T) {
 	text := `
 vmOpts: null

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -63,6 +63,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 	if !slices.Contains(limatype.ArchTypes, *y.Arch) {
 		errs = errors.Join(errs, fmt.Errorf("field `arch` must be one of %v; got %#q", limatype.ArchTypes, *y.Arch))
 	}
+	errs = errors.Join(errs, validateBlockDevices(y.BlockDevices))
 
 	if y.User.Shell != nil {
 		shell := *y.User.Shell
@@ -484,6 +485,23 @@ func IsSupportedWindowsShell(shell string) bool {
 		}
 	}
 	return false
+}
+
+func validateBlockDevices(blockDevices []string) error {
+	var errs error
+
+	for i, blockDevice := range blockDevices {
+		field := fmt.Sprintf("blockDevices[%d]", i)
+		if blockDevice == "" {
+			errs = errors.Join(errs, fmt.Errorf("field `%s` must not be empty", field))
+			continue
+		}
+		if !filepath.IsAbs(blockDevice) && !path.IsAbs(blockDevice) {
+			errs = errors.Join(errs, fmt.Errorf("field `%s` must be an absolute path, got %q", field, blockDevice))
+		}
+	}
+
+	return errs
 }
 
 func validateFileObject(f limatype.File, fieldName string) error {

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -235,6 +235,33 @@ additionalDisks:
 	assert.Error(t, err, "field `additionalDisks[0].name is invalid`: identifier must not be empty")
 }
 
+func TestValidateBlockDevices(t *testing.T) {
+	y, err := Load(t.Context(), []byte(`
+images:
+  - location: /
+vmType: qemu
+blockDevices:
+  - /dev/disk4
+`), "lima.yaml")
+	assert.NilError(t, err)
+
+	err = Validate(y, false)
+	assert.NilError(t, err)
+}
+
+func TestValidateBlockDevicesRequiresAbsolutePaths(t *testing.T) {
+	y, err := Load(t.Context(), []byte(`
+images:
+  - location: /
+blockDevices:
+  - disk4
+`), "lima.yaml")
+	assert.NilError(t, err)
+
+	err = Validate(y, false)
+	assert.ErrorContains(t, err, "field `blockDevices[0]` must be an absolute path")
+}
+
 func TestValidateParamName(t *testing.T) {
 	images := `images: [{"location": "/"}]`
 	validProvision := `provision: [{"script": "echo $PARAM_name $PARAM_NAME $PARAM_Name_123"}]`

--- a/pkg/networks/reconcile/reconcile.go
+++ b/pkg/networks/reconcile/reconcile.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"runtime"
 	"strings"
 	"sync"
@@ -23,6 +22,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/networks/usernet"
 	"github.com/lima-vm/lima/v2/pkg/osutil"
 	"github.com/lima-vm/lima/v2/pkg/store"
+	pkgsudoers "github.com/lima-vm/lima/v2/pkg/sudoers"
 )
 
 func Reconcile(ctx context.Context, newInst string) error {
@@ -79,12 +79,8 @@ func Reconcile(ctx context.Context, newInst string) error {
 }
 
 func sudo(ctx context.Context, user, group, command string) error {
-	args := []string{"--user", user, "--group", group, "--non-interactive"}
-	args = append(args, strings.Split(command, " ")...)
 	var stdout, stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, "sudo", args...)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd := pkgsudoers.NewCommand(ctx, user, group, nil, &stdout, &stderr, "", strings.Split(command, " ")...)
 	logrus.Infof("Running: %v", cmd.Args)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to run %v: stdout=%#q, stderr=%#q: %w",
@@ -138,9 +134,7 @@ func startDaemon(ctx context.Context, cfg *networks.Config, name, daemon string)
 		return err
 	}
 
-	args := []string{"--user", user.User, "--group", user.Group, "--non-interactive"}
-	args = append(args, strings.Split(cfg.StartCmd(name, daemon), " ")...)
-	cmd := exec.CommandContext(ctx, "sudo", args...)
+	cmd := pkgsudoers.NewCommand(ctx, user.User, user.Group, nil, nil, nil, "", strings.Split(cfg.StartCmd(name, daemon), " ")...)
 	// set directory to a path the daemon user has read access to because vde_switch calls getcwd() which
 	// can fail when called from directories like ~/Downloads, which has 700 permissions
 	cmd.Dir = cfg.Paths.VarRun

--- a/pkg/networks/sudoers.go
+++ b/pkg/networks/sudoers.go
@@ -13,20 +13,17 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/sudoers"
 )
 
-func Sudoers() (string, error) {
-	cfg, err := LoadConfig()
-	if err != nil {
-		return "", err
-	}
-
+func (c Config) Sudoers() (string, error) {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "%%%s ALL=(root:wheel) NOPASSWD:NOSETENV: %s\n", cfg.Group, cfg.MkdirCmd())
+	sb.WriteString(sudoers.NOPASSWD("%"+c.Group, "root", "wheel", c.MkdirCmd()))
 
 	// names must be in stable order to be able to check if sudoers file needs updating
-	names := make([]string, 0, len(cfg.Networks))
-	for name, nw := range cfg.Networks {
+	names := make([]string, 0, len(c.Networks))
+	for name, nw := range c.Networks {
 		if nw.Mode == ModeUserV2 {
 			continue // no sudo needed
 		}
@@ -38,19 +35,17 @@ func Sudoers() (string, error) {
 		sb.WriteRune('\n')
 		fmt.Fprintf(&sb, "# Manage %q network daemons\n", name)
 		for _, daemon := range []string{SocketVMNet} {
-			if ok, err := cfg.IsDaemonInstalled(daemon); err != nil {
+			if ok, err := c.IsDaemonInstalled(daemon); err != nil {
 				return "", err
 			} else if !ok {
 				continue
 			}
-			user, err := cfg.User(daemon)
+			user, err := c.User(daemon)
 			if err != nil {
 				return "", err
 			}
 			sb.WriteRune('\n')
-			fmt.Fprintf(&sb, "%%%s ALL=(%s:%s) NOPASSWD:NOSETENV: \\\n", cfg.Group, user.User, user.Group)
-			fmt.Fprintf(&sb, "    %s, \\\n", cfg.StartCmd(name, daemon))
-			fmt.Fprintf(&sb, "    %s\n", cfg.StopCmd(name, daemon))
+			sb.WriteString(sudoers.NOPASSWD("%"+c.Group, user.User, user.Group, c.StartCmd(name, daemon), c.StopCmd(name, daemon)))
 		}
 	}
 	return sb.String(), nil
@@ -75,10 +70,8 @@ func (c *Config) passwordLessSudo(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		cmd = exec.CommandContext(ctx, "sudo", "--user", user.User, "--group", user.Group, "--non-interactive", "true")
-		logrus.Infof("Running: %v", cmd.Args)
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to run %v: %w", cmd.Args, err)
+		if err := sudoers.Run(ctx, user.User, user.Group, nil, nil, nil, "", "true"); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -109,11 +102,14 @@ func (c *Config) VerifySudoAccess(ctx context.Context, sudoersFile string) error
 		}
 		return fmt.Errorf("can't read %#q: %w: (Hint: %s)", sudoersFile, err, hint)
 	}
-	sudoers, err := Sudoers()
+	sudoers, err := c.Sudoers()
 	if err != nil {
 		return err
 	}
-	if string(b) != sudoers {
+	// limactl sudoers writes a single file that may include additional
+	// non-network entries. Network startup only needs its own generated
+	// fragment to be present verbatim.
+	if !strings.Contains(string(b), sudoers) {
 		// Happens on upgrading socket_vmnet with Homebrew
 		return fmt.Errorf("sudoers file %#q is out of sync and must be regenerated (Hint: %s)", sudoersFile, hint)
 	}

--- a/pkg/networks/sudoers.go
+++ b/pkg/networks/sudoers.go
@@ -86,7 +86,7 @@ func (c *Config) VerifySudoAccess(ctx context.Context, sudoersFile string) error
 		}
 		return fmt.Errorf("passwordLessSudo error: %w", err)
 	}
-	hint := fmt.Sprintf("run `%s sudoers >etc_sudoers.d_lima && sudo install -o root etc_sudoers.d_lima %q`)",
+	hint := fmt.Sprintf("run `%s sudoers >etc_sudoers.d_lima && sudo install -o root etc_sudoers.d_lima %q`",
 		os.Args[0], sudoersFile)
 	b, err := os.ReadFile(sudoersFile)
 	if err != nil {
@@ -102,14 +102,14 @@ func (c *Config) VerifySudoAccess(ctx context.Context, sudoersFile string) error
 		}
 		return fmt.Errorf("can't read %#q: %w: (Hint: %s)", sudoersFile, err, hint)
 	}
-	sudoers, err := c.Sudoers()
+	networkSudoers, err := c.Sudoers()
 	if err != nil {
 		return err
 	}
 	// limactl sudoers writes a single file that may include additional
 	// non-network entries. Network startup only needs its own generated
 	// fragment to be present verbatim.
-	if !strings.Contains(string(b), sudoers) {
+	if !sudoers.ContainsActiveFragment(string(b), networkSudoers) {
 		// Happens on upgrading socket_vmnet with Homebrew
 		return fmt.Errorf("sudoers file %#q is out of sync and must be regenerated (Hint: %s)", sudoersFile, hint)
 	}

--- a/pkg/networks/sudoers_test.go
+++ b/pkg/networks/sudoers_test.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package networks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestVerifySudoAccessAllowsAdditionalFragments(t *testing.T) {
+	cfg := Config{
+		Group:    "everyone",
+		Networks: map[string]Network{},
+		Paths: Paths{
+			VarRun: "/private/var/run/lima",
+		},
+	}
+
+	networkSudoers, err := cfg.Sudoers()
+	assert.NilError(t, err)
+
+	composed := networkSudoers
+	if composed != "" && !strings.HasSuffix(composed, "\n") {
+		composed += "\n"
+	}
+	composed += "%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: /usr/local/bin/limactl sudo-open-block-device\n"
+
+	sudoersFile := filepath.Join(t.TempDir(), "lima.sudoers")
+	assert.NilError(t, os.WriteFile(sudoersFile, []byte(composed), 0o600))
+
+	assert.NilError(t, cfg.VerifySudoAccess(t.Context(), sudoersFile))
+}
+
+func TestVerifySudoAccessRejectsOutOfSyncNetworkFragment(t *testing.T) {
+	cfg := Config{
+		Group:    "everyone",
+		Networks: map[string]Network{},
+		Paths: Paths{
+			VarRun: "/private/var/run/lima",
+		},
+	}
+
+	networkSudoers, err := cfg.Sudoers()
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(networkSudoers, "NOPASSWD:NOSETENV"))
+
+	modified := strings.Replace(networkSudoers, "NOPASSWD:NOSETENV", "NOPASSWD", 1)
+	sudoersFile := filepath.Join(t.TempDir(), "lima.sudoers")
+	assert.NilError(t, os.WriteFile(sudoersFile, []byte(modified), 0o600))
+
+	err = cfg.VerifySudoAccess(t.Context(), sudoersFile)
+	assert.ErrorContains(t, err, "out of sync")
+}

--- a/pkg/networks/sudoers_test.go
+++ b/pkg/networks/sudoers_test.go
@@ -28,7 +28,7 @@ func TestVerifySudoAccessAllowsAdditionalFragments(t *testing.T) {
 	if composed != "" && !strings.HasSuffix(composed, "\n") {
 		composed += "\n"
 	}
-	composed += "%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: /usr/local/bin/limactl sudo-open-block-device\n"
+	composed += "alice ALL=(root:wheel) NOPASSWD:NOSETENV: /opt/lima/bin/limactl sudo-open-block-device /dev/rdisk2\n"
 
 	sudoersFile := filepath.Join(t.TempDir(), "lima.sudoers")
 	assert.NilError(t, os.WriteFile(sudoersFile, []byte(composed), 0o600))
@@ -52,6 +52,26 @@ func TestVerifySudoAccessRejectsOutOfSyncNetworkFragment(t *testing.T) {
 	modified := strings.Replace(networkSudoers, "NOPASSWD:NOSETENV", "NOPASSWD", 1)
 	sudoersFile := filepath.Join(t.TempDir(), "lima.sudoers")
 	assert.NilError(t, os.WriteFile(sudoersFile, []byte(modified), 0o600))
+
+	err = cfg.VerifySudoAccess(t.Context(), sudoersFile)
+	assert.ErrorContains(t, err, "out of sync")
+}
+
+func TestVerifySudoAccessRejectsCommentedNetworkFragment(t *testing.T) {
+	cfg := Config{
+		Group:    "everyone",
+		Networks: map[string]Network{},
+		Paths: Paths{
+			VarRun: "/private/var/run/lima",
+		},
+	}
+
+	networkSudoers, err := cfg.Sudoers()
+	assert.NilError(t, err)
+	commented := "# " + strings.ReplaceAll(networkSudoers, "\n", "\n# ")
+
+	sudoersFile := filepath.Join(t.TempDir(), "lima.sudoers")
+	assert.NilError(t, os.WriteFile(sudoersFile, []byte(commented), 0o600))
 
 	err = cfg.VerifySudoAccess(t.Context(), sudoersFile)
 	assert.ErrorContains(t, err, "out of sync")

--- a/pkg/sudoers/sudoers.go
+++ b/pkg/sudoers/sudoers.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sudoers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Args is the one place that defines Lima's non-interactive sudo invocation
+// shape. Callers own the actual helper command names and sudoers policy; this
+// package only keeps the invocation mechanics consistent.
+func Args(user, group string, args ...string) []string {
+	sudoArgs := []string{"--user", user, "--group", group, "--non-interactive"}
+	return append(sudoArgs, args...)
+}
+
+func NewCommand(ctx context.Context, user, group string, stdin io.Reader, stdout, stderr io.Writer, dir string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "sudo", Args(user, group, args...)...)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.Dir = dir
+	return cmd
+}
+
+func Run(ctx context.Context, user, group string, stdin io.Reader, stdout, stderr io.Writer, dir string, args ...string) error {
+	cmd := NewCommand(ctx, user, group, stdin, stdout, stderr, dir, args...)
+	logrus.Debugf("Running: %v", cmd.Args)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run %v: %w", cmd.Args, err)
+	}
+	return nil
+}
+
+// NOPASSWD renders a sudoers entry for one or more commands.
+func NOPASSWD(subject, runAsUser, runAsGroup string, commands ...string) string {
+	if len(commands) == 1 {
+		return fmt.Sprintf("%s ALL=(%s:%s) NOPASSWD:NOSETENV: %s\n", subject, runAsUser, runAsGroup, commands[0])
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s ALL=(%s:%s) NOPASSWD:NOSETENV: \\\n", subject, runAsUser, runAsGroup)
+	for i, command := range commands {
+		fmt.Fprintf(&sb, "    %s", command)
+		if i < len(commands)-1 {
+			sb.WriteString(", \\\n")
+		} else {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+// AssembleSudoersFragments joins already-rendered sudoers fragments into a
+// single file. The individual fragments stay owned by their domain packages;
+// this helper only handles the generic newline normalization needed to
+// concatenate them.
+func AssembleSudoersFragments(fragments ...string) string {
+	var sb strings.Builder
+	for _, fragment := range fragments {
+		if fragment == "" {
+			continue
+		}
+		if sb.Len() > 0 && !strings.HasSuffix(sb.String(), "\n") {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(fragment)
+	}
+	return sb.String()
+}

--- a/pkg/sudoers/sudoers.go
+++ b/pkg/sudoers/sudoers.go
@@ -75,3 +75,18 @@ func AssembleSudoersFragments(fragments ...string) string {
 	}
 	return sb.String()
 }
+
+func ContainsActiveFragment(file, fragment string) bool {
+	return strings.Contains(activeFragment(file), strings.TrimSpace(activeFragment(fragment)))
+}
+
+func activeFragment(s string) string {
+	var active []string
+	for line := range strings.SplitSeq(s, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		active = append(active, line)
+	}
+	return strings.Join(active, "\n")
+}

--- a/pkg/sudoers/sudoers_test.go
+++ b/pkg/sudoers/sudoers_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sudoers
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestArgs(t *testing.T) {
+	assert.DeepEqual(t, Args("root", "wheel", "true"), []string{
+		"--user", "root",
+		"--group", "wheel",
+		"--non-interactive",
+		"true",
+	})
+}
+
+func TestNewCommand(t *testing.T) {
+	stdin := strings.NewReader("")
+	cmd := NewCommand(t.Context(), "root", "wheel", stdin, io.Discard, io.Discard, "/tmp", "true")
+
+	assert.Equal(t, cmd.Args[0], "sudo")
+	assert.DeepEqual(t, cmd.Args[1:], Args("root", "wheel", "true"))
+	assert.Equal(t, cmd.Stdin, stdin)
+	assert.Equal(t, cmd.Stdout, io.Discard)
+	assert.Equal(t, cmd.Stderr, io.Discard)
+	assert.Equal(t, cmd.Dir, "/tmp")
+}
+
+func TestNOPASSWD(t *testing.T) {
+	assert.Equal(t, NOPASSWD("%everyone", "root", "wheel", "/usr/local/bin/limactl sudo-open-block-device"),
+		"%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: /usr/local/bin/limactl sudo-open-block-device\n")
+
+	assert.Equal(t, NOPASSWD("%everyone", "daemon", "staff", "/bin/start", "/bin/stop"),
+		"%everyone ALL=(daemon:staff) NOPASSWD:NOSETENV: \\\n    /bin/start, \\\n    /bin/stop\n")
+}

--- a/pkg/sudoers/sudoers_test.go
+++ b/pkg/sudoers/sudoers_test.go
@@ -33,9 +33,20 @@ func TestNewCommand(t *testing.T) {
 }
 
 func TestNOPASSWD(t *testing.T) {
-	assert.Equal(t, NOPASSWD("%everyone", "root", "wheel", "/usr/local/bin/limactl sudo-open-block-device"),
-		"%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: /usr/local/bin/limactl sudo-open-block-device\n")
+	assert.Equal(t, NOPASSWD("%everyone", "root", "wheel", "/bin/mkdir -m 775 -p /private/var/run/lima"),
+		"%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: /bin/mkdir -m 775 -p /private/var/run/lima\n")
 
 	assert.Equal(t, NOPASSWD("%everyone", "daemon", "staff", "/bin/start", "/bin/stop"),
 		"%everyone ALL=(daemon:staff) NOPASSWD:NOSETENV: \\\n    /bin/start, \\\n    /bin/stop\n")
+}
+
+func TestContainsActiveFragmentIgnoresCommentsOnBothSides(t *testing.T) {
+	file := "%admin ALL=(root:wheel) NOPASSWD:NOSETENV: /bin/mkdir -m 775 -p /private/var/run/lima\n" +
+		"\n# Manage \"shared\" network daemons\n\n" +
+		"%admin ALL=(root:wheel) NOPASSWD:NOSETENV: /opt/socket_vmnet/bin/socket_vmnet ...\n"
+	fragment := "%admin ALL=(root:wheel) NOPASSWD:NOSETENV: /bin/mkdir -m 775 -p /private/var/run/lima\n" +
+		"\n# Manage \"shared\" network daemons\n"
+
+	assert.Assert(t, ContainsActiveFragment(file, fragment))
+	assert.Assert(t, !ContainsActiveFragment("# "+strings.ReplaceAll(fragment, "\n", "\n# "), fragment))
 }

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -131,6 +131,13 @@ additionalDisks:
 #   format: true
 #   fsType: "ext4"
 
+# Attach host block devices directly to supported backends.
+# This is currently supported on macOS with `vmType: vz`.
+# Each entry must be an absolute host path, typically under /dev.
+# This requires limactl sudoers to allow the hidden block-device helper.
+# 🟢 Builtin default: []
+blockDevices: []
+
 ssh:
   # A localhost port of the host. Forwarded to port 22 of the guest.
   # 🟢 Builtin default: 0 (automatically assigned to a free port)

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -132,9 +132,9 @@ additionalDisks:
 #   fsType: "ext4"
 
 # Attach host block devices directly to supported backends.
-# This is currently supported on macOS with `vmType: vz`.
-# Each entry must be an absolute host path, typically under /dev.
-# This requires limactl sudoers to allow the hidden block-device helper.
+# Each entry is a host device path whose exact format is backend-specific.
+# The Darwin VZ helper accepts disk device paths like /dev/disk4 or /dev/rdisk4s1
+# and requires limactl sudoers --block-device=/dev/diskN.
 # 🟢 Builtin default: []
 blockDevices: []
 

--- a/website/content/en/docs/config/disk.md
+++ b/website/content/en/docs/config/disk.md
@@ -86,3 +86,57 @@ limactl edit default --disk 20
 > **Note:**
 > - Increasing disk size is supported, but shrinking disks is not recommended.
 > - The instance may need to be stopped before editing disk size.
+
+## Attach host block devices
+
+| ⚡ Requirement | Lima >= 2.2, macOS >= 14.0, vmType: vz |
+| ------------- | -------------------------------------- |
+
+Lima can attach a host block device directly to the guest.
+
+Example configuration:
+{{< tabpane text=true >}}
+{{% tab header="CLI" %}}
+```bash
+# hdiutil attach -nomount ram://65536   # create a ramdisk to test without a USB key or real drive
+limactl start --vm-type=vz --block-device=/dev/disk4 template:default
+```
+
+`/dev/rdiskN` also works:
+
+```bash
+# hdiutil attach -nomount ram://65536   # create a ramdisk to test without a USB key or real drive
+limactl start --vm-type=vz --block-device=/dev/rdisk4 template:default
+```
+{{% /tab %}}
+{{% tab header="YAML" %}}
+```yaml
+vmType: "vz"
+blockDevices:
+- /dev/disk4
+- /dev/rdisk5
+```
+{{% /tab %}}
+{{< /tabpane >}}
+
+The `--block-device` flag can be specified multiple times to attach multiple host block devices.
+
+### Sudoers setup
+
+Opening a host block device requires a privileged helper on macOS.
+Generate and install the Lima sudoers file before using `--block-device`:
+
+```sh
+limactl sudoers >etc_sudoers.d_lima
+less etc_sudoers.d_lima
+sudo install -o root etc_sudoers.d_lima /etc/sudoers.d/lima
+rm etc_sudoers.d_lima
+```
+
+`limactl sudoers` emits the entries needed for both vmnet helpers and block-device helpers.
+
+### Notes
+
+- The configured path must be an absolute host path under `/dev`, e.g. `/dev/disk4`, `/dev/rdisk4`, `/dev/sdc`, etc.
+- The guest will see a corresponding virtio `/dev/disk/by-id/virtio-disk4` block device attached, you are responsible for partitioning, formatting, and mounting any filesystems on the block devices
+- Avoid mounting filesystems on shared block devices on both host and guest at the same time, it will cause corruption as most filesystems are not designed to be shared by multiple live kernels at once.

--- a/website/content/en/docs/config/disk.md
+++ b/website/content/en/docs/config/disk.md
@@ -89,7 +89,7 @@ limactl edit default --disk 20
 
 ## Attach host block devices
 
-| ⚡ Requirement | Lima >= 2.2, macOS >= 14.0, vmType: vz |
+| ⚡ Requirement | Lima >= 2.3, macOS >= 14.0, vmType: vz |
 | ------------- | -------------------------------------- |
 
 Lima can attach a host block device directly to the guest.
@@ -124,19 +124,23 @@ The `--block-device` flag can be specified multiple times to attach multiple hos
 ### Sudoers setup
 
 Opening a host block device requires a privileged helper on macOS.
-Generate and install the Lima sudoers file before using `--block-device`:
+Generate and install the Lima sudoers file with the explicit block-device opt-in before using `--block-device`:
 
 ```sh
-limactl sudoers >etc_sudoers.d_lima
+limactl sudoers --block-device=/dev/disk4 >etc_sudoers.d_lima
 less etc_sudoers.d_lima
 sudo install -o root etc_sudoers.d_lima /etc/sudoers.d/lima
 rm etc_sudoers.d_lima
 ```
 
-`limactl sudoers` emits the entries needed for both vmnet helpers and block-device helpers.
+The block-device entry is scoped to the current user and is only generated when the `limactl`
+executable is installed in a root-owned path that cannot be modified by regular users.
+Homebrew-installed `limactl` does not satisfy this requirement; install a root-owned copy such as
+`sudo make PREFIX=/opt/lima install` before generating the sudoers entry.
+The helper only accepts real macOS disk device nodes such as `/dev/disk4` and `/dev/rdisk4s1`.
 
 ### Notes
 
-- The configured path must be an absolute host path under `/dev`, e.g. `/dev/disk4`, `/dev/rdisk4`, `/dev/sdc`, etc.
+- The configured path must be a macOS disk device path under `/dev`, e.g. `/dev/disk4` or `/dev/rdisk4s1`.
 - The guest will see a corresponding virtio `/dev/disk/by-id/virtio-disk4` block device attached, you are responsible for partitioning, formatting, and mounting any filesystems on the block devices
 - Avoid mounting filesystems on shared block devices on both host and guest at the same time, it will cause corruption as most filesystems are not designed to be shared by multiple live kernels at once.


### PR DESCRIPTION
Reintroduces host block-device attachment for builtin macOS VZ after #4866 was reverted in #5113 following the security report in #5112. Users explicitly authorize each device with `limactl sudoers --block-device=/dev/diskN`, then attach it with `--block-device` or YAML `blockDevices`.

## Security and lifecycle

- A dedicated `lima-privileged-block-device` helper opens only the device named in its sudoers-authorized argv. Grants are scoped to the current user; `limactl` itself is never granted root execution.
- The helper must be a regular executable; it and all ancestor directories must be root-owned, non-user-writable, free of symlinks and extended ACLs. Device paths are restricted to Darwin disk nodes and opened with `O_NOFOLLOW`.
- The private Unix socket handoff authenticates both peers, rejects socket symlinks, and validates a random nonce before receiving the descriptor. The receiver checks device type and device identity. Duplicated descriptors have close-on-exec set.
- Descriptors remain valid for the VM lifetime and close on failure or shutdown. Exported network helpers retain their existing process-lifetime behavior for krunkit.
- Whole-disk locks prevent instances sharing a `LIMA_HOME` from concurrently attaching the same disk through raw/block aliases or partitions. Within one VM, disjoint partitions reuse its lock; duplicate aliases and parent/child overlaps are rejected. External VZ driver use is rejected.
- Sudoers verification matches complete logical lines, so appending another command or splicing the grant into a preceding continuation cannot satisfy the expected fragment. Grant rendering is order-independent, and regeneration warns about omitted network and device grants.

The grant remains permission to read and write a device slot until removed from sudoers. It is not tied to a physical disk UUID. The documentation explains slot reuse, boot-disk risks, install layout, and the need to avoid concurrent host/guest or cross-user mounts.

## Review fixes and tests

Addresses the [September 16 review](https://jandubois.github.io/lima/20260916-233839-pr-5117.html) and [September 18 follow-up](https://jandubois.github.io/lima/20260918-123055-pr-5117.html): same-VM lock reuse, continuation-aware sudoers checks, stable grant ordering, missing release helpers, early path validation, unsupported-driver rejection, and cleanup/diagnostic corrections. The BATS suite creates a unique temporary sudoers fragment and revokes it before detaching its RAM disk, preserving existing grants.

The [latest September 18 review](https://jandubois.github.io/lima/20260918-211054-pr-5117.html) additionally led to:

- Root-controlled, readable sudoers files (`root:wheel 0444`), tested directly instead of copying through `sudo cat`; `visudo` runs before installation and privileged BATS retries are disabled so cleanup failures cannot be hidden.
- Startup-only helper preflight, allowing cleanup/deletion without the helper; macOS-version errors precede installation errors, and helper leaf checks reject directories/non-executables.
- Rejection of overlapping attachments while preserving disjoint partitions, accurate network-check warnings, and current-user/multi-user regeneration and revocation guidance.
- Simpler CLI YAML edits and artifact assertions for native privileged helpers. The shared artifact build intentionally also includes the existing Linux networking helper that was previously omitted.

Setup help explains protected binary installation without a source build, grant inspection/validation/installation, and revocation. VZ validates the helper installation before hostagent startup so installation errors reach the CLI. This retains the root-owned installation requirement; it does not add an automatic installer or automatic device authorization.

Regression tests cover real Unix socket connections and symlinks, rejected peers sending no data, descriptor identity, missing stat data, raw/block/partition lock collisions and release, duplicate devices, and runtime external-driver rejection. BATS covers real guest/host disk round trips plus multi-device sudoers checks and removal of temporary grants.

Regression-first checks reproduced overlapping attachments, missing-helper cleanup failure, and the missing network-check warning. New tests cover those paths and helper leaf validation; artifact fixtures fail when the native helper is absent. Earlier tests cover same-VM locking, grant ordering, retention warnings, configured paths, and continued sudoers lines, including real `visudo` behavior. Local affected-package tests, socket/lock race tests, golangci-lint, gomodjail, and protolint pass. A real macOS release archive passed the helper assertion. Manual macOS VM acceptance remains incomplete; no local VMs or privileged disk operations were run for this revision.

Hosted CI for signed commit `cb78c1b3`: 34 passed, 2 skipped, no failures or pending checks. All three VZ block-device BATS cases passed without retries: CLI disk roundtrip, installed-file sudoers checks/revocation, and YAML raw-disk roundtrip. One commit on current `master` (`376d3104`), GitHub signature verified and DCO passing.

Related: #1314, #2224; follow-ups #5104 and abiosoft/colima#1592.

Assisted-by: Codex
