### PR TITLE
fix port-forward tunnel Read exceeding the supplied buffer

### DIFF
--- a/pkg/portfwd/client.go
+++ b/pkg/portfwd/client.go
@@ -77,6 +77,10 @@ type GrpcClientRW struct {
 	protocol string
 	stream   api.GuestService_TunnelClient
 	cancel   context.CancelFunc
+
+	// rxBuf holds bytes received from the stream that did not fit in the
+	// buffer passed to the previous Read call.
+	rxBuf []byte
 }
 
 var _ net.Conn = (*GrpcClientRW)(nil)
@@ -95,12 +99,16 @@ func (g *GrpcClientRW) Write(p []byte) (n int, err error) {
 }
 
 func (g *GrpcClientRW) Read(p []byte) (n int, err error) {
-	in, err := g.stream.Recv()
-	if err != nil {
-		return 0, err
+	if len(g.rxBuf) == 0 {
+		in, err := g.stream.Recv()
+		if err != nil {
+			return 0, err
+		}
+		g.rxBuf = in.Data
 	}
-	copy(p, in.Data)
-	return len(in.Data), nil
+	n = copy(p, g.rxBuf)
+	g.rxBuf = g.rxBuf[n:]
+	return n, nil
 }
 
 func (g *GrpcClientRW) Close() error {

--- a/pkg/portfwd/client_test.go
+++ b/pkg/portfwd/client_test.go
@@ -4,6 +4,7 @@
 package portfwd
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"net"
@@ -44,6 +45,37 @@ func TestDialContextToGRPCTunnelClosesStreamFromTCPProxy(t *testing.T) {
 	case <-time.After(time.Second):
 		assert.Assert(t, false, "timed out waiting for TCP proxy handling to finish")
 	}
+}
+
+// recvOnlyTunnelClient implements only Recv of the bidi stream; the other
+// methods are never called by GrpcClientRW.Read.
+type recvOnlyTunnelClient struct {
+	api.GuestService_TunnelClient
+	msgs []*api.TunnelMessage
+}
+
+func (s *recvOnlyTunnelClient) Recv() (*api.TunnelMessage, error) {
+	if len(s.msgs) == 0 {
+		return nil, io.EOF
+	}
+	msg := s.msgs[0]
+	s.msgs = s.msgs[1:]
+	return msg, nil
+}
+
+func TestGrpcClientRWReadShortBuffer(t *testing.T) {
+	payload := bytes.Repeat([]byte("x"), 100)
+	rw := &GrpcClientRW{stream: &recvOnlyTunnelClient{msgs: []*api.TunnelMessage{{Data: payload}}}}
+
+	var got []byte
+	buf := make([]byte, 10)
+	for len(got) < len(payload) {
+		n, err := rw.Read(buf)
+		assert.NilError(t, err)
+		assert.Assert(t, n <= len(buf), "Read returned %d, larger than the %d-byte buffer", n, len(buf))
+		got = append(got, buf[:n]...)
+	}
+	assert.DeepEqual(t, got, payload)
 }
 
 func newTestGuestAgentClient(t *testing.T, guestService api.GuestServiceServer) *guestagentclient.GuestAgentClient {

--- a/pkg/portfwdserver/server.go
+++ b/pkg/portfwdserver/server.go
@@ -63,6 +63,10 @@ type GRPCServerRW struct {
 	id      string
 	stream  api.GuestService_TunnelServer
 	closeCh chan any
+
+	// rxBuf holds bytes received from the stream that did not fit in the
+	// buffer passed to the previous Read call.
+	rxBuf []byte
 }
 
 var _ net.Conn = (*GRPCServerRW)(nil)
@@ -73,12 +77,16 @@ func (g *GRPCServerRW) Write(p []byte) (n int, err error) {
 }
 
 func (g *GRPCServerRW) Read(p []byte) (n int, err error) {
-	in, err := g.stream.Recv()
-	if err != nil {
-		return 0, err
+	if len(g.rxBuf) == 0 {
+		in, err := g.stream.Recv()
+		if err != nil {
+			return 0, err
+		}
+		g.rxBuf = in.Data
 	}
-	copy(p, in.Data)
-	return len(in.Data), nil
+	n = copy(p, g.rxBuf)
+	g.rxBuf = g.rxBuf[n:]
+	return n, nil
 }
 
 func (g *GRPCServerRW) Close() error {

--- a/pkg/portfwdserver/server_test.go
+++ b/pkg/portfwdserver/server_test.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package portfwdserver
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/guestagent/api"
+)
+
+// recvOnlyTunnelServer implements only Recv of the bidi stream; the other
+// methods are never called by GRPCServerRW.Read.
+type recvOnlyTunnelServer struct {
+	api.GuestService_TunnelServer
+	msgs []*api.TunnelMessage
+}
+
+func (s *recvOnlyTunnelServer) Recv() (*api.TunnelMessage, error) {
+	if len(s.msgs) == 0 {
+		return nil, io.EOF
+	}
+	msg := s.msgs[0]
+	s.msgs = s.msgs[1:]
+	return msg, nil
+}
+
+func TestGRPCServerRWReadShortBuffer(t *testing.T) {
+	payload := bytes.Repeat([]byte("x"), 100)
+	rw := &GRPCServerRW{stream: &recvOnlyTunnelServer{msgs: []*api.TunnelMessage{{Data: payload}}}}
+
+	var got []byte
+	buf := make([]byte, 10)
+	for len(got) < len(payload) {
+		n, err := rw.Read(buf)
+		assert.NilError(t, err)
+		assert.Assert(t, n <= len(buf), "Read returned %d, larger than the %d-byte buffer", n, len(buf))
+		got = append(got, buf[:n]...)
+	}
+	assert.DeepEqual(t, got, payload)
+}


### PR DESCRIPTION
1. GrpcClientRW.Read and GRPCServerRW.Read copy a received message with copy(p, in.Data) but return len(in.Data), so when a message is larger than the read buffer the returned count is larger than len(p).
2. the io.Copy inside tcpproxy then slices buf[0:n] past the buffer and panics, and the leftover bytes are dropped; a UDP datagram up to 65507 bytes forwarded to a guest reaches this since tcpproxy reads with a 32 KiB buffer.
Return the copied count and keep the remainder for the next Read so nothing is lost.