### PR TITLE
reject local file references from remote templates in absPath

### DIFF
--- a/pkg/limatmpl/abs.go
+++ b/pkg/limatmpl/abs.go
@@ -102,13 +102,37 @@ func basePath(locator string) (string, error) {
 	return withVolume(base)
 }
 
+// isRemoteLocator reports whether the locator is fetched over the network, and
+// is therefore untrusted.
+func isRemoteLocator(locator string) bool {
+	u, err := url.Parse(locator)
+	if err != nil {
+		return false
+	}
+	switch u.Scheme {
+	case "http", "https", "github":
+		return true
+	}
+	return false
+}
+
 // absPath either returns the locator directly, or combines it with the basePath if the locator is a relative path.
 func absPath(locator, basePath string) (string, error) {
 	if locator == "" {
 		return "", errors.New("locator is empty")
 	}
+	// A template fetched from a remote location must not be able to pull in
+	// references to the local filesystem, otherwise it could inline the contents
+	// of arbitrary host files (e.g. an ssh private key) into a provisioning
+	// script. Relative references under a remote base stay remote (resolved via
+	// url.JoinPath below), so only file: locators and absolute local paths need
+	// to be rejected here.
+	remoteBase := isRemoteLocator(basePath)
 	u, err := url.Parse(locator)
 	if err == nil && len(u.Scheme) > 1 {
+		if remoteBase && u.Scheme == "file" {
+			return "", fmt.Errorf("local file locator %#q is not allowed from remote template %#q", locator, basePath)
+		}
 		return locator, nil
 	}
 	// Don't expand relative path to absolute. Tilde paths however are absolute paths already.
@@ -143,6 +167,9 @@ func absPath(locator, basePath string) (string, error) {
 			return u.JoinPath(locator).String(), nil
 		}
 		locator = filepath.Join(basePath, locator)
+	} else if remoteBase {
+		// Rooted (absolute) local path referenced from a remote template.
+		return "", fmt.Errorf("local file locator %#q is not allowed from remote template %#q", locator, basePath)
 	}
 	return withVolume(locator)
 }

--- a/pkg/limatmpl/abs_test.go
+++ b/pkg/limatmpl/abs_test.go
@@ -239,6 +239,21 @@ func TestAbsPath(t *testing.T) {
 		assert.Equal(t, actual, "file:///foo")
 	})
 
+	t.Run("A remote base must not reference a local absolute path", func(t *testing.T) {
+		_, err = absPath(volume+"/etc/passwd", "https://example.com")
+		assert.ErrorContains(t, err, "local")
+	})
+
+	t.Run("A remote base must not reference a file: locator", func(t *testing.T) {
+		_, err = absPath("file:///etc/passwd", "https://example.com")
+		assert.ErrorContains(t, err, "local")
+	})
+
+	t.Run("A remote base must not reference a tilde path", func(t *testing.T) {
+		_, err = absPath("~/.ssh/id_ed25519", "https://example.com")
+		assert.ErrorContains(t, err, "local")
+	})
+
 	t.Run("Can't have relative path when reading from STDIN", func(t *testing.T) {
 		_, err = absPath("foo", "-")
 		assert.ErrorContains(t, err, "STDIN")


### PR DESCRIPTION
1. absPath resolves base/provision/probe locators; for a template fetched over http(s)/github it returned file:// URLs and absolute local paths verbatim.
2. embedBase and embedAllScripts then Read those paths and inline the bytes into a provisioning script, so a downloaded template can read and exfiltrate arbitrary host files (ssh keys, etc.).

Relative references under a remote base already resolve remotely via url.JoinPath, so this only rejects the local file:// and absolute-path cases, next to the existing ../ guard. Added regression tests in abs_test.go covering the file://, absolute-path, and tilde cases under a remote base.