### PR TITLE
portfwdserver: fix socket FD leak per forwarded connection

### DIFF
--- a/pkg/portfwdserver/server.go
+++ b/pkg/portfwdserver/server.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/inetaf/tcpproxy"
@@ -39,7 +40,12 @@ func (s *TunnelServer) Start(stream api.GuestService_TunnelServer) error {
 	if err != nil {
 		return err
 	}
-	rw := &GRPCServerRW{stream: stream, id: in.Id, closeCh: make(chan any, 1)}
+	// The tunnel is unusable once this function returns, so close the dialed
+	// connection here as well. This both releases the FD even if the proxy
+	// goroutine is still blocked reading from the guest, and unblocks that
+	// read so the goroutine can finish.
+	defer conn.Close()
+	rw := &GRPCServerRW{stream: stream, id: in.Id, closeCh: make(chan any)}
 	go func() {
 		<-ctx.Done()
 		rw.Close()
@@ -52,7 +58,6 @@ func (s *TunnelServer) Start(stream api.GuestService_TunnelServer) error {
 
 	// The stream will be closed when this function returns.
 	// Wait here until rw.Close(), rw.CloseRead(), or rw.CloseWrite() is called.
-	// We can't close rw.closeCh since the calling order of Close* methods is not guaranteed.
 	<-rw.closeCh
 	logrus.Debugf("closed GRPCServerRW for id: %s", in.Id)
 
@@ -63,6 +68,13 @@ type GRPCServerRW struct {
 	id      string
 	stream  api.GuestService_TunnelServer
 	closeCh chan any
+	// closeOnce guards closeCh. Close, CloseRead, and CloseWrite may be
+	// called in any order and multiple times (e.g., tcpproxy calls
+	// CloseRead/CloseWrite from each copy direction and then Close), so
+	// they must be idempotent and must never block; otherwise the proxy
+	// goroutine gets stuck and never closes the dialed guest connection,
+	// leaking one FD per forwarded connection.
+	closeOnce sync.Once
 
 	// rxBuf holds bytes received from the stream that did not fit in the
 	// buffer passed to the previous Read call.
@@ -91,7 +103,7 @@ func (g *GRPCServerRW) Read(p []byte) (n int, err error) {
 
 func (g *GRPCServerRW) Close() error {
 	logrus.Debugf("closing GRPCServerRW for id: %s", g.id)
-	g.closeCh <- struct{}{}
+	g.closeOnce.Do(func() { close(g.closeCh) })
 	return nil
 }
 
@@ -100,13 +112,13 @@ func (g *GRPCServerRW) Close() error {
 
 func (g *GRPCServerRW) CloseRead() error {
 	logrus.Debugf("closing read GRPCServerRW for id: %s", g.id)
-	g.closeCh <- struct{}{}
+	g.closeOnce.Do(func() { close(g.closeCh) })
 	return nil
 }
 
 func (g *GRPCServerRW) CloseWrite() error {
 	logrus.Debugf("closing write GRPCServerRW for id: %s", g.id)
-	g.closeCh <- struct{}{}
+	g.closeOnce.Do(func() { close(g.closeCh) })
 	return nil
 }
 

--- a/pkg/portfwdserver/server_test.go
+++ b/pkg/portfwdserver/server_test.go
@@ -5,8 +5,11 @@ package portfwdserver
 
 import (
 	"bytes"
+	"context"
 	"io"
+	"net"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 
@@ -42,4 +45,111 @@ func TestGRPCServerRWReadShortBuffer(t *testing.T) {
 		got = append(got, buf[:n]...)
 	}
 	assert.DeepEqual(t, got, payload)
+}
+
+// TestGRPCServerRWCloseNeverBlocks reproduces the teardown sequence of
+// tcpproxy.DialProxy.HandleConn: each copy direction calls CloseRead or
+// CloseWrite, and HandleConn itself calls Close, while Start receives from
+// closeCh only once. None of the calls may block; a blocked Close used to
+// keep HandleConn from closing the dialed guest connection, leaking one FD
+// per forwarded connection (https://github.com/lima-vm/lima/issues/5210).
+func TestGRPCServerRWCloseNeverBlocks(t *testing.T) {
+	rw := &GRPCServerRW{closeCh: make(chan any)}
+	done := make(chan struct{})
+	go func() {
+		_ = rw.CloseWrite()
+		_ = rw.CloseRead()
+		_ = rw.Close()
+		_ = rw.Close() // ctx.Done goroutine in Start may call Close again
+		close(done)
+	}()
+	select {
+	case <-rw.closeCh:
+	case <-time.After(5 * time.Second):
+		assert.Assert(t, false, "closeCh was never signaled")
+	}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		assert.Assert(t, false, "Close/CloseRead/CloseWrite blocked")
+	}
+}
+
+// fakeTunnelStream is a minimal bidi stream: Recv returns queued messages
+// and io.EOF once recvCh is closed; Send discards data.
+type fakeTunnelStream struct {
+	api.GuestService_TunnelServer
+	ctx    context.Context
+	recvCh chan *api.TunnelMessage
+}
+
+func (s *fakeTunnelStream) Context() context.Context { return s.ctx }
+
+func (s *fakeTunnelStream) Recv() (*api.TunnelMessage, error) {
+	msg, ok := <-s.recvCh
+	if !ok {
+		return nil, io.EOF
+	}
+	return msg, nil
+}
+
+func (s *fakeTunnelStream) Send(*api.TunnelMessage) error { return nil }
+
+// TestTunnelServerClosesGuestConn verifies that the connection dialed to the
+// guest service is fully closed (not just shut down for writing) when the
+// tunnel stream ends (https://github.com/lima-vm/lima/issues/5210).
+func TestTunnelServerClosesGuestConn(t *testing.T) {
+	var lc net.ListenConfig
+	ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	assert.NilError(t, err)
+	defer ln.Close()
+
+	acceptCh := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			acceptCh <- conn
+		}
+	}()
+
+	recvCh := make(chan *api.TunnelMessage, 1)
+	recvCh <- &api.TunnelMessage{Id: "test", Protocol: "tcp", GuestAddr: ln.Addr().String()}
+	stream := &fakeTunnelStream{ctx: t.Context(), recvCh: recvCh}
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- NewTunnelServer().Start(stream)
+	}()
+
+	var guestConn net.Conn
+	select {
+	case guestConn = <-acceptCh:
+	case <-time.After(5 * time.Second):
+		assert.Assert(t, false, "tunnel server did not dial the guest address")
+	}
+	defer guestConn.Close()
+
+	// Simulate the host closing the tunnel.
+	close(recvCh)
+
+	select {
+	case err := <-startDone:
+		assert.NilError(t, err)
+	case <-time.After(5 * time.Second):
+		assert.Assert(t, false, "Start did not return after the stream ended")
+	}
+
+	// If the tunnel server fully closed its side, writes from the guest
+	// service eventually fail (RST). With a leaked FD they succeed forever.
+	deadline := time.After(5 * time.Second)
+	for {
+		if _, err := guestConn.Write([]byte("x")); err != nil {
+			return
+		}
+		select {
+		case <-deadline:
+			assert.Assert(t, false, "guest connection still writable; FD was not closed")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
 }


### PR DESCRIPTION
GRPCServerRW.closeCh was a 1-slot buffered channel received from exactly once in TunnelServer.Start, but tcpproxy.DialProxy.HandleConn invokes the Close* methods three times during teardown: CloseRead/CloseWrite from each copy direction's defer, then Close from its own deferred src.Close(). The third send blocked forever, and since HandleConn registers "defer dst.Close()" before "defer src.Close()", the dialed guest connection was never closed: one leaked socket FD and one leaked goroutine per forwarded connection, until the guest agent hit RLIMIT_NOFILE and port forwarding silently died.

Make Close/CloseRead/CloseWrite idempotent and non-blocking with sync.Once + close(closeCh), and close the dialed connection when Start returns so the FD is released even if the guest service keeps its side of the connection open.

Fix #5210

Note: used Claude