### PR TITLE
refactor: drop sudo requirement for fuse.conf check

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/35-setup-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/35-setup-packages.sh
@@ -34,6 +34,7 @@ EOF
 # otherwise apt-get fails with conflict
 if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
 	update_fuse_conf
+	echo "${LIMA_CIDATA_IID}" >/run/lima-fuse-ready
 fi
 
 SETUP_DNS=0

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -210,11 +210,11 @@ A possible workaround is to run "apt-get install sshfs" in the guest.
 		})
 		req = append(req, requirement{
 			description: "fuse to allow_other as user",
-			script: `#!/bin/sh
+			script: fmt.Sprintf(`#!/bin/sh
 set -eux
-sudo grep -q ^user_allow_other /etc/fuse*.conf
-`,
-			debugHint: `Append "user_allow_other" to /etc/fuse.conf (/etc/fuse3.conf) in the guest`,
+[ "$(cat /run/lima-fuse-ready 2>/dev/null)" = "%s" ]
+`, a.iid),
+			debugHint: `Waiting for /run/lima-fuse-ready to be created by the boot scripts.`,
 		})
 	} else {
 		req = append(req, startControlMasterReq)

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -220,6 +220,15 @@ The volume label is "cidata", as defined by [cloud-init NoCloud](https://docs.cl
 - `LIMA_CIDATA_PLAIN`: set to "1" when the instance is in plain mode (no mounts, port forwarding, or containerd), empty otherwise.
 - `LIMA_CIDATA_NO_CLOUD_INIT`: set to "1" if cloud-init should be skipped on this boot, empty otherwise.
 
+
+## Guest runtime files
+
+Boot scripts create the following marker files inside the guest at `/run/`:
+
+- `/run/lima-boot-done`: Written by `boot.sh` when provisioning is complete. Contains `LIMA_CIDATA_IID`.
+- `/run/lima-ssh-ready`: Written by `boot.Linux/07-etc-environment.sh` when SSH is ready. Contains `LIMA_CIDATA_IID`.
+- `/run/lima-fuse-ready`: Written by `boot.Linux/35-setup-packages.sh` after fuse.conf is configured for `allow_other`. Contains `LIMA_CIDATA_IID`. Only created when `LIMA_CIDATA_MOUNTTYPE=reverse-sshfs`.
+
 # VM lifecycle
 
 ![](/images/internals/lima-sequence-diagram.png)


### PR DESCRIPTION
Part of: #5109 
Replaces the sudo grep check for fuse.conf with an unprivileged notification file (/run/lima-fuse-configured) generated securely during cloud-init.
This eliminates a hard root dependency in hostagent