### PR TITLE
Windows: change the default VM driver from wsl2 to qemu

### DIFF
--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -420,8 +420,6 @@ func DefaultDriver() VMType {
 	switch runtime.GOOS {
 	case "darwin":
 		return VZ
-	case "windows":
-		return WSL2
 	default:
 		return QEMU
 	}

--- a/website/content/en/docs/releases/breaking.md
+++ b/website/content/en/docs/releases/breaking.md
@@ -3,6 +3,10 @@ title: Breaking changes
 weight: 20
 ---
 
+## v2.2.0
+- The default VM driver on Windows hosts was changed from `wsl2` to `qemu`,
+  as `wsl2` is not compatible with most templates.
+
 ## [v2.0.0](https://github.com/lima-vm/lima/releases/tag/v2.0.0)
 - `/tmp/lima` is no longer mounted by default.
 - SSH port is no longer hard-coded to 60022 for the "default" instance.


### PR DESCRIPTION
Fix #4788