### PR TITLE
fix out-of-bounds slice in detectValidPublicKey

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -514,7 +514,11 @@ func detectValidPublicKey(content string) bool {
 		return false
 	}
 	sigLength := binary.BigEndian.Uint32(decodedKey)
-	if uint32(len(decodedKey)) < sigLength {
+	// The format identifier occupies decodedKey[4 : 4+sigLength], so the buffer
+	// must hold sigLength bytes beyond the 4-byte length prefix, not just
+	// sigLength bytes in total. len(decodedKey) >= 4 is guaranteed above, so the
+	// subtraction cannot underflow.
+	if sigLength > uint32(len(decodedKey))-4 {
 		return false
 	}
 	sigFormat := string(decodedKey[4 : 4+sigLength])

--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -56,6 +56,9 @@ func Test_detectValidPublicKey(t *testing.T) {
 
 	assert.Check(t, !detectValidPublicKey("wrong-algo AAAAB3NzaC1kc3MAAACBAP/yAytaYzqXq01uTd5+1RC="))
 	assert.Check(t, !detectValidPublicKey("huge-length AAAD6A=="))
+	// Length prefix equal to the decoded length: sigLength (8) is not larger than
+	// len(decodedKey) (8) but the format field runs to offset 4+8, past the buffer.
+	assert.Check(t, !detectValidPublicKey("trailing-length AAAACAAAAAA="))
 	assert.Check(t, !detectValidPublicKey("arbitrary content"))
 	assert.Check(t, !detectValidPublicKey(""))
 }


### PR DESCRIPTION
1. sigLength is a 4-byte length prefix read from the base64-decoded key blob, and the format identifier is taken from decodedKey[4 : 4+sigLength], but the guard only rejects sigLength > len(decodedKey).
2. a ~/.ssh/*.pub entry whose length prefix is within 3 of the decoded length (e.g. equal to it) passes that guard, so the slice runs past the buffer and panics limactl while DefaultPubKeys scans the keys during start.
Compared sigLength against len(decodedKey)-4 so the 4-byte prefix is counted; len is already known to be >= 4, so the subtraction can't underflow. Added a Test_detectValidPublicKey case that panics without the change.