### PR TITLE
refactor: drop sudo for SSH host-services setup

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/26-host-services.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/26-host-services.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux
+
+# Pre-create /run/host-services owned by the guest user.
+# This allows the hostagent to create the SSH agent socket symlink
+# without requiring passwordless sudo.
+mkdir -p /run/host-services
+chmod 700 /run/host-services
+chown -R "${LIMA_CIDATA_USER}" /run/host-services

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -568,16 +568,18 @@ func (a *HostAgent) startHostAgentRoutines(ctx context.Context) error {
 		errs = append(errs, err)
 	}
 	if *a.instConfig.SSH.ForwardAgent {
-		faScript := `#!/bin/bash
+		if *a.instConfig.Plain {
+			logrus.Warn("Running in plain mode. Ignoring ssh.forwardAgent")
+		} else {
+			faScript := `#!/bin/bash
 set -eux -o pipefail
-sudo mkdir -p -m 700 /run/host-services
-sudo ln -sf "${SSH_AUTH_SOCK}" /run/host-services/ssh-auth.sock
-sudo chown -R "${USER}" /run/host-services`
-		faDesc := "linking ssh auth socket to static location /run/host-services/ssh-auth.sock"
-		stdout, stderr, err := ssh.ExecuteScript(a.instSSHAddress, a.sshLocalPort, a.sshConfig, faScript, faDesc)
-		logrus.Debugf("stdout=%#q, stderr=%#q, err=%v", stdout, stderr, err)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("stdout=%#q, stderr=%#q: %w", stdout, stderr, err))
+ln -sf "${SSH_AUTH_SOCK}" /run/host-services/ssh-auth.sock`
+			faDesc := "linking ssh auth socket to static location /run/host-services/ssh-auth.sock"
+			stdout, stderr, err := ssh.ExecuteScript(a.instSSHAddress, a.sshLocalPort, a.sshConfig, faScript, faDesc)
+			logrus.Debugf("stdout=%#q, stderr=%#q, err=%v", stdout, stderr, err)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("stdout=%#q, stderr=%#q: %w", stdout, stderr, err))
+			}
 		}
 	}
 	if *a.instConfig.MountType == limatype.REVSSHFS && !*a.instConfig.Plain {


### PR DESCRIPTION
part of: #5109 
Moves the creation and ownership setup of `/run/host-services` to a root-level cloud-init boot script (`26-host-services.sh`).