### PR TITLE
Change %q in logs and errors to %#q [Part4]

### DIFF
--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -135,7 +135,7 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		}
 		// There is no tilde-expansion for guest filenames
 		if strings.HasPrefix(*f.MountPoint, "~") {
-			errs = errors.Join(errs, fmt.Errorf("field `mounts[%d].mountPoint` must not start with \"~\"", i))
+			errs = errors.Join(errs, fmt.Errorf("field `mounts[%d].mountPoint` must not start with `~`", i))
 		}
 
 		if _, err := units.RAMInBytes(*f.NineP.Msize); err != nil {

--- a/pkg/localpathutil/localpathutil.go
+++ b/pkg/localpathutil/localpathutil.go
@@ -36,7 +36,7 @@ func Expand(orig string) (string, error) {
 			s = strings.Replace(s, "~", homeDir, 1)
 		} else {
 			// Paths like "~foo/bar" are unsupported.
-			return "", fmt.Errorf("unexpandable path %q", orig)
+			return "", fmt.Errorf("unexpandable path %#q", orig)
 		}
 	}
 	return filepath.Abs(s)

--- a/pkg/localpathutil/localpathutil_test.go
+++ b/pkg/localpathutil/localpathutil_test.go
@@ -54,7 +54,7 @@ func TestExpand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := Expand(tt.input)
 			if tt.wantErr {
-				assert.Assert(t, err != nil, "expected error for input %q", tt.input)
+				assert.Assert(t, err != nil, "expected error for input %#q", tt.input)
 				return
 			}
 			assert.NilError(t, err)

--- a/pkg/lockutil/lockutil_unix.go
+++ b/pkg/lockutil/lockutil_unix.go
@@ -37,11 +37,11 @@ func WithDirLock(dir string, fn func() error) error {
 	}
 	defer dirFile.Close()
 	if err := Flock(dirFile, unix.LOCK_EX); err != nil {
-		return fmt.Errorf("failed to lock %q: %w", dir, err)
+		return fmt.Errorf("failed to lock %#q: %w", dir, err)
 	}
 	defer func() {
 		if err := Flock(dirFile, unix.LOCK_UN); err != nil {
-			logrus.WithError(err).Errorf("failed to unlock %q", dir)
+			logrus.WithError(err).Errorf("failed to unlock %#q", dir)
 		}
 	}()
 	return fn()

--- a/pkg/lockutil/lockutil_windows.go
+++ b/pkg/lockutil/lockutil_windows.go
@@ -53,7 +53,7 @@ func WithDirLock(dir string, fn func() error) error {
 		0,                            // nNumberOfBytesToLockHigh
 		&syscall.Overlapped{},        // lpOverlapped
 	); err != nil {
-		return fmt.Errorf("failed to lock %q: %w", dir, err)
+		return fmt.Errorf("failed to lock %#q: %w", dir, err)
 	}
 
 	defer func() {
@@ -64,7 +64,7 @@ func WithDirLock(dir string, fn func() error) error {
 			0,                            // nNumberOfBytesToLockHigh
 			&syscall.Overlapped{},        // lpOverlapped
 		); err != nil {
-			logrus.WithError(err).Errorf("failed to unlock %q", dir)
+			logrus.WithError(err).Errorf("failed to unlock %#q", dir)
 		}
 	}()
 	return fn()

