### PR TITLE
docs(driver): document external driver gRPC API contract

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -115,21 +115,47 @@ type ConfiguredDriver struct {
 	Driver
 }
 
+// Info describes a driver instance: its identity, the guest-agent transport,
+// the instance directory and the driver's capability flags. It is returned by
+// Driver.Info and, for external drivers, carried as JSON in InfoResponse.
 type Info struct {
-	Name        string         `json:"name"`
-	VsockPort   int            `json:"vsockPort"`
-	VirtioPort  string         `json:"virtioPort"`
-	InstanceDir string         `json:"instanceDir,omitempty"`
-	Features    DriverFeatures `json:"features"`
+	// Name is the driver name, e.g. "qemu", "vz", "wsl2" or "krunkit".
+	Name string `json:"name"`
+	// VsockPort is the vsock port used by the guest agent, or 0 when vsock is
+	// not used.
+	VsockPort int `json:"vsockPort"`
+	// VirtioPort is the virtio-serial port name used by the guest agent, or
+	// empty when virtio-serial is not used.
+	VirtioPort string `json:"virtioPort"`
+	// InstanceDir is the absolute path of the instance directory.
+	InstanceDir string `json:"instanceDir,omitempty"`
+	// Features declares the driver's optional capabilities and behaviors.
+	Features DriverFeatures `json:"features"`
 }
 
+// DriverFeatures declares optional capabilities and behaviors of a driver. The
+// host agent reads them (via Info) to adapt provisioning, SSH and forwarding.
 type DriverFeatures struct {
-	CanRunGUI             bool     `json:"canRunGui,omitempty"`
-	DynamicSSHAddress     bool     `json:"dynamicSSHAddress"`
-	StaticSSHPort         bool     `json:"staticSSHPort"`
-	SkipSocketForwarding  bool     `json:"skipSocketForwarding"`
-	NoCloudInit           bool     `json:"noCloudInit"`
-	RosettaEnabled        bool     `json:"rosettaEnabled"`
-	RosettaBinFmt         bool     `json:"rosettaBinFmt"`
+	// CanRunGUI reports that the driver can display a GUI via RunGUI.
+	CanRunGUI bool `json:"canRunGui,omitempty"`
+	// DynamicSSHAddress reports that the SSH address is not known until after
+	// Start, so the host agent re-queries SSHAddress once the VM is running.
+	DynamicSSHAddress bool `json:"dynamicSSHAddress"`
+	// StaticSSHPort reports that the driver uses a fixed SSH port; when false the
+	// host agent allocates a free local port.
+	StaticSSHPort bool `json:"staticSSHPort"`
+	// SkipSocketForwarding reports that the host agent should skip unix-socket
+	// forwarding for this driver.
+	SkipSocketForwarding bool `json:"skipSocketForwarding"`
+	// NoCloudInit reports that the driver does not use cloud-init, so the host
+	// agent skips building the cloud-init seed.
+	NoCloudInit bool `json:"noCloudInit"`
+	// RosettaEnabled reports that Rosetta is enabled for the guest.
+	RosettaEnabled bool `json:"rosettaEnabled"`
+	// RosettaBinFmt reports that Rosetta is registered as a binfmt_misc handler
+	// in the guest.
+	RosettaBinFmt bool `json:"rosettaBinFmt"`
+	// SupportedImageFormats lists the disk image formats the driver can boot
+	// (e.g. "raw", "qcow2"), used to select or convert the instance image.
 	SupportedImageFormats []string `json:"supportedImageFormats,omitempty"`
 }

--- a/pkg/driver/external/driver.pb.go
+++ b/pkg/driver/external/driver.pb.go
@@ -22,9 +22,13 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// BootScriptsResponse carries the boot scripts injected into the VM.
 type BootScriptsResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Scripts       map[string][]byte      `protobuf:"bytes,1,rep,name=scripts,proto3" json:"scripts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Maps a script path to its content. Each key must be
+	// "boot.<OS>/<SCRIPT>", or "<SCRIPT>" as a deprecated alias for
+	// "boot.Linux/<SCRIPT>".
+	Scripts       map[string][]byte `protobuf:"bytes,1,rep,name=scripts,proto3" json:"scripts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -66,9 +70,11 @@ func (x *BootScriptsResponse) GetScripts() map[string][]byte {
 	return nil
 }
 
+// SSHAddressResponse carries the guest SSH address.
 type SSHAddressResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Address       string                 `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Host/IP used to SSH into the guest.
+	Address       string `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -110,9 +116,13 @@ func (x *SSHAddressResponse) GetAddress() string {
 	return ""
 }
 
