### PR TITLE
fix(qemu): fallback from hvf to tcg on macOS

### DIFF
--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -1067,11 +1067,19 @@ func Exe(arch limatype.Arch) (exe string, args []string, err error) {
 	return exe, args, nil
 }
 
+var hvSupport = sync.OnceValues(func() (string, error) {
+	return osutil.Sysctl(context.TODO(), "kern.hv_support")
+})
+
 func Accel(arch limatype.Arch) string {
 	if limatype.IsNativeArch(arch) {
 		switch runtime.GOOS {
 		case "darwin":
-			// TODO: return "tcg" if HVF is not available
+			s, err := hvSupport()
+			if err != nil || s != "1" {
+				logrus.WithError(err).Warn("Hypervisor API (kern.hv_support) is not available. Disabling HVF. Expect very poor performance.")
+				return "tcg"
+			}
 			return "hvf"
 		case "linux":
 			if _, err := os.Stat("/dev/kvm"); err != nil {


### PR DESCRIPTION
Fixes #5133

**Description:**
Currently, Lima hardcodes the `hvf` accelerator for macOS VMs. When running Lima inside a nested macOS VM environment(nested virtualization), `hvf` is unavailable, causing QEMU to immediately fail and crash.

To fix this, I separated the accelerator from the -machine string and used the dedicated -accel flag instead. Now, if the code detects hvf as the primary accelerator, it also explicitly appends -accel tcg right after it. This way, QEMU will try hardware acceleration first, but if it's unavailable (like in a nested VM), it safely falls back to software emulation instead of crashing.

**Testing:**
- Ran `go test -v ./pkg/driver/qemu/...` locally.