### PR TITLE
shell: clean up stale ssh.sock on --reconnect when the master is already dead

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -187,7 +187,20 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		}
 
 		if err := ssh.ExitMaster(inst.Hostname, inst.SSHLocalPort, sshConfig); err != nil {
-			return err
+			// `ssh -O exit` fails when the control socket file exists but the
+			// master process is already dead (unclean hostagent exit: kill -9,
+			// OOM, host crash). That stale state is exactly what --reconnect is
+			// meant to recover from, so only surface the error when a master is
+			// still alive; otherwise drop the stale socket and continue so a
+			// fresh master can be established.
+			removed, rmErr := sshutil.RemoveStaleControlMaster(ctx, inst.Dir)
+			if rmErr != nil {
+				return rmErr
+			}
+			if !removed {
+				return err
+			}
+			logrus.WithError(err).Warnf("Removed stale ssh control socket for the instance %#q after the master had already exited", instName)
 		}
 	}
 

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -330,6 +331,42 @@ func IsControlMasterExisting(instDir string) bool {
 	controlSock := filepath.Join(instDir, filenames.SSHSock)
 	_, err := os.Stat(controlSock)
 	return err == nil
+}
+
+// IsControlMasterRunning reports whether an SSH ControlMaster process is
+// actively listening on the instance's control socket. Unlike
+// IsControlMasterExisting, which only checks that the socket file is present,
+// this dials the socket to verify that a master is alive. A stale socket left
+// behind by an unclean master exit (kill -9, OOM, host crash, or the Cygwin
+// emulation file outliving its process) has no listener and returns false.
+func IsControlMasterRunning(ctx context.Context, instDir string) bool {
+	controlSock := filepath.Join(instDir, filenames.SSHSock)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(ctx, "unix", controlSock)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// RemoveStaleControlMaster removes the SSH control socket only when no master
+// process is listening on it. It returns true when a stale socket was removed.
+// A live master's socket is never touched (returns false), and a missing socket
+// is treated as a no-op (returns false). This lets callers recover from a wedged
+// session without clobbering a healthy ControlMaster.
+func RemoveStaleControlMaster(ctx context.Context, instDir string) (bool, error) {
+	if IsControlMasterRunning(ctx, instDir) {
+		return false, nil
+	}
+	existed := IsControlMasterExisting(instDir)
+	controlSock := filepath.Join(instDir, filenames.SSHSock)
+	if err := os.RemoveAll(controlSock); err != nil {
+		return false, err
+	}
+	return existed, nil
 }
 
 // SSHOpts adds the following options to CommonOptions: User, ControlMaster, ControlPath, ControlPersist.

--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -4,10 +4,16 @@
 package sshutil
 
 import (
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/coreos/go-semver/semver"
 	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 )
 
 func TestDefaultPubKeys(t *testing.T) {
@@ -52,6 +58,61 @@ func Test_detectValidPublicKey(t *testing.T) {
 	assert.Check(t, !detectValidPublicKey("huge-length AAAD6A=="))
 	assert.Check(t, !detectValidPublicKey("arbitrary content"))
 	assert.Check(t, !detectValidPublicKey(""))
+}
+
+func TestControlMasterStale(t *testing.T) {
+	// A leftover socket file with no listening master must be detected as
+	// not-running and removed, so --reconnect can recover the wedged session.
+	t.Run("stale socket is removed", func(t *testing.T) {
+		dir := t.TempDir()
+		sock := filepath.Join(dir, filenames.SSHSock)
+		assert.NilError(t, os.WriteFile(sock, []byte{}, 0o600))
+
+		assert.Check(t, !IsControlMasterRunning(t.Context(), dir))
+
+		removed, err := RemoveStaleControlMaster(t.Context(), dir)
+		assert.NilError(t, err)
+		assert.Check(t, removed)
+
+		_, statErr := os.Stat(sock)
+		assert.Check(t, errors.Is(statErr, os.ErrNotExist))
+	})
+
+	// No socket at all is a no-op, not an error.
+	t.Run("absent socket is a no-op", func(t *testing.T) {
+		dir := t.TempDir()
+
+		assert.Check(t, !IsControlMasterRunning(t.Context(), dir))
+
+		removed, err := RemoveStaleControlMaster(t.Context(), dir)
+		assert.NilError(t, err)
+		assert.Check(t, !removed)
+	})
+
+	// A live master (a real listener on the socket) must be detected as running
+	// and left untouched: only stale sockets are removed.
+	t.Run("live master socket is preserved", func(t *testing.T) {
+		dir := t.TempDir()
+		sock := filepath.Join(dir, filenames.SSHSock)
+		var lc net.ListenConfig
+		ln, err := lc.Listen(t.Context(), "unix", sock)
+		if err != nil {
+			// Some platforms / temp-dir path lengths cannot host a unix socket
+			// listener (e.g. macOS sun_path limit, Windows). The deterministic
+			// stale and absent cases above still provide coverage there.
+			t.Skipf("cannot create unix listener: %v", err)
+		}
+		defer ln.Close()
+
+		assert.Check(t, IsControlMasterRunning(t.Context(), dir))
+
+		removed, err := RemoveStaleControlMaster(t.Context(), dir)
+		assert.NilError(t, err)
+		assert.Check(t, !removed)
+
+		_, statErr := os.Stat(sock)
+		assert.NilError(t, statErr)
+	})
 }
 
 func Test_DisableControlMasterOptsFromSSHArgs(t *testing.T) {


### PR DESCRIPTION
## Summary

`limactl shell --reconnect <inst>` is the documented escape hatch (added in #3125) for resetting a wedged SSH multiplexed session. Today it fails with `exit status 255` when the SSH ControlMaster socket file (`<instDir>/ssh.sock`) still exists but the master process is already dead — which is exactly the wedged state `--reconnect` is meant to recover from.

`sshutil.IsControlMasterExisting` is a pure `os.Stat`; it does not verify the master is alive. After an unclean hostagent exit (`kill -9`, OOM, host crash, or the Cygwin/msys2 emulation file outliving its process) the socket survives. `ssh -O exit` then fails and the error was returned directly, so `--reconnect` exited non-zero with no recovery.

## Changes

- Add `sshutil.IsControlMasterRunning(instDir)` — dials the control socket to check whether a master is actually listening (a stale socket has no listener).
- Add `sshutil.RemoveStaleControlMaster(instDir)` — removes the control socket **only** when no master is listening; a live master's socket is never touched, and a missing socket is a no-op.
- In `cmd/limactl/shell.go`, on `ssh.ExitMaster` failure during `--reconnect`, remove the socket only if it is confirmed stale; if a master is still alive the original error is still returned.

This keeps the behavior unchanged for a live master (a genuine `ssh -O exit` failure is still surfaced) and recovers automatically when the master is already dead.

## Test plan

- New unit tests in `pkg/sshutil/sshutil_test.go` (`TestControlMasterStale`):
  - stale socket (no listener) is detected not-running and removed
  - absent socket is a no-op
  - a live unix listener is detected running and is preserved
- `go test ./pkg/sshutil/...`
- `go vet ./...`
- `gofmt -l` (clean)
- `go build ./...`

Fixes #4913
