### PR TITLE
downloader: fall back to built-in gzip decompression

### DIFF
--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -5,6 +5,7 @@ package downloader
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"errors"
@@ -525,8 +526,6 @@ func decompressorByMagic(file string) string {
 }
 
 func decompressLocal(ctx context.Context, decompressCmd, dst, src, ext, description string) error {
-	logrus.Infof("decompressing %s with %v", ext, decompressCmd)
-
 	st, err := os.Stat(src)
 	if err != nil {
 		return err
@@ -549,11 +548,6 @@ func decompressLocal(ctx context.Context, decompressCmd, dst, src, ext, descript
 		return err
 	}
 	defer out.Close()
-	buf := new(bytes.Buffer)
-	cmd := exec.CommandContext(ctx, decompressCmd, "-d") // -d --decompress
-	cmd.Stdin = bar.NewProxyReader(in)
-	cmd.Stdout = out
-	cmd.Stderr = buf
 	if !HideProgress {
 		if description == "" {
 			description = filepath.Base(src)
@@ -561,6 +555,37 @@ func decompressLocal(ctx context.Context, decompressCmd, dst, src, ext, descript
 		logrus.Infof("Decompressing %s", description)
 	}
 	bar.Start()
+	defer bar.Finish()
+	reader := bar.NewProxyReader(in)
+
+	// Prefer the external decompressor; fall back to a built-in pure-Go
+	// gzip decoder only when the binary is missing, so a plain Windows
+	// host with no gzip can still unpack a .tar.gz image. xz, bzip2, and
+	// zstd stay external-only.
+	if _, lookErr := exec.LookPath(decompressCmd); lookErr != nil {
+		var r io.Reader
+		switch decompressCmd {
+		case "gzip":
+			gz, err := gzip.NewReader(reader)
+			if err != nil {
+				return err
+			}
+			defer gz.Close()
+			r = gz
+		default:
+			return fmt.Errorf("decompressor %q not found and no built-in fallback: %w", decompressCmd, lookErr)
+		}
+		logrus.Infof("decompressing %s with built-in %s (external %q not found)", ext, decompressCmd, decompressCmd)
+		_, err = io.Copy(out, &ctxReader{ctx: ctx, r: r})
+		return err
+	}
+
+	logrus.Infof("decompressing %s with external %q", ext, decompressCmd)
+	buf := new(bytes.Buffer)
+	cmd := exec.CommandContext(ctx, decompressCmd, "-d")
+	cmd.Stdin = reader
+	cmd.Stdout = out
+	cmd.Stderr = buf
 	err = cmd.Run()
 	if err != nil {
 		var exitErr *exec.ExitError
@@ -568,8 +593,22 @@ func decompressLocal(ctx context.Context, decompressCmd, dst, src, ext, descript
 			exitErr.Stderr = buf.Bytes()
 		}
 	}
-	bar.Finish()
 	return err
+}
+
+// ctxReader makes an uninterruptible in-process decode cancellable: once ctx
+// is cancelled each Read returns its error, unwinding the io.Copy that drives
+// the decoder.
+type ctxReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (c *ctxReader) Read(p []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return c.r.Read(p)
 }
 
 func validateCachedDigest(shadDigest string, expectedDigest digest.Digest) error {

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -4,6 +4,8 @@
 package downloader
 
 import (
+	"compress/gzip"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -320,31 +322,48 @@ func TestDownloadLocal(t *testing.T) {
 }
 
 func TestDownloadCompressed(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		// FIXME: `assertion failed: error is not nil: exec: "gzip": executable file not found in %PATH%`
-		t.Skip("Skipping on windows")
-	}
+	testContents := []byte("TestDownloadCompressed")
 
-	t.Run("gzip", func(t *testing.T) {
-		ctx := t.Context()
+	// check builds a compressed fixture via write, downloads it with
+	// decompression, and asserts the result round-trips. With noExternal set,
+	// PATH is emptied so the built-in decoder runs instead of a host binary.
+	check := func(t *testing.T, ext string, write func(io.Writer) error, noExternal bool) {
+		t.Helper()
+		if noExternal {
+			t.Setenv("PATH", t.TempDir())
+		}
 		localPath := filepath.Join(t.TempDir(), t.Name())
-		localFile := filepath.Join(t.TempDir(), "test-file")
-		testDownloadCompressedContents := []byte("TestDownloadCompressed")
-		assert.NilError(t, os.WriteFile(localFile, testDownloadCompressedContents, 0o644))
-		assert.NilError(t, exec.CommandContext(ctx, "gzip", localFile).Run())
-		localFile += ".gz"
-		testLocalFileURL := "file://" + localFile
+		localFile := filepath.Join(t.TempDir(), "test-file"+ext)
+		f, err := os.Create(localFile)
+		assert.NilError(t, err)
+		assert.NilError(t, write(f))
+		assert.NilError(t, f.Close())
 
-		r, err := Download(ctx, localPath, testLocalFileURL, WithDecompress(true))
+		r, err := Download(t.Context(), localPath, "file://"+localFile, WithDecompress(true))
 		assert.NilError(t, err)
 		assert.Equal(t, StatusDownloaded, r.Status)
-
 		got, err := os.ReadFile(localPath)
 		assert.NilError(t, err)
-		assert.Equal(t, string(got), string(testDownloadCompressedContents))
-	})
+		assert.Equal(t, string(got), string(testContents))
+	}
+	writeGz := func(w io.Writer) error {
+		gz := gzip.NewWriter(w)
+		if _, err := gz.Write(testContents); err != nil {
+			return err
+		}
+		return gz.Close()
+	}
+
+	t.Run("gzip", func(t *testing.T) { check(t, ".gz", writeGz, false) })
+	t.Run("gzip without external binary", func(t *testing.T) { check(t, ".gz", writeGz, true) })
 
 	t.Run("bzip2", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			// External bzip2 ships with MSYS2/Git for Windows but not
+			// vanilla Windows, and there is no in-process equivalent
+			// in the standard library.
+			t.Skip("bzip2 binary required to build the fixture")
+		}
 		ctx := t.Context()
 		localPath := filepath.Join(t.TempDir(), t.Name())
 		localFile := filepath.Join(t.TempDir(), "test-file")


### PR DESCRIPTION
Prefer the external `gzip` binary, but decode in-process with `compress/gzip` when it is missing, so a plain Windows host (no `gzip`) can still unpack a .tar.gz` image. `xz`, `bzip2`, and `zstd` stay external-only. A `ctxReader` keeps the in-process decode cancellable, so a canceled download unwinds instead of running to the end.

No new dependency: `compress/gzip` is stdlib and was already linked into `limactl`, so this adds no measurable binary size.

Extracted from #4998