### PR TITLE
Add skipIfMissing to copyToHost rule

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -696,7 +696,7 @@ ln -sf "${SSH_AUTH_SOCK}" /run/host-services/ssh-auth.sock`
 	// Copy all config files _after_ the requirements are done
 	for _, rule := range a.instConfig.CopyToHost {
 		sshAddress, sshPort := a.sshAddressPort()
-		if err := copyToHost(ctx, a.sshConfig, sshAddress, sshPort, rule.HostFile, rule.GuestFile); err != nil {
+		if err := copyToHost(ctx, a.sshConfig, sshAddress, sshPort, rule.HostFile, rule.GuestFile, rule.SkipIfMissing); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -1266,7 +1266,7 @@ func isDeactivatedCloudInitMainService(line string) bool {
 	return strings.HasPrefix(line, "cloud-init-main.service: consumed")
 }
 
-func copyToHost(ctx context.Context, sshConfig *ssh.SSHConfig, sshAddress string, sshPort int, local, remote string) error {
+func copyToHost(ctx context.Context, sshConfig *ssh.SSHConfig, sshAddress string, sshPort int, local, remote string, skipIfMissing bool) error {
 	args := sshConfig.Args()
 	args = append(args,
 		"-p", strconv.Itoa(sshPort),
@@ -1295,6 +1295,12 @@ func copyToHost(ctx context.Context, sshConfig *ssh.SSHConfig, sshAddress string
 			)
 			cmd = exec.CommandContext(ctx, sshConfig.Binary(), sudoArgs...)
 			out, err = cmd.Output()
+		}
+		if errors.As(err, &exitErr) && strings.Contains(string(exitErr.Stderr), "No such file or directory") {
+			if skipIfMissing {
+				logrus.Infof("Skip missing %s (no such file or directory)", remote)
+				return nil
+			}
 		}
 		if err != nil {
 			return fmt.Errorf("failed to run %v: %#q: %w", cmd.Args, string(out), err)

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -313,9 +313,10 @@ type PortForward struct {
 }
 
 type CopyToHost struct {
-	GuestFile    string `yaml:"guest,omitempty" json:"guest,omitempty"`
-	HostFile     string `yaml:"host,omitempty" json:"host,omitempty"`
-	DeleteOnStop bool   `yaml:"deleteOnStop,omitempty" json:"deleteOnStop,omitempty"`
+	GuestFile     string `yaml:"guest,omitempty" json:"guest,omitempty"`
+	HostFile      string `yaml:"host,omitempty" json:"host,omitempty"`
+	SkipIfMissing bool   `yaml:"skipIfMissing,omitempty" json:"skipIfMissing,omitempty"`
+	DeleteOnStop  bool   `yaml:"deleteOnStop,omitempty" json:"deleteOnStop,omitempty"`
 }
 
 type Network struct {

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -554,9 +554,11 @@ networks:
 # copyToHost:
 # - guest: "/etc/myconfig.cfg"
 #   host: "{{.Dir}}/copied-from-guest/myconfig"
+# # skipIfMissing: false
 # # deleteOnStop: false
 # # "guest" can include these template variables: {{.Home}}, {{.Name}}, {{.Hostname}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
 # # "host" can include {{.Home}}, {{.Dir}}, {{.Name}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
+# # "skipIfMissing" will skip copying the file from the guest if the file is missing.
 # # "deleteOnStop" will delete the file from the host when the instance is stopped.
 
 # Message. Information to be shown to the user, given as a Go template for the instance.

--- a/templates/k3s.yaml
+++ b/templates/k3s.yaml
@@ -52,9 +52,6 @@ probes:
             echo >&2 "k3s is not running yet"
             exit 1
     fi
-    {{else}}
-    # create an empty file so that the "copyToHost" does not fail
-    sudo mkdir -p /etc/rancher/k3s && sudo touch /etc/rancher/k3s/k3s.yaml
     {{end}}
   hint: |
     The k3s kubeconfig file has not yet been created.
@@ -63,6 +60,7 @@ probes:
 copyToHost:
 - guest: "/etc/rancher/k3s/k3s.yaml"
   host: "{{.Dir}}/copied-from-guest/kubeconfig.yaml"
+  skipIfMissing: true
   deleteOnStop: true
 message: |
   {{- if not ( and .Param.url .Param.token ) -}}

--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -204,9 +204,6 @@ probes:
       echo >&2 "k8s is not running yet"
       exit 1
     fi
-    {{else}}
-    # create an empty file so that the "copyToHost" does not fail
-    sudo mkdir -p /root/.kube && sudo touch /root/.kube/config.localhost
     {{end}}
   hint: |
     The k8s kubeconfig file has not yet been created.
@@ -230,6 +227,7 @@ probes:
 copyToHost:
 - guest: "/root/.kube/config.localhost"
   host: "{{.Dir}}/copied-from-guest/kubeconfig.yaml"
+  skipIfMissing: true
   deleteOnStop: true
 message: |
   {{- if not ( and .Param.url .Param.token )}}


### PR DESCRIPTION
Instead of creating empty config files.

----

The minions didn't have any master config...

So the copyToHost step was failing on them.

And some workaround shell code was added.