--- a/pkg/mcp/toolset/toolset.go
+++ b/pkg/mcp/toolset/toolset.go
@@ -69,11 +69,11 @@ func newSFTPClient(ctx context.Context, inst *limatype.Instance) (*sftp.Client, 
 
 func (ts *ToolSet) RegisterInstance(ctx context.Context, inst *limatype.Instance) error {
 	if inst.Status != limatype.StatusRunning {
-		return fmt.Errorf("expected status of instance %q to be %q, got %q",
+		return fmt.Errorf("expected status of instance %#q to be %#q, got %#q",
 			inst.Name, limatype.StatusRunning, inst.Status)
 	}
 	if len(inst.Config.Mounts) == 0 {
-		logrus.Warnf("instance %q has no mount", inst.Name)
+		logrus.Warnf("instance %#q has no mount", inst.Name)
 	}
 	ts.inst = inst
 	var err error
@@ -107,7 +107,7 @@ func (ts *ToolSet) TranslateHostPath(hostPath string) (string, error) {
 		return "", errors.New("path is empty")
 	}
 	if !filepath.IsAbs(hostPath) {
-		return "", fmt.Errorf("expected an absolute path, got a relative path: %q", hostPath)
+		return "", fmt.Errorf("expected an absolute path, got a relative path: %#q", hostPath)
 	}
 	// TODO: make sure that hostPath is mounted
 	return hostPath, nil

--- a/pkg/networks/commands.go
+++ b/pkg/networks/commands.go
@@ -25,7 +25,7 @@ func (c *Config) Check(name string) error {
 	if _, ok := c.Networks[name]; ok {
 		return nil
 	}
-	return fmt.Errorf("network %q is not defined", name)
+	return fmt.Errorf("network %#q is not defined", name)
 }
 
 // Usernet returns true if the mode of given network is ModeUserV2.
@@ -33,7 +33,7 @@ func (c *Config) Usernet(name string) (bool, error) {
 	if nw, ok := c.Networks[name]; ok {
 		return nw.Mode == ModeUserV2, nil
 	}
-	return false, fmt.Errorf("network %q is not defined", name)
+	return false, fmt.Errorf("network %#q is not defined", name)
 }
 
 // DaemonPath returns the daemon path.
@@ -42,7 +42,7 @@ func (c *Config) DaemonPath(daemon string) (string, error) {
 	case SocketVMNet:
 		return c.Paths.SocketVMNet, nil
 	default:
-		return "", fmt.Errorf("unknown daemon type %q", daemon)
+		return "", fmt.Errorf("unknown daemon type %#q", daemon)
 	}
 }
 
@@ -81,14 +81,14 @@ func (c *Config) LogFile(name, daemon, stream string) string {
 func (c *Config) User(daemon string) (osutil.User, error) {
 	if ok, _ := c.IsDaemonInstalled(daemon); !ok {
 		daemonPath, _ := c.DaemonPath(daemon)
-		return osutil.User{}, fmt.Errorf("daemon %q (path=%q) is not available", daemon, daemonPath)
+		return osutil.User{}, fmt.Errorf("daemon %#q (path=%#q) is not available", daemon, daemonPath)
 	}
 	//nolint:gocritic // singleCaseSwitch: should rewrite switch statement to if statement
 	switch daemon {
 	case SocketVMNet:
 		return osutil.LookupUser("root")
 	}
-	return osutil.User{}, fmt.Errorf("daemon %q not defined", daemon)
+	return osutil.User{}, fmt.Errorf("daemon %#q not defined", daemon)
 }
 
 func (c *Config) MkdirCmd() string {
@@ -97,7 +97,7 @@ func (c *Config) MkdirCmd() string {
 
 func (c *Config) StartCmd(name, daemon string) string {
 	if ok, _ := c.IsDaemonInstalled(daemon); !ok {
-		panic(fmt.Errorf("daemon %q is not available", daemon))
+		panic(fmt.Errorf("daemon %#q is not available", daemon))
 	}
 	var cmd string
 	switch daemon {
@@ -117,7 +117,7 @@ func (c *Config) StartCmd(name, daemon string) string {
 		}
 		cmd += " " + c.Sock(name)
 	default:
-		panic(fmt.Errorf("unexpected daemon %q", daemon))
+		panic(fmt.Errorf("unexpected daemon %#q", daemon))
 	}
 	return cmd
 }

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -44,9 +44,9 @@ func defaultConfigBytes() ([]byte, error) {
 			args.SocketVMNet = realP
 			break
 		} else if errors.Is(err, exec.ErrNotFound) || errors.Is(err, os.ErrNotExist) {
-			logrus.WithError(err).Debugf("Failed to look up socket_vmnet path %q", candidate)
+			logrus.WithError(err).Debugf("Failed to look up socket_vmnet path %#q", candidate)
 		} else {
-			logrus.WithError(err).Warnf("Failed to look up socket_vmnet path %q", candidate)
+			logrus.WithError(err).Warnf("Failed to look up socket_vmnet path %#q", candidate)
 		}
 	}
 	if args.SocketVMNet == "" {
@@ -118,7 +118,7 @@ func loadCache() {
 			cfgDir := filepath.Dir(cfgFile)
 			cache.err = os.MkdirAll(cfgDir, 0o755)
 			if cache.err != nil {
-				cache.err = fmt.Errorf("could not create %q directory: %w", cfgDir, cache.err)
+				cache.err = fmt.Errorf("could not create %#q directory: %w", cfgDir, cache.err)
 				return
 			}
 			var b []byte
@@ -138,7 +138,7 @@ func loadCache() {
 		}
 		cache.err = yaml.Unmarshal(b, &cache.cfg)
 		if cache.err != nil {
-			cache.err = fmt.Errorf("cannot parse %q: %w", cfgFile, cache.err)
+			cache.err = fmt.Errorf("cannot parse %#q: %w", cfgFile, cache.err)
 			return
 		}
 		var strictCfg Config
@@ -149,7 +149,7 @@ func loadCache() {
 		}
 		cache.cfg, cache.err = fillDefaults(cache.cfg)
 		if cache.err != nil {
-			cache.err = fmt.Errorf("cannot fill default %q: %w", cfgFile, cache.err)
+			cache.err = fmt.Errorf("cannot fill default %#q: %w", cfgFile, cache.err)
 		}
 	})
 }

--- a/pkg/networks/reconcile/reconcile.go
+++ b/pkg/networks/reconcile/reconcile.go
@@ -48,7 +48,7 @@ func Reconcile(ctx context.Context, newInst string) error {
 				continue
 			}
 			if _, ok := cfg.Networks[nw.Lima]; !ok {
-				logrus.Errorf("network %q (used by instance %q) is missing from networks.yaml", nw.Lima, instName)
+				logrus.Errorf("network %#q (used by instance %#q) is missing from networks.yaml", nw.Lima, instName)
 				continue
 			}
 			activeNetwork[nw.Lima] = true
@@ -77,7 +77,7 @@ func sudo(ctx context.Context, user, group, command string) error {
 	cmd.Stderr = &stderr
 	logrus.Debugf("Running: %v", cmd.Args)
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to run %v: stdout=%q, stderr=%q: %w",
+		return fmt.Errorf("failed to run %v: stdout=%#q, stderr=%#q: %w",
 			cmd.Args, stdout.String(), stderr.String(), err)
 	}
 	return nil
@@ -99,14 +99,14 @@ func makeVarRun(ctx context.Context, cfg *networks.Config) error {
 	stat, ok := osutil.SysStat(fi)
 	if !ok {
 		// should never happen
-		return fmt.Errorf("could not retrieve stat buffer for %q", cfg.Paths.VarRun)
+		return fmt.Errorf("could not retrieve stat buffer for %#q", cfg.Paths.VarRun)
 	}
 	daemon, err := osutil.LookupUser("daemon")
 	if err != nil {
 		return err
 	}
 	if fi.Mode()&0o20 == 0 || stat.Gid != daemon.Gid {
-		return fmt.Errorf("%q doesn't seem to be writable by the daemon (gid:%d) group",
+		return fmt.Errorf("%#q doesn't seem to be writable by the daemon (gid:%d) group",
 			cfg.Paths.VarRun, daemon.Gid)
 	}
 	return nil
@@ -153,9 +153,9 @@ func startDaemon(ctx context.Context, cfg *networks.Config, name, daemon string)
 		return err
 	}
 
-	logrus.Debugf("Starting %q daemon for %q network: %v", daemon, name, cmd.Args)
+	logrus.Debugf("Starting %#q daemon for %#q network: %v", daemon, name, cmd.Args)
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to run %v: %w (Hint: check %q, %q)", cmd.Args, err, stdoutPath, stderrPath)
+		return fmt.Errorf("failed to run %v: %w (Hint: check %#q, %#q)", cmd.Args, err, stdoutPath, stderrPath)
 	}
 	return nil
 }
@@ -177,7 +177,7 @@ func validateConfig(ctx context.Context, cfg *networks.Config) error {
 }
 
 func startNetwork(ctx context.Context, cfg *networks.Config, name string) error {
-	logrus.Debugf("Make sure %q network is running", name)
+	logrus.Debugf("Make sure %#q network is running", name)
 
 	// Handle usernet first without sudo requirements
 	isUsernet, err := cfg.Usernet(name)
@@ -186,7 +186,7 @@ func startNetwork(ctx context.Context, cfg *networks.Config, name string) error 
 	}
 	if isUsernet {
 		if err := usernet.Start(ctx, name); err != nil {
-			return fmt.Errorf("failed to start usernet %q: %w", name, err)
+			return fmt.Errorf("failed to start usernet %#q: %w", name, err)
 		}
 		return nil
 	}
@@ -206,12 +206,12 @@ func startNetwork(ctx context.Context, cfg *networks.Config, name string) error 
 	if ok {
 		daemons = append(daemons, networks.SocketVMNet)
 	} else {
-		return fmt.Errorf("daemon %q needs to be installed", networks.SocketVMNet)
+		return fmt.Errorf("daemon %#q needs to be installed", networks.SocketVMNet)
 	}
 	for _, daemon := range daemons {
 		pid, _ := store.ReadPIDFile(cfg.PIDFile(name, daemon))
 		if pid == 0 {
-			logrus.Infof("Starting %s daemon for %q network", daemon, name)
+			logrus.Infof("Starting %s daemon for %#q network", daemon, name)
 			if err := startDaemon(ctx, cfg, name, daemon); err != nil {
 				return err
 			}
@@ -221,7 +221,7 @@ func startNetwork(ctx context.Context, cfg *networks.Config, name string) error 
 }
 
 func stopNetwork(ctx context.Context, cfg *networks.Config, name string) error {
-	logrus.Debugf("Make sure %q network is stopped", name)
+	logrus.Debugf("Make sure %#q network is stopped", name)
 	// Handle usernet first without sudo requirements
 	isUsernet, err := cfg.Usernet(name)
 	if err != nil {
@@ -229,7 +229,7 @@ func stopNetwork(ctx context.Context, cfg *networks.Config, name string) error {
 	}
 	if isUsernet {
 		if err := usernet.Stop(ctx, name); err != nil {
-			return fmt.Errorf("failed to stop usernet %q: %w", name, err)
+			return fmt.Errorf("failed to stop usernet %#q: %w", name, err)
 		}
 		return nil
 	}
@@ -246,7 +246,7 @@ func stopNetwork(ctx context.Context, cfg *networks.Config, name string) error {
 		}
 		pid, _ := store.ReadPIDFile(cfg.PIDFile(name, daemon))
 		if pid != 0 {
-			logrus.Infof("Stopping %s daemon for %q network", daemon, name)
+			logrus.Infof("Stopping %s daemon for %#q network", daemon, name)
 			if err := validateConfig(ctx, cfg); err != nil {
 				return err
 			}
@@ -267,7 +267,7 @@ func stopNetwork(ctx context.Context, cfg *networks.Config, name string) error {
 				break
 			}
 			if time.Since(startWaiting) > 5*time.Second {
-				logrus.Infof("%q daemon for %q network still running after 5 seconds", daemon, name)
+				logrus.Infof("%#q daemon for %#q network still running after 5 seconds", daemon, name)
 				break
 			}
 			time.Sleep(500 * time.Millisecond)

--- a/pkg/networks/sudoers.go
+++ b/pkg/networks/sudoers.go
@@ -100,12 +100,12 @@ func (c *Config) VerifySudoAccess(ctx context.Context, sudoersFile string) error
 		if errors.Is(err, os.ErrNotExist) {
 			err = c.passwordLessSudo(ctx)
 			if err == nil {
-				logrus.Debugf("%q does not exist, but sudo doesn't seem to require a password", sudoersFile)
+				logrus.Debugf("%#q does not exist, but sudo doesn't seem to require a password", sudoersFile)
 				return nil
 			}
-			logrus.Debugf("%q does not exist; passwordLessSudo error: %s", sudoersFile, err)
+			logrus.Debugf("%#q does not exist; passwordLessSudo error: %s", sudoersFile, err)
 		}
-		return fmt.Errorf("can't read %q: %w: (Hint: %s)", sudoersFile, err, hint)
+		return fmt.Errorf("can't read %#q: %w: (Hint: %s)", sudoersFile, err, hint)
 	}
 	sudoers, err := Sudoers()
 	if err != nil {
@@ -113,7 +113,7 @@ func (c *Config) VerifySudoAccess(ctx context.Context, sudoersFile string) error
 	}
 	if string(b) != sudoers {
 		// Happens on upgrading socket_vmnet with Homebrew
-		return fmt.Errorf("sudoers file %q is out of sync and must be regenerated (Hint: %s)", sudoersFile, hint)
+		return fmt.Errorf("sudoers file %#q is out of sync and must be regenerated (Hint: %s)", sudoersFile, hint)
 	}
 	return nil
 }

--- a/pkg/networks/usernet/config.go
+++ b/pkg/networks/usernet/config.go
@@ -39,7 +39,7 @@ func SockWithDirectory(dir, name string, sockType SockType) (string, error) {
 	}
 	sockPath := filepath.Join(dir, fmt.Sprintf("%s_%s.sock", name, sockType))
 	if len(sockPath) >= osutil.UnixPathMax {
-		return "", fmt.Errorf("usernet socket path %q too long: must be less than UNIX_PATH_MAX=%d characters, but is %d",
+		return "", fmt.Errorf("usernet socket path %#q too long: must be less than UNIX_PATH_MAX=%d characters, but is %d",
 			sockPath, osutil.UnixPathMax, len(sockPath))
 	}
 	return sockPath, nil
@@ -106,7 +106,7 @@ func Leases(name string) (string, error) {
 	}
 	sockPath := filepath.Join(filepath.Join(dir, name), "leases.json")
 	if len(sockPath) >= osutil.UnixPathMax {
-		return "", fmt.Errorf("usernet leases path %q too long: must be less than UNIX_PATH_MAX=%d characters, but is %d",
+		return "", fmt.Errorf("usernet leases path %#q too long: must be less than UNIX_PATH_MAX=%d characters, but is %d",
 			sockPath, osutil.UnixPathMax, len(sockPath))
 	}
 	return sockPath, nil

--- a/pkg/networks/validate.go
+++ b/pkg/networks/validate.go
@@ -49,7 +49,7 @@ func (c *Config) Validate() error {
 		}
 	}
 	if socketVMNetNotFound {
-		return fmt.Errorf("networks.yaml: %q (`paths.socketVMNet`) has to be installed", pathsMap["socketVMNet"])
+		return fmt.Errorf("networks.yaml: %#q (`paths.socketVMNet`) has to be installed", pathsMap["socketVMNet"])
 	}
 	// TODO(jandubois): validate network definitions
 	return nil
@@ -70,10 +70,10 @@ func validatePath(path string, allowDaemonGroupWritable bool) error {
 		return nil
 	}
 	if path[0] != '/' {
-		return fmt.Errorf("path %q is not an absolute path", path)
+		return fmt.Errorf("path %#q is not an absolute path", path)
 	}
 	if strings.ContainsRune(path, ' ') {
-		return fmt.Errorf("path %q contains whitespace", path)
+		return fmt.Errorf("path %#q contains whitespace", path)
 	}
 	fi, err := os.Lstat(path)
 	if err != nil {
@@ -86,12 +86,12 @@ func validatePath(path string, allowDaemonGroupWritable bool) error {
 	// TODO: should we allow symlinks when both the link and the target are secure?
 	// E.g. on macOS /var is a symlink to /private/var, /etc to /private/etc
 	if (fi.Mode() & fs.ModeSymlink) != 0 {
-		return fmt.Errorf("%s %q is a symlink", file, path)
+		return fmt.Errorf("%s %#q is a symlink", file, path)
 	}
 	stat, ok := osutil.SysStat(fi)
 	if !ok {
 		// should never happen
-		return fmt.Errorf("could not retrieve stat buffer for %q", path)
+		return fmt.Errorf("could not retrieve stat buffer for %#q", path)
 	}
 	if runtime.GOOS != "darwin" {
 		return errors.New("vmnet code must not be called on non-Darwin") // TODO: move to *_darwin.go
@@ -102,7 +102,7 @@ func validatePath(path string, allowDaemonGroupWritable bool) error {
 		return err
 	}
 	if stat.Uid != root.Uid {
-		return fmt.Errorf(`%s %q is not owned by %q (uid: %d), but by uid %d`, file, path, root.User, root.Uid, stat.Uid)
+		return fmt.Errorf(`%s %#q is not owned by %#q (uid: %d), but by uid %d`, file, path, root.User, root.Uid, stat.Uid)
 	}
 	if allowDaemonGroupWritable {
 		daemon, err := osutil.LookupUser("daemon")
@@ -110,18 +110,18 @@ func validatePath(path string, allowDaemonGroupWritable bool) error {
 			return err
 		}
 		if fi.Mode()&0o20 != 0 && stat.Gid != root.Gid && stat.Gid != daemon.Gid {
-			return fmt.Errorf(`%s %q is group-writable and group is neither %q (gid: %d) nor %q (gid: %d), but is gid: %d`,
+			return fmt.Errorf(`%s %#q is group-writable and group is neither %#q (gid: %d) nor %#q (gid: %d), but is gid: %d`,
 				file, path, root.User, root.Gid, daemon.User, daemon.Gid, stat.Gid)
 		}
 		if fi.Mode().IsDir() && fi.Mode()&1 == 0 && (fi.Mode()&0o010 == 0 || stat.Gid != daemon.Gid) {
-			return fmt.Errorf(`%s %q is not executable by the %q (gid: %d)" group`, file, path, daemon.User, daemon.Gid)
+			return fmt.Errorf(`%s %#q is not executable by the %#q (gid: %d)" group`, file, path, daemon.User, daemon.Gid)
 		}
 	} else if fi.Mode()&0o20 != 0 && stat.Gid != root.Gid {
-		return fmt.Errorf(`%s %q is group-writable and group is not %q (gid: %d), but is gid: %d`,
+		return fmt.Errorf(`%s %#q is group-writable and group is not %#q (gid: %d), but is gid: %d`,
 			file, path, root.User, root.Gid, stat.Gid)
 	}
 	if fi.Mode()&0o02 != 0 {
-		return fmt.Errorf("%s %q is world-writable", file, path)
+		return fmt.Errorf("%s %#q is world-writable", file, path)
 	}
 	if path != "/" {
 		return validatePath(filepath.Dir(path), allowDaemonGroupWritable)

--- a/pkg/osutil/mount_darwin.go
+++ b/pkg/osutil/mount_darwin.go
@@ -23,7 +23,7 @@ func Mount(ctx context.Context, fs, dev, mnt string, options []string) error {
 	cmd := exec.CommandContext(ctx, "mount", args...)
 	logrus.Debugf("Executing command: %v", cmd.Args)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to mount %q on %q: %w (output=%q)", dev, mnt, err, output)
+		return fmt.Errorf("failed to mount %#q on %#q: %w (output=%#q)", dev, mnt, err, output)
 	}
 	return nil
 }
@@ -32,7 +32,7 @@ func Umount(ctx context.Context, mnt string) error {
 	cmd := exec.CommandContext(ctx, "umount", mnt)
 	logrus.Debugf("Executing command: %v", cmd.Args)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to unmount %q: %w (output=%q)", mnt, err, output)
+		return fmt.Errorf("failed to unmount %#q: %w (output=%#q)", mnt, err, output)
 	}
 	return nil
 }

--- a/pkg/osutil/osutil_unix.go
+++ b/pkg/osutil/osutil_unix.go
@@ -32,7 +32,7 @@ func Sysctl(ctx context.Context, name string) (string, error) {
 	cmd.Stderr = &stderrBuf
 	stdout, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to run %v: %w (stdout=%q, stderr=%q)", cmd.Args, err,
+		return "", fmt.Errorf("failed to run %v: %w (stdout=%#q, stderr=%#q)", cmd.Args, err,
 			string(stdout), stderrBuf.String())
 	}
 	return strings.TrimSuffix(string(stdout), "\n"), nil

--- a/pkg/osutil/osversion_darwin.go
+++ b/pkg/osutil/osversion_darwin.go
@@ -27,7 +27,7 @@ var ProductVersion = sync.OnceValues(func() (*semver.Version, error) {
 	}
 	verSem, err := semver.NewVersion(verTrimmed)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse macOS version %q: %w", verTrimmed, err)
+		return nil, fmt.Errorf("failed to parse macOS version %#q: %w", verTrimmed, err)
 	}
 	return verSem, nil
 })

--- a/pkg/osutil/user.go
+++ b/pkg/osutil/user.go
@@ -107,7 +107,7 @@ func LimaUser(ctx context.Context, limaVersion string, warn bool, guestOS *limat
 	once.Do(func() {
 		limaUser = currentUser
 		if !regexUsername.MatchString(limaUser.Username) {
-			warning := fmt.Sprintf("local username %q is not a valid Linux username (must match %q); using %q instead",
+			warning := fmt.Sprintf("local username %#q is not a valid Linux username (must match %#q); using %#q instead",
 				limaUser.Username, regexUsername.String(), fallbackUser)
 			warnings = append(warnings, warning)
 			limaUser.Username = fallbackUser
@@ -122,7 +122,7 @@ func LimaUser(ctx context.Context, limaVersion string, warn bool, guestOS *limat
 				uid = fallbackUid
 			}
 			if _, err := parseUidGid(limaUser.Uid); err != nil {
-				warning := fmt.Sprintf("local uid %q is not a valid Linux uid (must be integer); using %d uid instead",
+				warning := fmt.Sprintf("local uid %#q is not a valid Linux uid (must be integer); using %d uid instead",
 					limaUser.Uid, uid)
 				warnings = append(warnings, warning)
 				limaUser.Uid = formatUidGid(uid)
@@ -136,7 +136,7 @@ func LimaUser(ctx context.Context, limaVersion string, warn bool, guestOS *limat
 				gid = fallbackGid
 			}
 			if _, err := parseUidGid(limaUser.Gid); err != nil {
-				warning := fmt.Sprintf("local gid %q is not a valid Linux gid (must be integer); using %d gid instead",
+				warning := fmt.Sprintf("local gid %#q is not a valid Linux gid (must be integer); using %d gid instead",
 					limaUser.Gid, gid)
 				warnings = append(warnings, warning)
 				limaUser.Gid = formatUidGid(gid)
@@ -163,7 +163,7 @@ func LimaUser(ctx context.Context, limaVersion string, warn bool, guestOS *limat
 	if versionutil.GreaterEqual(limaVersion, "1.0.0") {
 		if u.Username == "admin" {
 			if warn {
-				logrus.Warnf("local username %q is reserved; using %q instead", u.Username, fallbackUser)
+				logrus.Warnf("local username %#q is reserved; using %#q instead", u.Username, fallbackUser)
 			}
 			u.Username = fallbackUser
 		}

--- a/pkg/plist/plist_test.go
+++ b/pkg/plist/plist_test.go
@@ -116,9 +116,9 @@ func TestUnmarshalPlist(t *testing.T) {
 			var stderr bytes.Buffer
 			plutilCmd.Stderr = &stderr
 			plutilOutput, err := plutilCmd.Output()
-			assert.NilError(t, err, fmt.Sprintf("failed to run %v (stderr=%q)", plutilCmd.Args, stderr.String()))
+			assert.NilError(t, err, fmt.Sprintf("failed to run %v (stderr=%#q)", plutilCmd.Args, stderr.String()))
 			plutilOutputStr := string(plutilOutput)
-			assert.Equal(t, plutilExpectedValue, plutilOutputStr, "plutil output mismatch for key %q", plutilExpectedKey)
+			assert.Equal(t, plutilExpectedValue, plutilOutputStr, "plutil output mismatch for key %#q", plutilExpectedKey)
 		}
 	}
 }

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -163,7 +163,7 @@ func (plugin *Plugin) Run(ctx context.Context, args []string) {
 	if err == nil {
 		os.Exit(0) //nolint:revive // it's intentional to call os.Exit in this function
 	}
-	logrus.Fatalf("external command %q failed: %v", plugin.Path, err)
+	logrus.Fatalf("external command %#q failed: %v", plugin.Path, err)
 }
 
 var descRegex = regexp.MustCompile(`<limactl-desc>(.*?)</limactl-desc>`)
@@ -187,7 +187,7 @@ func extractDescFromScript(path string) string {
 	}
 
 	desc := strings.Trim(matches[1], " ")
-	logrus.Debugf("Plugin %s: extracted description: %q", filepath.Base(path), desc)
+	logrus.Debugf("Plugin %s: extracted description: %#q", filepath.Base(path), desc)
 	return desc
 }
 

--- a/pkg/portfwd/listener.go
+++ b/pkg/portfwd/listener.go
@@ -157,10 +157,10 @@ func key(protocol, hostAddress, guestAddress string) string {
 
 func prepareUnixSocket(hostSocket string) error {
 	if err := os.RemoveAll(hostSocket); err != nil {
-		return fmt.Errorf("can't clean up %q: %w", hostSocket, err)
+		return fmt.Errorf("can't clean up %#q: %w", hostSocket, err)
 	}
 	if err := os.MkdirAll(filepath.Dir(hostSocket), 0o755); err != nil {
-		return fmt.Errorf("can't create directory for local socket %q: %w", hostSocket, err)
+		return fmt.Errorf("can't create directory for local socket %#q: %w", hostSocket, err)
 	}
 	return nil
 }

--- a/pkg/portfwd/listener_darwin.go
+++ b/pkg/portfwd/listener_darwin.go
@@ -83,17 +83,17 @@ func (p pseudoLoopbackListener) Accept() (net.Conn, error) {
 	remoteAddr := conn.RemoteAddr().String() // ip:port
 	remoteAddrIP, _, err := net.SplitHostPort(remoteAddr)
 	if err != nil {
-		logrus.WithError(err).Debugf("pseudoloopback forwarder: rejecting non-loopback remoteAddr %q (unparsable)", remoteAddr)
+		logrus.WithError(err).Debugf("pseudoloopback forwarder: rejecting non-loopback remoteAddr %#q (unparsable)", remoteAddr)
 		conn.Close()
 		return nil, err
 	}
 	if !IsLoopback(remoteAddrIP) {
-		err := fmt.Errorf("pseudoloopback forwarder: rejecting non-loopback remoteAddr %q", remoteAddr)
+		err := fmt.Errorf("pseudoloopback forwarder: rejecting non-loopback remoteAddr %#q", remoteAddr)
 		logrus.Debug(err)
 		conn.Close()
 		return nil, err
 	}
-	logrus.Infof("pseudoloopback forwarder: accepting connection from %q", remoteAddr)
+	logrus.Infof("pseudoloopback forwarder: accepting connection from %#q", remoteAddr)
 	return conn, nil
 }
 
@@ -112,7 +112,7 @@ func (pk *pseudoLoopbackPacketConn) ReadFrom(bytes []byte) (n int, addr net.Addr
 		return 0, nil, err
 	}
 	if !IsLoopback(remoteAddrIP) {
-		return 0, nil, fmt.Errorf("pseudoloopback forwarder: rejecting non-loopback remoteAddr %q", remoteAddr)
+		return 0, nil, fmt.Errorf("pseudoloopback forwarder: rejecting non-loopback remoteAddr %#q", remoteAddr)
 	}
 	return n, remoteAddr, nil
 }
@@ -123,7 +123,7 @@ func (pk *pseudoLoopbackPacketConn) WriteTo(bytes []byte, remoteAddr net.Addr) (
 		return 0, err
 	}
 	if !IsLoopback(remoteAddrIP) {
-		return 0, fmt.Errorf("pseudoloopback forwarder: rejecting non-loopback remoteAddr %q", remoteAddr)
+		return 0, fmt.Errorf("pseudoloopback forwarder: rejecting non-loopback remoteAddr %#q", remoteAddr)
 	}
 	return pk.PacketConn.WriteTo(bytes, remoteAddr)
 }

--- a/pkg/qemuimgutil/qemuimgutil.go
+++ b/pkg/qemuimgutil/qemuimgutil.go
@@ -55,7 +55,7 @@ func resizeDisk(ctx context.Context, disk, format string, size int64) error {
 	args := []string{"resize", "-f", format, disk, strconv.FormatInt(size, 10)}
 	cmd := exec.CommandContext(ctx, "qemu-img", args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to run %v: %q: %w", cmd.Args, string(out), err)
+		return fmt.Errorf("failed to run %v: %#q: %w", cmd.Args, string(out), err)
 	}
 	return nil
 }
@@ -114,7 +114,7 @@ func convertToRaw(ctx context.Context, source, dest string) error {
 
 	info, err := getInfo(ctx, source)
 	if err != nil {
-		return fmt.Errorf("failed to get info for source disk %q: %w", source, err)
+		return fmt.Errorf("failed to get info for source disk %#q: %w", source, err)
 	}
 	if info.Format == "raw" {
 		return nil
@@ -136,7 +136,7 @@ func execQemuImgConvert(ctx context.Context, source, dest string) error {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to run %v: stdout=%q, stderr=%q: %w",
+		return fmt.Errorf("failed to run %v: stdout=%#q, stderr=%#q: %w",
 			cmd.Args, stdout.String(), stderr.String(), err)
 	}
 	return nil
@@ -156,7 +156,7 @@ func getInfo(ctx context.Context, f string) (*Info, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("failed to run %v: stdout=%q, stderr=%q: %w",
+		return nil, fmt.Errorf("failed to run %v: stdout=%#q, stderr=%#q: %w",
 			cmd.Args, stdout.String(), stderr.String(), err)
 	}
 	return parseInfo(stdout.Bytes())
@@ -172,7 +172,7 @@ func (q *QemuImageUtil) CreateDisk(ctx context.Context, disk string, size int64)
 	args := []string{"create", "-f", q.DefaultFormat, disk, strconv.FormatInt(size, 10)}
 	cmd := exec.CommandContext(ctx, "qemu-img", args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to run %v: %q: %w", cmd.Args, string(out), err)
+		return fmt.Errorf("failed to run %v: %#q: %w", cmd.Args, string(out), err)
 	}
 	return nil
 }
@@ -181,7 +181,7 @@ func (q *QemuImageUtil) CreateDisk(ctx context.Context, disk string, size int64)
 func (q *QemuImageUtil) ResizeDisk(ctx context.Context, disk string, size int64) error {
 	info, err := getInfo(ctx, disk)
 	if err != nil {
-		return fmt.Errorf("failed to get info for disk %q: %w", disk, err)
+		return fmt.Errorf("failed to get info for disk %#q: %w", disk, err)
 	}
 	return resizeDisk(ctx, disk, info.Format, size)
 }
@@ -205,15 +205,15 @@ func GetInfo(ctx context.Context, path string) (*Info, error) {
 // Currently only raw.Type is supported.
 func (q *QemuImageUtil) Convert(ctx context.Context, imageType image.Type, source, dest string, size *int64, allowSourceWithBackingFile bool) error {
 	if imageType != raw.Type {
-		return fmt.Errorf("QemuImageUtil.Convert only supports raw.Type, got %q", imageType)
+		return fmt.Errorf("QemuImageUtil.Convert only supports raw.Type, got %#q", imageType)
 	}
 	if !allowSourceWithBackingFile {
 		info, err := getInfo(ctx, source)
 		if err != nil {
-			return fmt.Errorf("failed to get info for source disk %q: %w", source, err)
+			return fmt.Errorf("failed to get info for source disk %#q: %w", source, err)
 		}
 		if info.BackingFilename != "" || info.FullBackingFilename != "" {
-			return fmt.Errorf("qcow2 image %q has an unexpected backing file: %q", source, info.BackingFilename)
+			return fmt.Errorf("qcow2 image %#q has an unexpected backing file: %#q", source, info.BackingFilename)
 		}
 	}
 
@@ -224,7 +224,7 @@ func (q *QemuImageUtil) Convert(ctx context.Context, imageType image.Type, sourc
 	if size != nil {
 		destInfo, err := getInfo(ctx, dest)
 		if err != nil {
-			return fmt.Errorf("failed to get info for converted disk %q: %w", dest, err)
+			return fmt.Errorf("failed to get info for converted disk %#q: %w", dest, err)
 		}
 
 		if *size > destInfo.VSize {
@@ -242,19 +242,19 @@ func AcceptableAsBaseDisk(info *Info) error {
 		// NOP
 	default:
 		logrus.WithField("filename", info.Filename).
-			Warnf("Unsupported image format %q. The image may not boot, or may have an extra privilege to access the host filesystem. Use with caution.", info.Format)
+			Warnf("Unsupported image format %#q. The image may not boot, or may have an extra privilege to access the host filesystem. Use with caution.", info.Format)
 	}
 	if info.BackingFilename != "" {
-		return fmt.Errorf("base disk (%q) must not have a backing file (%q)", info.Filename, info.BackingFilename)
+		return fmt.Errorf("base disk (%#q) must not have a backing file (%#q)", info.Filename, info.BackingFilename)
 	}
 	if info.FullBackingFilename != "" {
-		return fmt.Errorf("base disk (%q) must not have a backing file (%q)", info.Filename, info.FullBackingFilename)
+		return fmt.Errorf("base disk (%#q) must not have a backing file (%#q)", info.Filename, info.FullBackingFilename)
 	}
 	if info.FormatSpecific != nil {
 		if vmdk := info.FormatSpecific.Vmdk(); vmdk != nil {
 			for _, e := range vmdk.Extents {
 				if e.Filename != info.Filename {
-					return fmt.Errorf("base disk (%q) must not have an extent file (%q)", info.Filename, e.Filename)
+					return fmt.Errorf("base disk (%#q) must not have an extent file (%#q)", info.Filename, e.Filename)
 				}
 			}
 		}
@@ -265,13 +265,13 @@ func AcceptableAsBaseDisk(info *Info) error {
 	// NOP
 	case 1:
 		if info.Filename != info.Children[0].Info.Filename {
-			return fmt.Errorf("base disk (%q) child must not have a different filename (%q)", info.Filename, info.Children[0].Info.Filename)
+			return fmt.Errorf("base disk (%#q) child must not have a different filename (%#q)", info.Filename, info.Children[0].Info.Filename)
 		}
 		if len(info.Children[0].Info.Children) > 0 {
-			return fmt.Errorf("base disk (%q) child must not have children of its own", info.Filename)
+			return fmt.Errorf("base disk (%#q) child must not have children of its own", info.Filename)
 		}
 	default:
-		return fmt.Errorf("base disk (%q) must not have multiple children: %+v", info.Filename, info.Children)
+		return fmt.Errorf("base disk (%#q) must not have multiple children: %+v", info.Filename, info.Children)
 	}
 	return nil
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -90,7 +90,7 @@ func registerExternalDriver(name, path string) {
 	}
 
 	if _, exists := internalDrivers[name]; exists {
-		logrus.Debugf("Driver %q is already registered as an internal driver, skipping external registration", name)
+		logrus.Debugf("Driver %#q is already registered as an internal driver, skipping external registration", name)
 		return
 	}
 
@@ -111,13 +111,13 @@ func discoverDrivers() error {
 
 			info, err := os.Stat(path)
 			if err != nil {
-				logrus.Warnf("Error accessing external driver path %q: %v", path, err)
+				logrus.Warnf("Error accessing external driver path %#q: %v", path, err)
 				continue
 			}
 
 			if info.IsDir() {
 				if err := discoverDriversInDir(path); err != nil {
-					logrus.Warnf("Error discovering external drivers in %q: %v", path, err)
+					logrus.Warnf("Error discovering external drivers in %#q: %v", path, err)
 				}
 			} else if isExecutable(info.Mode()) {
 				registerDriverFile(path)
@@ -134,7 +134,7 @@ func discoverDrivers() error {
 	for _, dir := range stdDriverDirs {
 		if _, err := os.Stat(dir); err == nil {
 			if err := discoverDriversInDir(dir); err != nil {
-				logrus.Warnf("Error discovering external drivers in %q: %v", dir, err)
+				logrus.Warnf("Error discovering external drivers in %#q: %v", dir, err)
 			}
 		}
 	}
@@ -144,7 +144,7 @@ func discoverDrivers() error {
 func discoverDriversInDir(dir string) error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return fmt.Errorf("failed to read driver directory %q: %w", dir, err)
+		return fmt.Errorf("failed to read driver directory %#q: %w", dir, err)
 	}
 
 	for _, entry := range entries {
@@ -154,7 +154,7 @@ func discoverDriversInDir(dir string) error {
 
 		info, err := entry.Info()
 		if err != nil {
-			logrus.Warnf("Failed to get info for %q: %v", entry.Name(), err)
+			logrus.Warnf("Failed to get info for %#q: %v", entry.Name(), err)
 			continue
 		}
 

--- a/pkg/sshutil/format.go
+++ b/pkg/sshutil/format.go
@@ -87,12 +87,12 @@ func Format(w io.Writer, sshPath, instName string, format FormatT, opts []string
 		for _, o := range opts {
 			kv := strings.SplitN(o, "=", 2)
 			if len(kv) != 2 {
-				return fmt.Errorf("unexpected option %q", o)
+				return fmt.Errorf("unexpected option %#q", o)
 			}
 			fmt.Fprintf(w, "  %s %s\n", kv[0], kv[1])
 		}
 	default:
-		return fmt.Errorf("unknown format: %q", format)
+		return fmt.Errorf("unknown format: %#q", format)
 	}
 	return nil
 }

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -82,7 +82,7 @@ func readPublicKey(f string) (PubKey, error) {
 	if err == nil {
 		entry.Content = strings.TrimSpace(string(content))
 	} else {
-		err = fmt.Errorf("failed to read ssh public key %q: %w", f, err)
+		err = fmt.Errorf("failed to read ssh public key %#q: %w", f, err)
 	}
 	return entry, err
 }
@@ -104,7 +104,7 @@ func DefaultPubKeys(ctx context.Context, loadDotSSH bool) ([]PubKey, error) {
 			return nil, err
 		}
 		if err := os.MkdirAll(configDir, 0o700); err != nil {
-			return nil, fmt.Errorf("could not create %q directory: %w", configDir, err)
+			return nil, fmt.Errorf("could not create %#q directory: %w", configDir, err)
 		}
 		if err := lockutil.WithDirLock(configDir, func() error {
 			// no passphrase, no user@host comment
@@ -119,7 +119,7 @@ func DefaultPubKeys(ctx context.Context, loadDotSSH bool) ([]PubKey, error) {
 				"-C", "lima", "-f", privPath)
 			logrus.Debugf("executing %v", keygenCmd.Args)
 			if out, err := keygenCmd.CombinedOutput(); err != nil {
-				return fmt.Errorf("failed to run %v: %q: %w", keygenCmd.Args, string(out), err)
+				return fmt.Errorf("failed to run %v: %#q: %w", keygenCmd.Args, string(out), err)
 			}
 			return nil
 		}); err != nil {
@@ -147,12 +147,12 @@ func DefaultPubKeys(ctx context.Context, loadDotSSH bool) ([]PubKey, error) {
 	}
 	for _, f := range files {
 		if !strings.HasSuffix(f, ".pub") {
-			panic(fmt.Errorf("unexpected ssh public key filename %q", f))
+			panic(fmt.Errorf("unexpected ssh public key filename %#q", f))
 		}
 		entry, err := readPublicKey(f)
 		if err == nil {
 			if !detectValidPublicKey(entry.Content) {
-				logrus.Warnf("public key %q doesn't seem to be in ssh format", entry.Filename)
+				logrus.Warnf("public key %#q doesn't seem to be in ssh format", entry.Filename)
 			} else {
 				res = append(res, entry)
 			}
@@ -216,7 +216,7 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 		}
 		for _, f := range files {
 			if !strings.HasSuffix(f, ".pub") {
-				panic(fmt.Errorf("unexpected ssh public key filename %q", f))
+				panic(fmt.Errorf("unexpected ssh public key filename %#q", f))
 			}
 			privateKeyPath := strings.TrimSuffix(f, ".pub")
 			_, err = os.Stat(privateKeyPath)
@@ -336,7 +336,7 @@ func IsControlMasterExisting(instDir string) bool {
 func SSHOpts(ctx context.Context, sshExe SSHExe, instDir, username string, useDotSSH, forwardAgent, forwardX11, forwardX11Trusted bool) ([]string, error) {
 	controlSock := filepath.Join(instDir, filenames.SSHSock)
 	if len(controlSock) >= osutil.UnixPathMax {
-		return nil, fmt.Errorf("socket path %q is too long: >= UNIX_PATH_MAX=%d", controlSock, osutil.UnixPathMax)
+		return nil, fmt.Errorf("socket path %#q is too long: >= UNIX_PATH_MAX=%d", controlSock, osutil.UnixPathMax)
 	}
 	opts, err := CommonOpts(ctx, sshExe, useDotSSH)
 	if err != nil {
@@ -441,7 +441,7 @@ func detectOpenSSHInfo(ctx context.Context, sshExe SSHExe) openSSHInfo {
 	cmd := exec.CommandContext(ctx, sshExe.Exe, sshArgs...)
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		logrus.Warnf("failed to run %v: stderr=%q", cmd.Args, stderr.String())
+		logrus.Warnf("failed to run %v: stderr=%#q", cmd.Args, stderr.String())
 	} else {
 		info = openSSHInfo{
 			Version:         *ParseOpenSSHVersion(stderr.Bytes()),

--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -14,7 +14,7 @@ func TestDefaultPubKeys(t *testing.T) {
 	keys, _ := DefaultPubKeys(t.Context(), true)
 	t.Logf("found %d public keys", len(keys))
 	for _, key := range keys {
-		t.Logf("%s: %q", key.Filename, key.Content)
+		t.Logf("%s: %#q", key.Filename, key.Content)
 	}
 }
 

--- a/pkg/store/disk.go
+++ b/pkg/store/disk.go
@@ -82,7 +82,7 @@ func inspectDisk(fName string) (size int64, format string, _ error) {
 	}
 	sz := img.Size()
 	if sz < 0 {
-		return -1, "", fmt.Errorf("cannot determine size of %q", fName)
+		return -1, "", fmt.Errorf("cannot determine size of %#q", fName)
 	}
 
 	return sz, string(img.Type()), nil
@@ -101,7 +101,7 @@ func (d *Disk) Unlock() error {
 func (d *Disk) LockForInstance(instanceDir string) error {
 	if d.Instance != "" {
 		if d.InstanceDir != instanceDir {
-			return fmt.Errorf("in use by instance %q", d.Instance)
+			return fmt.Errorf("in use by instance %#q", d.Instance)
 		}
 		if err := d.Unlock(); err != nil {
 			return fmt.Errorf("failed to unlock for reuse in the same instance: %w", err)

--- a/pkg/store/instance.go
+++ b/pkg/store/instance.go
@@ -73,14 +73,14 @@ func Inspect(ctx context.Context, instName string) (*limatype.Instance, error) {
 		haClient, err := hostagentclient.NewHostAgentClient(haSock)
 		if err != nil {
 			inst.Status = limatype.StatusBroken
-			inst.Errors = append(inst.Errors, fmt.Errorf("failed to connect to %q: %w", haSock, err))
+			inst.Errors = append(inst.Errors, fmt.Errorf("failed to connect to %#q: %w", haSock, err))
 		} else {
 			ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 			defer cancel()
 			info, err := haClient.Info(ctx)
 			if err != nil {
 				inst.Status = limatype.StatusBroken
-				inst.Errors = append(inst.Errors, fmt.Errorf("failed to get Info from %q: %w", haSock, err))
+				inst.Errors = append(inst.Errors, fmt.Errorf("failed to get Info from %#q: %w", haSock, err))
 			} else {
 				inst.SSHLocalPort = info.SSHLocalPort
 				inst.AutoStartedIdentifier = info.AutoStartedIdentifier
@@ -92,7 +92,7 @@ func Inspect(ctx context.Context, instName string) (*limatype.Instance, error) {
 		if port, err := sshPortFromConfig(sshConfigPath); err == nil {
 			inst.SSHLocalPort = port
 		} else if !errors.Is(err, os.ErrNotExist) {
-			inst.Errors = append(inst.Errors, fmt.Errorf("failed to extract SSH local port from %q: %w", sshConfigPath, err))
+			inst.Errors = append(inst.Errors, fmt.Errorf("failed to extract SSH local port from %#q: %w", sshConfigPath, err))
 		}
 	}
 
@@ -124,7 +124,7 @@ func Inspect(ctx context.Context, instName string) (*limatype.Instance, error) {
 
 	tmpl, err := template.New("format").Parse(y.Message)
 	if err != nil {
-		inst.Errors = append(inst.Errors, fmt.Errorf("message %q is not a valid template: %w", y.Message, err))
+		inst.Errors = append(inst.Errors, fmt.Errorf("message %#q is not a valid template: %w", y.Message, err))
 		inst.Status = limatype.StatusBroken
 	} else {
 		data, err := AddGlobalFields(inst)
@@ -136,7 +136,7 @@ func Inspect(ctx context.Context, instName string) (*limatype.Instance, error) {
 			var message strings.Builder
 			err = tmpl.Execute(&message, data)
 			if err != nil {
-				inst.Errors = append(inst.Errors, fmt.Errorf("cannot execute template %q: %w", y.Message, err))
+				inst.Errors = append(inst.Errors, fmt.Errorf("cannot execute template %#q: %w", y.Message, err))
 				inst.Status = limatype.StatusBroken
 			} else {
 				inst.Message = message.String()
@@ -148,7 +148,7 @@ func Inspect(ctx context.Context, instName string) (*limatype.Instance, error) {
 	if version, err := os.ReadFile(limaVersionFile); err == nil {
 		inst.LimaVersion = strings.TrimSpace(string(version))
 		if _, err = versionutil.Parse(inst.LimaVersion); err != nil {
-			logrus.Warnf("treating lima version %q from %q as very latest release", inst.LimaVersion, limaVersionFile)
+			logrus.Warnf("treating lima version %#q from %#q as very latest release", inst.LimaVersion, limaVersionFile)
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		inst.Errors = append(inst.Errors, err)
@@ -246,7 +246,7 @@ func sshPortFromConfig(configPath string) (int, error) {
 			return strconv.Atoi(port)
 		}
 	}
-	return 0, fmt.Errorf("port not found in %q", configPath)
+	return 0, fmt.Errorf("port not found in %#q", configPath)
 }
 
 type FormatData struct {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -122,7 +122,7 @@ func LoadYAMLByFilePath(ctx context.Context, filePath string) (*limatype.LimaYAM
 		return nil, err
 	}
 	if err := driverutil.ResolveVMType(ctx, y, filePath); err != nil {
-		return nil, fmt.Errorf("failed to resolve vm for %q: %w", filePath, err)
+		return nil, fmt.Errorf("failed to resolve vm for %#q: %w", filePath, err)
 	}
 	if err := limayaml.Validate(y, false); err != nil {
 		return nil, err

--- a/pkg/sysprof/sysprof_darwin.go
+++ b/pkg/sysprof/sysprof_darwin.go
@@ -42,7 +42,7 @@ func SystemProfiler(ctx context.Context, dataType string) ([]byte, error) {
 			logrus.Warn("Can't fetch system_profiler data; maybe OS is older than macOS Catalina 10.15")
 			return []byte("{}"), nil
 		}
-		return nil, fmt.Errorf("failed to run %v: stdout=%q, stderr=%q: %w",
+		return nil, fmt.Errorf("failed to run %v: stdout=%#q, stderr=%#q: %w",
 			cmd.Args, stdout.String(), stderr.String(), err)
 	}
 	return stdout.Bytes(), nil

--- a/pkg/templatestore/templatestore.go
+++ b/pkg/templatestore/templatestore.go
@@ -50,7 +50,7 @@ func templatesPaths() ([]string, error) {
 func Read(name string) ([]byte, error) {
 	doubleDot := ".."
 	if strings.Contains(name, doubleDot) {
-		return nil, fmt.Errorf("template name %q must not contain %q", name, doubleDot)
+		return nil, fmt.Errorf("template name %#q must not contain %#q", name, doubleDot)
 	}
 	paths, err := templatesPaths()
 	if err != nil {
@@ -69,7 +69,7 @@ func Read(name string) ([]byte, error) {
 			return b, err
 		}
 	}
-	return nil, fmt.Errorf("template %q not found", name)
+	return nil, fmt.Errorf("template %#q not found", name)
 }
 
 const Default = "default"

--- a/pkg/usrlocal/usrlocal.go
+++ b/pkg/usrlocal/usrlocal.go
@@ -161,7 +161,7 @@ func chooseGABinary(candidates []string) (string, error) {
 	for _, f := range candidates {
 		if _, err := os.Stat(f); err != nil {
 			if !errors.Is(err, fs.ErrNotExist) {
-				logrus.WithError(err).Warnf("failed to stat %q", f)
+				logrus.WithError(err).Warnf("failed to stat %#q", f)
 			}
 			continue
 		}
@@ -173,7 +173,7 @@ func chooseGABinary(candidates []string) (string, error) {
 	case 1:
 		return entries[0], nil
 	default:
-		logrus.Warnf("multiple files found, choosing %q from %v; consider removing the other ones",
+		logrus.Warnf("multiple files found, choosing %#q from %v; consider removing the other ones",
 			entries[0], candidates)
 		return entries[0], nil
 	}

--- a/pkg/windows/process_windows.go
+++ b/pkg/windows/process_windows.go
@@ -31,7 +31,7 @@ func GetProcessCommandLine(ctx context.Context, name string) ([]string, error) {
 
 	var outJSON CommandLineJSON
 	if err = json.Unmarshal(out, &outJSON); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal %q as %T: %w", out, outJSON, err)
+		return nil, fmt.Errorf("failed to unmarshal %#q as %T: %w", out, outJSON, err)
 	}
 
 	var ret []string

--- a/pkg/windows/registry_windows.go
+++ b/pkg/windows/registry_windows.go
@@ -33,7 +33,7 @@ func AddVSockRegistryKey(port int) error {
 	}
 
 	if slices.Contains(used, port) {
-		return fmt.Errorf("port %q in use", port)
+		return fmt.Errorf("port %#q in use", port)
 	}
 
 	vsockKeyPath := fmt.Sprintf(`%x%s`, port, magicVSOCKSuffix)
@@ -125,11 +125,11 @@ func GetDistroID(name string) (string, error) {
 			registry.READ,
 		)
 		if err != nil {
-			return "", fmt.Errorf("failed to read subkey %q for key %q: %w", k, wslDistroInfoPrefix, err)
+			return "", fmt.Errorf("failed to read subkey %#q for key %#q: %w", k, wslDistroInfoPrefix, err)
 		}
 		dn, _, err := subKey.GetStringValue("DistributionName")
 		if err != nil {
-			return "", fmt.Errorf("failed to read 'DistributionName' value for subkey %q of %q: %w", k, wslDistroInfoPrefix, err)
+			return "", fmt.Errorf("failed to read 'DistributionName' value for subkey %#q of %#q: %w", k, wslDistroInfoPrefix, err)
 		}
 		if dn == name {
 			out = k
@@ -138,7 +138,7 @@ func GetDistroID(name string) (string, error) {
 	}
 
 	if out == "" {
-		return "", fmt.Errorf("failed to find matching DistroID for %q", name)
+		return "", fmt.Errorf("failed to find matching DistroID for %#q", name)
 	}
 
 	return out, nil
@@ -221,7 +221,7 @@ func getUsedPorts(key registry.Key) ([]int, error) {
 		if len(split) == 2 {
 			i, err := strconv.Atoi(split[0])
 			if err != nil {
-				return nil, fmt.Errorf("failed convert %q to int: %w", split[0], err)
+				return nil, fmt.Errorf("failed convert %#q to int: %w", split[0], err)
 			}
 			out = append(out, i)
 		}

--- a/pkg/windows/wsl_util_windows.go
+++ b/pkg/windows/wsl_util_windows.go
@@ -36,7 +36,7 @@ func GetInstanceVMID(ctx context.Context, instanceName string) (string, error) {
 	}
 
 	if vmID == "" {
-		return "", fmt.Errorf("failed to find VM ID for instance %q", instanceName)
+		return "", fmt.Errorf("failed to find VM ID for instance %#q", instanceName)
 	}
 
 	return vmID, nil

--- a/pkg/yqutil/yqutil.go
+++ b/pkg/yqutil/yqutil.go
@@ -44,7 +44,7 @@ func EvaluateExpressionWithEncoder(expression, content string, encoder yqlib.Enc
 	if expression == "" {
 		return content, nil
 	}
-	logrus.Debugf("Evaluating yq expression: %q", expression)
+	logrus.Debugf("Evaluating yq expression: %#q", expression)
 	memory := logging.NewMemoryBackend(0)
 	backend := logging.AddModuleLevel(memory)
 	logging.SetBackend(backend)


### PR DESCRIPTION
Change %q in logs and errors to %#q and update the codes so that backticks are used everywhere in logs and errors. (all files in the following directories) .

- `pkg/limayaml`
- `pkg/localpathutil`
- `pkg/lockutil`
- `pkg/mcp`
- `pkg/networks`
- `pkg/osutil`
- `pkg/plist`
- `pkg/plugins`
- `pkg/portfwd`
- `pkg/qemuimgutil`
- `pkg/registry`
- `pkg/sshutil`
- `pkg/store`
- `pkg/sysprof`
- `pkg/templatestore`
- `pkg/usrlocal`
- `pkg/windows`
- `pkg/yqutil`

Related issue: #4898 
This PR is the last batch for the issue, following #4909 , #5017 , and #5029.