### PR TITLE
Minor improvements to kubernetes documentation

### DIFF
--- a/templates/k3s.yaml
+++ b/templates/k3s.yaml
@@ -20,7 +20,7 @@
 # (The token for the start command printed here)
 #
 # $ limactl start --name k3s-1 --network lima:user-v2 template:k3s \
-#                 --set '.param.url="<URL_FROM_ABOVE>" | .param.token="<TOKEN_FROM_ABOVE>"'
+#                 --param url="<URL_FROM_ABOVE>" --param token="<TOKEN_FROM_ABOVE>"
 
 minimumLimaVersion: 2.0.0
 

--- a/templates/k3s.yaml
+++ b/templates/k3s.yaml
@@ -13,10 +13,10 @@
 # A multi-node cluster can be created by starting multiple instances of this template
 # connected via the `lima:user-v2` network.
 #
-# $ limactl start --name k3s-0 --network lima:user-v2 template:k3s
-# $ printf "https://lima-%s.internal:6443\n" k3s-0
+# $ limactl start --name k3s --network lima:user-v2 template:k3s
+# $ printf "https://lima-%s.internal:6443\n" k3s
 # (The url for the start command printed here)
-# $ limactl shell k3s-0 sudo cat /var/lib/rancher/k3s/server/node-token
+# $ limactl shell k3s sudo cat /var/lib/rancher/k3s/server/node-token
 # (The token for the start command printed here)
 #
 # $ limactl start --name k3s-1 --network lima:user-v2 template:k3s \

--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -13,8 +13,8 @@
 # A multi-node cluster can be created by starting multiple instances of this template
 # connected via the `lima:user-v2` network.
 #
-# $ limactl start --name k8s-0 --network lima:user-v2 template:k8s
-# $ limactl shell k8s-0 sudo kubeadm token create --print-join-command
+# $ limactl start --name k8s --network lima:user-v2 template:k8s
+# $ limactl shell k8s sudo kubeadm token create --print-join-command
 # (The parameters for the start command printed here)
 #
 # $ limactl start --name k8s-1 --network lima:user-v2 template:k8s \

--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -18,8 +18,8 @@
 # (The parameters for the start command printed here)
 #
 # $ limactl start --name k8s-1 --network lima:user-v2 template:k8s \
-#                 --set '.param.url="<ADDRESS_FROM_ABOVE>" | .param.token="<TOKEN_FROM_ABOVE>" | \
-#                        .param.discoveryTokenCaCertHash="<DISCOVERY_TOKEN_CA_CERT_HASH_FROM_ABOVE>"'
+#                 --param url="<ADDRESS_FROM_ABOVE>" --param token="<TOKEN_FROM_ABOVE>" \
+#                 --param discoveryTokenCaCertHash="<DISCOVERY_TOKEN_CA_CERT_HASH_FROM_ABOVE>"
 
 minimumLimaVersion: 2.0.0
 

--- a/website/content/en/docs/examples/containers/kubernetes/_index.md
+++ b/website/content/en/docs/examples/containers/kubernetes/_index.md
@@ -73,8 +73,8 @@ The following templates are designed to support multi-node mode:
 {{< tabpane text=true >}}
 {{% tab header="Lima v2.0" %}}
 ```bash
-limactl start --name k8s-0 --network lima:user-v2 template:k8s
-limactl shell k8s-0 sudo kubeadm token create --print-join-command
+limactl start --name k8s --network lima:user-v2 template:k8s
+limactl shell k8s sudo kubeadm token create --print-join-command
 # (The join command printed here)
 ```
 
@@ -86,8 +86,8 @@ limactl shell k8s-1 sudo <JOIN_COMMAND_FROM_ABOVE>
 {{% /tab %}}
 {{% tab header="Lima v2.1 (k8s)" %}}
 ```bash
-limactl start --name k8s-0 --network lima:user-v2 template:k8s
-limactl shell k8s-0 sudo kubeadm token create --print-join-command
+limactl start --name k8s --network lima:user-v2 template:k8s
+limactl shell k8s sudo kubeadm token create --print-join-command
 # (The parameters for the start command printed here)
 ```
 
@@ -99,10 +99,10 @@ limactl start --name k8s-1 --network lima:user-v2 template:k8s \
 {{% /tab %}}
 {{% tab header="Lima v2.1 (k3s)" %}}
 ```bash
-limactl start --name k3s-0 --network lima:user-v2 template:k3s
-printf "https://lima-%s.internal:6443\n" k3s-0
+limactl start --name k3s --network lima:user-v2 template:k3s
+printf "https://lima-%s.internal:6443\n" k3s
 # (The url for the start command printed here)
-limactl shell k3s-0 sudo cat /var/lib/rancher/k3s/server/node-token
+limactl shell k3s sudo cat /var/lib/rancher/k3s/server/node-token
 # (The token for the start command printed here)
 ```
 

--- a/website/content/en/docs/examples/containers/kubernetes/_index.md
+++ b/website/content/en/docs/examples/containers/kubernetes/_index.md
@@ -93,8 +93,8 @@ limactl shell k8s-0 sudo kubeadm token create --print-join-command
 
 ```bash
 limactl start --name k8s-1 --network lima:user-v2 template:k8s \
-              --set '.param.url="https://<ADDRESS_FROM_ABOVE>" | .param.token="<TOKEN_FROM_ABOVE>" | \
-                     .param.discoveryTokenCaCertHash="<DISCOVERY_TOKEN_CA_CERT_HASH_FROM_ABOVE>"'
+              --param url="https://<ADDRESS_FROM_ABOVE>" --param token="<TOKEN_FROM_ABOVE>" \
+              --param discoveryTokenCaCertHash="<DISCOVERY_TOKEN_CA_CERT_HASH_FROM_ABOVE>"
 ```
 {{% /tab %}}
 {{% tab header="Lima v2.1 (k3s)" %}}
@@ -108,7 +108,7 @@ limactl shell k3s-0 sudo cat /var/lib/rancher/k3s/server/node-token
 
 ```bash
 limactl start --name k3s-1 --network lima:user-v2 template:k3s \
-              --set '.param.url="<URL_FROM_ABOVE>" | .param.token="<TOKEN_FROM_ABOVE>"'
+              --param url="<URL_FROM_ABOVE>" --param token="<TOKEN_FROM_ABOVE>"
 ```
 {{% /tab %}}
 {{< /tabpane >}}


### PR DESCRIPTION
Fixes the single quote issue mentioned on Slack, and also the kubernetes.lima issue with instance name.

```
No k3s or k8s existing instances found. Either create one with
limactl create --name=k3s template:k3s
limactl create --name=k8s template:k8s
or set LIMA_INSTANCE to the name of your Kubernetes instance
```

The machine test case can still use special node name and the yq params, this change was for humans...