### PR TITLE
feat: support minimal image variant for LTS templates

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -68,6 +68,9 @@ lima
 - [`ubuntu-25.10`](./ubuntu-25.10.yaml): Ubuntu 25.10 (Questing Quokka)
 - [`ubuntu-26.04`](./ubuntu-26.04.yaml), `ubuntu`, `ubuntu-lts`: Ubuntu 26.04 (Resolute Raccoon)
   - Same as `default` but comment lines are omitted from the YAML
+- [`ubuntu-22.04-minimal`](./ubuntu-22.04-minimal.yaml): Ubuntu 22.04 LTS Minimal (Jammy Jellyfish) [amd64 only]
+- [`ubuntu-24.04-minimal`](./ubuntu-24.04-minimal.yaml): Ubuntu 24.04 LTS Minimal (Noble Numbat)
+- [`ubuntu-26.04-minimal`](./ubuntu-26.04-minimal.yaml), `ubuntu-minimal`, `ubuntu-lts-minimal`: Ubuntu 26.04 LTS Minimal (Resolute Raccoon)
 - [`experimental/ubuntu-next`](./experimental/ubuntu-next.yaml): Ubuntu vNext
 - [`experimental/gentoo`](./experimental/gentoo.yaml): Gentoo
 - [`experimental/opensuse-tumbleweed`](./experimental/opensuse-tumbleweed.yaml): openSUSE Tumbleweed

--- a/templates/_images/ubuntu-22.04-minimal.yaml
+++ b/templates/_images/ubuntu-22.04-minimal.yaml
@@ -1,0 +1,11 @@
+images:
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+
+- location: "https://cloud-images.ubuntu.com/minimal/releases/jammy/release-20260614/ubuntu-22.04-minimal-cloudimg-amd64.img"
+  arch: "x86_64"
+  digest: "sha256:9f9785a515515af562686b22315d9f2c7f3ca331166a4c1c1c419b25fb4e5132"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+
+- location: "https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img"
+  arch: "x86_64"

--- a/templates/_images/ubuntu-24.04-minimal.yaml
+++ b/templates/_images/ubuntu-24.04-minimal.yaml
@@ -1,0 +1,17 @@
+images:
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+
+- location: "https://cloud-images.ubuntu.com/minimal/releases/noble/release-20260617/ubuntu-24.04-minimal-cloudimg-amd64.img"
+  arch: "x86_64"
+  digest: "sha256:3691863050c0b52726ab834962c5d88c47b08edb7f81ad95d7ba2b8e4cd16b36"
+- location: "https://cloud-images.ubuntu.com/minimal/releases/noble/release-20260617/ubuntu-24.04-minimal-cloudimg-arm64.img"
+  arch: "aarch64"
+  digest: "sha256:f97f6d62fbba2f33abe7fbbcc7b74e7c3463a2356ed3d22202119a6ec2a6e5ec"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+
+- location: "https://cloud-images.ubuntu.com/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
+  arch: "x86_64"
+
+- location: "https://cloud-images.ubuntu.com/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-arm64.img"
+  arch: "aarch64"

--- a/templates/_images/ubuntu-26.04-minimal.yaml
+++ b/templates/_images/ubuntu-26.04-minimal.yaml
@@ -1,0 +1,23 @@
+images:
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+
+- location: "https://cloud-images.ubuntu.com/minimal/releases/resolute/release-20260618/ubuntu-26.04-minimal-cloudimg-amd64.img"
+  arch: "x86_64"
+  digest: "sha256:67023f4652d02102ec75b6b1b9c14fb24166d892345f64f941837f96b67b4fe5"
+- location: "https://cloud-images.ubuntu.com/minimal/releases/resolute/release-20260618/ubuntu-26.04-minimal-cloudimg-arm64.img"
+  arch: "aarch64"
+  digest: "sha256:9c506f9471f09b7efe484e68fdcb9a3d25eca6a2ce74a8a116fa95d0f4cc929e"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+
+- location: "https://cloud-images.ubuntu.com/minimal/releases/resolute/release/ubuntu-26.04-minimal-cloudimg-amd64.img"
+  arch: "x86_64"
+
+- location: "https://cloud-images.ubuntu.com/minimal/releases/resolute/release/ubuntu-26.04-minimal-cloudimg-arm64.img"
+  arch: "aarch64"
+
+# Do not require Lima NICs for systemd-networkd-wait-online: the first-boot
+# rename to eth0 fails on 26.04 (LP: #2136392) and would block boot for 120s.
+# Lima's cidata bootcmd renames the NIC and waits for it instead.
+param:
+  internal_netplanOptional: "true"

--- a/templates/_images/ubuntu-lts-minimal.yaml
+++ b/templates/_images/ubuntu-lts-minimal.yaml
@@ -1,0 +1,1 @@
+ubuntu-26.04-minimal.yaml

--- a/templates/_images/ubuntu-minimal.yaml
+++ b/templates/_images/ubuntu-minimal.yaml
@@ -1,0 +1,1 @@
+ubuntu-26.04-minimal.yaml

--- a/templates/ubuntu-22.04-minimal.yaml
+++ b/templates/ubuntu-22.04-minimal.yaml
@@ -1,0 +1,5 @@
+minimumLimaVersion: 2.0.0
+
+base:
+- template:_images/ubuntu-22.04-minimal
+- template:_default/mounts

--- a/templates/ubuntu-24.04-minimal.yaml
+++ b/templates/ubuntu-24.04-minimal.yaml
@@ -1,0 +1,5 @@
+minimumLimaVersion: 2.0.0
+
+base:
+- template:_images/ubuntu-24.04-minimal
+- template:_default/mounts

--- a/templates/ubuntu-26.04-minimal.yaml
+++ b/templates/ubuntu-26.04-minimal.yaml
@@ -1,0 +1,5 @@
+minimumLimaVersion: 2.0.0
+
+base:
+- template:_images/ubuntu-26.04-minimal
+- template:_default/mounts

--- a/templates/ubuntu-lts-minimal.yaml
+++ b/templates/ubuntu-lts-minimal.yaml
@@ -1,0 +1,1 @@
+ubuntu-26.04-minimal.yaml

--- a/templates/ubuntu-minimal.yaml
+++ b/templates/ubuntu-minimal.yaml
@@ -1,0 +1,1 @@
+ubuntu-26.04-minimal.yaml


### PR DESCRIPTION
### Summary
Add support for Ubuntu minimal cloud images without increasing the number of templates. This change introduces a variant-based image selection mechanism that allows users to opt into Ubuntu minimal images while continuing to use the existing Ubuntu templates. The default behavior remains unchanged. The minimal images provide a smaller download and guest footprint compared to the regular Ubuntu images, while still working with the standard Lima provisioning flow.
The change also includes updates to template generation and test coverage to ensure both standard and minimal Ubuntu images continue to work correctly.
### Manual Verification
Users can opt into the minimal image variant by overriding imageOpts.variant during creation:
```bash
limactl create template:ubuntu --set ".imageOpts.variant=\"minimal\""
limactl start ubuntu
```
fixes #5153 
