### PR TITLE
mount: set 9p cache=mmap to fix file truncation

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -46,7 +46,7 @@ const (
 	Default9pProtocolVersion string = "9p2000.L"
 	Default9pMsize           string = "128KiB"
 	Default9pCacheForRO      string = "fscache"
-	Default9pCacheForRW      string = "mmap"
+	Default9pCache           string = "mmap"
 
 	DefaultVirtiofsQueueSize int = 1024
 )
@@ -777,11 +777,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 			mount.Writable = ptr.Of(false)
 		}
 		if mount.NineP.Cache == nil {
-			if *mount.Writable {
-				mounts[i].NineP.Cache = ptr.Of(Default9pCacheForRW)
-			} else {
-				mounts[i].NineP.Cache = ptr.Of(Default9pCacheForRO)
-			}
+			mounts[i].NineP.Cache = ptr.Of(Default9pCache)
 		}
 	}
 

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -214,7 +214,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Mounts[0].NineP.SecurityModel = ptr.Of(Default9pSecurityModel)
 	expect.Mounts[0].NineP.ProtocolVersion = ptr.Of(Default9pProtocolVersion)
 	expect.Mounts[0].NineP.Msize = ptr.Of(Default9pMsize)
-	expect.Mounts[0].NineP.Cache = ptr.Of(Default9pCacheForRO)
+	expect.Mounts[0].NineP.Cache = ptr.Of(Default9pCache)
 	expect.Mounts[0].Virtiofs.QueueSize = nil
 	// Only missing Mounts field is Writable, and the default value is also the null value: false
 	expect.Mounts[1].Location = filepath.Join(instDir, y.Param["ONE"])
@@ -226,7 +226,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Mounts[1].NineP.SecurityModel = ptr.Of(Default9pSecurityModel)
 	expect.Mounts[1].NineP.ProtocolVersion = ptr.Of(Default9pProtocolVersion)
 	expect.Mounts[1].NineP.Msize = ptr.Of(Default9pMsize)
-	expect.Mounts[1].NineP.Cache = ptr.Of(Default9pCacheForRO)
+	expect.Mounts[1].NineP.Cache = ptr.Of(Default9pCache)
 	expect.Mounts[1].Virtiofs.QueueSize = nil
 
 	expect.MountType = ptr.Of(limatype.NINEP)
@@ -446,7 +446,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Mounts[0].NineP.SecurityModel = ptr.Of(Default9pSecurityModel)
 	expect.Mounts[0].NineP.ProtocolVersion = ptr.Of(Default9pProtocolVersion)
 	expect.Mounts[0].NineP.Msize = ptr.Of(Default9pMsize)
-	expect.Mounts[0].NineP.Cache = ptr.Of(Default9pCacheForRO)
+	expect.Mounts[0].NineP.Cache = ptr.Of(Default9pCache)
 	expect.Mounts[0].Virtiofs.QueueSize = nil
 	expect.HostResolver.Hosts = map[string]string{
 		"default": d.HostResolver.Hosts["default"],


### PR DESCRIPTION
on linux after vm start  copy data into share  dir  (for an example /home/ubuntu/containerd.zip)
on host 
```
-rw-r--r--.  1 root   root    607497541 Jun 22 13:11 containerd.zip
[root@anolis bin]# sha256sum /home/ubuntu/containerd.zip
11db316940f1b7bdb5d3d3c7d9d2a072fcc27a7506604338a72ab57d10e9a129  /home/ubuntu/containerd.zip

```
on guest 
```
[ubuntu@lima-test01 ubuntu]$ ls -al /home/ubuntu|grep containerd.zip
-rw-r--r--   1 root   root     34816000 Jun 22 13:10 containerd.zip
[ubuntu@lima-test01 ubuntu]$ sha256sum /home/ubuntu/containerd.zip 
f3682a59925a55cc9c81b047f0ba8f5883df1981ef8426b6ce6576d767b2dbe7  /home/ubuntu/containerd.zip
```
I find file is incomplete.