### PR TITLE
feat: enforce WSL2 rootfs image format requirements with improved validation and documentation

### DIFF
--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -114,14 +114,24 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 	if cfg.VMType != nil {
 		if cfg.Images != nil && cfg.Arch != nil {
 			// TODO: real filetype checks
-			tarFileRegex := regexp.MustCompile(`.*tar\.*`)
+			tarFileRegex := regexp.MustCompile(`\.(tar|tgz|txz|tbz2|tzst|tar\.(gz|xz|bz2|zstd|zst))$`)
+			unsupportedVMImgRegex := regexp.MustCompile(`\.(qcow2|raw|img|iso|ipsw)(\.(gz|xz|bz2|zstd|zst))?$`)
+			squashfsRegex := regexp.MustCompile(`\.squashfs(\.(gz|xz|bz2|zstd|zst))?$`)
 			for i, image := range cfg.Images {
 				if unknown := reflectutil.UnknownNonEmptyFields(image, "File"); len(unknown) > 0 {
 					logrus.Warnf("Ignoring: vmType %s: images[%d]: %+v", *cfg.VMType, i, unknown)
 				}
-				match := tarFileRegex.MatchString(image.Location)
-				if image.Arch == *cfg.Arch && !match {
-					return fmt.Errorf("unsupported image type for vmType: %s, tarball root file system required: %#q", *cfg.VMType, image.Location)
+				if image.Arch == *cfg.Arch {
+					location := image.Location
+					if !tarFileRegex.MatchString(location) {
+						if unsupportedVMImgRegex.MatchString(location) {
+							return fmt.Errorf("unsupported image type for %s: %q. %s only supports importing tar archive root filesystems, not standard VM disk images", *cfg.VMType, location, *cfg.VMType)
+						}
+						if squashfsRegex.MatchString(location) {
+							return fmt.Errorf("unsupported image type for %s: %q. %s does not natively support importing SquashFS images; please convert the image to a tar archive before importing", *cfg.VMType, location, *cfg.VMType)
+						}
+						return fmt.Errorf("unsupported image type for %s: %q. A tar archive root filesystem (.tar, .tar.gz, .tar.xz, etc.) is required", *cfg.VMType, location)
+					}
 				}
 			}
 		}

--- a/pkg/driver/wsl2/wsl_driver_windows_test.go
+++ b/pkg/driver/wsl2/wsl_driver_windows_test.go
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package wsl2
+
+import (
+	"runtime"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+)
+
+func TestValidateConfigImages(t *testing.T) {
+	var arch limatype.Arch
+	switch runtime.GOARCH {
+	case "amd64":
+		arch = limatype.X8664
+	case "arm64":
+		arch = limatype.AARCH64
+	default:
+		arch = runtime.GOARCH
+	}
+	vmType := limatype.WSL2
+
+	tests := []struct {
+		name        string
+		images      []limatype.Image
+		expectedErr string
+	}{
+		{
+			name: "Valid tarball format .tar",
+			images: []limatype.Image{
+				{
+					File: limatype.File{
+						Location: "/path/to/rootfs.tar",
+						Arch:     arch,
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "Valid tarball format .tar.gz",
+			images: []limatype.Image{
+				{
+					File: limatype.File{
+						Location: "/path/to/rootfs.tar.gz",
+						Arch:     arch,
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "Valid tarball format .tgz",
+			images: []limatype.Image{
+				{
+					File: limatype.File{
+						Location: "/path/to/rootfs.tgz",
+						Arch:     arch,
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "Valid tarball format .tar.xz",
+			images: []limatype.Image{
+				{
+					File: limatype.File{
+						Location: "/path/to/rootfs.tar.xz",
+						Arch:     arch,
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "Unsupported VM image format .qcow2",
+			images: []limatype.Image{
+				{
+					File: limatype.File{
+						Location: "/path/to/rootfs.qcow2",
+						Arch:     arch,
+					},
+				},
+			},
+			expectedErr: "unsupported image type for wsl2: \"/path/to/rootfs.qcow2\". wsl2 only supports importing tar archive root filesystems, not standard VM disk images",
+		},
+		{
+			name: "Unsupported VM image format .qcow2.gz",
+			images: []limatype.Image{
+				{
+					File: limatype.File{
+						Location: "/path/to/rootfs.qcow2.gz",
+						Arch:     arch,
+					},
+				},
+			},
+			expectedErr: "unsupported image type for wsl2: \"/path/to/rootfs.qcow2.gz\". wsl2 only supports importing tar archive root filesystems, not standard VM disk images",
+		},
+		{
+			name: "Unsupported VM image format .raw",
+			images: []limatype.Image{
+				{
+					File: limatype.File{
+						Location: "/path/to/rootfs.raw",
+						Arch:     arch,
+					},
+				},
+			},
+			expectedErr: "unsupported image type for wsl2: \"/path/to/rootfs.raw\". wsl2 only supports importing tar archive root filesystems, not standard VM disk images",
+		},
+		{
+			name: "Unsupported SquashFS image format",
+			images: []limatype.Image{
+				{
+					File: limatype.File{
+						Location: "/path/to/rootfs.squashfs",
+						Arch:     arch,
+					},
+				},
+			},
+			expectedErr: "unsupported image type for wsl2: \"/path/to/rootfs.squashfs\". wsl2 does not natively support importing SquashFS images; please convert the image to a tar archive before importing",
+		},
+		{
+			name: "Generic unsupported format",
+			images: []limatype.Image{
+				{
+					File: limatype.File{
+						Location: "/path/to/rootfs.zip",
+						Arch:     arch,
+					},
+				},
+			},
+			expectedErr: "unsupported image type for wsl2: \"/path/to/rootfs.zip\". A tar archive root filesystem (.tar, .tar.gz, .tar.xz, etc.) is required",
+		},
+		{
+			name: "Unsupported VM image format .qcow2.zst",
+			images: []limatype.Image{
+				{
+					File: limatype.File{
+						Location: "/path/to/rootfs.qcow2.zst",
+						Arch:     arch,
+					},
+				},
+			},
+			expectedErr: "unsupported image type for wsl2: \"/path/to/rootfs.qcow2.zst\". wsl2 only supports importing tar archive root filesystems, not standard VM disk images",
+		},
+		{
+			name: "Unsupported VM image format .raw.bz2",
+			images: []limatype.Image{
+				{
+					File: limatype.File{
+						Location: "/path/to/rootfs.raw.bz2",
+						Arch:     arch,
+					},
+				},
+			},
+			expectedErr: "unsupported image type for wsl2: \"/path/to/rootfs.raw.bz2\". wsl2 only supports importing tar archive root filesystems, not standard VM disk images",
+		},
+		{
+			name: "Unsupported SquashFS image format .squashfs.gz",
+			images: []limatype.Image{
+				{
+					File: limatype.File{
+						Location: "/path/to/rootfs.squashfs.gz",
+						Arch:     arch,
+					},
+				},
+			},
+			expectedErr: "unsupported image type for wsl2: \"/path/to/rootfs.squashfs.gz\". wsl2 does not natively support importing SquashFS images; please convert the image to a tar archive before importing",
+		},
+		{
+			name: "Different arch is ignored",
+			images: []limatype.Image{
+				{
+					File: limatype.File{
+						Location: "/path/to/rootfs.qcow2",
+						Arch:     "different_arch",
+					},
+				},
+			},
+			expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &limatype.LimaYAML{
+				VMType: &vmType,
+				Arch:   &arch,
+				Images: tt.images,
+			}
+			err := validateConfig(t.Context(), cfg)
+			if tt.expectedErr == "" {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.expectedErr)
+			}
+		})
+	}
+}

--- a/website/content/en/docs/config/vmtype/wsl2.md
+++ b/website/content/en/docs/config/vmtype/wsl2.md
@@ -41,5 +41,38 @@ containerd:
 ### Known Issues
 - "wsl2" currently doesn't support many of Lima's options. See [this file](https://github.com/lima-vm/lima/blob/master/pkg/wsl2/wsl_driver_windows.go#L19) for the latest supported options.
 - When running lima using "wsl2", `${LIMA_HOME}/<INSTANCE>/serial.log` will not contain kernel boot logs
-- WSL2 requires a `tar` formatted rootfs archive instead of a VM image
+- WSL2 requires a `tar` formatted rootfs archive instead of a VM image. Standard VM disk images (like `.qcow2`, `.raw`, etc.) or `.squashfs` images cannot be natively imported by WSL2.
 - Windows doesn't ship with ssh.exe, gzip.exe, etc. which are used by Lima at various points. The easiest way around this is to run `winget install -e --id Git.MinGit` (winget is now built in to Windows as well), and add the resulting `C:\Program Files\Git\usr\bin\` directory to your path.
+
+### Rootfs Image Requirements & Building Custom Images
+
+WSL2 does not run a standard virtual machine disk image directly. Instead, `wsl.exe` imports a guest root filesystem from a `.tar` or `.tar.gz` archive.
+
+If you want to build and use your own custom rootfs, you can build it from a standard Linux container image using a Dockerfile:
+
+1. **Create a Dockerfile:**
+   Your custom rootfs must preinstall essential packages like `openssh-server`, `sudo`, `iptables`, and `sshfs`, and enable `user_allow_other` in `/etc/fuse.conf`. Here is an example using `ubuntu`:
+
+   ```dockerfile
+   FROM ubuntu:24.04
+
+   # Install required dependencies
+   RUN apt-get update && apt-get install -y --no-install-recommends \
+       bash \
+       openssh-server \
+       sudo \
+       iptables \
+       sshfs \
+       ca-certificates \
+       && rm -rf /var/lib/apt/lists/*
+
+   # Enable user_allow_other in fuse configuration
+   RUN echo "user_allow_other" >> /etc/fuse.conf
+   ```
+
+2. **Build & Export the Rootfs Archive:**
+   You can build the image and export its root filesystem directly as a `.tar` archive using Docker BuildKit's output option:
+   ```bash
+   docker build -o type=tar,dest=custom-rootfs.tar .
+   ```
+


### PR DESCRIPTION
This PR implements the first phase of WSL2 support #5152 by focusing on configuration validation and documentation.

**Changes**

- Validate image formats supported by the WSL2 driver during configuration validation instead of failing later during import.
- Document the image format requirements for WSL2