### PR TITLE
Windows: detect the SSH toolchain and convert paths for native OpenSSH

### DIFF
--- a/pkg/ioutilx/ioutilx.go
+++ b/pkg/ioutilx/ioutilx.go
@@ -50,13 +50,39 @@ func FromUTF16leToString(r io.Reader) (string, error) {
 	return string(out), nil
 }
 
+// WindowsSubsystemPath converts a Windows path to a Cygwin/MSYS form
+// (C:\Users\jan -> /c/Users/jan) via cygpath on PATH. A caller holding a
+// specific ssh toolchain should use WindowsSubsystemPathWithCygpath, which
+// runs that toolchain's own cygpath and respects its fstab.
 func WindowsSubsystemPath(ctx context.Context, orig string) (string, error) {
-	out, err := exec.CommandContext(ctx, "cygpath", filepath.ToSlash(orig)).CombinedOutput()
-	if err != nil {
-		logrus.WithError(err).Errorf("failed to convert path to mingw, maybe not using Git ssh?")
-		return "", err
+	return WindowsSubsystemPathWithCygpath(ctx, "cygpath", orig)
+}
+
+// WindowsSubsystemPathWithCygpath converts a Windows path with the given
+// cygpathExe ("cygpath" for PATH, or an absolute path to bind the
+// conversion to one Cygwin install). When cygpath is unavailable it falls
+// back to a native conversion of the drive-letter case; UNC and other
+// non-drive-letter inputs return an error.
+func WindowsSubsystemPathWithCygpath(ctx context.Context, cygpathExe, orig string) (string, error) {
+	out, err := exec.CommandContext(ctx, cygpathExe, filepath.ToSlash(orig)).CombinedOutput()
+	if err == nil {
+		return strings.TrimSpace(string(out)), nil
 	}
-	return strings.TrimSpace(string(out)), nil
+	logrus.WithError(err).Debugf("cygpath unavailable for %q (output: %q), attempting native conversion", orig, strings.TrimSpace(string(out)))
+	// Only an absolute drive-letter path has a well-defined Cygwin form
+	// here. A drive-relative "C:foo" would become an unrelated absolute
+	// path, so reject it.
+	if filepath.IsAbs(orig) {
+		if vol := filepath.VolumeName(orig); len(vol) == 2 && vol[1] == ':' {
+			// orig[2:] starts with a separator for an absolute drive path
+			// (C:\foo, C:/foo); strip it so the result stays canonical.
+			tail := strings.TrimPrefix(filepath.ToSlash(orig[2:]), "/")
+			converted := "/" + strings.ToLower(vol[:1]) + "/" + tail
+			logrus.Debugf("native cygpath fallback: %q -> %q", orig, converted)
+			return converted, nil
+		}
+	}
+	return "", fmt.Errorf("cannot convert %q to a Cygwin-style path: cygpath unavailable and input is not an absolute drive-letter path", orig)
 }
 
 func WindowsSubsystemPathForLinux(ctx context.Context, orig, distro string) (string, error) {

--- a/pkg/ioutilx/ioutilx_test.go
+++ b/pkg/ioutilx/ioutilx_test.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ioutilx
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// TestWindowsSubsystemPathWithCygpath_Fallback exercises the native
+// drive-letter fallback path: when the cygpath binary is unreachable,
+// absolute drive-letter inputs convert in-process (e.g. C:\foo -> /c/foo)
+// and inputs without a drive letter return an error.
+func TestWindowsSubsystemPathWithCygpath_Fallback(t *testing.T) {
+	ctx := t.Context()
+	// A bogus binary name guarantees the fallback path runs on every
+	// platform without inventing a Windows-only test.
+	const bogusCygpath = "no-such-cygpath-binary-xyz"
+
+	t.Run("drive-letter backslash", func(t *testing.T) {
+		if runtime.GOOS != "windows" {
+			t.Skip("filepath.VolumeName / IsAbs treat C:\\foo as a relative path on non-Windows")
+		}
+		got, err := WindowsSubsystemPathWithCygpath(ctx, bogusCygpath, `C:\Users\USER`)
+		assert.NilError(t, err)
+		assert.Equal(t, got, "/c/Users/USER")
+	})
+
+	t.Run("drive-letter forward-slash", func(t *testing.T) {
+		if runtime.GOOS != "windows" {
+			t.Skip("filepath.VolumeName / IsAbs only recognize drive letters on Windows")
+		}
+		got, err := WindowsSubsystemPathWithCygpath(ctx, bogusCygpath, `C:/Users/USER`)
+		assert.NilError(t, err)
+		assert.Equal(t, got, "/c/Users/USER")
+	})
+
+	t.Run("non-drive-letter rejected", func(t *testing.T) {
+		// UNC and POSIX inputs both lack a drive letter; on every
+		// platform the fallback must refuse rather than fabricate.
+		for _, input := range []string{`\\server\share\foo`, "/etc/hosts", "relative.txt"} {
+			_, err := WindowsSubsystemPathWithCygpath(ctx, bogusCygpath, input)
+			assert.ErrorContains(t, err, "cannot convert", "input=%q", input)
+		}
+	})
+
+	t.Run("lowercases drive letter", func(t *testing.T) {
+		if runtime.GOOS != "windows" {
+			t.Skip("Windows-only")
+		}
+		got, err := WindowsSubsystemPathWithCygpath(ctx, bogusCygpath, `D:\path`)
+		assert.NilError(t, err)
+		assert.Assert(t, strings.HasPrefix(got, "/d/"), "got %q", got)
+	})
+}

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -61,6 +61,13 @@ func NewSSHExe() (SSHExe, error) {
 		}
 	}
 
+	if runtime.GOOS == "windows" {
+		if exe := pickCompleteSSHOnWindows(); exe != "" {
+			sshExe.Exe = exe
+			return sshExe, nil
+		}
+	}
+
 	executable, err := exec.LookPath("ssh")
 	if err != nil {
 		return SSHExe{}, err
@@ -68,6 +75,164 @@ func NewSSHExe() (SSHExe, error) {
 	sshExe.Exe = executable
 
 	return sshExe, nil
+}
+
+// pickCompleteSSHOnWindows returns an ssh.exe whose directory also has
+// scp.exe and ssh-keygen.exe, which Lima needs for create and copy.
+// MinGit ships ssh.exe without those, so a partial install is skipped for
+// the next complete one on PATH, then the native install under
+// %SystemRoot%\System32\OpenSSH. Returns "" when none qualifies, so the
+// caller falls through to exec.LookPath instead of picking a partial one.
+func pickCompleteSSHOnWindows() string {
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			continue
+		}
+		sshPath := filepath.Join(dir, "ssh.exe")
+		if _, err := os.Stat(sshPath); err != nil {
+			continue
+		}
+		if missing := missingSiblings(dir, "scp.exe", "ssh-keygen.exe"); len(missing) > 0 {
+			logrus.Debugf("skipping ssh at %q: missing %v in same directory (likely MinGit or another partial install)", sshPath, missing)
+			continue
+		}
+		return sshPath
+	}
+	nativeSSH := filepath.Join(systemRoot(), "System32", "OpenSSH", "ssh.exe")
+	if _, err := os.Stat(nativeSSH); err == nil {
+		return nativeSSH
+	}
+	return ""
+}
+
+// systemRoot returns %SystemRoot%, or C:\Windows when unset — honouring
+// installs (Windows PE, some enterprise setups) that put it off the C: drive.
+func systemRoot() string {
+	if r := os.Getenv("SystemRoot"); r != "" {
+		return r
+	}
+	return `C:\Windows`
+}
+
+func missingSiblings(dir string, siblings ...string) []string {
+	var missing []string
+	for _, s := range siblings {
+		if _, err := os.Stat(filepath.Join(dir, s)); err != nil {
+			missing = append(missing, s)
+		}
+	}
+	return missing
+}
+
+var (
+	// cygwinDetectCache maps a resolved ssh path to its sibling cygpath.exe,
+	// or "" when that ssh is not Cygwin-based. Each path is probed once.
+	cygwinDetectCache   = map[string]string{}
+	cygwinDetectCacheRW sync.RWMutex
+)
+
+// IsSSHCygwin reports whether sshExe is a Cygwin-based OpenSSH (Git for
+// Windows, MSYS2, Cygwin) rather than native Windows OpenSSH; always false
+// on non-Windows. See cygpathForSSH for the detection and caching.
+func IsSSHCygwin(sshExe SSHExe) bool {
+	_, ok := cygpathForSSH(sshExe)
+	return ok
+}
+
+// cygpathForSSH returns the cygpath.exe beside sshExe (resolved through
+// symlinks) and whether sshExe is Cygwin-based. Callers pass the returned
+// path to exec.Command so conversions run through that toolchain's own
+// cygpath, even when $SSH points outside PATH. ("", false) on non-Windows
+// or empty input; results are cached per resolved path.
+func cygpathForSSH(sshExe SSHExe) (string, bool) {
+	if runtime.GOOS != "windows" || sshExe.Exe == "" {
+		return "", false
+	}
+	path := sshExe.Exe
+	if !filepath.IsAbs(path) {
+		resolved, err := exec.LookPath(path)
+		if err != nil {
+			logrus.WithError(err).Debugf("cygpathForSSH: cannot resolve %q via PATH; assuming native", sshExe.Exe)
+			return "", false
+		}
+		path = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	cygwinDetectCacheRW.RLock()
+	cached, ok := cygwinDetectCache[path]
+	cygwinDetectCacheRW.RUnlock()
+	if ok {
+		return cached, cached != ""
+	}
+	cygpathExe := filepath.Join(filepath.Dir(path), "cygpath.exe")
+	if _, err := os.Stat(cygpathExe); err != nil {
+		logrus.Debugf("ssh at %q detected as native Windows OpenSSH (no cygpath.exe alongside)", path)
+		cygpathExe = ""
+	} else {
+		logrus.Debugf("ssh at %q detected as Cygwin-based (found %q alongside)", path, cygpathExe)
+	}
+	cygwinDetectCacheRW.Lock()
+	cygwinDetectCache[path] = cygpathExe
+	cygwinDetectCacheRW.Unlock()
+	return cygpathExe, cygpathExe != ""
+}
+
+// PathForSSH converts orig to the path form Lima's ssh-family invocations
+// expect; unchanged on non-Windows. On Windows, Cygwin-based ssh (Git for
+// Windows, MSYS2) gets a /c/Users/... form from the sibling cygpath, which
+// respects the toolchain's fstab; native Windows OpenSSH gets forward
+// slashes (C:/Users/...), which native ssh, ssh-keygen, and scp accept.
+func PathForSSH(ctx context.Context, sshExe SSHExe, orig string) (string, error) {
+	if runtime.GOOS != "windows" {
+		return orig, nil
+	}
+	if cygpathExe, ok := cygpathForSSH(sshExe); ok {
+		return ioutilx.WindowsSubsystemPathWithCygpath(ctx, cygpathExe, orig)
+	}
+	return filepath.ToSlash(orig), nil
+}
+
+// SftpServerForSSH returns the sftp-server binary from sshExe's toolchain,
+// so a locally-spawned sftp-server (reverse-sshfs) uses the same path form
+// PathForSSH produces. For Cygwin-based ssh the sibling cygpath resolves
+// /usr/lib/ssh/sftp-server; for native OpenSSH it is sftp-server.exe beside
+// ssh.exe. Returns "" on non-Windows, empty input, or no match, leaving the
+// caller to fall back to its library's auto-detection.
+func SftpServerForSSH(ctx context.Context, sshExe SSHExe) string {
+	if runtime.GOOS != "windows" || sshExe.Exe == "" {
+		return ""
+	}
+	if cygpathExe, ok := cygpathForSSH(sshExe); ok {
+		out, err := exec.CommandContext(ctx, cygpathExe, "-w", "/usr/lib/ssh/sftp-server").Output()
+		if err != nil {
+			return ""
+		}
+		candidate := strings.TrimSpace(string(out))
+		for _, p := range []string{candidate, candidate + ".exe"} {
+			if _, err := os.Stat(p); err == nil {
+				return p
+			}
+		}
+		return ""
+	}
+	path := sshExe.Exe
+	if !filepath.IsAbs(path) {
+		resolved, err := exec.LookPath(path)
+		if err != nil {
+			return ""
+		}
+		path = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	sftpServer := filepath.Join(filepath.Dir(path), "sftp-server.exe")
+	if _, err := os.Stat(sftpServer); err != nil {
+		return ""
+	}
+	return sftpServer
 }
 
 type PubKey struct {
@@ -111,7 +276,11 @@ func DefaultPubKeys(ctx context.Context, loadDotSSH bool) ([]PubKey, error) {
 			// no passphrase, no user@host comment
 			privPath := filepath.Join(configDir, filenames.UserPrivateKey)
 			if runtime.GOOS == "windows" {
-				privPath, err = ioutilx.WindowsSubsystemPath(ctx, privPath)
+				sshExe, sshErr := NewSSHExe()
+				if sshErr != nil {
+					return sshErr
+				}
+				privPath, err = PathForSSH(ctx, sshExe, privPath)
 				if err != nil {
 					return err
 				}
@@ -198,7 +367,7 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 		return nil, err
 	}
 	var opts []string
-	idf, err := identityFileEntry(ctx, privateKeyPath)
+	idf, err := identityFileEntry(ctx, sshExe, privateKeyPath)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +402,7 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 				// Fail on permission-related and other path errors
 				return nil, err
 			}
-			idf, err = identityFileEntry(ctx, privateKeyPath)
+			idf, err = identityFileEntry(ctx, sshExe, privateKeyPath)
 			if err != nil {
 				return nil, err
 			}
@@ -285,9 +454,9 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 	return opts, nil
 }
 
-func identityFileEntry(ctx context.Context, privateKeyPath string) (string, error) {
+func identityFileEntry(ctx context.Context, sshExe SSHExe, privateKeyPath string) (string, error) {
 	if runtime.GOOS == "windows" {
-		privateKeyPath, err := ioutilx.WindowsSubsystemPath(ctx, privateKeyPath)
+		privateKeyPath, err := PathForSSH(ctx, sshExe, privateKeyPath)
 		if err != nil {
 			return "", err
 		}
@@ -381,7 +550,7 @@ func SSHOpts(ctx context.Context, sshExe SSHExe, instDir, username string, useDo
 	}
 	controlPath := fmt.Sprintf(`ControlPath="%s"`, controlSock)
 	if runtime.GOOS == "windows" {
-		controlSock, err = ioutilx.WindowsSubsystemPath(ctx, controlSock)
+		controlSock, err = PathForSSH(ctx, sshExe, controlSock)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/coreos/go-semver/semver"
@@ -22,6 +23,132 @@ func TestDefaultPubKeys(t *testing.T) {
 	for _, key := range keys {
 		t.Logf("%s: %#q", key.Filename, key.Content)
 	}
+}
+
+// TestPickCompleteSSHOnWindows: an ssh.exe missing scp.exe or
+// ssh-keygen.exe (MinGit's shape) is skipped for the next complete
+// install on PATH.
+func TestPickCompleteSSHOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only PATH walk")
+	}
+
+	mkDir := func(t *testing.T, exes ...string) string {
+		t.Helper()
+		dir := resolvedTempDir(t)
+		for _, exe := range exes {
+			assert.NilError(t, os.WriteFile(filepath.Join(dir, exe), nil, 0o644))
+		}
+		return dir
+	}
+
+	t.Run("complete install on PATH is picked", func(t *testing.T) {
+		full := mkDir(t, "ssh.exe", "scp.exe", "ssh-keygen.exe")
+		t.Setenv("PATH", full)
+		assert.Equal(t, pickCompleteSSHOnWindows(), filepath.Join(full, "ssh.exe"))
+	})
+
+	t.Run("incomplete install before complete install is skipped", func(t *testing.T) {
+		mingit := mkDir(t, "ssh.exe")
+		full := mkDir(t, "ssh.exe", "scp.exe", "ssh-keygen.exe")
+		t.Setenv("PATH", mingit+string(os.PathListSeparator)+full)
+		assert.Equal(t, pickCompleteSSHOnWindows(), filepath.Join(full, "ssh.exe"))
+	})
+
+	t.Run("falls back to native install when nothing on PATH is complete", func(t *testing.T) {
+		nativeSSH := filepath.Join(systemRoot(), "System32", "OpenSSH", "ssh.exe")
+		if _, err := os.Stat(nativeSSH); err != nil {
+			t.Skipf("native OpenSSH not present at %q on this host", nativeSSH)
+		}
+		mingit := mkDir(t, "ssh.exe")
+		t.Setenv("PATH", mingit)
+		assert.Equal(t, pickCompleteSSHOnWindows(), nativeSSH)
+	})
+}
+
+// resolvedTempDir is t.TempDir() run through EvalSymlinks, matching what
+// the production helpers compute. On GitHub Windows runners t.TempDir()
+// is an 8.3 short path (C:\Users\RUNNER~1\...) that the helpers expand,
+// so a raw compare would fail.
+func resolvedTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	assert.NilError(t, err)
+	return resolved
+}
+
+// TestCygpathForSSH: cygpathForSSH must return the cygpath beside the
+// given ssh.exe, not one off PATH — PathForSSH runs it directly, so a
+// regression would route conversions through the wrong toolchain.
+func TestCygpathForSSH(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("cygpath detection only runs on Windows")
+	}
+
+	t.Run("cygwin", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		sshExe := filepath.Join(dir, "ssh.exe")
+		cygpathExe := filepath.Join(dir, "cygpath.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+		assert.NilError(t, os.WriteFile(cygpathExe, nil, 0o644))
+
+		got, ok := cygpathForSSH(SSHExe{Exe: sshExe})
+		assert.Equal(t, ok, true, "ssh.exe next to cygpath.exe should be Cygwin")
+		assert.Equal(t, got, cygpathExe, "should return the sibling cygpath, not bare 'cygpath'")
+		assert.Equal(t, IsSSHCygwin(SSHExe{Exe: sshExe}), true)
+	})
+
+	t.Run("native", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		sshExe := filepath.Join(dir, "ssh.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+
+		got, ok := cygpathForSSH(SSHExe{Exe: sshExe})
+		assert.Equal(t, ok, false, "ssh.exe with no sibling cygpath.exe should be native")
+		assert.Equal(t, got, "")
+		assert.Equal(t, IsSSHCygwin(SSHExe{Exe: sshExe}), false)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		got, ok := cygpathForSSH(SSHExe{})
+		assert.Equal(t, ok, false)
+		assert.Equal(t, got, "")
+	})
+}
+
+// TestSftpServerForSSH: the sftp-server returned must come from the same
+// install as sshExe, so its Windows path form matches what reverse-sshfs
+// feeds to sshocker.
+func TestSftpServerForSSH(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only path handling")
+	}
+	ctx := t.Context()
+
+	t.Run("native: sibling sftp-server.exe next to ssh.exe", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		sshExe := filepath.Join(dir, "ssh.exe")
+		sftpExe := filepath.Join(dir, "sftp-server.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+		assert.NilError(t, os.WriteFile(sftpExe, nil, 0o644))
+
+		got := SftpServerForSSH(ctx, SSHExe{Exe: sshExe})
+		assert.Equal(t, got, sftpExe)
+	})
+
+	t.Run("native: no sibling sftp-server.exe returns empty", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		sshExe := filepath.Join(dir, "ssh.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+
+		got := SftpServerForSSH(ctx, SSHExe{Exe: sshExe})
+		assert.Equal(t, got, "", "no sftp-server.exe sibling -> caller falls back to sshocker auto-detect")
+	})
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		assert.Equal(t, SftpServerForSSH(ctx, SSHExe{}), "")
+	})
 }
 
 func TestParseOpenSSHVersion(t *testing.T) {


### PR DESCRIPTION
On Windows, Lima runs `cygpath` to translate key and socket paths, assuming a Cygwin-based ssh (Git for Windows / MSYS2). With only native Windows OpenSSH installed, `cygpath` is unavailable and `limactl create` fails immediately.

Detect which toolchain the selected `ssh` belongs to and convert paths to the form it expects: the sibling `cygpath` (respecting its `fstab`) for Cygwin-based `ssh`, or forward slashes (`C:/Users/...`) for native Windows OpenSSH. Also pick a complete `ssh` install, skipping a partial one like MinGit that lacks `scp` or `ssh-keygen`, and add an `ioutilx` native fallback so path conversion no longer hard-fails when `cygpath` is absent.

This unblocks `limactl create` on plain Windows; `limactl copy` and reverse-sshfs mounts are separate follow-ups.

Extracted from #4998