+// InfoResponse carries driver metadata and capability flags.
 type InfoResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	InfoJson      []byte                 `protobuf:"bytes,1,opt,name=info_json,json=infoJson,proto3" json:"info_json,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// JSON-encoded driver.Info (name, ports, instance dir and feature flags).
+	// JSON keeps it in sync with the Go type. The full set of fields is defined at
+	// https://pkg.go.dev/github.com/lima-vm/lima/v2/pkg/driver#Info
+	InfoJson      []byte `protobuf:"bytes,1,opt,name=info_json,json=infoJson,proto3" json:"info_json,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -154,15 +164,18 @@ func (x *InfoResponse) GetInfoJson() []byte {
 	return nil
 }
 
-// StartResponse is a streamed response for Start() RPC. It tries to mimic
-// errChan from pkg/driver/driver.go. The server sends an initial response
-// with success=true when Start() is initiated. If errors occur, they are
-// sent as success=false with the error field populated. When the error channel
-// closes, a final success=true message is sent.
+// StartResponse is a streamed response for the Start RPC. It mimics the
+// errChan from pkg/driver/driver.go. The server sends an initial response with
+// success=true once Start is initiated (this unblocks the client). If errors
+// occur they are sent as success=false with the error field populated. When the
+// error channel closes, a final success=true message is sent and the stream ends.
 type StartResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
-	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// True for the initial "started" message and the final "done" message, and
+	// false for each streamed error.
+	Success bool `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	// Error message when success is false; empty otherwise.
+	Error         string `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -211,9 +224,11 @@ func (x *StartResponse) GetError() string {
 	return ""
 }
 
+// SetConfigRequest carries the instance configuration for Configure.
 type SetConfigRequest struct {
-	state              protoimpl.MessageState `protogen:"open.v1"`
-	InstanceConfigJson []byte                 `protobuf:"bytes,1,opt,name=instance_config_json,json=instanceConfigJson,proto3" json:"instance_config_json,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// JSON-encoded limatype.Instance. JSON keeps it in sync with the Go type.
+	InstanceConfigJson []byte `protobuf:"bytes,1,opt,name=instance_config_json,json=instanceConfigJson,proto3" json:"instance_config_json,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -255,9 +270,14 @@ func (x *SetConfigRequest) GetInstanceConfigJson() []byte {
 	return nil
 }
 
+// SetConfigResponse carries the instance configuration after Configure applied
+// the driver's defaults and validation. It is returned so the caller picks up
+// those changes (the in-process interface mutates the instance in place).
 type SetConfigResponse struct {
-	state              protoimpl.MessageState `protogen:"open.v1"`
-	InstanceConfigJson []byte                 `protobuf:"bytes,1,opt,name=instance_config_json,json=instanceConfigJson,proto3" json:"instance_config_json,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// JSON-encoded limatype.Instance after Configure applied the driver's defaults
+	// and validation. JSON keeps it in sync with the Go type.
+	InstanceConfigJson []byte `protobuf:"bytes,1,opt,name=instance_config_json,json=instanceConfigJson,proto3" json:"instance_config_json,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -299,9 +319,11 @@ func (x *SetConfigResponse) GetInstanceConfigJson() []byte {
 	return nil
 }
 
+// ChangeDisplayPasswordRequest carries the new display password.
 type ChangeDisplayPasswordRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Password      string                 `protobuf:"bytes,1,opt,name=password,proto3" json:"password,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// New VM display (e.g. VNC) password.
+	Password      string `protobuf:"bytes,1,opt,name=password,proto3" json:"password,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -343,9 +365,11 @@ func (x *ChangeDisplayPasswordRequest) GetPassword() string {
 	return ""
 }
 
+// GetDisplayConnectionResponse carries the VM display connection string.
 type GetDisplayConnectionResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Connection    string                 `protobuf:"bytes,1,opt,name=connection,proto3" json:"connection,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Driver-specific display connection string.
+	Connection    string `protobuf:"bytes,1,opt,name=connection,proto3" json:"connection,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -387,9 +411,11 @@ func (x *GetDisplayConnectionResponse) GetConnection() string {
 	return ""
 }
 
+// CreateSnapshotRequest identifies the snapshot to create.
 type CreateSnapshotRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Tag           string                 `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Names the snapshot.
+	Tag           string `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -431,9 +457,11 @@ func (x *CreateSnapshotRequest) GetTag() string {
 	return ""
 }
 
+// ApplySnapshotRequest identifies the snapshot to restore.
 type ApplySnapshotRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Tag           string                 `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Names the snapshot to restore.
+	Tag           string `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -475,9 +503,11 @@ func (x *ApplySnapshotRequest) GetTag() string {
 	return ""
 }
 
+// DeleteSnapshotRequest identifies the snapshot to delete.
 type DeleteSnapshotRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Tag           string                 `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Names the snapshot to delete.
+	Tag           string `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -519,9 +549,11 @@ func (x *DeleteSnapshotRequest) GetTag() string {
 	return ""
 }
 
+// ListSnapshotsResponse carries the existing snapshots.
 type ListSnapshotsResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Snapshots     string                 `protobuf:"bytes,1,opt,name=snapshots,proto3" json:"snapshots,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Driver-formatted list of existing snapshots.
+	Snapshots     string `protobuf:"bytes,1,opt,name=snapshots,proto3" json:"snapshots,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -563,9 +595,12 @@ func (x *ListSnapshotsResponse) GetSnapshots() string {
 	return ""
 }
 
