### PR TITLE
networks: avoid %everyone in default sudoers

### DIFF
--- a/pkg/networks/commands_test.go
+++ b/pkg/networks/commands_test.go
@@ -38,10 +38,6 @@ func TestLogFile(t *testing.T) {
 func TestUser(t *testing.T) {
 	config, err := DefaultConfig()
 	assert.NilError(t, err)
-	if runtime.GOOS != "darwin" && config.Group == "everyone" {
-		// The "everyone" group is a specific macOS feature to include non-local accounts.
-		config.Group = "staff"
-	}
 	if runtime.GOOS == "windows" {
 		// unimplemented
 		t.Skip()
@@ -84,11 +80,11 @@ func TestStartCmd(t *testing.T) {
 		}
 
 		cmd := config.StartCmd("shared", SocketVMNet)
-		assert.Equal(t, cmd, "/opt/socket_vmnet/bin/socket_vmnet --pidfile="+filepath.Join(varRunDir, "shared_socket_vmnet.pid")+" --socket-group=everyone --vmnet-mode=shared "+
+		assert.Equal(t, cmd, "/opt/socket_vmnet/bin/socket_vmnet --pidfile="+filepath.Join(varRunDir, "shared_socket_vmnet.pid")+" --socket-group=admin --vmnet-mode=shared "+
 			"--vmnet-gateway=192.168.105.1 --vmnet-dhcp-end=192.168.105.254 --vmnet-mask=255.255.255.0 "+filepath.Join(varRunDir, "socket_vmnet.shared"))
 
 		cmd = config.StartCmd("bridged", SocketVMNet)
-		assert.Equal(t, cmd, "/opt/socket_vmnet/bin/socket_vmnet --pidfile="+filepath.Join(varRunDir, "bridged_socket_vmnet.pid")+" --socket-group=everyone --vmnet-mode=bridged "+
+		assert.Equal(t, cmd, "/opt/socket_vmnet/bin/socket_vmnet --pidfile="+filepath.Join(varRunDir, "bridged_socket_vmnet.pid")+" --socket-group=admin --vmnet-mode=bridged "+
 			"--vmnet-interface=en0 "+filepath.Join(varRunDir, "socket_vmnet.bridged"))
 	})
 }

--- a/pkg/networks/networks.TEMPLATE.yaml
+++ b/pkg/networks/networks.TEMPLATE.yaml
@@ -15,7 +15,10 @@ paths:
   varRun: /private/var/run/lima
   sudoers: /private/etc/sudoers.d/lima
 
-group: everyone
+# The group that is allowed to run socket_vmnet via sudo and to access the
+# socket_vmnet socket (macOS only; ignored on other platforms). Non-admin users
+# must set this to a group they belong to (e.g. "staff").
+group: admin
 
 networks:
   user-v2:

--- a/pkg/networks/networks.go
+++ b/pkg/networks/networks.go
@@ -7,7 +7,7 @@ import "net"
 
 type Config struct {
 	Paths    Paths              `yaml:"paths" json:"paths"`
-	Group    string             `yaml:"group,omitempty" json:"group,omitempty"` // default: "everyone"
+	Group    string             `yaml:"group,omitempty" json:"group,omitempty"` // default: "admin"
 	Networks map[string]Network `yaml:"networks" json:"networks"`
 }
 

--- a/website/content/en/docs/config/network/vmnet.md
+++ b/website/content/en/docs/config/network/vmnet.md
@@ -103,7 +103,10 @@ paths:
   varRun: /private/var/run/lima
   sudoers: /private/etc/sudoers.d/lima
 
-group: everyone
+# The group that is allowed to run socket_vmnet via sudo and to access the
+# socket_vmnet socket (macOS only; ignored on other platforms). Non-admin users
+# must set this to a group they belong to (e.g. "staff").
+group: admin
 
 networks:
   shared:
@@ -163,6 +166,20 @@ less etc_sudoers.d_lima  # verify that the file looks correct
 sudo install -o root etc_sudoers.d_lima /etc/sudoers.d/lima
 rm etc_sudoers.d_lima
 ```
+
+The `sudoers` file grants the members of the `group` configured in `networks.yaml`
+permission to run `socket_vmnet` as root. Since Lima v2.2, `group` defaults to
+`admin` instead of `everyone`, so the permission is no longer granted to non-admin
+and non-local accounts. A non-admin user must set `group` to a group they belong
+to (e.g. `staff`).
+
+{{% alert title="Note" color="warning" %}}
+Existing installations keep whatever `group` is already written in
+`$LIMA_HOME/_config/networks.yaml` (the file is never rewritten once it exists).
+To narrow an existing `group: everyone`, edit the field, make sure every user of
+the networks is a member of the new group, and regenerate the `sudoers` file with
+the command above.
+{{% /alert %}}
 
 The IP address is automatically assigned by macOS's bootpd.
 If the IP address is not assigned, try the following commands:

--- a/website/content/en/docs/releases/breaking.md
+++ b/website/content/en/docs/releases/breaking.md
@@ -4,6 +4,8 @@ weight: 20
 ---
 
 ## v2.2.0
+- The default [`socket_vmnet` group](../config/network/vmnet.md) in `networks.yaml` was changed from `everyone` to
+  `admin`. A non-admin user must set `group` to a group they belong to (e.g. `staff`).
 - The default VM driver on Windows hosts was changed from `wsl2` to `qemu`,
   as `wsl2` is not compatible with most templates.
 


### PR DESCRIPTION

`limactl sudoers` and the generated `networks.yaml` defaulted `group` to `everyone`, which on macOS grants every account (including non-local / directory accounts) permission to run `socket_vmnet` as `root:wheel` and to access the vmnet socket. For the common single-user workstation this is broader than necessary.

Change the default to `admin`. It is tighter than `everyone` (and `staff`), and it matches the realistic audience: installing the sudoers file already requires `sudo`, which on macOS is granted to admins by default, so `%admin` covers exactly the users who can use this feature. A non-admin user must set `group` to a group they belong to (e.g. `staff`).

Existing `networks.yaml` files are not rewritten, so current installations keep their `everyone` value; the new default only applies to fresh setups.

Proper per-user scoping is deferred until `socket_vmnet` gains `--socket-user=USER`.

Closes #5118