### PR TITLE
feat(cli): add `--shell` flag

### DIFF
--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -93,6 +93,11 @@ func RegisterEdit(cmd *cobra.Command, commentPrefix string) {
 		}
 		return drivers, cobra.ShellCompDirectiveNoFileComp
 	})
+
+	flags.String("shell", "", commentPrefix+"User login shell in the guest (e.g. /bin/bash, /bin/zsh)")
+	_ = cmd.RegisterFlagCompletionFunc("shell", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return []string{"/bin/bash", "/bin/zsh", "cmd.exe", "powershell.exe", "pwsh.exe"}, cobra.ShellCompDirectiveNoFileComp
+	})
 }
 
 // RegisterCreate registers flags related to in-place YAML modification, for `limactl create`.
@@ -416,6 +421,7 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool, params map[string]stri
 			false,
 			false,
 		},
+		{"shell", d(".user.shell = %q"), false, false},
 	}
 	var exprs []string
 	for _, def := range defs {

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/instance"
 	"github.com/lima-vm/lima/v2/pkg/ioutilx"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limayaml"
 	"github.com/lima-vm/lima/v2/pkg/localpathutil"
 	"github.com/lima-vm/lima/v2/pkg/networks/reconcile"
 	"github.com/lima-vm/lima/v2/pkg/sshutil"
@@ -289,8 +290,23 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if shell == "" {
-		shell = `"$SHELL"`
+	if *inst.Config.OS == limatype.WINDOWS {
+		if shell == "" {
+			if inst.Config.User.Shell != nil {
+				shell = *inst.Config.User.Shell
+			} else {
+				shell = "cmd.exe"
+			}
+		}
+		if !limayaml.IsSupportedWindowsShell(shell) {
+			return fmt.Errorf("unsupported shell %#q for Windows guest, must be one of %v", shell, limayaml.SupportedWindowsShells)
+		}
+	} else if shell == "" {
+		if inst.Config.User.Shell != nil {
+			shell = shellescape.Quote(*inst.Config.User.Shell)
+		} else {
+			shell = `"$SHELL"`
+		}
 	} else {
 		shell = shellescape.Quote(shell)
 	}
@@ -315,7 +331,7 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	script := fmt.Sprintf("%s ; exec %s%s -l", changeDirCmd, envPrefix, shell)
 	if *inst.Config.OS == limatype.WINDOWS {
 		// TODO: When we implement a file mount for Windows guest, we should change directory here.
-		script = "cmd.exe"
+		script = windowsQuoteShell(shell)
 	}
 	if len(args) > 1 {
 		quotedArgs := make([]string, len(args[1:]))
@@ -330,8 +346,10 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		}
 		switch *inst.Config.OS {
 		case limatype.WINDOWS:
+			// cmd.exe uses "/c", while powershell.exe / pwsh.exe use "-Command".
+			flag := windowsShellCommandFlag(shell)
 			// On Windows, commands should be double-quoted.
-			script += fmt.Sprintf(` /c "%s"`, strings.Join(quotedArgs, " "))
+			script += fmt.Sprintf(` %s "%s"`, flag, strings.Join(quotedArgs, " "))
 		default:
 			script += fmt.Sprintf(
 				" -c %s",
@@ -465,6 +483,33 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		return askUserForRsyncBack(ctx, cmd, inst, sshExecForRsync, hostCurrentDir, destRsyncDir, rsync, tty)
 	}
 	return nil
+}
+
+// windowsShellCommandFlag returns the flag used to pass a command string to the
+// given Windows shell. cmd.exe uses "/c", while powershell.exe and pwsh.exe use "-Command".
+// The shell may be an absolute path (e.g. `C:\Windows\System32\cmd.exe`);
+// only its basename is inspected.
+func windowsShellCommandFlag(shell string) string {
+	if i := strings.LastIndexAny(shell, `/\`); i >= 0 {
+		shell = shell[i+1:]
+	}
+	if strings.EqualFold(shell, "cmd.exe") {
+		return "/c"
+	}
+	return "-Command"
+}
+
+// windowsQuoteShell wraps an absolute Windows shell path in double quotes
+// when it contains whitespace, so the remote command line parses correctly.
+// Already-quoted values are returned unchanged.
+func windowsQuoteShell(shell string) string {
+	if strings.HasPrefix(shell, `"`) && strings.HasSuffix(shell, `"`) && len(shell) >= 2 {
+		return shell
+	}
+	if !strings.ContainsAny(shell, " \t") {
+		return shell
+	}
+	return `"` + shell + `"`
 }
 
 func askUserForRsyncBack(ctx context.Context, cmd *cobra.Command, inst *limatype.Instance, sshCmd *exec.Cmd, hostCurrentDir, destRsyncDir string, rsync copytool.CopyTool, tty bool) error {

--- a/cmd/limactl/shell_test.go
+++ b/cmd/limactl/shell_test.go
@@ -97,3 +97,40 @@ func TestRsyncStatsString(t *testing.T) {
 		})
 	}
 }
+
+func TestWindowsShellCommandFlag(t *testing.T) {
+	tests := []struct {
+		shell string
+		want  string
+	}{
+		{"cmd.exe", "/c"},
+		{"CMD.EXE", "/c"},
+		{`C:\Windows\System32\cmd.exe`, "/c"},
+		{`C:/Windows/System32/cmd.exe`, "/c"},
+		{"powershell.exe", "-Command"},
+		{"pwsh.exe", "-Command"},
+		{`C:\Program Files\PowerShell\7\pwsh.exe`, "-Command"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.shell, func(t *testing.T) {
+			assert.Equal(t, tt.want, windowsShellCommandFlag(tt.shell))
+		})
+	}
+}
+
+func TestWindowsQuoteShell(t *testing.T) {
+	tests := []struct {
+		shell string
+		want  string
+	}{
+		{"cmd.exe", "cmd.exe"},
+		{`C:\Windows\System32\cmd.exe`, `C:\Windows\System32\cmd.exe`},
+		{`C:\Program Files\PowerShell\7\pwsh.exe`, `"C:\Program Files\PowerShell\7\pwsh.exe"`},
+		{`"C:\already\quoted.exe"`, `"C:\already\quoted.exe"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.shell, func(t *testing.T) {
+			assert.Equal(t, tt.want, windowsQuoteShell(tt.shell))
+		})
+	}
+}

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -204,6 +204,8 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 			y.User.Shell = ptr.Of("/bin/sh")
 		case limatype.DARWIN:
 			y.User.Shell = ptr.Of("/bin/zsh")
+		case limatype.WINDOWS:
+			y.User.Shell = ptr.Of("cmd.exe")
 		default:
 			y.User.Shell = ptr.Of("/bin/bash")
 		}

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -65,6 +65,17 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		errs = errors.Join(errs, fmt.Errorf("field `arch` must be one of %v; got %#q", limatype.ArchTypes, *y.Arch))
 	}
 
