### PR TITLE
Support Windows 11 x86-64

### DIFF
--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -150,6 +150,7 @@ func templateArgs(ctx context.Context, bootScripts bool, instDir, name string, i
 		NoCloudInit:    noCloudInit,
 		Param:          instConfig.Param,
 		LegacyBIOS:     *instConfig.Firmware.LegacyBIOS,
+		TPM:            *instConfig.TPM,
 	}
 
 	firstUsernetIndex := limayaml.FirstUsernetIndex(instConfig)
@@ -592,6 +593,11 @@ func GenerateWindowsISO(ctx context.Context, instDir, name string, instConfig *l
 	// The generated password is used only for an initial setup.
 	// After that, the password is overwritten.
 	if err := args.generateWindowsInitialPassword(); err != nil {
+		return "", err
+	}
+
+	// Check OS version (Windows 11 or server 2025). This differentiates autounattend.xml.
+	if err := args.checkWindowsVersion(instDir); err != nil {
 		return "", err
 	}
 

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -10,12 +10,15 @@ import (
 	"fmt"
 	"io/fs"
 	"path"
+	"path/filepath"
+	"strings"
 
 	"github.com/sethvargo/go-password/password"
 
 	"github.com/lima-vm/lima/v2/pkg/identifiers"
 	"github.com/lima-vm/lima/v2/pkg/iso9660util"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/textutil"
 )
 
@@ -28,6 +31,10 @@ const templateFSRoot = "cidata.TEMPLATE.d"
 var windowsTemplateFS embed.FS
 
 const windowsTemplateFSRoot = "wincidata.TEMPLATE.d"
+
+// This is for checking whether Windows OS is 11 or server 2025.
+// For example, Windows 11 x86-64's label is CCCOMA_X64FRE_EN-US_DV9.
+const windowsClientISOLabelPrefix = "CCCOMA_"
 
 type CACerts struct {
 	RemoveDefaults *bool
@@ -126,6 +133,8 @@ type TemplateArgs struct {
 	NoCloudInit                     bool
 	WindowsInitialPassword          string
 	LegacyBIOS                      bool
+	IsWindowsServer                 bool
+	TPM                             bool
 }
 
 func (t *TemplateArgs) generateWindowsInitialPassword() error {
@@ -137,6 +146,19 @@ func (t *TemplateArgs) generateWindowsInitialPassword() error {
 	}
 
 	t.WindowsInitialPassword = pw
+	return nil
+}
+
+// checkWindowsVersion checks if a guest VM is Windows 11 (true) or Windows server 2025 (false).
+func (t *TemplateArgs) checkWindowsVersion(instDir string) error {
+	imagePath := filepath.Join(instDir, filenames.ISO)
+	label, err := iso9660util.Label(imagePath)
+	if err != nil {
+		return fmt.Errorf("failed to get ISO label: %w", err)
+	}
+
+	t.IsWindowsServer = !strings.HasPrefix(label, windowsClientISOLabelPrefix)
+
 	return nil
 }
 

--- a/pkg/cidata/template_test.go
+++ b/pkg/cidata/template_test.go
@@ -4,6 +4,7 @@
 package cidata
 
 import (
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -211,43 +212,109 @@ func TestTemplateNICRename(t *testing.T) {
 }
 
 func TestExecuteTemplateWindowsISO(t *testing.T) {
-	args := &TemplateArgs{
-		Name:                   "windows",
-		User:                   "windows-user",
-		WindowsInitialPassword: "dummy-password",
+	testCases := []struct {
+		name                        string
+		args                        *TemplateArgs
+		expectedAutounattendStrings []string
+		expectedFirstLogonStrings   []string
+	}{
+		{
+			name: "windows server 2025",
+			args: &TemplateArgs{
+				Name:                   "windows",
+				User:                   "windows-user",
+				WindowsInitialPassword: "dummy-password",
+				TPM:                    true,
+				IsWindowsServer:        true,
+			},
+			expectedAutounattendStrings: []string{
+				`<Path>E:\viostor\2k25\amd64</Path>`,
+				`<Username>windows-user</Username>`,
+				`<Value>dummy-password</Value>`,
+				`<Type>EFI</Type>`,
+			},
+			expectedFirstLogonStrings: []string{
+				`$logfile = "C:\Users\windows-user\lima-setup.log"`,
+			},
+		},
+		{
+			name: "windows 11",
+			args: &TemplateArgs{
+				Name:                   "windows",
+				User:                   "windows-user",
+				WindowsInitialPassword: "dummy-password",
+				TPM:                    true,
+			},
+			expectedAutounattendStrings: []string{
+				`<Path>E:\viostor\w11\amd64</Path>`,
+				`<Username>windows-user</Username>`,
+				`<Value>dummy-password</Value>`,
+				`<Type>EFI</Type>`,
+			},
+			expectedFirstLogonStrings: []string{
+				`$logfile = "C:\Users\windows-user\lima-setup.log"`,
+			},
+		},
+		{
+			name: "legacyBIOS",
+			args: &TemplateArgs{
+				Name:                   "windows",
+				User:                   "windows-user",
+				WindowsInitialPassword: "dummy-password",
+				LegacyBIOS:             true,
+				TPM:                    true,
+				IsWindowsServer:        true,
+			},
+			expectedAutounattendStrings: []string{
+				`<Path>E:\viostor\2k25\amd64</Path>`,
+				`<Username>windows-user</Username>`,
+				`<Value>dummy-password</Value>`,
+				`<Label>BIOS</Label>`,
+			},
+			expectedFirstLogonStrings: []string{
+				`$logfile = "C:\Users\windows-user\lima-setup.log"`,
+			},
+		},
+		{
+			name: "disable TPM on Windows 11",
+			args: &TemplateArgs{
+				Name:                   "windows",
+				User:                   "windows-user",
+				WindowsInitialPassword: "dummy-password",
+				TPM:                    false,
+			},
+			expectedAutounattendStrings: []string{
+				`<Path>E:\viostor\w11\amd64</Path>`,
+				`<Username>windows-user</Username>`,
+				`<Value>dummy-password</Value>`,
+				`<Type>EFI</Type>`,
+				`BypassTPMCheck`,
+			},
+			expectedFirstLogonStrings: []string{
+				`$logfile = "C:\Users\windows-user\lima-setup.log"`,
+			},
+		},
 	}
 
-	layout, err := ExecuteTemplateWindowsISO(args)
-	assert.NilError(t, err)
-	for _, f := range layout {
-		b, err := io.ReadAll(f.Reader)
-		assert.NilError(t, err)
-		switch f.Path {
-		case "autounattend.xml":
-			t.Log(string(b))
-			assert.Assert(t, strings.Contains(
-				string(b),
-				`<Username>windows-user</Username>`,
-			))
-			assert.Assert(t, strings.Contains(
-				string(b),
-				`<Value>dummy-password</Value>`,
-			))
-			// It confirms the file has UEFI setting.
-			assert.Assert(t, strings.Contains(
-				string(b),
-				`<Type>EFI</Type>`,
-			))
-			// It confirms the file doesn't have BIOS setting.
-			assert.Assert(t, !strings.Contains(
-				string(b),
-				`<Label>BIOS</Label>`,
-			))
-		case "first_logon.ps1":
-			assert.Assert(t, strings.Contains(
-				string(b),
-				`$logfile = "C:\Users\windows-user\lima-setup.log"`,
-			))
-		}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			layout, err := ExecuteTemplateWindowsISO(tt.args)
+			assert.NilError(t, err)
+			for _, f := range layout {
+				b, err := io.ReadAll(f.Reader)
+				s := string(b)
+				assert.NilError(t, err)
+				switch f.Path {
+				case "autounattend.xml":
+					for _, expected := range tt.expectedAutounattendStrings {
+						assert.Assert(t, strings.Contains(s, expected), fmt.Sprintf("expected: %s", expected))
+					}
+				case "first_logon.ps1":
+					for _, expected := range tt.expectedFirstLogonStrings {
+						assert.Assert(t, strings.Contains(s, expected), fmt.Sprintf("expected: %s", expected))
+					}
+				}
+			}
+		})
 	}
 }

--- a/pkg/cidata/wincidata.TEMPLATE.d/autounattend.xml
+++ b/pkg/cidata/wincidata.TEMPLATE.d/autounattend.xml
@@ -6,22 +6,22 @@
         xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
         <DriverPaths>
             <PathAndCredentials wcm:action="add" wcm:keyValue="1">
-                <Path>E:\viostor\2k25\amd64</Path>
+                <Path>E:\viostor\{{ if .IsWindowsServer }}2k25{{ else }}w11{{ end }}\amd64</Path>
             </PathAndCredentials>
             <PathAndCredentials wcm:action="add" wcm:keyValue="2">
-                <Path>E:\vioinput\2k25\amd64</Path>
+                <Path>E:\vioinput\{{ if .IsWindowsServer }}2k25{{ else }}w11{{ end }}\amd64</Path>
             </PathAndCredentials>
             <PathAndCredentials wcm:action="add" wcm:keyValue="3">
-                <Path>E:\NetKVM\2k25\amd64</Path>
+                <Path>E:\NetKVM\{{ if .IsWindowsServer }}2k25{{ else }}w11{{ end }}\amd64</Path>
             </PathAndCredentials>
             <PathAndCredentials wcm:action="add" wcm:keyValue="4">
-                <Path>E:\viofs\2k25\amd64</Path>
+                <Path>E:\viofs\{{ if .IsWindowsServer }}2k25{{ else }}w11{{ end }}\amd64</Path>
             </PathAndCredentials>
             <PathAndCredentials wcm:action="add" wcm:keyValue="5">
-                <Path>E:\Balloon\2k25\amd64</Path>
+                <Path>E:\Balloon\{{ if .IsWindowsServer }}2k25{{ else }}w11{{ end }}\amd64</Path>
             </PathAndCredentials>
             <PathAndCredentials wcm:action="add" wcm:keyValue="6">
-                <Path>E:\viorng\2k25\amd64</Path>
+                <Path>E:\viorng\{{ if .IsWindowsServer }}2k25{{ else }}w11{{ end }}\amd64</Path>
             </PathAndCredentials>
         </DriverPaths>
     </component>
@@ -33,12 +33,46 @@
       <UserLocale>en-US</UserLocale>
     </component>
     <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      {{ if not .IsWindowsServer }}
+      <!-- Windows 11 has hardware requirements. (ref: https://www.microsoft.com/en-gb/windows/windows-11-specifications). -->
+      <!-- For flexibility, we bypass those requirements. -->
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>3</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassCPUCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>4</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassStorageCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        {{ if not .TPM }}
+        <!-- Those requirements are only bypassed when TPM is disabled. -->
+        <!-- By default, TPM is enabled for Windows 11. -->
+        <RunSynchronousCommand wcm:action="add">
+          <Order>5</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\LabConfig" /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>6</Order>
+          <Path>reg add "HKLM\SYSTEM\Setup\MoSetup" /v AllowUpgradesWithUnsupportedTPMOrCPU /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        {{ end }}
+      </RunSynchronous>
+      {{ end }}
       <ImageInstall>
         <OSImage>
           <InstallFrom>
             <MetaData wcm:action="add">
               <Key>/IMAGE/INDEX</Key>
-              <Value>1</Value>
+              <Value>{{ if .IsWindowsServer }}1{{ else }}6{{ end }}</Value>
             </MetaData>
           </InstallFrom>
           <InstallTo>
@@ -132,6 +166,12 @@
       <UserData>
         <AcceptEula>true</AcceptEula>
         <FullName />
+        {{ if not .IsWindowsServer }}
+        <!-- This field necessary for skipping product key step on Win-11 -->
+        <ProductKey>
+          <WillShowUI>Never</WillShowUI>
+        </ProductKey>
+        {{ end }}
         <Organization />
       </UserData>
     </component>

--- a/pkg/iso9660util/iso9660util.go
+++ b/pkg/iso9660util/iso9660util.go
@@ -109,3 +109,24 @@ func IsISO9660(imagePath string) (bool, error) {
 	_, err = iso9660.Read(backendFile, fileInfo.Size(), 0, 0)
 	return err == nil, nil
 }
+
+func Label(imagePath string) (string, error) {
+	imageFile, err := os.Open(imagePath)
+	if err != nil {
+		return "", err
+	}
+	defer imageFile.Close()
+	backendFile := file.New(imageFile, true)
+
+	fileInfo, err := imageFile.Stat()
+	if err != nil {
+		return "", err
+	}
+
+	f, err := iso9660.Read(backendFile, fileInfo.Size(), 0, 0)
+	if err != nil {
+		return "", err
+	}
+
+	return f.Label(), nil
+}

--- a/templates/windows-11.yaml
+++ b/templates/windows-11.yaml
@@ -1,0 +1,34 @@
+# Windows guest is currently experimental. It only runs on QEMU, and it requires plain: true.
+os: "Windows"
+vmType: "qemu"
+arch: "x86_64"
+
+images:
+# Currently there is no way to download Windows 11 ISO automatically.
+# You have to download the ISO from https://www.microsoft.com/en-us/software-download/windows11 and set the local path here.
+# Please download `English (United States)` version. Otherwise VM installation is stopped in the middle.
+- location: "~/Downloads/Win11_25H2_English_x64_v2.iso"
+  arch: "x86_64"
+
+# Windows 11 guest uses TPM emulation by default.
+# You can turn off TPM (in that case, lima bypasses Windows 11's initial TPM check).
+tpm: true
+
+osOpts:
+  Windows:
+    # Virtio-win ISO contains virtio drivers for windows. It is necessary for lots of QEMU options which use virtio (virtio interface for mounting qcow2 disk, virtio-net, virtio-serial, virtio-rng, virtio-keyboard, and virtio-mouse)
+    # In addition, the driver for virtio-fs will be used in the future.
+    # Virtio-win ISO supports both x86_64 and aarch64 (inside the ISO it contains drivers for both archs).
+    virtioWin:
+    - location: https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-0.1.271-1/virtio-win-0.1.271.iso
+      arch: "x86_64"
+      digest: "sha256:bbe6166ad86a490caefad438fef8aa494926cb0a1b37fa1212925cfd81656429"
+    - location: https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-0.1.271-1/virtio-win-0.1.271.iso
+      arch: "aarch64"
+      digest: "sha256:bbe6166ad86a490caefad438fef8aa494926cb0a1b37fa1212925cfd81656429"
+
+plain: true
+
+video:
+  # This is for development purpose. You can set `none`.
+  display: default

--- a/templates/windows.yaml
+++ b/templates/windows.yaml
@@ -1,0 +1,1 @@
+windows-11.yaml

--- a/website/content/en/docs/usage/guests/windows.md
+++ b/website/content/en/docs/usage/guests/windows.md
@@ -3,24 +3,35 @@ title: Windows
 weight: 2
 ---
 
-| ⚡ Requirement | Lima >= 2.2, QEMU |
+| ⚡ Requirement | Lima >= 2.2, QEMU, swtpm |
 |-------------------|-----------------------------|
 
 Running Windows guests is experimentally supported since Lima v2.2.
 
-```bash
+{{< tabpane text=true >}}
+{{% tab header="Windows 11" %}}
+```
+limactl start template:windows
+```
+{{% /tab %}}
+{{% tab header="Windows server 2025" %}}
+```
 limactl start template:windows-2025
 ```
+{{% /tab %}}
+{{< /tabpane >}}
 
 The user password is randomly generated and stored in the `%USERPROFILE%\password.txt` file in the VM.
 Consider changing it after the first login.
 
-For Windows server 2025, Trusted Platform Module (TPM) is not required. However, there are some benefits if your VM has TPM. For example, you can install [BitLocker disk encryption](https://learn.microsoft.com/en-us/windows/security/operating-system-security/data-protection/bitlocker/install-server). In order to use TPM emulation on your VM, you need to install `swtpm` and set `tpm: true` on your yaml file.
+By default, Windows 11 enables Trusted Platform Module (TPM) emulation because of the hardware requirement. However, you can turn it off (in that case, lima bypasses the hardware check). In order to use TPM emulation, you need to install `swtpm` on your host computer.
+
+For Windows server 2025, TPM emulation is disabled by default. However, there are some benefits if you enable TPM emulation. For example, you can install [BitLocker disk encryption](https://learn.microsoft.com/en-us/windows/security/operating-system-security/data-protection/bitlocker/install-server) on your VM.
 
 ## Difference from Linux guests
 - Several features are not implemented yet. See [Caveats](#caveats) below.
 
 ## Caveats
-- Currently only Windows server 2025 (x86-64) is supported
+- Currently only x86-64 is supported for both Windows 11 and server 2025
 - QEMU is the only VM driver that supports Windows guests
 - Only plain mode is supported (no file mount, no dynamic port-forwarding)


### PR DESCRIPTION
This PR implements Windows 11 guest. Currently, it only works on x86-64 architecture.

~Since the branch is created from the branch of #5138 , only the second commit is for Windows 11 implementation. Once #5138 is merged, this PR will be tidied up.~
[Update]
This PR was cleaned up.