### PR TITLE
Implement TPM emulation

### DIFF
--- a/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
@@ -231,6 +231,10 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 		return fmt.Errorf("field `mountType` must be %#q or %#q for krunkit driver, got %#q", limatype.VIRTIOFS, limatype.REVSSHFS, *cfg.MountType)
 	}
 
+	if cfg.TPM != nil && *cfg.TPM {
+		return errors.New("field `tpm` is not supported in krunkit driver")
+	}
+
 	if cfg.NestedVirtualization != nil && *cfg.NestedVirtualization {
 		if macOSProductVersion.LessThan(*semver.New("15.0.0")) {
 			return errors.New("nested virtualization requires macOS 15 or newer")

--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -702,6 +702,24 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 		args = appendArgsIfNoConflict(args, "-initrd", initrd)
 	}
 
+	// TPM emulation.
+	if *y.TPM {
+		swtpmSock := filepath.Join(cfg.InstanceDir, filenames.SwtpmSock)
+		args = append(args, "-chardev", fmt.Sprintf("socket,id=chrtpm,path=%s", swtpmSock))
+		args = append(args, "-tpmdev", "emulator,id=tpm0,chardev=chrtpm")
+
+		var tpmDevice string
+		switch *y.Arch {
+		case limatype.X8664:
+			tpmDevice = "tpm-crb"
+		case limatype.AARCH64, limatype.ARMV7L, limatype.RISCV64:
+			tpmDevice = "tpm-tis-device"
+		default:
+			return "", nil, fmt.Errorf("TPM is not supported for architecture %#q", *y.Arch)
+		}
+		args = append(args, "-device", tpmDevice+",tpmdev=tpm0")
+	}
+
 	// Network
 	// Configure default usernetwork with limayaml.MACAddress(driver.Instance.Dir) for eth0 interface
 	firstUsernetIndex := limayaml.FirstUsernetIndex(y)
@@ -1096,6 +1114,45 @@ func Accel(arch limatype.Arch) string {
 		}
 	}
 	return "tcg"
+}
+
+func findSwtpm() (string, error) {
+	exe, err := exec.LookPath("swtpm")
+	if err != nil {
+		return "", fmt.Errorf("swtpm not found in PATH: %w (hint: install swtpm)", err)
+	}
+	return exe, nil
+}
+
+func SwtpmCmdline(cfg Config) (exe string, args []string, err error) {
+	if runtime.GOOS == "windows" {
+		return "", nil, errors.New("swtpm is not supported on Windows host")
+	}
+
+	swtpmExe, err := findSwtpm()
+	if err != nil {
+		return "", nil, err
+	}
+
+	stateDir := filepath.Join(cfg.InstanceDir, filenames.SwtpmDir)
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return "", nil, fmt.Errorf("failed to create swtpm state directory: %w", err)
+	}
+
+	swtpmSock := filepath.Join(cfg.InstanceDir, filenames.SwtpmSock)
+	_ = os.Remove(swtpmSock)
+	_ = os.Remove(filepath.Join(stateDir, ".lock"))
+
+	args = []string{
+		"socket",
+		"--tpmstate", "dir=" + stateDir,
+		"--ctrl", "type=unixio,path=" + swtpmSock,
+		"--tpm2",
+		"--terminate",
+		"--log", "level=1",
+	}
+
+	return swtpmExe, args, nil
 }
 
 func parseQemuVersion(output string) (*semver.Version, error) {

--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -19,6 +19,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -50,6 +51,9 @@ type LimaQemuDriver struct {
 	qWaitCh chan error
 
 	vhostCmds []*exec.Cmd
+
+	swtpmCmd    *exec.Cmd
+	swtpmWaitCh chan error
 }
 
 var _ driver.Driver = (*LimaQemuDriver)(nil)
@@ -391,6 +395,13 @@ func (l *LimaQemuDriver) Start(ctx context.Context) (chan error, error) {
 		}()
 	}
 
