### PR TITLE
reject line breaks in ssh config option values

### DIFF
--- a/pkg/sshutil/format.go
+++ b/pkg/sshutil/format.go
@@ -63,6 +63,13 @@ func quoteOption(o string) string {
 // Format formats the ssh options.
 func Format(w io.Writer, sshPath, instName string, format FormatT, opts []string) error {
 	fakeHostname := hostname.FromInstName(instName) // TODO: support customization
+	for _, o := range opts {
+		// A line break in an option value (e.g. a crafted user.name) would inject
+		// extra ssh_config directives such as ProxyCommand into the generated config.
+		if strings.ContainsAny(o, "\r\n") {
+			return fmt.Errorf("ssh option %#q contains a line break", o)
+		}
+	}
 	switch format {
 	case FormatCmd:
 		args := []string{sshPath}

--- a/pkg/sshutil/format_test.go
+++ b/pkg/sshutil/format_test.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sshutil
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestFormatConfig(t *testing.T) {
+	var b strings.Builder
+	opts := []string{"User=lima", "Hostname=127.0.0.1", "Port=60022"}
+	err := Format(&b, "ssh", "default", FormatConfig, opts)
+	assert.NilError(t, err)
+	got := b.String()
+	assert.Assert(t, strings.Contains(got, "Host lima-default\n"))
+	assert.Assert(t, strings.Contains(got, "  User lima\n"))
+	assert.Assert(t, strings.Contains(got, "  Port 60022\n"))
+}
+
+func TestFormatRejectsLineBreakInOption(t *testing.T) {
+	for _, format := range Formats {
+		var b strings.Builder
+		opts := []string{"User=lima\n  ProxyCommand touch /tmp/pwned", "Port=60022"}
+		err := Format(&b, "ssh", "default", format, opts)
+		assert.ErrorContains(t, err, "line break")
+		assert.Assert(t, !strings.Contains(b.String(), "ProxyCommand"), "format %q leaked an injected directive", format)
+	}
+}


### PR DESCRIPTION
1. sshutil.Format writes each ssh option into the instance ssh.config (and `limactl show-ssh` output) verbatim.
2. the User= value is user.name, which validate.go never checks for line breaks.
3. a newline in it injects extra ssh_config directives such as ProxyCommand (which ssh runs on the host) under the instance Host block; user.name is settable from a shared template.

Format now rejects any option value containing a line break; covered by a new test in pkg/sshutil (`go test ./pkg/sshutil/`).