### PR TITLE
krunkit: disable ssh.overVsock by default

### DIFF
--- a/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
@@ -270,7 +270,11 @@ func (l *LimaKrunkitDriver) FillConfig(_ context.Context, cfg *limatype.LimaYAML
 	cfg.VMType = ptr.Of(vmType)
 
 	if cfg.SSH.OverVsock == nil {
-		cfg.SSH.OverVsock = ptr.Of(cfg.OS != nil && *cfg.OS == limatype.LINUX)
+		// ssh.overVsock is known not to work since Fedora 44: https://github.com/lima-vm/lima/issues/5085
+		// cfg.SSH.OverVsock = ptr.Of(cfg.OS != nil && *cfg.OS == limatype.LINUX)
+		cfg.SSH.OverVsock = ptr.Of(false)
+	} else if *cfg.SSH.OverVsock {
+		logrus.Warn("ssh.overVsock is known not to work since Fedora 44: https://github.com/lima-vm/lima/issues/5085")
 	}
 
 	return validateConfig(cfg)


### PR DESCRIPTION
ssh.overVsock is known not to work since Fedora 44. 

Workaround for:
- #5085