+	// Start swtpm for TPM emulation.
+	if *l.Instance.Config.TPM {
+		if err := l.runSwtpm(ctx, qCfg); err != nil {
+			return nil, err
+		}
+	}
+
 	logrus.Infof("Starting QEMU (hint: to watch the boot progress, see %#q)", filepath.Join(qCfg.InstanceDir, "serial*.log"))
 	logrus.Debugf("qCmd.Args: %v", qCmd.Args)
 	if err := qCmd.Start(); err != nil {
@@ -426,6 +437,67 @@ func (l *LimaQemuDriver) ChangeDisplayPassword(_ context.Context, password strin
 
 func (l *LimaQemuDriver) DisplayConnection(_ context.Context) (string, error) {
 	return l.getVNCDisplayPort()
+}
+
+func (l *LimaQemuDriver) runSwtpm(ctx context.Context, qCfg Config) error {
+	var swtpmCmd *exec.Cmd
+	swtpmExe, swtpmArgs, err := SwtpmCmdline(qCfg)
+	if err != nil {
+		return err
+	}
+
+	swtpmCmd = exec.CommandContext(ctx, swtpmExe, swtpmArgs...)
+	swtpmCmd.SysProcAttr = executil.BackgroundSysProcAttr
+
+	swtpmStdout, err := swtpmCmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	go logPipeRoutine(swtpmStdout, "swtpm[stdout]")
+
+	swtpmStderr, err := swtpmCmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	go logPipeRoutine(swtpmStderr, "swtpm[stderr]")
+
+	logrus.Info("Starting swtpm for TPM emulation")
+	logrus.Debugf("swtpmCmd.Args: %v", swtpmCmd.Args)
+	if err := swtpmCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start swtpm: %w", err)
+	}
+
+	swtpmSock := filepath.Join(l.Instance.Dir, filenames.SwtpmSock)
+	l.swtpmWaitCh = make(chan error, 1)
+	go func() {
+		l.swtpmWaitCh <- swtpmCmd.Wait()
+		close(l.swtpmWaitCh)
+	}()
+
+	var swtpmSockExists bool
+	for attempt := range 5 {
+		logrus.Debugf("Waiting for swtpm socket %s (attempt %d)", swtpmSock, attempt)
+		if _, err := os.Stat(swtpmSock); err == nil {
+			swtpmSockExists = true
+			break
+		}
+		retry := time.NewTimer(200 * time.Millisecond)
+		select {
+		case err = <-l.swtpmWaitCh:
+			retry.Stop()
+			return fmt.Errorf("swtpm exited before creating socket: %w", err)
+		case <-retry.C:
+		}
+	}
+
+	if !swtpmSockExists {
+		_ = swtpmCmd.Process.Kill()
+		return fmt.Errorf("swtpm socket %s never appeared", swtpmSock)
+	}
+
+	l.swtpmCmd = swtpmCmd
+
+	return nil
 }
 
 func waitFileExists(path string, timeout time.Duration) error {
@@ -532,6 +604,39 @@ func (l *LimaQemuDriver) killVhosts() error {
 	return errors.Join(errs...)
 }
 
+func (l *LimaQemuDriver) killSwtpm() error {
+	if l.swtpmCmd == nil || l.swtpmCmd.Process == nil {
+		return nil
+	}
+
+	logrus.Debug("shutting down swtpm process")
+	if err := l.swtpmCmd.Process.Signal(syscall.SIGTERM); err != nil {
+		if errors.Is(err, os.ErrProcessDone) {
+			logrus.Debug("swtpm process was already done")
+			return nil
+		}
+	}
+
+	select {
+	case err, ok := <-l.swtpmWaitCh:
+		if !ok {
+			logrus.Debug("swtpm wait channel was closed")
+		}
+		if err != nil {
+			logrus.Errorf("swtpm exited with error: %v", err)
+			return err
+		}
+		return nil
+	case <-time.After(5 * time.Second):
+	}
+
+	if err := l.swtpmCmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("failed to kill swtpm: %w", err)
+	}
+
+	return nil
+}
+
 func (l *LimaQemuDriver) shutdownQEMU(ctx context.Context, timeout time.Duration, qCmd *exec.Cmd, qWaitCh <-chan error) error {
 	// "power button" refers to ACPI on the most archs, except RISC-V
 	logrus.Info("Shutting down QEMU with the power button")
@@ -567,7 +672,7 @@ func (l *LimaQemuDriver) shutdownQEMU(ctx context.Context, timeout time.Duration
 		if !ok {
 			logrus.Info("QEMU wait channel was closed")
 			_ = l.removeVNCFiles()
-			return l.killVhosts()
+			return errors.Join(l.killVhosts(), l.killSwtpm())
 		}
 		entry := logrus.NewEntry(logrus.StandardLogger())
 		if qWaitErr != nil {
@@ -575,12 +680,12 @@ func (l *LimaQemuDriver) shutdownQEMU(ctx context.Context, timeout time.Duration
 		}
 		entry.Info("QEMU has exited")
 		_ = l.removeVNCFiles()
-		return errors.Join(qWaitErr, l.killVhosts())
+		return errors.Join(qWaitErr, l.killVhosts(), l.killSwtpm())
 	case <-timeoutCtx.Done():
 		if qCmd.ProcessState != nil {
 			logrus.Info("QEMU has already exited")
 			_ = l.removeVNCFiles()
-			return l.killVhosts()
+			return errors.Join(l.killVhosts(), l.killSwtpm())
 		}
 		logrus.Warnf("QEMU did not exit in %v, forcibly killing QEMU", timeout)
 		return l.killQEMU(ctx, timeout, qCmd, qWaitCh)
@@ -601,7 +706,7 @@ func (l *LimaQemuDriver) killQEMU(_ context.Context, _ time.Duration, qCmd *exec
 	qemuPIDPath := filepath.Join(l.Instance.Dir, filenames.PIDFile(*l.Instance.Config.VMType))
 	_ = os.RemoveAll(qemuPIDPath)
 	_ = l.removeVNCFiles()
-	return errors.Join(qWaitErr, l.killVhosts())
+	return errors.Join(qWaitErr, l.killVhosts(), l.killSwtpm())
 }
 
 func logPipeRoutine(r io.Reader, header string) {

--- a/pkg/driver/qemu/qemu_test.go
+++ b/pkg/driver/qemu/qemu_test.go
@@ -4,9 +4,15 @@
 package qemu
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 )
 
 func TestArgValue(t *testing.T) {
@@ -88,4 +94,60 @@ func TestParseQemuVersion(t *testing.T) {
 		}
 		assert.Equal(t, tc.expectedValue, v.String())
 	}
+}
+
+func TestSwtpmCmdline(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("swtpm unix socket mode is not supported on Windows host")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Create a mock swtpm binary.
+	binDir := filepath.Join(tmpDir, "bin")
+	err := os.MkdirAll(binDir, 0o755)
+	assert.NilError(t, err)
+	swtpmPath := filepath.Join(binDir, "swtpm")
+	err = os.WriteFile(swtpmPath, []byte{}, 0o755)
+	assert.NilError(t, err)
+
+	// Overwrite PATH so that the function find the mock binary.
+	t.Setenv("PATH", binDir)
+
+	// Setup configs and expected value
+	cfg := Config{
+		Name:        "tpm-test",
+		InstanceDir: tmpDir,
+		LimaYAML:    &limatype.LimaYAML{},
+	}
+
+	stateDir := filepath.Join(tmpDir, filenames.SwtpmDir)
+	swtpmSock := filepath.Join(tmpDir, filenames.SwtpmSock)
+
+	expectedArgs := []string{
+		"socket",
+		"--tpmstate", "dir=" + stateDir,
+		"--ctrl", "type=unixio,path=" + swtpmSock,
+		"--tpm2",
+		"--terminate",
+		"--log", "level=1",
+	}
+
+	exe, args, err := SwtpmCmdline(cfg)
+	assert.NilError(t, err)
+	assert.Equal(t, exe, swtpmPath)
+	assert.DeepEqual(t, args, expectedArgs)
+
+	// Verify that state directory was created.
+	_, err = os.Stat(stateDir)
+	assert.NilError(t, err)
+
+	// Verify that stale socket is removed.
+	err = os.WriteFile(swtpmSock, []byte("stale socket"), 0o644)
+	assert.NilError(t, err)
+	// Call again to clean up the stale socket.
+	_, _, err = SwtpmCmdline(cfg)
+	assert.NilError(t, err)
+	_, err = os.Stat(swtpmSock)
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -75,6 +75,7 @@ var knownYamlProperties = []string{
 	"Rosetta",
 	"SSH",
 	"TimeZone",
+	"TPM",
 	"UpgradePackages",
 	"User",
 	"Video",
@@ -271,6 +272,9 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 	}
 	if cfg.MountType != nil && *cfg.MountType == limatype.NINEP {
 		return fmt.Errorf("field `mountType` must be %#q or %#q for VZ driver , got %#q", limatype.REVSSHFS, limatype.VIRTIOFS, *cfg.MountType)
+	}
+	if cfg.TPM != nil && *cfg.TPM {
+		return errors.New("field `tpm` is not supported on VZ driver")
 	}
 	if *cfg.Firmware.LegacyBIOS {
 		logrus.Warnf("vmType %s: ignoring `firmware.legacyBIOS`", *cfg.VMType)

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -43,6 +43,7 @@ var knownYamlProperties = []string{
 	"PropagateProxyEnv",
 	"Provision",
 	"SSH",
+	"TPM",
 	"VMType",
 }
 
@@ -109,6 +110,10 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 
 	if !limatype.IsNativeArch(*cfg.Arch) {
 		return fmt.Errorf("unsupported arch: %#q", *cfg.Arch)
+	}
+
+	if cfg.TPM != nil && *cfg.TPM {
+		return errors.New("field `tpm` is not supported on WSL2 driver")
 	}
 
 	if cfg.VMType != nil {

--- a/pkg/limatype/filenames/filenames.go
+++ b/pkg/limatype/filenames/filenames.go
@@ -76,6 +76,10 @@ const (
 	MntDir    = "mnt" // mount point (macOS guests only)
 
 	Protected = "protected" // empty file; used by `limactl protect`
+
+	// Swtpm is used for TPM emulation.
+	SwtpmSock = "swtpm.sock"
+	SwtpmDir  = "swtpm"
 )
 
 // Filenames used under a disk directory
@@ -102,6 +106,7 @@ func PIDFile(name string) string {
 // SkipOnClone files should be skipped on cloning an instance.
 var SkipOnClone = []string{
 	Protected,
+	SwtpmDir, // TPM state must not be shared between instances.
 }
 
 // NullifyOnClone files should be nullified on cloning an instance.

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -58,6 +58,7 @@ type LimaYAML struct {
 	TimeZone             *string `yaml:"timezone,omitempty" json:"timezone,omitempty" jsonschema:"nullable"`
 	NestedVirtualization *bool   `yaml:"nestedVirtualization,omitempty" json:"nestedVirtualization,omitempty" jsonschema:"nullable"`
 	User                 User    `yaml:"user,omitempty" json:"user,omitempty"`
+	TPM                  *bool   `yaml:"tpm,omitempty" json:"tpm,omitempty" jsonschema:"nullable"`
 }
 
 type BaseTemplates []LocatorWithDigest

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -844,6 +844,16 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 		y.Plain = ptr.Of(false)
 	}
 
+	if y.TPM == nil {
+		y.TPM = d.TPM
+	}
+	if o.TPM != nil {
+		y.TPM = o.TPM
+	}
+	if y.TPM == nil {
+		y.TPM = ptr.Of(false)
+	}
+
 	fixUpForPlainMode(y)
 }
 

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -121,6 +121,7 @@ func TestFillDefault(t *testing.T) {
 			Shell:   ptr.Of("/bin/bash"),
 			UID:     ptr.Of(uint32(uid)),
 		},
+		TPM: ptr.Of(false),
 	}
 
 	defaultPortForward := limatype.PortForward{
@@ -297,6 +298,7 @@ func TestFillDefault(t *testing.T) {
 	}
 
 	expect.NestedVirtualization = ptr.Of(false)
+	expect.TPM = ptr.Of(false)
 
 	FillDefault(t.Context(), &y, &limatype.LimaYAML{}, &limatype.LimaYAML{}, filePath, false)
 	assert.DeepEqual(t, &y, &expect, opts...)
@@ -424,6 +426,7 @@ func TestFillDefault(t *testing.T) {
 				"minimumVersion": "9.1.0",
 			},
 		},
+		TPM: ptr.Of(true),
 	}
 
 	expect = d
@@ -460,6 +463,7 @@ func TestFillDefault(t *testing.T) {
 	}
 
 	expect.Plain = ptr.Of(false)
+	expect.TPM = ptr.Of(true)
 
 	y = limatype.LimaYAML{}
 	FillDefault(t.Context(), &y, &d, &limatype.LimaYAML{}, filePath, false)
@@ -716,6 +720,7 @@ func TestFillDefault(t *testing.T) {
 			},
 		},
 	}
+	expect.TPM = ptr.Of(false)
 
 	FillDefault(t.Context(), &y, &d, &o, filePath, false)
 	assert.DeepEqual(t, &y, &expect, opts...)

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -416,6 +416,14 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 			}
 		}
 	}
