### PR TITLE
hack: fail early when host prerequisites are missing

### DIFF
--- a/hack/common.inc.sh
+++ b/hack/common.inc.sh
@@ -18,6 +18,21 @@ function ERROR() {
 	echo >&2 "TEST| [ERROR] $*"
 }
 
+# check_required_commands CMD...
+# Exits 1 (listing every missing command) if any required host command is absent.
+function check_required_commands() {
+	local missing=()
+	local cmd
+	for cmd in "$@"; do
+		command -v "${cmd}" >/dev/null 2>&1 || missing+=("${cmd}")
+	done
+	if [ "${#missing[@]}" -gt 0 ]; then
+		ERROR "Missing required host command(s): ${missing[*]}"
+		ERROR "Please install them before running this test."
+		exit 1
+	fi
+}
+
 if [[ ${BASH_VERSINFO:-0} -lt 4 ]]; then
 	ERROR "Bash version is too old: ${BASH_VERSION}"
 	exit 1

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -117,6 +117,15 @@ case "$(limactl tmpl yq "$FILE_HOST" '.networks[].lima')" in
 	;;
 esac
 
+# Fail early (before the expensive VM create/boot) if a host command required by the
+# enabled checks is missing. Tools that are optional at runtime (guarded by `command -v`,
+# e.g. rsync, w3m) are intentionally not required here.
+required_commands=(limactl curl jq timeout diff)
+[[ -n ${CHECKS["port-forwards"]} ]] && required_commands+=(perl nc socat)
+[[ -n ${CHECKS["container-engine"]} && ${OS_HOST} != "Msys" ]] && required_commands+=(dig)
+[[ -n ${CHECKS["vmnet"]} ]] && required_commands+=("${IPERF3}")
+check_required_commands "${required_commands[@]}"
+
 if [[ -n ${CHECKS["port-forwards"]} ]]; then
 	tmpconfig="$HOME_HOST/lima-config-tmp"
 	mkdir -p "${tmpconfig}"


### PR DESCRIPTION
test-templates.sh boots a VM before invoking host tools such as nc, socat, dig, curl, jq and timeout (directly and via test-port-forwarding.pl). When one of them is missing, the script failed only after a full create + boot cycle, wasting minutes on a confusing late error.

Check the host commands required by the enabled checks up front, before `limactl create`, and abort while listing every missing command. The list is gated by the enabled checks, so a tool is only required when the check that uses it runs. Add a reusable check_required_commands() helper to common.inc.sh. Commands that are optional at runtime (rsync, w3m) are intentionally not required.

Fixes #5038