### PR TITLE
Add separate ADOPTERS.md for the CNCF project.yaml

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,8 @@
+# Adopters
+
+- [Rancher Desktop](https://rancherdesktop.io/): Kubernetes and container management to the desktop
+- [Colima](https://github.com/abiosoft/colima): Docker (and Kubernetes) on macOS with minimal setup
+- [Finch](https://github.com/runfinch/finch): Finch is a command line client for local container development
+- [Podman Desktop](https://podman-desktop.io/): Podman Desktop GUI has a plug-in for Lima virtual machines
+
+For a full list, check out: <https://github.com/lima-vm/lima/discussions/2390>


### PR DESCRIPTION
Same as on the project web site: https://lima-vm.io/

Copied from the project README.md, for text and links.