+	if y.TPM != nil && *y.TPM {
+		switch *y.Arch {
+		case limatype.X8664, limatype.AARCH64, limatype.ARMV7L, limatype.RISCV64:
+			// supported
+		default:
+			errs = errors.Join(errs, fmt.Errorf("field `tpm` is not supported on architecture %#q", *y.Arch))
+		}
+	}
 
 	return errs
 }

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -631,6 +631,13 @@ plain: null
 # 🟢 Builtin default: false
 nestedVirtualization: null
 
+# EXPERIMENTAL
+# When enabled, an emulated TPM 2.0 device is provided to the guest via swtpm.
+# Requires swtpm to be installed on the host. Only supported with vmType: qemu.
+# Currently not supported on Windows hosts as swtpm doesn't support Windows.
+# 🟢 Builtin default: false
+tpm: null
+
 # ===================================================================== #
 # GLOBAL DEFAULTS AND OVERRIDES
 # ===================================================================== #

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -87,6 +87,10 @@ VNC:
 - `vncdisplay`: VNC display host/port
 - `vncpassword`: VNC display password
 
+TPM:
+- `swtpm.sock`: SWTPM (Software TPM Emulator) socket.
+- `swtpm`: A directory where TPM's state will be written.
+
 Guest agent:
 
 Each drivers use their own mode of communication

