### PR TITLE
nerdctl: update from v2.2.2 to v2.3.3

### DIFF
--- a/pkg/limayaml/containerd.yaml
+++ b/pkg/limayaml/containerd.yaml
@@ -1,11 +1,11 @@
 # nerdctl version must be >= 2.1.6 since Lima v2.0.0.
 # Port forwarding in rootful mode no longer works with older versions of nerdctl.
 archives:
-- location: https://github.com/containerd/nerdctl/releases/download/v2.2.2/nerdctl-full-2.2.2-linux-amd64.tar.gz
+- location: https://github.com/containerd/nerdctl/releases/download/v2.3.3/nerdctl-full-2.3.3-linux-amd64.tar.gz
   arch: x86_64
-  digest: sha256:8a477f35533c6cc1120c19558d8142967c74f25a4b952b481f48104e030de914
-- location: https://github.com/containerd/nerdctl/releases/download/v2.2.2/nerdctl-full-2.2.2-linux-arm64.tar.gz
+  digest: sha256:8d39a120d8414e3aff15ac05accf51bbbad6baf54764ae709b09087e4544c1ad
+- location: https://github.com/containerd/nerdctl/releases/download/v2.3.3/nerdctl-full-2.3.3-linux-arm64.tar.gz
   arch: aarch64
-  digest: sha256:55d68d2613b5f065021146bac21f620cde9e7fdd4bd3eff74cd324f5462e107a
+  digest: sha256:2322f29f451189dd790b5d7c599b4600c210ff0f2c10244308a8e6a024274066
 # No arm-v7
 # No riscv64


### PR DESCRIPTION
https://github.com/containerd/nerdctl/releases/tag/v2.3.0 https://github.com/containerd/nerdctl/releases/tag/v2.3.1 https://github.com/containerd/nerdctl/releases/tag/v2.3.2 https://github.com/containerd/nerdctl/releases/tag/v2.3.3

nerdctl v2.3.3 contains [containerd v2.3.2](https://github.com/containerd/containerd/releases/tag/v2.3.2), which fixes
CVE-2026-50195, CVE-2026-53488, CVE-2026-53492, CVE-2026-53489, CVE-2026-47262