### PR TITLE
Add parameter for Kubernetes registry (k8s)

### DIFF
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -85,9 +85,20 @@ provision:
               runtime_type = "io.containerd.runc.v2"
               [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
                 SystemdCgroup = true
+    {{- if .Param.mirror }}
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
+    {{- end}}
       [plugins."io.containerd.cri.v1.runtime".cni]
         bin_dirs = ["/usr/local/libexec/cni","/opt/cni/bin"]
     EOF
+    {{if .Param.mirror }}
+    mkdir -p /etc/containerd/certs.d/_default
+    cat <<EOF >/etc/containerd/certs.d/_default/hosts.toml
+    [host."{{.Param.mirror}}"]
+      capabilities = ["pull", "resolve"]
+    EOF
+    {{end}}
     systemctl restart containerd
 # See <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/>
 - mode: system
@@ -229,6 +240,9 @@ message: |
   ------
   {{end -}}
 param:
+  # The mirror to use when pulling images from registry
+  # For a local mirror use for instance "http://host.lima.internal:8080"
+  mirror: ""
   # The stability can be either "stable" or "prerelease"
   # <https://build.opensuse.org/project/subprojects/isv:kubernetes:core>
   stability: "stable"


### PR DESCRIPTION
Now supports a parameter "mirror" for pulling the images from:

```yaml
mirror: "http://host.lima.internal:8080"
```

A pull-through cache for e.g. `registry.k8s.io` and `ghcr.io` at:

https://aceeric.github.io/ociregistry/

----

Closes #4875

This is a nicer fix than the manual tarballs, since it caches _all_ images...

```shell
ociregistry --image-path /tmp/images serve --port 8080 &
```

`INFO[0457] serving manifest from cache: "registry.k8s.io/pause:3.10.2" `

```shell
ociregistry --image-path /tmp/images list
```

> To view the image store: find /tmp/images. There you will see the manifests and blobs comprising the cache. To clean up, simply stop the server and rm -rf /tmp/images. Everything the server persisted to the file system is under that one directory.

https://github.com/aceeric/ociregistry (MIT license, [modified](https://github.com/aceeric/ociregistry/commit/73f3e7537c41666fb5b8802b97c89b44e3c7d37f))