+// ForwardGuestAgentResponse reports how the guest agent is reached.
 type ForwardGuestAgentResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ShouldForward bool                   `protobuf:"varint,1,opt,name=should_forward,json=shouldForward,proto3" json:"should_forward,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// True when the host agent forwards the guest agent socket over SSH; false
+	// means the driver provides a direct connection via GuestAgentConn.
+	ShouldForward bool `protobuf:"varint,1,opt,name=should_forward,json=shouldForward,proto3" json:"should_forward,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/pkg/driver/external/driver.proto
+++ b/pkg/driver/external/driver.proto
@@ -4,90 +4,215 @@ import "google/protobuf/empty.proto";
 
 option go_package = "github.com/lima-vm/lima/v2/pkg/driver/external";
 
+// Driver is the transport used by an external VM driver. It is the gRPC
+// projection of the Go `driver.Driver` interface (pkg/driver/driver.go): the
+// host agent runs a gRPC client and each external driver binary
+// (lima-driver-<name>) runs the server. The RPCs mirror the interface methods
+// one-to-one, so this file is the authoritative contract for driver authors.
+//
+// Call ordering on the instance start path: instance.Prepare (pkg/instance)
+// runs steps 1-4, then the host agent (pkg/hostagent) boots the VM and runs
+// steps 5-7. Creating an instance without starting it (limactl create) only
+// runs Configure and Create.
+//   1. Configure  - set the instance config; must run before any method that
+//      depends on it.
+//   2. Validate    - reject configs the driver cannot support.
+//   3. Create      - first-time provisioning; a no-op on existing instances.
+//   4. CreateDisk  - create the instance disk(s).
+//   5. Start       - begin booting the VM. It returns once boot has been
+//      initiated (the initial StartResponse), not once the guest has finished
+//      booting; later boot errors arrive on the stream. See StartResponse.
+//   6. AdditionalSetupForSSH - runs right after Start returns (boot initiated,
+//      the guest is not necessarily up yet), before the first SSH connection.
+//   7. SSHAddress  - re-queried after Start only when Info reports
+//      Features.dynamicSSHAddress.
+//
+// Unless stated otherwise, an RPC returning google.protobuf.Empty completes
+// synchronously and reports failures as a gRPC error status. Requests and
+// responses that carry structured data use JSON payloads (Info, Configure) to
+// stay in sync with the Go types without duplicating them here.
+//
+// Concurrency: the start-path RPCs above are invoked sequentially in the
+// order listed. Once the VM is running, the host agent polls read-only RPCs
+// (notably Info and ForwardGuestAgent) from background goroutines, so the
+// driver server must be safe to handle concurrent RPCs.
 service Driver {
+  // Validate reports whether the driver supports the currently configured
+  // instance. It is called early on the start path, before Create. Returning
+  // an error aborts the operation.
   rpc Validate(google.protobuf.Empty) returns (google.protobuf.Empty);
+
+  // Create performs first-time provisioning of the instance (e.g. writing a
+  // "vz-identifier" file). It MUST return successfully (no-op) when called
+  // against an instance that already exists, and it MUST NOT create the disks
+  // (that is CreateDisk's job).
   rpc Create(google.protobuf.Empty) returns (google.protobuf.Empty);
+
+  // CreateDisk creates the instance disk(s). It is called after Create.
   rpc CreateDisk(google.protobuf.Empty) returns (google.protobuf.Empty);
+
+  // Start begins booting the VM. It is a server-streaming RPC that mirrors the
+  // `(chan error, error)` return of the in-process interface: the call returns
+  // once boot has been initiated (the initial StartResponse), not once the
+  // guest has finished booting, and later boot errors arrive on the stream. See
+  // StartResponse for the streaming protocol.
   rpc Start(google.protobuf.Empty) returns (stream StartResponse);
+
+  // Stop terminates the running VM. It blocks until the VM has fully exited
+  // (or the driver's internal shutdown deadline elapses) and returns a gRPC
+  // error status if the shutdown failed.
   rpc Stop(google.protobuf.Empty) returns (google.protobuf.Empty);
+
+  // Delete removes the instance created by Create (and its driver-specific
+  // files). The generic instance directory is removed by the host agent.
   rpc Delete(google.protobuf.Empty) returns (google.protobuf.Empty);
+
+  // BootScripts returns the boot scripts to inject into the VM via cloud-init.
+  // See BootScriptsResponse for the required key format.
   rpc BootScripts(google.protobuf.Empty) returns (BootScriptsResponse);
 
+  // RunGUI starts the GUI synchronously. It blocks and returns only after the
+  // VM terminates. It is only used by drivers that report Features.canRunGui.
   rpc RunGUI(google.protobuf.Empty) returns (google.protobuf.Empty);
+
+  // ChangeDisplayPassword sets the password for the VM display (e.g. VNC).
   rpc ChangeDisplayPassword(ChangeDisplayPasswordRequest) returns (google.protobuf.Empty);
+
+  // GetDisplayConnection returns the connection string for the VM display.
   rpc GetDisplayConnection(google.protobuf.Empty) returns (GetDisplayConnectionResponse);
 
+  // CreateSnapshot creates a VM snapshot identified by the given tag.
   rpc CreateSnapshot(CreateSnapshotRequest) returns (google.protobuf.Empty);
+
+  // ApplySnapshot restores the VM to the snapshot identified by the given tag.
   rpc ApplySnapshot(ApplySnapshotRequest) returns (google.protobuf.Empty);
+
+  // DeleteSnapshot removes the snapshot identified by the given tag.
   rpc DeleteSnapshot(DeleteSnapshotRequest) returns (google.protobuf.Empty);
+
+  // ListSnapshots returns the driver-formatted list of existing snapshots.
   rpc ListSnapshots(google.protobuf.Empty) returns (ListSnapshotsResponse);
 
+  // ForwardGuestAgent reports whether the host agent must forward the guest
+  // agent socket over SSH. When false, the driver provides a direct guest agent
+  // connection via GuestAgentConn (e.g. vsock/virtio).
   rpc ForwardGuestAgent(google.protobuf.Empty) returns (ForwardGuestAgentResponse);
+
+  // GuestAgentConn returns a direct guest agent connection, used when
+  // ForwardGuestAgent is false; it returns nil when the socket is forwarded
+  // over SSH instead. Over this transport the server bridges the connection to
+  // a unix socket in the instance directory when it is not already one, so the
+  // client relies on that socket rather than on a returned connection.
   rpc GuestAgentConn(google.protobuf.Empty) returns (google.protobuf.Empty);
 
+  // Configure sets the instance configuration on the driver. It must be called
+  // before RPCs that depend on the config.
   rpc Configure(SetConfigRequest) returns (SetConfigResponse);
+
+  // Info returns driver metadata and capability flags (see InfoResponse). The
+  // host agent uses it to discover features such as dynamicSSHAddress.
   rpc Info(google.protobuf.Empty) returns (InfoResponse);
+
+  // SSHAddress returns the address used to SSH into the guest. For drivers that
+  // report Features.dynamicSSHAddress the address is not known until after
+  // Start, so the host agent re-queries it at that point.
   rpc SSHAddress(google.protobuf.Empty) returns (SSHAddressResponse);
 
   // AdditionalSetupForSSH provides additional setup required for SSH connection.
-  // It is called after VM is started, before first SSH connection.
+  // It is called right after Start returns (boot initiated, the guest is not
+  // necessarily up yet), before the first SSH connection.
   rpc AdditionalSetupForSSH(google.protobuf.Empty) returns (google.protobuf.Empty);
 }
 