+	if y.User.Shell != nil {
+		shell := *y.User.Shell
+		if *y.OS == limatype.WINDOWS {
+			if !IsSupportedWindowsShell(shell) {
+				errs = errors.Join(errs, fmt.Errorf("field `user.shell` must be one of %v for Windows guest, got %#q", SupportedWindowsShells, shell))
+			}
+		} else if !path.IsAbs(shell) {
+			errs = errors.Join(errs, fmt.Errorf("field `user.shell` must be an absolute path, got %#q", shell))
+		}
+	}
+
 	if len(y.Images) == 0 {
 		errs = errors.Join(errs, errors.New("field `images` must be set"))
 	}
@@ -433,6 +444,22 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 	}
 
 	return errs
+}
+
+var SupportedWindowsShells = []string{"cmd.exe", "powershell.exe", "pwsh.exe"}
+
+func IsSupportedWindowsShell(shell string) bool {
+	// Normalize both forward and backward slashes since Windows-style paths may
+	// be validated on a non-Windows host.
+	if i := strings.LastIndexAny(shell, `/\`); i >= 0 {
+		shell = shell[i+1:]
+	}
+	for _, s := range SupportedWindowsShells {
+		if strings.EqualFold(shell, s) {
+			return true
+		}
+	}
+	return false
 }
 
 func validateFileObject(f limatype.File, fieldName string) error {

--- a/pkg/limayaml/validate_test.go
+++ b/pkg/limayaml/validate_test.go
@@ -484,3 +484,88 @@ osOpts:
 		})
 	}
 }
+
+func TestIsSupportedWindowsShell(t *testing.T) {
+	tests := []struct {
+		shell string
+		want  bool
+	}{
+		{"cmd.exe", true},
+		{"CMD.EXE", true},
+		{"powershell.exe", true},
+		{"pwsh.exe", true},
+		{`C:\Windows\System32\cmd.exe`, true},
+		{`C:/Windows/System32/cmd.exe`, true},
+		{`C:\Program Files\PowerShell\7\pwsh.exe`, true},
+		{"bash.exe", false},
+		{"cmd", false},
+		{"/bin/bash", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.shell, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsSupportedWindowsShell(tt.shell))
+		})
+	}
+}
+
+func TestValidateUserShell(t *testing.T) {
+	posixImages := `images: [{"location": "/"}]`
+	windowsBase := `
+os: Windows
+arch: x86_64
+vmType: qemu
+images:
+  - location: /
+osOpts:
+  Windows:
+    virtioWin:
+    - location: /
+      arch: "x86_64"
+`
+
+	tests := []struct {
+		name       string
+		yaml       string
+		wantErrMsg string
+	}{
+		{
+			name: "posix absolute path ok",
+			yaml: posixImages + "\nuser:\n  shell: /bin/bash\n",
+		},
+		{
+			name:       "posix relative path rejected",
+			yaml:       posixImages + "\nuser:\n  shell: bash\n",
+			wantErrMsg: "field `user.shell` must be an absolute path, got `bash`",
+		},
+		{
+			name: "windows cmd.exe ok",
+			yaml: windowsBase + "\nuser:\n  shell: cmd.exe\n",
+		},
+		{
+			name: "windows pwsh.exe ok",
+			yaml: windowsBase + "\nuser:\n  shell: pwsh.exe\n",
+		},
+		{
+			name: "windows absolute cmd.exe ok",
+			yaml: windowsBase + "\nuser:\n  shell: 'C:\\Windows\\System32\\cmd.exe'\n",
+		},
+		{
+			name:       "windows posix shell rejected",
+			yaml:       windowsBase + "\nuser:\n  shell: /bin/bash\n",
+			wantErrMsg: "field `user.shell` must be one of [cmd.exe powershell.exe pwsh.exe] for Windows guest, got `/bin/bash`",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			y, err := Load(t.Context(), []byte(tt.yaml), "template.yaml")
+			assert.NilError(t, err)
+			err = Validate(y, false)
+			if tt.wantErrMsg == "" {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErrMsg)
+			}
+		})
+	}
+}

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -365,8 +365,11 @@ user:
   # It can use the following template variables: {{.Name}}, {{.Hostname}}, {{.UID}}, {{.User}}, and {{.Param.Key}}.
   # 🟢 Builtin default: "/home/{{.User}}.guest" (Also accessible as "/home/{{.User}}.linux")
   home: null
-  # Shell. Needs to be an absolute path.
-  # 🟢 Builtin default: "/bin/bash"
+  # Shell. Needs to be an absolute path on POSIX guests.
+  # For Windows guests, this is the command-line interpreter used by `limactl shell`,
+  # and must be one of "cmd.exe", "powershell.exe", or "pwsh.exe".
+  # The shell must already exist in the guest image.
+  # 🟢 Builtin default: "/bin/bash" (Linux), "/bin/zsh" (macOS), "/bin/sh" (FreeBSD), "cmd.exe" (Windows)
   shell: null
 
 vmOpts:

--- a/website/content/en/docs/usage/_index.md
+++ b/website/content/en/docs/usage/_index.md
@@ -67,3 +67,13 @@ The guest home directory exists independently on the following path:
 ### Shell completion
 - To enable bash completion, add `source <(limactl completion bash)` to `~/.bash_profile`.
 - To enable zsh completion, see `limactl completion zsh --help`
+
+### User shell
+
+The default login shell inside the guest can be overridden via the `user.shell`
+field in the instance YAML, or with `--shell` on `limactl create` / `limactl edit`.
+The shell must already exist in the guest image.
+
+On an existing instance, `chsh` inside the guest can be used to change the login shell.
+
+To launch a different shell for a single session, use `limactl shell --shell=SHELL`.


### PR DESCRIPTION
This PR adds first-class support for configuring the guest login shell via an OS-independent `user.shell` field and `--shell` flag. The configured shell is always used as the default when entering the guest with `limactl shell`. To use a different shell temporarily (provided it is already installed in the guest), pass `--shell`. On Windows guests, the shell must be one of `cmd.exe`, `powershell.exe`, or `pwsh.exe`.

### Fixes

> > [#5138 (comment)](https://github.com/lima-vm/lima/pull/5138#discussion_r3448643816)
> > 
> > `powershell.exe` seemed to work fine on my end, but `cmd.exe` should remain default for now. Perhaps we can add a field to [`WindowsOpts`](https://github.com/lima-vm/lima/pull/5138/changes#diff-3d1d6bc5aa22dc83bddc658fe4150883993556096584bd9108305a0939efcd01R350) to switch between cmd and powershell?
> 
> Let's discuss this in a separate issue/PR.
> There should be an OS-independent property to specify the command line shell.
> 
> _Originally posted by @AkihiroSuda in https://github.com/lima-vm/lima/issues/5138#issuecomment-4846417279_
            