### PR TITLE
feat(template): support template-less image variant selection

### DIFF
--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -105,6 +105,8 @@ func RegisterCreate(cmd *cobra.Command, commentPrefix string) {
 		return []string{"x86_64", "aarch64", "riscv64", "armv7l", "s390x", "ppc64le"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
+	flags.String("image-variant", "", commentPrefix+"Image variant")
+
 	flags.String("containerd", "", commentPrefix+"containerd mode (user, system, user+system, none)")
 	_ = cmd.RegisterFlagCompletionFunc("containerd", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return []string{"user", "system", "user+system", "none"}, cobra.ShellCompDirectiveNoFileComp
@@ -374,6 +376,22 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool, params map[string]stri
 			false,
 		},
 		{"ssh-port", d(".ssh.localPort = %s"), false, false},
+		{
+			"image-variant",
+			func(_ *flag.Flag) ([]string, error) {
+				variant, err := flags.GetString("image-variant")
+				if err != nil {
+					return nil, err
+				}
+				if variant == "" {
+					return nil, errors.New("`--image-variant` must not be empty")
+				}
+				expr := fmt.Sprintf(`.images = [.images[] | select(.variant == %q)]`, variant)
+				return []string{expr}, nil
+			},
+			true,
+			false,
+		},
 		{"arch", d(".arch = %q"), true, false},
 		{
 			"containerd",

--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -299,7 +299,7 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 	}
 
 	for i, image := range cfg.Images {
-		if unknown := reflectutil.UnknownNonEmptyFields(image, "File", "Kernel", "Initrd"); len(unknown) > 0 {
+		if unknown := reflectutil.UnknownNonEmptyFields(image, "File", "Kernel", "Initrd", "Variant"); len(unknown) > 0 {
 			logrus.Warnf("vmType %s: ignoring images[%d]: %+v", *cfg.VMType, i, unknown)
 		}
 	}

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -125,7 +125,7 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 			// TODO: real filetype checks
 			tarFileRegex := regexp.MustCompile(`.*tar\.*`)
 			for i, image := range cfg.Images {
-				if unknown := reflectutil.UnknownNonEmptyFields(image, "File"); len(unknown) > 0 {
+				if unknown := reflectutil.UnknownNonEmptyFields(image, "File", "Variant"); len(unknown) > 0 {
 					logrus.Warnf("Ignoring: vmType %s: images[%d]: %+v", *cfg.VMType, i, unknown)
 				}
 				match := tarFileRegex.MatchString(image.Location)

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -93,8 +93,25 @@ func Prepare(ctx context.Context, inst *limatype.Instance, guestAgent string) (*
 	initrd := filepath.Join(inst.Dir, filenames.Initrd)
 	if !osutil.FileExists(imagePath) && !osutil.FileExists(disk) {
 		var ensuredImage bool
+		var targetVariant string
+		var targetVariantSet bool
+		for _, img := range inst.Config.Images {
+			if img.Arch == *inst.Config.Arch {
+				targetVariant = img.Variant
+				targetVariantSet = true
+				break
+			}
+		}
+
+		if len(inst.Config.Images) == 0 {
+			return nil, errors.New("no images are configured (did you set --image-variant to a value not present in the template?)")
+		}
 		errs := make([]error, len(inst.Config.Images))
 		for i, f := range inst.Config.Images {
+			if targetVariantSet && f.Variant != targetVariant {
+				errs[i] = fmt.Errorf("%w: variant mismatch (expected %q, got %q)", fileutils.ErrSkipped, targetVariant, f.Variant)
+				continue
+			}
 			if _, err := fileutils.DownloadFile(ctx, imagePath, f.File, true, "the image", *inst.Config.Arch); err != nil {
 				errs[i] = err
 				continue

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -150,9 +150,10 @@ type Kernel struct {
 }
 
 type Image struct {
-	File   `yaml:",inline"`
-	Kernel *Kernel `yaml:"kernel,omitempty" json:"kernel,omitempty"`
-	Initrd *File   `yaml:"initrd,omitempty" json:"initrd,omitempty"`
+	File    `yaml:",inline"`
+	Kernel  *Kernel `yaml:"kernel,omitempty" json:"kernel,omitempty"`
+	Initrd  *File   `yaml:"initrd,omitempty" json:"initrd,omitempty"`
+	Variant string  `yaml:"variant,omitempty" json:"variant,omitempty"`
 }
 
 type Disk struct {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -943,3 +943,42 @@ func TestContainerdUserExplicitOverride(t *testing.T) {
 	assert.Equal(t, *y.Containerd.User, true,
 		"explicit Containerd.User=true must be preserved on non-Linux guests")
 }
+
+func TestUnmarshalImageVariant(t *testing.T) {
+	yamlBytes := []byte(`
+images:
+- location: "server-img.img"
+  variant: "server"
+- location: "minimal-img.img"
+  variant: "minimal"
+`)
+	var y limatype.LimaYAML
+	err := Unmarshal(yamlBytes, &y, "test")
+	assert.NilError(t, err)
+	assert.Equal(t, len(y.Images), 2)
+	assert.Equal(t, y.Images[0].Variant, "server")
+	assert.Equal(t, y.Images[1].Variant, "minimal")
+}
+
+func TestDefaultSelectedImageIsStandard(t *testing.T) {
+	// Verify that the default order of the images in the standard template
+	// places standard/server before minimal so standard users don't regress.
+	data, err := os.ReadFile("../../templates/_images/ubuntu-24.04.yaml")
+	assert.NilError(t, err)
+	var y limatype.LimaYAML
+	err = Unmarshal(data, &y, "ubuntu-24.04.yaml")
+	assert.NilError(t, err)
+
+	var foundServer, foundMinimal bool
+	for _, img := range y.Images {
+		switch img.Variant {
+		case "server":
+			foundServer = true
+			assert.Assert(t, !foundMinimal, "standard/server images must be listed before minimal images to prevent fallback regressions")
+		case "minimal":
+			foundMinimal = true
+		}
+	}
+	assert.Assert(t, foundServer, "should have found standard/server images")
+	assert.Assert(t, foundMinimal, "should have found minimal images")
+}

--- a/templates/_images/debian-12.yaml
+++ b/templates/_images/debian-12.yaml
@@ -4,22 +4,56 @@ images:
 - location: "https://cloud.debian.org/images/cloud/bookworm/20260615-2510/debian-12-genericcloud-amd64-20260615-2510.qcow2"
   arch: "x86_64"
   digest: "sha512:800df5e7a08fb4e1f8e955c3cd866e6b2303b85d60d3eef1fc3c8600b0c3dc34a8fc7c47ab46942bd8ae5dedcba160ee58208ed4885bd6ac98b51cac21b5fcb9"
+  variant: "genericcloud"
 - location: "https://cloud.debian.org/images/cloud/bookworm/20260615-2510/debian-12-genericcloud-arm64-20260615-2510.qcow2"
   arch: "aarch64"
   digest: "sha512:0e59d55897ada3307ac68fd4145d76a6897d27cfde1722ca5d04f6a83f20c2ed92fc708c32d999fbbf988d970fc4089184caad6053ec09ab54ee7b603659c7cc"
+  variant: "genericcloud"
 - location: "https://cloud.debian.org/images/cloud/bookworm/20260615-2510/debian-12-generic-ppc64el-20260615-2510.qcow2"
   arch: "ppc64le"
   digest: "sha512:bc0cee83ea982f55f1f87045cb7c2a6d3b8d16d146b985dd55d612a0317d25e512c62ca8ae4045784d689f608208d8e148f147a3bc1f8f8e28ca998c3453499d"
+  variant: "generic"
+
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 
 - location: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2
   arch: x86_64
+  variant: "genericcloud"
 
 - location: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-arm64.qcow2
   arch: aarch64
+  variant: "genericcloud"
 
 - location: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-generic-ppc64el.qcow2
   arch: ppc64le
+  variant: "generic"
+
+# Try to use release-yyyyMMdd nocloud image if available.
+- location: "https://cloud.debian.org/images/cloud/bookworm/20260615-2510/debian-12-nocloud-amd64-20260615-2510.qcow2"
+  arch: "x86_64"
+  digest: "sha512:ce54e8970d8f7c1448a52767417cc7b7a6bb87dc2a9b60ec954a214dad9aa7f2ff1e1373aba1321a1df6e0cb4f9ec5cbfc619ebb2d7ceab620bc7839e2cab938"
+  variant: "nocloud"
+- location: "https://cloud.debian.org/images/cloud/bookworm/20260615-2510/debian-12-nocloud-arm64-20260615-2510.qcow2"
+  arch: "aarch64"
+  digest: "sha512:6f0772ab93a023e0eb046ce0af11800161677ed8f23d00087de653a529fcc71d88215dd3bef75de6348a2b0da1c54e11156d4dd141d26bb55c487fda4718977e"
+  variant: "nocloud"
+- location: "https://cloud.debian.org/images/cloud/bookworm/20260615-2510/debian-12-nocloud-ppc64el-20260615-2510.qcow2"
+  arch: "ppc64le"
+  digest: "sha512:7cf4ca5b92f22084551e8d2211256c2b1cba8496a6c172a87666b3fb7bcb8939d7802d29db851d24dc202d1fd1b2b73dcf3c9c1a02eef40e661c7f3d307d5e53"
+  variant: "nocloud"
+
+# Fallback nocloud images
+- location: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-nocloud-amd64.qcow2
+  arch: x86_64
+  variant: "nocloud"
+
+- location: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-nocloud-arm64.qcow2
+  arch: aarch64
+  variant: "nocloud"
+
+- location: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-nocloud-ppc64el.qcow2
+  arch: ppc64le
+  variant: "nocloud"
 
 mountTypesUnsupported: [9p]

--- a/templates/_images/debian-13.yaml
+++ b/templates/_images/debian-13.yaml
@@ -4,28 +4,63 @@ images:
 - location: "https://cloud.debian.org/images/cloud/trixie/20260623-2518/debian-13-genericcloud-amd64-20260623-2518.qcow2"
   arch: "x86_64"
   digest: "sha512:df2bd468b08566c0409a7982d6489d73499ad22f9a28646b538c2f21d08f15040a5e4737952ca209e9ad4488cd00793191791be9f135dee93082c86fcca3300c"
+  variant: "genericcloud"
 - location: "https://cloud.debian.org/images/cloud/trixie/20260623-2518/debian-13-genericcloud-arm64-20260623-2518.qcow2"
   arch: "aarch64"
   digest: "sha512:fd35e5ec7bd31bc3821ba43135574ac42bdf0ded4dc6e3c8a86995e00b4206db60f2a7782bb9d94188f2b302df782d3afb5b13bdeaba25efe8c39bc51cec83a8"
+  variant: "genericcloud"
 - location: "https://cloud.debian.org/images/cloud/trixie/20260623-2518/debian-13-generic-ppc64el-20260623-2518.qcow2"
   arch: "ppc64le"
   digest: "sha512:b07f6a3a847275d8ae29dd18607cfdc4c280cd1edfd70ac1c978a0194ba7299efb507357548c85f72d82b985a5ab83e197236926435b6e2b7a98028fb90fd520"
+  variant: "generic"
 - location: "https://cloud.debian.org/images/cloud/trixie/20260623-2518/debian-13-generic-riscv64-20260623-2518.qcow2"
   arch: "riscv64"
   digest: "sha512:eb174e672082ca548aa8c7f6ab8f6fedeb6ab47df26f3239f09d9f198b7ac10971ca4d861277d707559748945f5fde3b3fc58e3cad4f38fac789ac79a1c29e12"
+  variant: "generic"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 
 - location: https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-genericcloud-amd64-daily.qcow2
   arch: x86_64
+  variant: "genericcloud"
 
 - location: https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-genericcloud-arm64-daily.qcow2
   arch: aarch64
+  variant: "genericcloud"
 
 - location: https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-ppc64el-daily.qcow2
   arch: ppc64le
+  variant: "generic"
 
 - location: https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-riscv64-daily.qcow2
   arch: riscv64
+  variant: "generic"
+
+# Try to use release-yyyyMMdd nocloud image if available.
+- location: "https://cloud.debian.org/images/cloud/trixie/20260623-2518/debian-13-nocloud-amd64-20260623-2518.qcow2"
+  arch: "x86_64"
+  digest: "sha512:247a02c7cfa029fc0cfe17916dca088fec8edcd7f5f60920f8b020150bb372237047374b965dbb39542d4d76ef0183a1ff10dbfe5cc485798d663b2d6c56f78b"
+  variant: "nocloud"
+- location: "https://cloud.debian.org/images/cloud/trixie/20260623-2518/debian-13-nocloud-arm64-20260623-2518.qcow2"
+  arch: "aarch64"
+  digest: "sha512:f808dce6cc97c99b3f0a51eae437836f8b3c7d09f98f289042e0b39128eb398147126283ce1582d5fb78160a2a264e243fd0ea2022c3cdd2cb3fdade0db4d4c7"
+  variant: "nocloud"
+- location: "https://cloud.debian.org/images/cloud/trixie/20260623-2518/debian-13-nocloud-ppc64el-20260623-2518.qcow2"
+  arch: "ppc64le"
+  digest: "sha512:c8e354ca92f8b1ccda6dc26e1595e4037ba5dbdac1f6eb0edd3c2f9815e1bb1c8710204ff13d1c68857a1d08d0af479451c205a85a2676914d779d0060607168"
+  variant: "nocloud"
+
+# Fallback nocloud images
+- location: https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-nocloud-amd64-daily.qcow2
+  arch: x86_64
+  variant: "nocloud"
+
+- location: https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-nocloud-arm64-daily.qcow2
+  arch: aarch64
+  variant: "nocloud"
+
+- location: https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-nocloud-ppc64el-daily.qcow2
+  arch: ppc64le
+  variant: "nocloud"
 
 mountTypesUnsupported: [9p]

--- a/templates/_images/ubuntu-22.04.yaml
+++ b/templates/_images/ubuntu-22.04.yaml
@@ -4,38 +4,61 @@ images:
 - location: "https://cloud-images.ubuntu.com/releases/jammy/release-20260627/ubuntu-22.04-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:070de108b25df4c9eacc4a297c6afc583bdd58cabf159e61d4152bc6541a6b54"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/jammy/release-20260627/ubuntu-22.04-server-cloudimg-arm64.img"
   arch: "aarch64"
   digest: "sha256:93f72138e1c6a868900236ba6d792b4d70e035b47e9f32d645972db06ba527e8"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/jammy/release-20260627/ubuntu-22.04-server-cloudimg-riscv64.img"
   arch: "riscv64"
   digest: "sha256:f160e252d9d6ef132eb9e27ebb9951874180807d435758f26e2f018000846bac"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/jammy/release-20260627/ubuntu-22.04-server-cloudimg-armhf.img"
   arch: "armv7l"
   digest: "sha256:c4f89150bffdd5cd21addf19327a73ce934207bb7c0c66236cba1c0e6ae502ab"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/jammy/release-20260627/ubuntu-22.04-server-cloudimg-s390x.img"
   arch: "s390x"
   digest: "sha256:af5a8fd9c85c62ae9b32854ce4d7c1d2498ac4ccc36c9a953fa5137c665eaae9"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/jammy/release-20260627/ubuntu-22.04-server-cloudimg-ppc64el.img"
   arch: "ppc64le"
   digest: "sha256:509404eb4a0164412b5711e6ca1ae91b1307b44e37d63571f724a0facfa37cb2"
+  variant: "server"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 
 - location: https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-amd64.img
   arch: x86_64
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-arm64.img
   arch: aarch64
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-riscv64.img
   arch: riscv64
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-armhf.img
   arch: armv7l
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-s390x.img
   arch: s390x
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-ppc64el.img
   arch: ppc64le
+  variant: "server"
+
+# Try to use release-yyyyMMdd minimal image if available.
+- location: "https://cloud-images.ubuntu.com/minimal/releases/jammy/release-20260614/ubuntu-22.04-minimal-cloudimg-amd64.img"
+  arch: "x86_64"
+  digest: "sha256:9f9785a515515af562686b22315d9f2c7f3ca331166a4c1c1c419b25fb4e5132"
+  variant: "minimal"
+
+# Fallback minimal images
+- location: "https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img"
+  arch: "x86_64"
+  variant: "minimal"

--- a/templates/_images/ubuntu-24.04.yaml
+++ b/templates/_images/ubuntu-24.04.yaml
@@ -4,38 +4,69 @@ images:
 - location: "https://cloud-images.ubuntu.com/releases/noble/release-20260615/ubuntu-24.04-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:5fa5b05e5ec239858c4531485d6023b0896448c2df7c63b34f8dae6ea6051a44"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/noble/release-20260615/ubuntu-24.04-server-cloudimg-arm64.img"
   arch: "aarch64"
   digest: "sha256:cafa1a965b591b7c4184b484ffd8e625981a79d48f9b4ae8a4adf7b4c5ade927"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/noble/release-20260615/ubuntu-24.04-server-cloudimg-riscv64.img"
   arch: "riscv64"
   digest: "sha256:05afa75b6b2fd6e3038bda3053e72db3cd89e4c97653b0ab2ce237740befcd50"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/noble/release-20260615/ubuntu-24.04-server-cloudimg-armhf.img"
   arch: "armv7l"
   digest: "sha256:42276fdd60414e141c9969b9ac7eda3c632a2ac7de4dd139afbe36a89d6551c4"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/noble/release-20260615/ubuntu-24.04-server-cloudimg-s390x.img"
   arch: "s390x"
   digest: "sha256:ec5e269e4ed9ab90ad813c1a907e12c92dd138c9e421a0874459dc49185b34aa"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/noble/release-20260615/ubuntu-24.04-server-cloudimg-ppc64el.img"
   arch: "ppc64le"
   digest: "sha256:e7364b45455846242d9ef571c1a015ac25e92f2b0e0e9a06b101b449379ecf08"
+  variant: "server"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 
 - location: https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img
   arch: x86_64
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-arm64.img
   arch: aarch64
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-riscv64.img
   arch: riscv64
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-armhf.img
   arch: armv7l
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-s390x.img
   arch: s390x
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-ppc64el.img
   arch: ppc64le
+  variant: "server"
+
+# Try to use release-yyyyMMdd minimal image if available.
+- location: "https://cloud-images.ubuntu.com/minimal/releases/noble/release-20260617/ubuntu-24.04-minimal-cloudimg-amd64.img"
+  arch: "x86_64"
+  digest: "sha256:3691863050c0b52726ab834962c5d88c47b08edb7f81ad95d7ba2b8e4cd16b36"
+  variant: "minimal"
+- location: "https://cloud-images.ubuntu.com/minimal/releases/noble/release-20260617/ubuntu-24.04-minimal-cloudimg-arm64.img"
+  arch: "aarch64"
+  digest: "sha256:f97f6d62fbba2f33abe7fbbcc7b74e7c3463a2356ed3d22202119a6ec2a6e5ec"
+  variant: "minimal"
+
+# Fallback minimal images
+- location: "https://cloud-images.ubuntu.com/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
+  arch: "x86_64"
+  variant: "minimal"
+
+- location: "https://cloud-images.ubuntu.com/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-arm64.img"
+  arch: "aarch64"
+  variant: "minimal"

--- a/templates/_images/ubuntu-26.04.yaml
+++ b/templates/_images/ubuntu-26.04.yaml
@@ -4,41 +4,72 @@ images:
 - location: "https://cloud-images.ubuntu.com/releases/resolute/release-20260627/ubuntu-26.04-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:3ee4f67f322abb2d1d1f0fffc957f7411404ad6635dd35b026c8ff05ac6e534c"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/resolute/release-20260627/ubuntu-26.04-server-cloudimg-arm64.img"
   arch: "aarch64"
   digest: "sha256:3d8db37fa9a8a0c8676dfc0ee3eb41fd0049d66cb055a792bddc8f4123443ae1"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/resolute/release-20260627/ubuntu-26.04-server-cloudimg-riscv64.img"
   arch: "riscv64"
   digest: "sha256:117843962e8228a2bbd7e6ea76d22156064280f03736a21692834c2bb8572dd5"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/resolute/release-20260627/ubuntu-26.04-server-cloudimg-armhf.img"
   arch: "armv7l"
   digest: "sha256:104eea355a9547d06131fd6c59e544110b01d4f3a7fb05068e3aafbd325e37bf"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/resolute/release-20260627/ubuntu-26.04-server-cloudimg-s390x.img"
   arch: "s390x"
   digest: "sha256:3b66fd7adf2084a25643da6dfb7f063d2409a43ba36408bfdaf5255e3cc25744"
+  variant: "server"
 - location: "https://cloud-images.ubuntu.com/releases/resolute/release-20260627/ubuntu-26.04-server-cloudimg-ppc64el.img"
   arch: "ppc64le"
   digest: "sha256:f2eaf924c5cc2a45602446eceafbd50fb6f04be0c183f0542d613d5d938535e3"
+  variant: "server"
 # Fallback to the latest release image.
 # Hint: run `limactl prune` to invalidate the cache
 
 - location: https://cloud-images.ubuntu.com/releases/resolute/release/ubuntu-26.04-server-cloudimg-amd64.img
   arch: x86_64
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/resolute/release/ubuntu-26.04-server-cloudimg-arm64.img
   arch: aarch64
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/resolute/release/ubuntu-26.04-server-cloudimg-riscv64.img
   arch: riscv64
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/resolute/release/ubuntu-26.04-server-cloudimg-armhf.img
   arch: armv7l
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/resolute/release/ubuntu-26.04-server-cloudimg-s390x.img
   arch: s390x
+  variant: "server"
 
 - location: https://cloud-images.ubuntu.com/releases/resolute/release/ubuntu-26.04-server-cloudimg-ppc64el.img
   arch: ppc64le
+  variant: "server"
+
+# Try to use release-yyyyMMdd minimal image if available.
+- location: "https://cloud-images.ubuntu.com/minimal/releases/resolute/release-20260618/ubuntu-26.04-minimal-cloudimg-amd64.img"
+  arch: "x86_64"
+  digest: "sha256:67023f4652d02102ec75b6b1b9c14fb24166d892345f64f941837f96b67b4fe5"
+  variant: "minimal"
+- location: "https://cloud-images.ubuntu.com/minimal/releases/resolute/release-20260618/ubuntu-26.04-minimal-cloudimg-arm64.img"
+  arch: "aarch64"
+  digest: "sha256:9c506f9471f09b7efe484e68fdcb9a3d25eca6a2ce74a8a116fa95d0f4cc929e"
+  variant: "minimal"
+
+# Fallback minimal images
+- location: "https://cloud-images.ubuntu.com/minimal/releases/resolute/release/ubuntu-26.04-minimal-cloudimg-amd64.img"
+  arch: "x86_64"
+  variant: "minimal"
+
+- location: "https://cloud-images.ubuntu.com/minimal/releases/resolute/release/ubuntu-26.04-minimal-cloudimg-arm64.img"
+  arch: "aarch64"
+  variant: "minimal"
 
 # # NOTE: Intel Mac with macOS prior to 15.5 requires setting vmType to qemu
 # # https://github.com/lima-vm/lima/issues/3334

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -17,7 +17,10 @@ arch: null
 
 
 # OpenStack-compatible disk image.
-# Each image has a `location` URL for the disk image, an `arch` setting, and an optional `digest`.
+# Each image has a `location` URL for the disk image, an `arch` setting, an optional `digest`,
+# and an optional `variant` (e.g. "server", "minimal", "genericcloud").
+# If multiple image variants are defined for the target architecture, the first one is used by default,
+# but they can be filtered using the `--image-variant` flag when running `limactl start` or `limactl create`.
 # To specify a custom kernel and initial RAM disk, nest `kernel` and `initrd` under an image entry:
 #   - location: "https://example.com/image.qcow2"
 #     # kernel specifies a custom kernel to boot.


### PR DESCRIPTION
### Description

This PR adds support for image variants (for example, Ubuntu Minimal or Debian NoCloud) without introducing additional template files such as `ubuntu-minimal.yaml` or `debian-nocloud.yaml`.

A new `variant` field is added to image entries, allowing users to select specific image variants dynamically with the existing `--set` flag.

To preserve the current behavior, standard/server images are listed before minimal variants, ensuring that default template usage continues to select standard images.

### How to use

Start Ubuntu 24.04 Minimal:

```bash
llimactl start --image-variant=minimal template:ubuntu-24.04

```

Start Debian 12 NoCloud:

```bash
limactl start --image-variant=nocloud template:debian-12
```

### Tests

Added `TestDefaultSelectedImageIsStandard` to verify that standard images remain the default selection by ensuring they are ordered before minimal variants.

Fixes #5153 
Fixes #5158 