### PR TITLE
cidata: use cp to rewrite /etc/fstab, clarify unescape_fstab comment

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/05-lima-mounts.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/05-lima-mounts.sh
@@ -18,7 +18,7 @@ fi
 # https://github.com/abiosoft/colima/issues/1471
 if grep -q virtiofs /etc/fstab; then
 	escape_fstab.sh </etc/fstab >/etc/fstab.lima.tmp &&
-		cat /etc/fstab.lima.tmp >/etc/fstab && rm -f /etc/fstab.lima.tmp
+		cp /etc/fstab.lima.tmp /etc/fstab && rm -f /etc/fstab.lima.tmp
 	# Mount entries cc_mounts skipped due to the previously broken line (already-mounted ones
 	# are a no-op). On Oracle Linux the virtiofs module is installed later in
 	# 30-install-packages.sh (REMOUNT_VIRTIOFS=1 remounts then), so tolerate failure here.

--- a/pkg/cidata/cidata.TEMPLATE.d/util/unescape_fstab.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/util/unescape_fstab.sh
@@ -6,7 +6,12 @@
 # Read a string on stdin and write it to stdout with the octal escapes used in
 # /etc/fstab and /proc/mounts decoded to their literal characters:
 # "\040" -> space, "\011" -> tab, "\012" -> newline, "\134" -> backslash,
-# "\043" -> "#". The inverse of util/escape_fstab.sh.
+# "\043" -> "#".
+#
+# This decodes the full set of escapes the kernel emits in /proc/mounts and that
+# mount(8) reads from /etc/fstab -- a superset of what util/escape_fstab.sh
+# produces (only \040, \011 and \134). It round-trips that script's output
+# (unescape(escape(x)) == x) but is not its exact inverse.
 # https://github.com/torvalds/linux/blob/v6.6/fs/proc_namespace.c#L89
 
 set -eu


### PR DESCRIPTION
Replace `cat /etc/fstab.lima.tmp >/etc/fstab` with `cp` in `boot.Linux/05-lima-mounts.sh`. 

Also reword the `util/unescape_fstab.sh` header: it decodes the full set of octal escapes the kernel emits in `/proc/mounts` (a superset of what `escape_fstab.sh` produces), so it round-trips escape's output but is not its exact two-sided inverse.

Follow-up to #5145.