### PR TITLE
docs(config): document plain mode

### DIFF
--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -631,6 +631,7 @@ guestInstallPrefix: null
 # - guest agent will not be running
 # - dependency packages like sshfs will not be installed into the VM
 # User-specified provisioning scripts will be still executed.
+# See https://lima-vm.io/docs/config/plain/ for the full behavior.
 # 🟢 Builtin default: false
 plain: null
 

--- a/website/content/en/docs/config/mount.md
+++ b/website/content/en/docs/config/mount.md
@@ -5,6 +5,8 @@ weight: 50
 
 Lima supports several methods for mounting the host filesystem into the guest.
 
+> **See also:** In [plain mode](./plain.md), all filesystem mounts are disabled.
+
 The default mount type is shown in the following table:
 
 | Lima Version | Default                                                       |

--- a/website/content/en/docs/config/plain.md
+++ b/website/content/en/docs/config/plain.md
@@ -1,0 +1,75 @@
+---
+title: Plain mode
+weight: 60
+---
+
+Plain mode makes the VM instance as close as possible to a physical host by
+disabling Lima's convenience features such as filesystem mounts, dynamic port
+forwarding, and the built-in containerd.
+
+It is useful when you want to provision the guest with plain old `ssh` and `rsync`,
+without relying on Lima-specific integrations. See the
+[GitHub Actions example](../examples/gha.md#plain-mode) for a typical use case.
+
+## Enabling plain mode
+
+{{< tabpane text=true >}}
+{{% tab header="YAML" %}}
+```yaml
+plain: true
+```
+{{% /tab %}}
+{{% tab header="CLI (start)" %}}
+```bash
+limactl start --plain
+```
+{{% /tab %}}
+{{% tab header="CLI (edit)" %}}
+```bash
+limactl edit <instance> --plain
+```
+{{% /tab %}}
+{{< /tabpane >}}
+
+Plain mode is disabled (`false`) by default.
+
+## What is disabled
+
+When plain mode is enabled, the following features are turned off, and the
+corresponding YAML properties are ignored:
+
+- **Filesystem mounts** (`mounts`)
+- **Dynamic port forwarding** (`portForwards` rules that are not `static: true`)
+- **Built-in containerd** (`containerd.system` and `containerd.user`)
+- **The guest agent daemon**
+- **Rosetta** (`rosetta`)
+- **SSH agent forwarding** (`ssh.forwardAgent`)
+- **Host clock synchronization**
+
+Dependency packages such as `sshfs` are not installed into the VM either.
+
+## What still works
+
+- **Static port forwarding**: `portForwards` rules with `static: true` are still
+  established.
+- **Provisioning scripts**: user, system, and data provisioning scripts are still
+  executed.
+- **Base guest setup**: the base user and SSH keys are still configured.
+
+## Accessing the instance
+
+`limactl shell <instance>` and `ssh` both work, as in a non-plain instance.
+In plain mode, plain `ssh` is often preferred to keep the guest free of
+Lima-specific conventions. See [SSH](../usage/ssh.md) for details.
+
+## See also
+
+Plain mode applies to all guest operating systems. For OS-specific differences, see
+the [Guest OS](../usage/guests/_index.md) pages:
+
+- [Linux](../usage/guests/linux.md#plain-mode)
+- [FreeBSD](../usage/guests/freebsd.md#plain-mode)
+- [macOS](../usage/guests/macos.md#plain-mode)
+
+For the underlying mechanics (boot scripts, `LIMA_CIDATA_PLAIN`, guest agent
+injection), see the [internals reference](../dev/internals.md).

--- a/website/content/en/docs/config/port.md
+++ b/website/content/en/docs/config/port.md
@@ -5,6 +5,8 @@ weight: 31
 
 Lima supports automatic port-forwarding of localhost ports from guest to host.
 
+> **See also:** In [plain mode](./plain.md), dynamic port forwarding is disabled and only rules with `static: true` are forwarded.
+
 ## Port forwarding types
 
 Lima supports two port forwarders: SSH and GRPC.

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -159,11 +159,11 @@ See [Building Ansible inventories](https://docs.ansible.com/ansible/latest/inven
 - `network-config`: [Cloud-init Networking Config Version 2](https://docs.cloud-init.io/en/latest/reference/network-config-format-v2.html)
 - `lima.env`: The `LIMA_CIDATA_*` environment variables (see below) available during `boot.sh` processing
 - `param.env`: The `PARAM_*` environment variables corresponding to the `param` settings from `lima.yaml`
-- `lima-guestagent`: Lima guest agent binary
+- `lima-guestagent`: Lima guest agent binary. On Linux, omitted in [plain mode](../config/plain.md) (the guest agent daemon does not run). On macOS, always injected, as it is required for fake-cloud-init.
 - `nerdctl-full.tgz`: [`nerdctl-full-<VERSION>-<OS>-<ARCH>.tar.gz`](https://github.com/containerd/nerdctl/releases)
 - `boot.sh`: Boot script
 - `boot.<OS>/*`: Boot script modules
-- `boot.essential.<OS>/*`: Essential boot script modules, executed in plain mode too.
+- `boot.essential.<OS>/*`: Essential boot script modules, executed in [plain mode](../config/plain.md) too (unlike `boot.<OS>/*`, which is skipped in plain mode).
 - `util/*`: Utility command scripts, executed in the boot script modules
 - `provision.data/*`: Custom provision files (data)
 - `provision.dependency/*`: Custom provision scripts (dependency)
@@ -221,7 +221,7 @@ The volume label is "cidata", as defined by [cloud-init NoCloud](https://docs.cl
 - `LIMA_CIDATA_VMTYPE`: the VM driver type ("qemu", "vz", "wsl2", ...), used to conditionally enable VM-specific behavior (e.g. virtiofs mounts on `vz`).
 - `LIMA_CIDATA_VSOCK_PORT`: the vsock port used by the guest agent (0 when vsock is not used).
 - `LIMA_CIDATA_VIRTIO_PORT`: the virtio-serial port name used by the guest agent (empty when virtio-serial is not used).
-- `LIMA_CIDATA_PLAIN`: set to "1" when the instance is in plain mode (no mounts, port forwarding, or containerd), empty otherwise.
+- `LIMA_CIDATA_PLAIN`: set to "1" when the instance is in [plain mode](../config/plain.md) (no mounts, port forwarding, or containerd), empty otherwise.
 - `LIMA_CIDATA_NO_CLOUD_INIT`: set to "1" if cloud-init should be skipped on this boot, empty otherwise.
 
 

--- a/website/content/en/docs/examples/gha.md
+++ b/website/content/en/docs/examples/gha.md
@@ -58,7 +58,8 @@ See also <https://github.com/lima-vm/lima-actions>.
 
 ### Plain mode
 
-The `--plain` mode is useful when you want the VM instance to be as close as possible to a physical host:
+The `--plain` mode is useful when you want the VM instance to be as close as possible to a physical host.
+See [Config » Plain mode](../config/plain.md) for the full behavior:
 
 ```yaml
     - name: "Start Fedora"

--- a/website/content/en/docs/usage/guests/freebsd.md
+++ b/website/content/en/docs/usage/guests/freebsd.md
@@ -36,3 +36,8 @@ Prerequisites:
 ### FreeBSD prior to 15.1
 - No support for mounting host directories.
   Use `limactl cp` or `limactl shell --sync` to share files with the host.
+
+## Plain mode
+The guest agent, containerd, and automatic port forwarding are not available on
+FreeBSD guests regardless of the mode, so [plain mode](../../config/plain.md)
+additionally disables only the host directory mounts (on FreeBSD 15.1 and later).

--- a/website/content/en/docs/usage/guests/linux.md
+++ b/website/content/en/docs/usage/guests/linux.md
@@ -5,5 +5,10 @@ weight: 1
 
 Linux is the default guest operating system.
 
+## Plain mode
+[Plain mode](../../config/plain.md) applies fully to Linux guests: filesystem mounts,
+dynamic port forwarding, the built-in containerd, and the guest agent daemon are all
+disabled.
+
 ## See also
 - [Templates](../../templates/_index.md)

--- a/website/content/en/docs/usage/guests/macos.md
+++ b/website/content/en/docs/usage/guests/macos.md
@@ -39,3 +39,8 @@ limactl shell macos cat /Users/${USER}.guest/password
   Use `ssh -L` to manually set up port forwarding, or,
   use the [`vzNAT`](../../config/network/vmnet.md#vznat) network to access the guest by its IP.
 - No support for installing custom `caCerts`
+
+## Plain mode
+containerd and automatic port forwarding are not available on macOS guests regardless
+of the mode, so [plain mode](../../config/plain.md) additionally disables only the
+host directory mounts.


### PR DESCRIPTION
Add a dedicated `config/plain.md` page describing plain mode behavior for each guest OS (Linux, FreeBSD, macOS): what it disables, what still works, how to access the instance, and how it works internally.

Cross-link the new page from the GitHub Actions example, the port forwarding and mount pages, and the plain: comment in the default template.

Closes #5003