### PR TITLE
cmd/limactl: include name in network list --json output

### DIFF
--- a/cmd/limactl/network.go
+++ b/cmd/limactl/network.go
@@ -93,29 +93,32 @@ func networkListAction(cmd *cobra.Command, args []string) error {
 
 	allNetworks := slices.Sorted(maps.Keys(config.Networks))
 
-	networks := []string{}
+	networkNames := []string{}
 	if len(args) > 0 {
 		for _, arg := range args {
 			matches := nameMatches(arg, allNetworks)
 			if len(matches) > 0 {
-				networks = append(networks, matches...)
+				networkNames = append(networkNames, matches...)
 			} else {
 				logrus.Warnf("No network matching %v found.", arg)
 			}
 		}
 	} else {
-		networks = allNetworks
+		networkNames = allNetworks
 	}
 
 	if jsonFormat {
 		w := cmd.OutOrStdout()
-		for _, name := range networks {
+		for _, name := range networkNames {
 			nw, ok := config.Networks[name]
 			if !ok {
 				logrus.Errorf("network %#q does not exist", nw)
 				continue
 			}
-			j, err := json.Marshal(nw)
+			j, err := json.Marshal(struct {
+				Name string `json:"name"`
+				networks.Network
+			}{Name: name, Network: nw})
 			if err != nil {
 				return err
 			}
@@ -126,7 +129,7 @@ func networkListAction(cmd *cobra.Command, args []string) error {
 
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 4, 8, 4, ' ', 0)
 	fmt.Fprintln(w, "NAME\tMODE\tGATEWAY\tINTERFACE")
-	for _, name := range networks {
+	for _, name := range networkNames {
 		nw, ok := config.Networks[name]
 		if !ok {
 			logrus.Errorf("network %#q does not exist", nw)


### PR DESCRIPTION
This is to address #517

`limactl network list --json` displayed the Network value struct only.
The name is the map key and was dropped... Wrap each row in an anonymous struct embedding networks.

Making the change I encountered a conflict between the local variable `networks` and the imported `networks` package. 
Therefore rename the local `networks` slice to `networkNames`.