+// BootScriptsResponse carries the boot scripts injected into the VM.
 message BootScriptsResponse {
+  // Maps a script path to its content. Each key must be
+  // "boot.<OS>/<SCRIPT>", or "<SCRIPT>" as a deprecated alias for
+  // "boot.Linux/<SCRIPT>".
   map<string, bytes> scripts = 1;
 }
 
+// SSHAddressResponse carries the guest SSH address.
 message SSHAddressResponse {
+  // Host/IP used to SSH into the guest.
   string address = 1;
 }
 
-message InfoResponse{
+// InfoResponse carries driver metadata and capability flags.
+message InfoResponse {
+  // JSON-encoded driver.Info (name, ports, instance dir and feature flags).
+  // JSON keeps it in sync with the Go type. The full set of fields is defined at
+  // https://pkg.go.dev/github.com/lima-vm/lima/v2/pkg/driver#Info
   bytes info_json = 1;
 }
 
-// StartResponse is a streamed response for Start() RPC. It tries to mimic
-// errChan from pkg/driver/driver.go. The server sends an initial response
-// with success=true when Start() is initiated. If errors occur, they are
-// sent as success=false with the error field populated. When the error channel
-// closes, a final success=true message is sent.
+// StartResponse is a streamed response for the Start RPC. It mimics the
+// errChan from pkg/driver/driver.go. The server sends an initial response with
+// success=true once Start is initiated (this unblocks the client). If errors
+// occur they are sent as success=false with the error field populated. When the
+// error channel closes, a final success=true message is sent and the stream ends.
 message StartResponse {
+  // True for the initial "started" message and the final "done" message, and
+  // false for each streamed error.
   bool success = 1;
+  // Error message when success is false; empty otherwise.
   string error = 2;
 }
 
+// SetConfigRequest carries the instance configuration for Configure.
 message SetConfigRequest {
+  // JSON-encoded limatype.Instance. JSON keeps it in sync with the Go type.
   bytes instance_config_json = 1;
 }
 
+// SetConfigResponse carries the instance configuration after Configure applied
+// the driver's defaults and validation. It is returned so the caller picks up
+// those changes (the in-process interface mutates the instance in place).
 message SetConfigResponse {
+  // JSON-encoded limatype.Instance after Configure applied the driver's defaults
+  // and validation. JSON keeps it in sync with the Go type.
   bytes instance_config_json = 1;
 }
 
+// ChangeDisplayPasswordRequest carries the new display password.
 message ChangeDisplayPasswordRequest {
+  // New VM display (e.g. VNC) password.
   string password = 1;
 }
 
+// GetDisplayConnectionResponse carries the VM display connection string.
 message GetDisplayConnectionResponse {
+  // Driver-specific display connection string.
   string connection = 1;
 }
 
+// CreateSnapshotRequest identifies the snapshot to create.
 message CreateSnapshotRequest {
+  // Names the snapshot.
   string tag = 1;
 }
 
+// ApplySnapshotRequest identifies the snapshot to restore.
 message ApplySnapshotRequest {
+  // Names the snapshot to restore.
   string tag = 1;
 }
 
+// DeleteSnapshotRequest identifies the snapshot to delete.
 message DeleteSnapshotRequest {
+  // Names the snapshot to delete.
   string tag = 1;
 }
 
+// ListSnapshotsResponse carries the existing snapshots.
 message ListSnapshotsResponse {
+  // Driver-formatted list of existing snapshots.
   string snapshots = 1;
 }
 
+// ForwardGuestAgentResponse reports how the guest agent is reached.
 message ForwardGuestAgentResponse {
+  // True when the host agent forwards the guest agent socket over SSH; false
+  // means the driver provides a direct connection via GuestAgentConn.
   bool should_forward = 1;
 }

--- a/pkg/driver/external/driver_grpc.pb.go
+++ b/pkg/driver/external/driver_grpc.pb.go
@@ -45,28 +45,105 @@ const (
 // DriverClient is the client API for Driver service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// Driver is the transport used by an external VM driver. It is the gRPC
+// projection of the Go `driver.Driver` interface (pkg/driver/driver.go): the
+// host agent runs a gRPC client and each external driver binary
+// (lima-driver-<name>) runs the server. The RPCs mirror the interface methods
+// one-to-one, so this file is the authoritative contract for driver authors.
+//
+// Call ordering on the instance start path: instance.Prepare (pkg/instance)
+// runs steps 1-4, then the host agent (pkg/hostagent) boots the VM and runs
+// steps 5-7. Creating an instance without starting it (limactl create) only
+// runs Configure and Create.
+//  1. Configure  - set the instance config; must run before any method that
+//     depends on it.
+//  2. Validate    - reject configs the driver cannot support.
+//  3. Create      - first-time provisioning; a no-op on existing instances.
+//  4. CreateDisk  - create the instance disk(s).
+//  5. Start       - begin booting the VM. It returns once boot has been
+//     initiated (the initial StartResponse), not once the guest has finished
+//     booting; later boot errors arrive on the stream. See StartResponse.
+//  6. AdditionalSetupForSSH - runs right after Start returns (boot initiated,
+//     the guest is not necessarily up yet), before the first SSH connection.
+//  7. SSHAddress  - re-queried after Start only when Info reports
+//     Features.dynamicSSHAddress.
+//
+// Unless stated otherwise, an RPC returning google.protobuf.Empty completes
+// synchronously and reports failures as a gRPC error status. Requests and
+// responses that carry structured data use JSON payloads (Info, Configure) to
+// stay in sync with the Go types without duplicating them here.
+//
+// Concurrency: the start-path RPCs above are invoked sequentially in the
+// order listed. Once the VM is running, the host agent polls read-only RPCs
+// (notably Info and ForwardGuestAgent) from background goroutines, so the
+// driver server must be safe to handle concurrent RPCs.
 type DriverClient interface {
+	// Validate reports whether the driver supports the currently configured
+	// instance. It is called early on the start path, before Create. Returning
+	// an error aborts the operation.
 	Validate(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// Create performs first-time provisioning of the instance (e.g. writing a
+	// "vz-identifier" file). It MUST return successfully (no-op) when called
+	// against an instance that already exists, and it MUST NOT create the disks
+	// (that is CreateDisk's job).
 	Create(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// CreateDisk creates the instance disk(s). It is called after Create.
 	CreateDisk(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// Start begins booting the VM. It is a server-streaming RPC that mirrors the
+	// `(chan error, error)` return of the in-process interface: the call returns
+	// once boot has been initiated (the initial StartResponse), not once the
+	// guest has finished booting, and later boot errors arrive on the stream. See
+	// StartResponse for the streaming protocol.
 	Start(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[StartResponse], error)
+	// Stop terminates the running VM. It blocks until the VM has fully exited
+	// (or the driver's internal shutdown deadline elapses) and returns a gRPC
+	// error status if the shutdown failed.
 	Stop(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// Delete removes the instance created by Create (and its driver-specific
+	// files). The generic instance directory is removed by the host agent.
 	Delete(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// BootScripts returns the boot scripts to inject into the VM via cloud-init.
+	// See BootScriptsResponse for the required key format.
 	BootScripts(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*BootScriptsResponse, error)
+	// RunGUI starts the GUI synchronously. It blocks and returns only after the
+	// VM terminates. It is only used by drivers that report Features.canRunGui.
 	RunGUI(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// ChangeDisplayPassword sets the password for the VM display (e.g. VNC).
 	ChangeDisplayPassword(ctx context.Context, in *ChangeDisplayPasswordRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// GetDisplayConnection returns the connection string for the VM display.
 	GetDisplayConnection(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*GetDisplayConnectionResponse, error)
+	// CreateSnapshot creates a VM snapshot identified by the given tag.
 	CreateSnapshot(ctx context.Context, in *CreateSnapshotRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// ApplySnapshot restores the VM to the snapshot identified by the given tag.
 	ApplySnapshot(ctx context.Context, in *ApplySnapshotRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// DeleteSnapshot removes the snapshot identified by the given tag.
 	DeleteSnapshot(ctx context.Context, in *DeleteSnapshotRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// ListSnapshots returns the driver-formatted list of existing snapshots.
 	ListSnapshots(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*ListSnapshotsResponse, error)
+	// ForwardGuestAgent reports whether the host agent must forward the guest
+	// agent socket over SSH. When false, the driver provides a direct guest agent
+	// connection via GuestAgentConn (e.g. vsock/virtio).
 	ForwardGuestAgent(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*ForwardGuestAgentResponse, error)
+	// GuestAgentConn returns a direct guest agent connection, used when
+	// ForwardGuestAgent is false; it returns nil when the socket is forwarded
+	// over SSH instead. Over this transport the server bridges the connection to
+	// a unix socket in the instance directory when it is not already one, so the
+	// client relies on that socket rather than on a returned connection.
 	GuestAgentConn(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// Configure sets the instance configuration on the driver. It must be called
+	// before RPCs that depend on the config.
 	Configure(ctx context.Context, in *SetConfigRequest, opts ...grpc.CallOption) (*SetConfigResponse, error)
+	// Info returns driver metadata and capability flags (see InfoResponse). The
+	// host agent uses it to discover features such as dynamicSSHAddress.
 	Info(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*InfoResponse, error)
+	// SSHAddress returns the address used to SSH into the guest. For drivers that
+	// report Features.dynamicSSHAddress the address is not known until after
+	// Start, so the host agent re-queries it at that point.
 	SSHAddress(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*SSHAddressResponse, error)
 	// AdditionalSetupForSSH provides additional setup required for SSH connection.
-	// It is called after VM is started, before first SSH connection.
+	// It is called right after Start returns (boot initiated, the guest is not
+	// necessarily up yet), before the first SSH connection.
 	AdditionalSetupForSSH(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -290,28 +367,105 @@ func (c *driverClient) AdditionalSetupForSSH(ctx context.Context, in *emptypb.Em
 // DriverServer is the server API for Driver service.
 // All implementations must embed UnimplementedDriverServer
 // for forward compatibility.
+//
+// Driver is the transport used by an external VM driver. It is the gRPC
+// projection of the Go `driver.Driver` interface (pkg/driver/driver.go): the
+// host agent runs a gRPC client and each external driver binary
+// (lima-driver-<name>) runs the server. The RPCs mirror the interface methods
+// one-to-one, so this file is the authoritative contract for driver authors.
+//
+// Call ordering on the instance start path: instance.Prepare (pkg/instance)
+// runs steps 1-4, then the host agent (pkg/hostagent) boots the VM and runs
+// steps 5-7. Creating an instance without starting it (limactl create) only
+// runs Configure and Create.
+//  1. Configure  - set the instance config; must run before any method that
+//     depends on it.
+//  2. Validate    - reject configs the driver cannot support.
+//  3. Create      - first-time provisioning; a no-op on existing instances.
+//  4. CreateDisk  - create the instance disk(s).
+//  5. Start       - begin booting the VM. It returns once boot has been
+//     initiated (the initial StartResponse), not once the guest has finished
+//     booting; later boot errors arrive on the stream. See StartResponse.
+//  6. AdditionalSetupForSSH - runs right after Start returns (boot initiated,
+//     the guest is not necessarily up yet), before the first SSH connection.
+//  7. SSHAddress  - re-queried after Start only when Info reports
+//     Features.dynamicSSHAddress.
+//
+// Unless stated otherwise, an RPC returning google.protobuf.Empty completes
+// synchronously and reports failures as a gRPC error status. Requests and
+// responses that carry structured data use JSON payloads (Info, Configure) to
+// stay in sync with the Go types without duplicating them here.
+//
+// Concurrency: the start-path RPCs above are invoked sequentially in the
+// order listed. Once the VM is running, the host agent polls read-only RPCs
+// (notably Info and ForwardGuestAgent) from background goroutines, so the
+// driver server must be safe to handle concurrent RPCs.
 type DriverServer interface {
+	// Validate reports whether the driver supports the currently configured
+	// instance. It is called early on the start path, before Create. Returning
+	// an error aborts the operation.
 	Validate(context.Context, *emptypb.Empty) (*emptypb.Empty, error)
+	// Create performs first-time provisioning of the instance (e.g. writing a
+	// "vz-identifier" file). It MUST return successfully (no-op) when called
+	// against an instance that already exists, and it MUST NOT create the disks
+	// (that is CreateDisk's job).
 	Create(context.Context, *emptypb.Empty) (*emptypb.Empty, error)
+	// CreateDisk creates the instance disk(s). It is called after Create.
 	CreateDisk(context.Context, *emptypb.Empty) (*emptypb.Empty, error)
+	// Start begins booting the VM. It is a server-streaming RPC that mirrors the
+	// `(chan error, error)` return of the in-process interface: the call returns
+	// once boot has been initiated (the initial StartResponse), not once the
+	// guest has finished booting, and later boot errors arrive on the stream. See
+	// StartResponse for the streaming protocol.
 	Start(*emptypb.Empty, grpc.ServerStreamingServer[StartResponse]) error
+	// Stop terminates the running VM. It blocks until the VM has fully exited
+	// (or the driver's internal shutdown deadline elapses) and returns a gRPC
+	// error status if the shutdown failed.
 	Stop(context.Context, *emptypb.Empty) (*emptypb.Empty, error)
+	// Delete removes the instance created by Create (and its driver-specific
+	// files). The generic instance directory is removed by the host agent.
 	Delete(context.Context, *emptypb.Empty) (*emptypb.Empty, error)
+	// BootScripts returns the boot scripts to inject into the VM via cloud-init.
+	// See BootScriptsResponse for the required key format.
 	BootScripts(context.Context, *emptypb.Empty) (*BootScriptsResponse, error)
+	// RunGUI starts the GUI synchronously. It blocks and returns only after the
+	// VM terminates. It is only used by drivers that report Features.canRunGui.
 	RunGUI(context.Context, *emptypb.Empty) (*emptypb.Empty, error)
+	// ChangeDisplayPassword sets the password for the VM display (e.g. VNC).
 	ChangeDisplayPassword(context.Context, *ChangeDisplayPasswordRequest) (*emptypb.Empty, error)
+	// GetDisplayConnection returns the connection string for the VM display.
 	GetDisplayConnection(context.Context, *emptypb.Empty) (*GetDisplayConnectionResponse, error)
+	// CreateSnapshot creates a VM snapshot identified by the given tag.
 	CreateSnapshot(context.Context, *CreateSnapshotRequest) (*emptypb.Empty, error)
+	// ApplySnapshot restores the VM to the snapshot identified by the given tag.
 	ApplySnapshot(context.Context, *ApplySnapshotRequest) (*emptypb.Empty, error)
+	// DeleteSnapshot removes the snapshot identified by the given tag.
 	DeleteSnapshot(context.Context, *DeleteSnapshotRequest) (*emptypb.Empty, error)
+	// ListSnapshots returns the driver-formatted list of existing snapshots.
 	ListSnapshots(context.Context, *emptypb.Empty) (*ListSnapshotsResponse, error)
+	// ForwardGuestAgent reports whether the host agent must forward the guest
+	// agent socket over SSH. When false, the driver provides a direct guest agent
+	// connection via GuestAgentConn (e.g. vsock/virtio).
 	ForwardGuestAgent(context.Context, *emptypb.Empty) (*ForwardGuestAgentResponse, error)
+	// GuestAgentConn returns a direct guest agent connection, used when
+	// ForwardGuestAgent is false; it returns nil when the socket is forwarded
+	// over SSH instead. Over this transport the server bridges the connection to
+	// a unix socket in the instance directory when it is not already one, so the
+	// client relies on that socket rather than on a returned connection.
 	GuestAgentConn(context.Context, *emptypb.Empty) (*emptypb.Empty, error)
+	// Configure sets the instance configuration on the driver. It must be called
+	// before RPCs that depend on the config.
 	Configure(context.Context, *SetConfigRequest) (*SetConfigResponse, error)
+	// Info returns driver metadata and capability flags (see InfoResponse). The
+	// host agent uses it to discover features such as dynamicSSHAddress.
 	Info(context.Context, *emptypb.Empty) (*InfoResponse, error)
+	// SSHAddress returns the address used to SSH into the guest. For drivers that
+	// report Features.dynamicSSHAddress the address is not known until after
+	// Start, so the host agent re-queries it at that point.
 	SSHAddress(context.Context, *emptypb.Empty) (*SSHAddressResponse, error)
 	// AdditionalSetupForSSH provides additional setup required for SSH connection.
-	// It is called after VM is started, before first SSH connection.
+	// It is called right after Start returns (boot initiated, the guest is not
+	// necessarily up yet), before the first SSH connection.
 	AdditionalSetupForSSH(context.Context, *emptypb.Empty) (*emptypb.Empty, error)
 	mustEmbedUnimplementedDriverServer()
 }

--- a/website/content/en/docs/dev/drivers.md
+++ b/website/content/en/docs/dev/drivers.md
@@ -58,12 +58,19 @@ type Driver interface {
 	SnapshotManager
 	GuestAgent
 
-	Info() Info
+	Info(ctx context.Context) Info
 	Configure(ctx context.Context, inst *limatype.Instance) (*ConfiguredDriver, error)
-	FillConfig(ctx context.Context, cfg *limatype.LimaYAML, filePath string) error
 	SSHAddress(ctx context.Context) (string, error)
+	AdditionalSetupForSSH(ctx context.Context) error
 }
 ```
+
+   The gRPC transport that carries these methods to an external driver is defined
+   in [`driver.proto`](https://github.com/lima-vm/lima/blob/master/pkg/driver/external/driver.proto),
+   whose per-RPC doc comments are the authoritative contract (call ordering,
+   idempotency and per-RPC semantics) for driver authors. The Go side is
+   documented as godoc on the [`driver.Driver`](https://pkg.go.dev/github.com/lima-vm/lima/v2/pkg/driver#Driver)
+   interface.
 
 2. **Create main.go**: Use [`server.Serve()`](https://pkg.go.dev/github.com/lima-vm/lima/v2/pkg/driver/external/server#Serve) to expose your driver:
 
@@ -91,6 +98,48 @@ func main() {
 ```bash
 limactl create myinstance --vm-type=mydriver template:default
 ```
+
+## Driver lifecycle & call ordering
+
+Drivers are unaware whether they are internal or external, but external driver
+authors need to know when each method is invoked. The sequence below is the
+instance *start* path: `instance.Prepare` (in `pkg/instance`) runs steps 1-4,
+then the hostagent (`pkg/hostagent`) boots the VM and runs steps 5-7:
+
+1. **`Configure`** - sets the instance configuration on the driver. It must run
+   before any method that depends on the config.
+2. **`Validate`** - rejects a config the driver cannot support. Returning an
+   error aborts the start.
+3. **`Create`** - first-time provisioning (e.g. writing a driver identifier
+   file). It **must** be a no-op (succeed) when the instance already exists, and
+   it must **not** create the disks.
+4. **`CreateDisk`** - creates the instance disk(s).
+5. **`Start`** - begins booting the VM. It is streaming and returns as soon as
+   boot has been *initiated* (the initial "started" message), **not** once the
+   guest has finished booting; it then streams any runtime errors, then a final
+   "done" (see the `StartResponse` message in `driver.proto`).
+6. **`AdditionalSetupForSSH`** - runs right after `Start` returns (boot
+   initiated, the guest is not necessarily up yet), before the first SSH
+   connection.
+7. **`SSHAddress`** - re-queried after `Start` only when `Info` reports
+   `Features.dynamicSSHAddress` (e.g. WSL2, whose address is not known until the
+   VM is up).
+
+The guest agent is reached in one of two ways, chosen by what
+**`ForwardGuestAgent`** returns. When it returns `true`, the host agent forwards
+the guest-agent socket over SSH and **`GuestAgentConn`** returns `nil`. When it
+returns `false`, the driver provides a direct guest-agent connection (e.g.
+vsock/virtio) through **`GuestAgentConn`**.
+
+These start-path methods are invoked sequentially in the order above. Creating an
+instance without starting it (`limactl create`) only runs `Configure` and
+`Create`. Once the VM is running, the host agent polls read-only methods (notably
+**`Info`** and **`ForwardGuestAgent`**) from background goroutines, so a driver's
+gRPC server must be safe to handle concurrent calls.
+
+For the full per-method contract, see the doc comments in
+[`driver.proto`](https://github.com/lima-vm/lima/blob/master/pkg/driver/external/driver.proto)
+and the [`driver.Driver`](https://pkg.go.dev/github.com/lima-vm/lima/v2/pkg/driver#Driver) godoc.
 
 ## Examples
 


### PR DESCRIPTION
Document the external driver gRPC API contract by adding detailed doc comments to every RPC and message in `driver.proto`. These comments are the authoritative contract (call ordering, idempotency, per-method semantics) and also improve the godoc for the `driver.Driver` interface.

  - `driver.proto`: service-level call-ordering overview plus per-RPC/field docs (idempotency of Create, conditional SSHAddress, Start streaming, guest agent forwarding)
  - `driver.go`: doc comments on the `Info` and `DriverFeatures` structs carried as JSON in `InfoResponse`
  - `website`: a hand-written "Driver lifecycle and call ordering" section in `drivers.md`, cross-linking to `driver.proto` and the `driver.Driver` godoc

The `protoc-gen-doc` auto-generated reference was descoped from this PR and moved to a separate discussion in #5224.

Fixes #4896