### PR TITLE
feat: log all host-side sudo invocations with non-debug level

### DIFF
--- a/cmd/limactl/autostart_darwin.go
+++ b/cmd/limactl/autostart_darwin.go
@@ -153,6 +153,6 @@ func runSudo(ctx context.Context, args ...string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
-	logrus.Debugf("running: sudo %v", args)
+	logrus.Infof("running: sudo %v", args)
 	return cmd.Run()
 }

--- a/pkg/networks/reconcile/reconcile.go
+++ b/pkg/networks/reconcile/reconcile.go
@@ -75,7 +75,7 @@ func sudo(ctx context.Context, user, group, command string) error {
 	cmd := exec.CommandContext(ctx, "sudo", args...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	logrus.Debugf("Running: %v", cmd.Args)
+	logrus.Infof("Running: %v", cmd.Args)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to run %v: stdout=%#q, stderr=%#q: %w",
 			cmd.Args, stdout.String(), stderr.String(), err)
@@ -153,7 +153,7 @@ func startDaemon(ctx context.Context, cfg *networks.Config, name, daemon string)
 		return err
 	}
 
-	logrus.Debugf("Starting %#q daemon for %#q network: %v", daemon, name, cmd.Args)
+	logrus.Infof("Starting %#q daemon for %#q network: %v", daemon, name, cmd.Args)
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to run %v: %w (Hint: check %#q, %#q)", cmd.Args, err, stdoutPath, stderrPath)
 	}

--- a/pkg/networks/sudoers.go
+++ b/pkg/networks/sudoers.go
@@ -59,6 +59,7 @@ func Sudoers() (string, error) {
 func (c *Config) passwordLessSudo(ctx context.Context) error {
 	// Flush cached sudo password
 	cmd := exec.CommandContext(ctx, "sudo", "-k")
+	logrus.Infof("Running: %v", cmd.Args)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to run %v: %w", cmd.Args, err)
 	}
@@ -75,6 +76,7 @@ func (c *Config) passwordLessSudo(ctx context.Context) error {
 			return err
 		}
 		cmd = exec.CommandContext(ctx, "sudo", "--user", user.User, "--group", user.Group, "--non-interactive", "true")
+		logrus.Infof("Running: %v", cmd.Args)
 		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("failed to run %v: %w", cmd.Args, err)
 		}


### PR DESCRIPTION
#### Summary : 

- Refactored all log levels to use logrus.Infof so that all host-side executions of sudo are logged at a non-debug level.
- Verified that the updated code builds successfully and all unit tests pass.

fixes #5114 