### PR TITLE
Windows: detect the SSH toolchain and convert paths for native OpenSSH

### DIFF
--- a/pkg/ioutilx/ioutilx.go
+++ b/pkg/ioutilx/ioutilx.go
@@ -50,13 +50,49 @@ func FromUTF16leToString(r io.Reader) (string, error) {
 	return string(out), nil
 }
 
+// WindowsSubsystemPath converts a Windows path to a Cygwin/MSYS form
+// (C:\Users\jan -> /c/Users/jan) via cygpath on PATH. A caller holding a
+// specific ssh toolchain should use WindowsSubsystemPathWithCygpath, which
+// runs that toolchain's own cygpath and respects its fstab.
 func WindowsSubsystemPath(ctx context.Context, orig string) (string, error) {
-	out, err := exec.CommandContext(ctx, "cygpath", filepath.ToSlash(orig)).CombinedOutput()
-	if err != nil {
-		logrus.WithError(err).Errorf("failed to convert path to mingw, maybe not using Git ssh?")
-		return "", err
+	return WindowsSubsystemPathWithCygpath(ctx, "cygpath", orig)
+}
+
+// WindowsSubsystemPathWithCygpath converts a Windows path with the given
+// cygpathExe ("cygpath" for PATH, or an absolute path to bind the
+// conversion to one Cygwin install). When cygpath is unavailable it falls
+// back to a native conversion of the drive-letter case; Universal Naming Convention
+// (UNC) and other non-drive-letter inputs return an error.
+func WindowsSubsystemPathWithCygpath(ctx context.Context, cygpathExe, orig string) (string, error) {
+	out, err := exec.CommandContext(ctx, cygpathExe, filepath.ToSlash(orig)).CombinedOutput()
+	if err == nil {
+		return strings.TrimSpace(string(out)), nil
 	}
-	return strings.TrimSpace(string(out)), nil
+
+	logrus.WithError(err).Debugf("cygpath unavailable for %#q (output: %#q), attempting native conversion", orig, strings.TrimSpace(string(out)))
+
+	return windowsSubsystemPathWithoutCygpath(orig)
+}
+
+func windowsSubsystemPathWithoutCygpath(orig string) (string, error) {
+	// Only an absolute drive-letter path ("C:\foo") has a well-defined
+	// Cygwin form here. A drive-relative path ("C:foo") would become
+	// an unrelated absolute path, so reject it.
+	if !filepath.IsAbs(orig) {
+		return "", fmt.Errorf("cannot convert %#q to a Cygwin-style path: input is not an absolute drive-letter path", orig)
+	}
+
+	// UNC path ("\\server\share\foo") is rejected here.
+	if vol := filepath.VolumeName(orig); len(vol) == 2 && vol[1] == ':' {
+		// orig[2:] starts with a separator for an absolute drive path
+		// (C:\foo, C:/foo); strip it so the result stays canonical.
+		tail := strings.TrimPrefix(filepath.ToSlash(orig[2:]), "/")
+		converted := "/" + strings.ToLower(vol[:1]) + "/" + tail
+		logrus.Debugf("native cygpath fallback: %#q -> %#q", orig, converted)
+		return converted, nil
+	}
+
+	return "", fmt.Errorf("cannot convert %#q to a Cygwin-style path: cygpath is unavailable and input is not an absolute drive-letter path", orig)
 }
 
 func WindowsSubsystemPathForLinux(ctx context.Context, orig, distro string) (string, error) {

--- a/pkg/ioutilx/ioutilx_windows_test.go
+++ b/pkg/ioutilx/ioutilx_windows_test.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ioutilx
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// TestWindowsSubsystemPathWithoutCygpath exercises the native
+// drive-letter fallback path: when the cygpath binary is unreachable,
+// absolute drive-letter inputs convert in-process (e.g., "C:\foo" -> "/c/foo")
+// and inputs without a drive letter return an error.
+func TestWindowsSubsystemPathWithoutCygpath(t *testing.T) {
+	t.Run("drive-letter backslash", func(t *testing.T) {
+		got, err := windowsSubsystemPathWithoutCygpath(`C:\Users\USER`)
+		assert.NilError(t, err)
+		assert.Equal(t, got, "/c/Users/USER")
+	})
+
+	t.Run("drive-letter forward-slash", func(t *testing.T) {
+		got, err := windowsSubsystemPathWithoutCygpath(`C:/Users/USER`)
+		assert.NilError(t, err)
+		assert.Equal(t, got, "/c/Users/USER")
+	})
+
+	t.Run("non-drive-letter rejected", func(t *testing.T) {
+		// UNC and POSIX inputs both lack a drive letter; on every
+		// platform the fallback must refuse rather than fabricate.
+		for _, input := range []string{`\\server\share\foo`, "/etc/hosts", "relative.txt"} {
+			_, err := windowsSubsystemPathWithoutCygpath(input)
+			assert.ErrorContains(t, err, "cannot convert", "input=%q", input)
+		}
+	})
+
+	t.Run("lowercases drive letter", func(t *testing.T) {
+		got, err := windowsSubsystemPathWithoutCygpath(`d:\path`)
+		assert.NilError(t, err)
+		assert.Assert(t, strings.HasPrefix(got, "/d/"), "got %q", got)
+	})
+}

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -61,6 +61,13 @@ func NewSSHExe() (SSHExe, error) {
 		}
 	}
 
+	if runtime.GOOS == "windows" {
+		if exe := pickCompleteSSHOnWindows(); exe != "" {
+			sshExe.Exe = exe
+			return sshExe, nil
+		}
+	}
+
 	executable, err := exec.LookPath("ssh")
 	if err != nil {
 		return SSHExe{}, err
@@ -68,6 +75,168 @@ func NewSSHExe() (SSHExe, error) {
 	sshExe.Exe = executable
 
 	return sshExe, nil
+}
+
+// pickCompleteSSHOnWindows returns an ssh.exe whose directory also has
+// scp.exe and ssh-keygen.exe, which Lima needs for create and copy.
+// MinGit ships ssh.exe without those, so a partial install is skipped for
+// the next complete one on PATH, then the native install under
+// %SystemRoot%\System32\OpenSSH. Returns "" when none qualifies, so the
+// caller falls through to exec.LookPath instead of picking a partial one.
+func pickCompleteSSHOnWindows() string {
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			continue
+		}
+		sshPath := filepath.Join(dir, "ssh.exe")
+		if _, err := os.Stat(sshPath); err != nil {
+			continue
+		}
+		if missing := missingSiblings(dir, "scp.exe", "ssh-keygen.exe"); len(missing) > 0 {
+			logrus.Debugf("skipping ssh at %#q: missing %v in same directory (likely MinGit or another partial install)", sshPath, missing)
+			continue
+		}
+		return sshPath
+	}
+	nativeSSH := filepath.Join(systemRoot(), "System32", "OpenSSH", "ssh.exe")
+	if _, err := os.Stat(nativeSSH); err == nil {
+		return nativeSSH
+	}
+
+	return ""
+}
+
+// systemRoot returns %SystemRoot%, or C:\Windows when unset - honouring
+// installs (Windows PE, some enterprise setups) that put it off the C: drive.
+func systemRoot() string {
+	if r := os.Getenv("SystemRoot"); r != "" {
+		return r
+	}
+	return `C:\Windows`
+}
+
+// missingSiblings returns the names in siblings that do not exist in dir.
+// siblings must be clean paths as they are joined with dir as-is.
+func missingSiblings(dir string, siblings ...string) []string {
+	var missing []string
+	for _, s := range siblings {
+		if _, err := os.Stat(filepath.Join(dir, s)); err != nil {
+			missing = append(missing, s)
+		}
+	}
+	return missing
+}
+
+var (
+	// cygwinDetectCache maps a resolved ssh path to its sibling cygpath.exe,
+	// or "" when that ssh is not Cygwin-based. Each path is probed once.
+	cygwinDetectCache   = map[string]string{}
+	cygwinDetectCacheRW sync.RWMutex
+)
+
+// IsSSHCygwin reports whether sshExe is a Cygwin-based OpenSSH (Git for
+// Windows, MSYS2, Cygwin) rather than native Windows OpenSSH; always false
+// on non-Windows. See cygpathForSSH for the detection and caching.
+func IsSSHCygwin(sshExe SSHExe) bool {
+	_, ok := cygpathForSSH(sshExe)
+	return ok
+}
+
+// cygpathForSSH returns the cygpath.exe besides sshExe (resolved through
+// symlinks) and whether sshExe is Cygwin-based. Callers pass the returned
+// path to exec.Command so conversions run through that toolchain's own
+// cygpath, even when $SSH points outside PATH. It returns
+// ("", false) on non-Windows or empty input; results are cached per resolved path.
+func cygpathForSSH(sshExe SSHExe) (string, bool) {
+	if runtime.GOOS != "windows" || sshExe.Exe == "" {
+		return "", false
+	}
+	path := sshExe.Exe
+	if !filepath.IsAbs(path) {
+		resolved, err := exec.LookPath(path)
+		if err != nil {
+			logrus.WithError(err).Debugf("cygpathForSSH: cannot resolve %#q via PATH; assuming native", path)
+			return "", false
+		}
+		path = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	cygwinDetectCacheRW.RLock()
+	cached, ok := cygwinDetectCache[path]
+	cygwinDetectCacheRW.RUnlock()
+	if ok {
+		return cached, cached != ""
+	}
+	cygpathExe := filepath.Join(filepath.Dir(path), "cygpath.exe")
+	if _, err := os.Stat(cygpathExe); err != nil {
+		logrus.Debugf("ssh at %#q detected as native Windows OpenSSH (no cygpath.exe alongside)", path)
+		cygpathExe = ""
+	} else {
+		logrus.Debugf("ssh at %#q detected as Cygwin-based (found %#q alongside)", path, cygpathExe)
+	}
+	cygwinDetectCacheRW.Lock()
+	cygwinDetectCache[path] = cygpathExe
+	cygwinDetectCacheRW.Unlock()
+
+	return cygpathExe, cygpathExe != ""
+}
+
+// PathForSSH converts orig to the path form Lima's ssh-family invocations
+// expect; unchanged on non-Windows. On Windows, Cygwin-based ssh (Git for
+// Windows, MSYS2) gets a /c/Users/... form from the sibling cygpath, which
+// respects the toolchain's fstab; native Windows OpenSSH gets forward
+// slashes (C:/Users/...), which native ssh, ssh-keygen, and scp accept.
+func PathForSSH(ctx context.Context, sshExe SSHExe, orig string) (string, error) {
+	if runtime.GOOS != "windows" {
+		return orig, nil
+	}
+	if cygpathExe, ok := cygpathForSSH(sshExe); ok {
+		return ioutilx.WindowsSubsystemPathWithCygpath(ctx, cygpathExe, orig)
+	}
+	return filepath.ToSlash(orig), nil
+}
+
+// SftpServerForSSH returns the path of sftp-server binary from sshExe's toolchain,
+// so a locally-spawned sftp-server (reverse-sshfs) uses the same path form
+// PathForSSH produces. For Cygwin-based ssh the sibling cygpath resolves
+// /usr/lib/ssh/sftp-server; for native OpenSSH it is sftp-server.exe beside
+// ssh.exe. Returns "" on non-Windows, empty input, or no match, leaving the
+// caller to fall back to its library's auto-detection.
+func SftpServerForSSH(ctx context.Context, sshExe SSHExe) string {
+	if runtime.GOOS != "windows" || sshExe.Exe == "" {
+		return ""
+	}
+	if cygpathExe, ok := cygpathForSSH(sshExe); ok {
+		out, err := exec.CommandContext(ctx, cygpathExe, "-w", "/usr/lib/ssh/sftp-server").Output()
+		if err != nil {
+			return ""
+		}
+		candidate := strings.TrimSpace(string(out))
+		for _, p := range []string{candidate, candidate + ".exe"} {
+			if _, err := os.Stat(p); err == nil {
+				return p
+			}
+		}
+		return ""
+	}
+	path := sshExe.Exe
+	if !filepath.IsAbs(path) {
+		resolved, err := exec.LookPath(path)
+		if err != nil {
+			return ""
+		}
+		path = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	sftpServer := filepath.Join(filepath.Dir(path), "sftp-server.exe")
+	if _, err := os.Stat(sftpServer); err != nil {
+		return ""
+	}
+	return sftpServer
 }
 
 type PubKey struct {
@@ -111,7 +280,11 @@ func DefaultPubKeys(ctx context.Context, loadDotSSH bool) ([]PubKey, error) {
 			// no passphrase, no user@host comment
 			privPath := filepath.Join(configDir, filenames.UserPrivateKey)
 			if runtime.GOOS == "windows" {
-				privPath, err = ioutilx.WindowsSubsystemPath(ctx, privPath)
+				sshExe, sshErr := NewSSHExe()
+				if sshErr != nil {
+					return sshErr
+				}
+				privPath, err = PathForSSH(ctx, sshExe, privPath)
 				if err != nil {
 					return err
 				}
@@ -198,7 +371,7 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 		return nil, err
 	}
 	var opts []string
-	idf, err := identityFileEntry(ctx, privateKeyPath)
+	idf, err := identityFileEntry(ctx, sshExe, privateKeyPath)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +406,7 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 				// Fail on permission-related and other path errors
 				return nil, err
 			}
-			idf, err = identityFileEntry(ctx, privateKeyPath)
+			idf, err = identityFileEntry(ctx, sshExe, privateKeyPath)
 			if err != nil {
 				return nil, err
 			}
@@ -285,9 +458,9 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 	return opts, nil
 }
 
-func identityFileEntry(ctx context.Context, privateKeyPath string) (string, error) {
+func identityFileEntry(ctx context.Context, sshExe SSHExe, privateKeyPath string) (string, error) {
 	if runtime.GOOS == "windows" {
-		privateKeyPath, err := ioutilx.WindowsSubsystemPath(ctx, privateKeyPath)
+		privateKeyPath, err := PathForSSH(ctx, sshExe, privateKeyPath)
 		if err != nil {
 			return "", err
 		}
@@ -381,7 +554,7 @@ func SSHOpts(ctx context.Context, sshExe SSHExe, instDir, username string, useDo
 	}
 	controlPath := fmt.Sprintf(`ControlPath="%s"`, controlSock)
 	if runtime.GOOS == "windows" {
-		controlSock, err = ioutilx.WindowsSubsystemPath(ctx, controlSock)
+		controlSock, err = PathForSSH(ctx, sshExe, controlSock)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -24,6 +24,15 @@ func TestDefaultPubKeys(t *testing.T) {
 	}
 }
 
+// TestDefaultPubKeys_WithoutExistingKey tests DefaultPubKeys without an existing public key.
+func TestDefaultPubKeys_WithoutExistingKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("LIMA_HOME", tmpDir)
+	keys, err := DefaultPubKeys(t.Context(), false)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(keys))
+}
+
 func TestParseOpenSSHVersion(t *testing.T) {
 	assert.Check(t, ParseOpenSSHVersion([]byte("OpenSSH_8.4p1 Ubuntu")).Equal(
 		semver.Version{Major: 8, Minor: 4, Patch: 1, PreRelease: "", Metadata: ""}))

--- a/pkg/sshutil/sshutil_windows_test.go
+++ b/pkg/sshutil/sshutil_windows_test.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sshutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// TestPickCompleteSSHOnWindows: an ssh.exe missing scp.exe or
+// ssh-keygen.exe (MinGit's shape) is skipped for the next complete
+// install on PATH.
+func TestPickCompleteSSHOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only PATH walk")
+	}
+
+	mkDir := func(t *testing.T, exes ...string) string {
+		t.Helper()
+		dir := resolvedTempDir(t)
+		for _, exe := range exes {
+			assert.NilError(t, os.WriteFile(filepath.Join(dir, exe), nil, 0o644))
+		}
+		return dir
+	}
+
+	t.Run("complete install on PATH is picked", func(t *testing.T) {
+		full := mkDir(t, "ssh.exe", "scp.exe", "ssh-keygen.exe")
+		t.Setenv("PATH", full)
+		assert.Equal(t, pickCompleteSSHOnWindows(), filepath.Join(full, "ssh.exe"))
+	})
+
+	t.Run("incomplete install before complete install is skipped", func(t *testing.T) {
+		mingit := mkDir(t, "ssh.exe")
+		full := mkDir(t, "ssh.exe", "scp.exe", "ssh-keygen.exe")
+		t.Setenv("PATH", mingit+string(os.PathListSeparator)+full)
+		assert.Equal(t, pickCompleteSSHOnWindows(), filepath.Join(full, "ssh.exe"))
+	})
+
+	t.Run("falls back to native install when nothing on PATH is complete", func(t *testing.T) {
+		nativeSSH := filepath.Join(systemRoot(), "System32", "OpenSSH", "ssh.exe")
+		if _, err := os.Stat(nativeSSH); err != nil {
+			t.Skipf("native OpenSSH not present at %q on this host", nativeSSH)
+		}
+		mingit := mkDir(t, "ssh.exe")
+		t.Setenv("PATH", mingit)
+		assert.Equal(t, pickCompleteSSHOnWindows(), nativeSSH)
+	})
+}
+
+// resolvedTempDir is t.TempDir() run through EvalSymlinks, matching what
+// the production helpers compute. On GitHub Windows runners t.TempDir()
+// is an 8.3 short path (C:\Users\RUNNER~1\...) that the helpers expand,
+// so a raw compare would fail.
+func resolvedTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	assert.NilError(t, err)
+	return resolved
+}


### PR DESCRIPTION
This PR is derived from #5196 , and most of the work is done by @jandubois .

Changes from the original PR are:
- Modify log/error messages (using `%#q` instead of `%q`)
- Slightly modify comments
- Add a test case `TestDefaultPubKeys_WithoutExistingKey` in sshutil_test.go because `TestDefaultPubKeys` always succeeds if a public key is already created under `.lima/_config/`