### PR TITLE
verify expected digest when reusing cached image without digest file

### DIFF
--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -379,6 +379,15 @@ func getCached(ctx context.Context, localPath, remote string, o options) (*Resul
 		if err := copyLocal(ctx, localPath, shadData, ext, o.decompress, "", ""); err != nil {
 			return nil, err
 		}
+	} else if o.expectedDigest != "" {
+		// The cache has no digest sidecar (e.g. it was populated by an earlier
+		// digest-less download of the same URL), but a digest is expected now.
+		// Verify the cached data against it instead of falling back to the
+		// last-modified comparison below, which would otherwise reuse the file
+		// with no integrity check when the remote HEAD request fails.
+		if err := copyLocal(ctx, localPath, shadData, ext, o.decompress, o.description, o.expectedDigest); err != nil {
+			return nil, err
+		}
 	} else {
 		if err := copyLocal(ctx, localPath, shadData, ext, o.decompress, o.description, o.expectedDigest); err != nil {
 			return nil, err

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -277,6 +277,15 @@ func getCached(ctx context.Context, localPath, remote string, o options) (*Resul
 		if err := copyLocal(ctx, localPath, shadData, ext, o.decompress, "", ""); err != nil {
 			return nil, err
 		}
+	} else if o.expectedDigest != "" {
+		// The cache has no digest sidecar (e.g. it was populated by an earlier
+		// digest-less download of the same URL), but a digest is expected now.
+		// Verify the cached data against it instead of falling back to the
+		// last-modified comparison below, which would otherwise reuse the file
+		// with no integrity check when the remote HEAD request fails.
+		if err := copyLocal(ctx, localPath, shadData, ext, o.decompress, o.description, o.expectedDigest); err != nil {
+			return nil, err
+		}
 	} else {
 		if match, lmCached, lmRemote, err := matchLastModified(ctx, shadTime, remote); err != nil {
 			logrus.WithError(err).Info("Failed to retrieve last-modified for cached digest-less image; using cached image.")

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -286,6 +286,12 @@ func getCached(ctx context.Context, localPath, remote string, o options) (*Resul
 		if err := copyLocal(ctx, localPath, shadData, ext, o.decompress, o.description, o.expectedDigest); err != nil {
 			return nil, err
 		}
+		// The verification succeeded; record the digest (best effort) so that
+		// later cache hits compare against the digest file instead of
+		// re-hashing the data.
+		if err := os.WriteFile(shadDigest, []byte(o.expectedDigest.String()), 0o644); err != nil {
+			logrus.WithError(err).Warnf("Failed to write digest file %#q", shadDigest)
+		}
 	} else {
 		if match, lmCached, lmRemote, err := matchLastModified(ctx, shadTime, remote); err != nil {
 			logrus.WithError(err).Info("Failed to retrieve last-modified for cached digest-less image; using cached image.")

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -388,6 +388,12 @@ func getCached(ctx context.Context, localPath, remote string, o options) (*Resul
 		if err := copyLocal(ctx, localPath, shadData, ext, o.decompress, o.description, o.expectedDigest); err != nil {
 			return nil, err
 		}
+		// The verification succeeded; record the digest (best effort) so that
+		// later cache hits compare against the digest file instead of
+		// re-hashing the data.
+		if err := os.WriteFile(shadDigest, []byte(o.expectedDigest.String()), 0o644); err != nil {
+			logrus.WithError(err).Warnf("Failed to write digest file %#q", shadDigest)
+		}
 	} else {
 		if err := copyLocal(ctx, localPath, shadData, ext, o.decompress, o.description, o.expectedDigest); err != nil {
 			return nil, err

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -271,6 +271,59 @@ func TestRedownloadRemote(t *testing.T) {
 	})
 }
 
+func TestCachedWithoutDigestSidecar(t *testing.T) {
+	// A cache entry populated by an earlier digest-less download has no
+	// "<algo>.digest" sidecar. When the same URL is later requested with an
+	// expected digest and the remote HEAD request fails, the cached data must
+	// still be verified against the expected digest before being reused.
+	content := []byte("cached-content")
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			// Force matchLastModified to fail so the code cannot fall back to
+			// the last-modified comparison.
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+		_, _ = w.Write(content)
+	})
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	remote := ts.URL + "/image"
+
+	t.Run("mismatch is rejected", func(t *testing.T) {
+		ctx := t.Context()
+		cacheDir := filepath.Join(t.TempDir(), "cache")
+
+		// Prime the cache with a digest-less download (no sidecar is written).
+		r, err := Download(ctx, filepath.Join(t.TempDir(), "1"), remote, WithCacheDir(cacheDir))
+		assert.NilError(t, err)
+		assert.Equal(t, StatusDownloaded, r.Status)
+
+		// Now request the same URL with a digest that does not match the cached
+		// bytes. The stale/mismatching cache must not be reused as valid.
+		wrongDigest := digest.Digest("sha256:8313944efb4f38570c689813f288058b674ea6c487017a5a4738dc674b65f9d9")
+		_, err = Download(ctx, filepath.Join(t.TempDir(), "2"), remote,
+			WithExpectedDigest(wrongDigest), WithCacheDir(cacheDir))
+		assert.ErrorContains(t, err, "expected digest")
+	})
+
+	t.Run("match is used", func(t *testing.T) {
+		ctx := t.Context()
+		cacheDir := filepath.Join(t.TempDir(), "cache")
+
+		r, err := Download(ctx, filepath.Join(t.TempDir(), "1"), remote, WithCacheDir(cacheDir))
+		assert.NilError(t, err)
+		assert.Equal(t, StatusDownloaded, r.Status)
+
+		correctDigest := digest.SHA256.FromBytes(content)
+		r, err = Download(ctx, filepath.Join(t.TempDir(), "2"), remote,
+			WithExpectedDigest(correctDigest), WithCacheDir(cacheDir))
+		assert.NilError(t, err)
+		assert.Equal(t, StatusUsedCache, r.Status)
+	})
+}
+
 func TestDownloadLocal(t *testing.T) {
 	const emptyFileDigest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 	const testDownloadLocalDigest = "sha256:0c1e0fba69e8919b306d030bf491e3e0c46cf0a8140ff5d7516ba3a83cbea5b3"

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -332,6 +332,59 @@ func TestRedownloadRemote(t *testing.T) {
 	})
 }
 
+func TestCachedWithoutDigestSidecar(t *testing.T) {
+	// A cache entry populated by an earlier digest-less download has no
+	// "<algo>.digest" sidecar. When the same URL is later requested with an
+	// expected digest and the remote HEAD request fails, the cached data must
+	// still be verified against the expected digest before being reused.
+	content := []byte("cached-content")
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			// Force matchLastModified to fail so the code cannot fall back to
+			// the last-modified comparison.
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+		_, _ = w.Write(content)
+	})
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	remote := ts.URL + "/image"
+
+	t.Run("mismatch is rejected", func(t *testing.T) {
+		ctx := t.Context()
+		cacheDir := filepath.Join(t.TempDir(), "cache")
+
+		// Prime the cache with a digest-less download (no sidecar is written).
+		r, err := Download(ctx, filepath.Join(t.TempDir(), "1"), remote, WithCacheDir(cacheDir))
+		assert.NilError(t, err)
+		assert.Equal(t, StatusDownloaded, r.Status)
+
+		// Now request the same URL with a digest that does not match the cached
+		// bytes. The stale/mismatching cache must not be reused as valid.
+		wrongDigest := digest.Digest("sha256:8313944efb4f38570c689813f288058b674ea6c487017a5a4738dc674b65f9d9")
+		_, err = Download(ctx, filepath.Join(t.TempDir(), "2"), remote,
+			WithExpectedDigest(wrongDigest), WithCacheDir(cacheDir))
+		assert.ErrorContains(t, err, "expected digest")
+	})
+
+	t.Run("match is used", func(t *testing.T) {
+		ctx := t.Context()
+		cacheDir := filepath.Join(t.TempDir(), "cache")
+
+		r, err := Download(ctx, filepath.Join(t.TempDir(), "1"), remote, WithCacheDir(cacheDir))
+		assert.NilError(t, err)
+		assert.Equal(t, StatusDownloaded, r.Status)
+
+		correctDigest := digest.SHA256.FromBytes(content)
+		r, err = Download(ctx, filepath.Join(t.TempDir(), "2"), remote,
+			WithExpectedDigest(correctDigest), WithCacheDir(cacheDir))
+		assert.NilError(t, err)
+		assert.Equal(t, StatusUsedCache, r.Status)
+	})
+}
+
 func TestDownloadLocal(t *testing.T) {
 	const emptyFileDigest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 	const testDownloadLocalDigest = "sha256:0c1e0fba69e8919b306d030bf491e3e0c46cf0a8140ff5d7516ba3a83cbea5b3"

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -382,6 +382,13 @@ func TestCachedWithoutDigestSidecar(t *testing.T) {
 			WithExpectedDigest(correctDigest), WithCacheDir(cacheDir))
 		assert.NilError(t, err)
 		assert.Equal(t, StatusUsedCache, r.Status)
+
+		// The digest file is recorded after verification, so subsequent cache
+		// hits do not have to re-hash the data.
+		shadDigest := filepath.Join(cacheDirectoryPath(cacheDir, remote), "sha256.digest")
+		b, err := os.ReadFile(shadDigest)
+		assert.NilError(t, err)
+		assert.Equal(t, correctDigest.String(), string(b))
 	})
 }
 

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -321,6 +321,13 @@ func TestCachedWithoutDigestSidecar(t *testing.T) {
 			WithExpectedDigest(correctDigest), WithCacheDir(cacheDir))
 		assert.NilError(t, err)
 		assert.Equal(t, StatusUsedCache, r.Status)
+
+		// The digest file is recorded after verification, so subsequent cache
+		// hits do not have to re-hash the data.
+		shadDigest := filepath.Join(cacheDirectoryPath(cacheDir, remote), "sha256.digest")
+		b, err := os.ReadFile(shadDigest)
+		assert.NilError(t, err)
+		assert.Equal(t, correctDigest.String(), string(b))
 	})
 }
 


### PR DESCRIPTION
1. getCached selects its validation path from whether the cache has an `<algo>.digest` file. When a digest is expected but that file is absent (the same URL was cached earlier without a digest), it takes the digest-less branch.
2. that branch only compares Last-Modified, and when the remote HEAD request fails it reuses the cached bytes while returning ValidatedDigest=true, so the expected digest is never checked and a caller pinning a digest can boot a mismatching cached image.

Added a branch that validates the cached data against the expected digest before reuse when no digest file is present; the else path stays for genuinely digest-less images. Test covers the mismatch (now rejected) and the matching offline case (still served from cache).