### PR TITLE
templates/freebsd-15: support 9p mounts

### DIFF
--- a/templates/freebsd-15.yaml
+++ b/templates/freebsd-15.yaml
@@ -2,7 +2,4 @@ minimumLimaVersion: 2.1.0
 
 base:
 - template:_images/freebsd-15
-# - template:_default/mounts
-
-# Mounts are not functional in freebsd-15.
-# Seems to be working in experimental/freebsd-16.
+- template:_default/mounts

--- a/website/content/en/docs/usage/guests/freebsd.md
+++ b/website/content/en/docs/usage/guests/freebsd.md
@@ -11,7 +11,7 @@ Running FreeBSD guests is experimentally supported since Lima v2.1.
 {{< tabpane text=true >}}
 {{% tab header="FreeBSD 15" %}}
 ```
-limactl start --mount-none template:freebsd-15
+limactl start template:freebsd-15
 ```
 {{% /tab %}}
 {{% tab header="FreeBSD 16 (CURRENT)" %}}
@@ -33,6 +33,6 @@ Prerequisites:
 - No support for installing custom `caCerts`
 - And more
 
-### FreeBSD prior to 16
+### FreeBSD prior to 15.1
 - No support for mounting host directories.
   Use `limactl cp` or `limactl shell --sync` to share files with the host.


### PR DESCRIPTION
9p mounts seem to work since FreeBSD 15.1

- - -

Depends on:
- https://github.com/lima-vm/lima/pull/5170