--- a/website/content/en/docs/releases/experimental.md
+++ b/website/content/en/docs/releases/experimental.md
@@ -12,6 +12,7 @@ The following features are experimental and subject to change:
 - `video.display: vnc` and relevant configuration (`video.vnc.display`)
 - `audio.device`
 - `mountInotify: true`
+- `tpm: true`
 - `External drivers`: building and using drivers as separate executables (see [Virtual Machine Drivers](../dev/drivers))
 - [`vmType: krunkit`](../config/vmtype/krunkit.md)
 - [`github` URL scheme](../templates/github.md): referencing templates on GitHub with `github:` URLs


### PR DESCRIPTION
This PR is part of https://github.com/lima-vm/lima/issues/4852.
It adds a feature to enable TMP emulation  following https://github.com/lima-vm/lima/pull/5079 by @Shardz4. (Thank you so much 🙏 )

I validated that TPM successfully implemented on ubuntu VM (x86-64) as follows.
**validation1:**

```bash
sudo dmesg | grep -i tpm
[    0.000000] efi: TPMFinalLog=0x7fbd7000 SMBIOS=0x7f91a000 ACPI=0x7fb7e000 ACPI 2.0=0x7fb7e014 MEMATTR=0x7e013018 MOKvar=0x7f915000 INITRD=0x7e01f698 RNG=0x7fb73018 TPMEventLog=0x7e003018 
[    0.034809] ACPI: TPM2 0x000000007FB76000 00004C (v04 BOCHS  BXPC     00000001 BXPC 00000001)
[    0.034842] ACPI: Reserving TPM2 table memory at [mem 0x7fb76000-0x7fb7604b]
[    3.772329] systemd[1]: systemd 259.5-0ubuntu3 running in system mode (+PAM +AUDIT +SELINUX +APPARMOR +IMA +IPE +SMACK +SECCOMP +GCRYPT -GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +KMOD +LIBCRYPTSETUP +LIBCRYPTSETUP_PLUGINS +LIBFDISK +PCRE2 +PWQUALITY +P11KIT +QRENCODE +TPM2 +BZIP2 +LZ4 +XZ +ZLIB +ZSTD +BPF_FRAMEWORK +BTF -XKBCOMMON -UTMP +SYSVINIT +LIBARCHIVE)
[    4.696020] systemd[1]: systemd-pcrphase-initrd.service - TPM PCR Barrier (initrd) skipped, unmet condition check ConditionSecurity=measured-uki
[    9.943566] systemd[1]: systemd 259.5-0ubuntu3 running in system mode (+PAM +AUDIT +SELINUX +APPARMOR +IMA +IPE +SMACK +SECCOMP +GCRYPT -GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +KMOD +LIBCRYPTSETUP +LIBCRYPTSETUP_PLUGINS +LIBFDISK +PCRE2 +PWQUALITY +P11KIT +QRENCODE +TPM2 +BZIP2 +LZ4 +XZ +ZLIB +ZSTD +BPF_FRAMEWORK +BTF -XKBCOMMON -UTMP +SYSVINIT +LIBARCHIVE)
[   11.864092] systemd[1]: systemd-pcrextend.socket - TPM PCR Measurements skipped, unmet condition check ConditionSecurity=measured-uki
[   11.864135] systemd[1]: systemd-pcrlock.socket - Make TPM PCR Policy skipped, unmet condition check ConditionSecurity=measured-uki
[   12.091215] systemd[1]: systemd-pcrmachine.service - TPM PCR Machine ID Measurement skipped, unmet condition check ConditionSecurity=measured-uki
[   12.091338] systemd[1]: systemd-pcrproduct.service - TPM NvPCR Product ID Measurement skipped, unmet condition check ConditionSecurity=measured-uki
[   12.101255] systemd[1]: systemd-tpm2-setup-early.service - Early TPM SRK Setup skipped, unmet condition check ConditionSecurity=measured-uki
```

**validation2:**
```bash
sudo apt install tpm2-tools 
sudo tpm2_getrandom --hex 16
91ec2926cab41c0a990024b5d972d665
```