### PR TITLE
Windows 11 ARM64 support

### DIFF
--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -127,6 +127,7 @@ func templateArgs(ctx context.Context, bootScripts bool, instDir, name string, i
 	args := TemplateArgs{
 		Debug:              debugutil.Debug,
 		OS:                 *instConfig.OS,
+		Arch:               *instConfig.Arch,
 		BootScripts:        bootScripts,
 		Name:               name,
 		Hostname:           hostname.FromInstName(name), // TODO: support customization

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -91,6 +91,7 @@ type Disk struct {
 type TemplateArgs struct {
 	Debug                           bool
 	OS                              limatype.OS
+	Arch                            limatype.Arch
 	Name                            string // instance name
 	Hostname                        string // instance hostname
 	IID                             string // instance id

--- a/pkg/cidata/template_test.go
+++ b/pkg/cidata/template_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
 )
 
 var defaultRemoveDefaults = false
@@ -222,6 +224,7 @@ func TestExecuteTemplateWindowsISO(t *testing.T) {
 			name: "windows server 2025",
 			args: &TemplateArgs{
 				Name:                   "windows",
+				Arch:                   limatype.X8664,
 				User:                   "windows-user",
 				WindowsInitialPassword: "dummy-password",
 				TPM:                    true,
@@ -232,15 +235,17 @@ func TestExecuteTemplateWindowsISO(t *testing.T) {
 				`<Username>windows-user</Username>`,
 				`<Value>dummy-password</Value>`,
 				`<Type>EFI</Type>`,
+				`<Value>1</Value>`,
 			},
 			expectedFirstLogonStrings: []string{
 				`$logfile = "C:\Users\windows-user\lima-setup.log"`,
 			},
 		},
 		{
-			name: "windows 11",
+			name: "windows 11 x86_64",
 			args: &TemplateArgs{
 				Name:                   "windows",
+				Arch:                   limatype.X8664,
 				User:                   "windows-user",
 				WindowsInitialPassword: "dummy-password",
 				TPM:                    true,
@@ -250,6 +255,7 @@ func TestExecuteTemplateWindowsISO(t *testing.T) {
 				`<Username>windows-user</Username>`,
 				`<Value>dummy-password</Value>`,
 				`<Type>EFI</Type>`,
+				`<Value>6</Value>`,
 			},
 			expectedFirstLogonStrings: []string{
 				`$logfile = "C:\Users\windows-user\lima-setup.log"`,
@@ -259,6 +265,7 @@ func TestExecuteTemplateWindowsISO(t *testing.T) {
 			name: "legacyBIOS",
 			args: &TemplateArgs{
 				Name:                   "windows",
+				Arch:                   limatype.X8664,
 				User:                   "windows-user",
 				WindowsInitialPassword: "dummy-password",
 				LegacyBIOS:             true,
@@ -270,6 +277,7 @@ func TestExecuteTemplateWindowsISO(t *testing.T) {
 				`<Username>windows-user</Username>`,
 				`<Value>dummy-password</Value>`,
 				`<Label>BIOS</Label>`,
+				`<Value>1</Value>`,
 			},
 			expectedFirstLogonStrings: []string{
 				`$logfile = "C:\Users\windows-user\lima-setup.log"`,
@@ -279,6 +287,7 @@ func TestExecuteTemplateWindowsISO(t *testing.T) {
 			name: "disable TPM on Windows 11",
 			args: &TemplateArgs{
 				Name:                   "windows",
+				Arch:                   limatype.X8664,
 				User:                   "windows-user",
 				WindowsInitialPassword: "dummy-password",
 				TPM:                    false,
@@ -289,6 +298,28 @@ func TestExecuteTemplateWindowsISO(t *testing.T) {
 				`<Value>dummy-password</Value>`,
 				`<Type>EFI</Type>`,
 				`BypassTPMCheck`,
+				`<Value>6</Value>`,
+			},
+			expectedFirstLogonStrings: []string{
+				`$logfile = "C:\Users\windows-user\lima-setup.log"`,
+			},
+		},
+		{
+			name: "Windows 11 arm64",
+			args: &TemplateArgs{
+				Name:                   "windows",
+				Arch:                   limatype.AARCH64,
+				User:                   "windows-user",
+				WindowsInitialPassword: "dummy-password",
+				TPM:                    false,
+			},
+			expectedAutounattendStrings: []string{
+				`<Path>E:\viostor\w11\arm64</Path>`,
+				`<Username>windows-user</Username>`,
+				`<Value>dummy-password</Value>`,
+				`<Type>EFI</Type>`,
+				`BypassTPMCheck`,
+				`<Value>3</Value>`,
 			},
 			expectedFirstLogonStrings: []string{
 				`$logfile = "C:\Users\windows-user\lima-setup.log"`,

--- a/pkg/cidata/wincidata.TEMPLATE.d/autounattend.xml
+++ b/pkg/cidata/wincidata.TEMPLATE.d/autounattend.xml
@@ -1,38 +1,46 @@
+{{ $windowsVersionDir := "w11" -}}
+{{ if .IsWindowsServer -}}
+{{ $windowsVersionDir = "2k25" -}}
+{{ end -}}
+{{ $windowsArchDir := "arm64" -}}
+{{ if eq .Arch "x86_64" -}}
+{{ $windowsArchDir = "amd64" -}}
+{{ end -}}
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:schemas-microsoft-com:unattend">
   <settings pass="windowsPE">
     <component name="Microsoft-Windows-PnpCustomizationsWinPE" publicKeyToken="31bf3856ad364e35"
-        language="neutral" versionScope="nonSxS" processorArchitecture="amd64"
+        language="neutral" versionScope="nonSxS" processorArchitecture="{{ $windowsArchDir }}"
         xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
         <DriverPaths>
             <PathAndCredentials wcm:action="add" wcm:keyValue="1">
-                <Path>E:\viostor\{{ if .IsWindowsServer }}2k25{{ else }}w11{{ end }}\amd64</Path>
+                <Path>E:\viostor\{{ $windowsVersionDir }}\{{ $windowsArchDir }}</Path>
             </PathAndCredentials>
             <PathAndCredentials wcm:action="add" wcm:keyValue="2">
-                <Path>E:\vioinput\{{ if .IsWindowsServer }}2k25{{ else }}w11{{ end }}\amd64</Path>
+                <Path>E:\vioinput\{{ $windowsVersionDir }}\{{ $windowsArchDir }}</Path>
             </PathAndCredentials>
             <PathAndCredentials wcm:action="add" wcm:keyValue="3">
-                <Path>E:\NetKVM\{{ if .IsWindowsServer }}2k25{{ else }}w11{{ end }}\amd64</Path>
+                <Path>E:\NetKVM\{{ $windowsVersionDir }}\{{ $windowsArchDir }}</Path>
             </PathAndCredentials>
             <PathAndCredentials wcm:action="add" wcm:keyValue="4">
-                <Path>E:\viofs\{{ if .IsWindowsServer }}2k25{{ else }}w11{{ end }}\amd64</Path>
+                <Path>E:\viofs\{{ $windowsVersionDir }}\{{ $windowsArchDir }}</Path>
             </PathAndCredentials>
             <PathAndCredentials wcm:action="add" wcm:keyValue="5">
-                <Path>E:\Balloon\{{ if .IsWindowsServer }}2k25{{ else }}w11{{ end }}\amd64</Path>
+                <Path>E:\Balloon\{{ $windowsVersionDir }}\{{ $windowsArchDir }}</Path>
             </PathAndCredentials>
             <PathAndCredentials wcm:action="add" wcm:keyValue="6">
-                <Path>E:\viorng\{{ if .IsWindowsServer }}2k25{{ else }}w11{{ end }}\amd64</Path>
+                <Path>E:\viorng\{{ $windowsVersionDir }}\{{ $windowsArchDir }}</Path>
             </PathAndCredentials>
         </DriverPaths>
     </component>
 
-    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="{{ $windowsArchDir }}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       <InputLocale>en-US</InputLocale>
       <SystemLocale>en-US</SystemLocale>
       <UILanguage>en-US</UILanguage>
       <UserLocale>en-US</UserLocale>
     </component>
-    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+    <component name="Microsoft-Windows-Setup" processorArchitecture="{{ $windowsArchDir }}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       {{ if not .IsWindowsServer }}
       <!-- Windows 11 has hardware requirements. (ref: https://www.microsoft.com/en-gb/windows/windows-11-specifications). -->
       <!-- For flexibility, we bypass those requirements. -->
@@ -72,7 +80,7 @@
           <InstallFrom>
             <MetaData wcm:action="add">
               <Key>/IMAGE/INDEX</Key>
-              <Value>{{ if .IsWindowsServer }}1{{ else }}6{{ end }}</Value>
+              <Value>{{ if .IsWindowsServer }}1{{ else if eq .Arch "x86_64" }}6{{ else }}3{{ end }}</Value>
             </MetaData>
           </InstallFrom>
           <InstallTo>
@@ -177,24 +185,24 @@
     </component>
   </settings>
   <settings pass="specialize">
-    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="{{ $windowsArchDir }}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       <InputLocale>en-US</InputLocale>
       <SystemLocale>en-US</SystemLocale>
       <UILanguage>en-US</UILanguage>
       <UserLocale>en-US</UserLocale>
     </component>
-    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="{{ $windowsArchDir }}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       <ComputerName>lima</ComputerName>
     </component>
   </settings>
   <settings pass="oobeSystem">
-    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="{{ $windowsArchDir }}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       <InputLocale>en-US</InputLocale>
       <SystemLocale>en-US</SystemLocale>
       <UILanguage>en-US</UILanguage>
       <UserLocale>en-US</UserLocale>
     </component>
-    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="{{ $windowsArchDir }}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       <UserAccounts>
         <LocalAccounts>
           <LocalAccount wcm:action="add">

--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -675,7 +675,18 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	}
 	if isoPresent {
 		args = appendArgsIfNoConflict(args, "-boot", "order=d,splash-time=0,menu=on")
-		args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,media=cdrom,readonly=on", isoPath))
+		// For aarch64, QEMU uses `virt` machine type but it doesn't recognize CDROM drive.
+		// In order to attach ISO files, we need to use USB devices instead.
+		if *y.OS == limatype.WINDOWS && *y.Arch == limatype.AARCH64 {
+			// Those two lines are necessary here, otherwise QEMU raises an error `No 'usb-bus' bus found for device 'usb-storage'`.
+			args = append(args, "-device", "qemu-xhci")
+			args = append(args, "-device", "usb-kbd")
+
+			args = append(args, "-drive", fmt.Sprintf("file=%s,if=none,id=cd0,format=raw,media=cdrom,readonly=on", isoPath))
+			args = append(args, "-device", "usb-storage,drive=cd0")
+		} else {
+			args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,media=cdrom,readonly=on", isoPath))
+		}
 	} else {
 		args = appendArgsIfNoConflict(args, "-boot", "order=c,splash-time=0,menu=on")
 	}
@@ -688,7 +699,12 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	// virtio-win must be mounted before cidata.iso otherwise
 	// autounattend.xml can't find virtio drivers.
 	if *y.OS == limatype.WINDOWS && len(winOpts.VirtioWin) > 0 {
-		args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,media=cdrom,readonly=on", filepath.Join(cfg.InstanceDir, filenames.VirtioWin)))
+		if *y.Arch == limatype.AARCH64 {
+			args = append(args, "-drive", fmt.Sprintf("file=%s,if=none,id=cd1,format=raw,media=cdrom,readonly=on", filepath.Join(cfg.InstanceDir, filenames.VirtioWin)))
+			args = append(args, "-device", "usb-storage,drive=cd1")
+		} else {
+			args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,media=cdrom,readonly=on", filepath.Join(cfg.InstanceDir, filenames.VirtioWin)))
+		}
 	}
 
 	for _, extraDisk := range extraDisks {
@@ -700,7 +716,12 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	case limatype.WINDOWS:
 		// We can't use virtio-scsi for Windows's cidata, because autounattend in cidata installs virtio-win drivers.
 		// Until then, the VM can't detect virtio.
-		args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,media=cdrom,readonly=on", filepath.Join(cfg.InstanceDir, filenames.CIDataISO)))
+		if *y.Arch == limatype.AARCH64 {
+			args = append(args, "-drive", fmt.Sprintf("file=%s,if=none,id=cd2,format=raw,media=cdrom,readonly=on", filepath.Join(cfg.InstanceDir, filenames.CIDataISO)))
+			args = append(args, "-device", "usb-storage,drive=cd2")
+		} else {
+			args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,media=cdrom,readonly=on", filepath.Join(cfg.InstanceDir, filenames.CIDataISO)))
+		}
 	default:
 		args = append(args,
 			"-drive", "id=cdrom0,if=none,format=raw,readonly=on,file="+filepath.Join(cfg.InstanceDir, filenames.CIDataISO),
@@ -871,7 +892,11 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 		case limatype.X8664, limatype.RISCV64:
 			args = append(args, "-device", "virtio-vga")
 		default:
-			args = append(args, "-device", "virtio-gpu")
+			if *y.OS == limatype.WINDOWS {
+				args = append(args, "-device", "ramfb")
+			} else {
+				args = append(args, "-device", "virtio-gpu")
+			}
 		}
 		args = append(args, "-device", "virtio-keyboard-pci")
 		args = append(args, "-device", "virtio-"+input+"-pci")

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -55,8 +55,8 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		if *y.VMType != limatype.QEMU {
 			errs = errors.Join(errs, fmt.Errorf("currently Windows guest is only supported on %#q; got %#q", limatype.QEMU, *y.VMType))
 		}
-		if !slices.Contains([]limatype.Arch{limatype.X8664}, *y.Arch) {
-			errs = errors.Join(errs, fmt.Errorf("currently Windows guest is only supported on [%#q]; got %#q", limatype.X8664, *y.Arch))
+		if !slices.Contains([]limatype.Arch{limatype.X8664, limatype.AARCH64}, *y.Arch) {
+			errs = errors.Join(errs, fmt.Errorf("currently Windows guest is only supported on [%#q, %#q]; got %#q", limatype.X8664, limatype.AARCH64, *y.Arch))
 		}
 	default:
 		errs = errors.Join(errs, fmt.Errorf("field `os` must be one of %#q; got %#q", limatype.OSTypes, *y.OS))

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -464,9 +464,9 @@ osOpts:
 			wantErrMsg: "currently Windows guest is only supported on `qemu`; got `vz`",
 		},
 		{
-			name:       "x86_64 only supports Windows guest",
+			name:       "x86_64 and aarch64 only support Windows guest",
 			yaml:       fmt.Sprintf(baseYaml, limatype.ARMV7L, limatype.QEMU),
-			wantErrMsg: "currently Windows guest is only supported on [`x86_64`]; got `armv7l`",
+			wantErrMsg: "currently Windows guest is only supported on [`x86_64`, `aarch64`]; got `armv7l`",
 		},
 	}
 

--- a/templates/windows-11.yaml
+++ b/templates/windows-11.yaml
@@ -1,7 +1,6 @@
 # Windows guest is currently experimental. It only runs on QEMU, and it requires plain: true.
 os: "Windows"
 vmType: "qemu"
-arch: "x86_64"
 
 images:
 # Currently there is no way to download Windows 11 ISO automatically.
@@ -9,6 +8,8 @@ images:
 # Please download `English (United States)` version. Otherwise VM installation is stopped in the middle.
 - location: "~/Downloads/Win11_25H2_English_x64_v2.iso"
   arch: "x86_64"
+- location: "~/Downloads/Win11_25H2_English_Arm64_v2.iso"
+  arch: "aarch64"
 
 # Windows 11 guest uses TPM emulation by default.
 # You can turn off TPM (in that case, lima bypasses Windows 11's initial TPM check).

--- a/website/content/en/docs/usage/guests/windows.md
+++ b/website/content/en/docs/usage/guests/windows.md
@@ -32,6 +32,6 @@ For Windows server 2025, TPM emulation is disabled by default. However, there ar
 - Several features are not implemented yet. See [Caveats](#caveats) below.
 
 ## Caveats
-- Currently only x86-64 is supported for both Windows 11 and server 2025
+- For Windows 11 guest, you need to download the installer ISO manually from [here](https://www.microsoft.com/en-us/software-download/windows11)
 - QEMU is the only VM driver that supports Windows guests
 - Only plain mode is supported (no file mount, no dynamic port-forwarding)


### PR DESCRIPTION
This PR implements Windows 11 ARM64 support.

Since the branch is created from the branch of #5164, only the second commit is for Windows 11 ARM64 implementation.
Once #5164 is merged, this PR will be tidied up.