### PR TITLE
feat(prune): sweep leftover partial downloads from the cache

### DIFF
--- a/cmd/limactl/prune.go
+++ b/cmd/limactl/prune.go
@@ -64,7 +64,9 @@ func pruneAction(cmd *cobra.Command, _ []string) error {
 			}
 		}
 	}
-	return nil
+
+	// Sweep leftover partial downloads (data.part / data.tmp.*) from the kept entries.
+	return downloader.RemoveStaleTempFiles(opt)
 }
 
 func knownLocations(ctx context.Context) (map[string]limatype.File, error) {

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -1015,3 +1015,49 @@ func RemoveAllCacheDir(opts ...Opt) error {
 	logrus.Infof("Pruning %#q", o.cacheDir)
 	return os.RemoveAll(o.cacheDir)
 }
+
+// RemoveStaleTempFiles removes leftover partial-download files ("data.part" and
+// legacy "data.tmp.*") from the cache, keeping the completed "data" files.
+// Each cache entry is locked before its partial files are removed, so a download
+// currently in progress is never disturbed.
+func RemoveStaleTempFiles(opts ...Opt) error {
+	var o options
+	if err := o.apply(opts); err != nil {
+		return err
+	}
+	if o.cacheDir == "" {
+		return nil
+	}
+	entries, err := CacheEntries(opts...)
+	if err != nil {
+		return err
+	}
+	for _, dir := range entries {
+		if err := removeStaleTempFilesInDir(dir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeStaleTempFilesInDir(dir string) error {
+	return lockutil.WithDirLock(dir, func() error {
+		patterns := []string{
+			filepath.Join(dir, "data.part"),
+			filepath.Join(dir, "data.tmp.*"),
+		}
+		for _, pattern := range patterns {
+			matches, err := filepath.Glob(pattern)
+			if err != nil {
+				return err
+			}
+			for _, m := range matches {
+				logrus.Debugf("Removing stale partial download %#q", m)
+				if err := os.Remove(m); err != nil && !errors.Is(err, os.ErrNotExist) {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -208,6 +208,33 @@ func countResults(t *testing.T, results chan downloadResult) (downloaded, cached
 	return downloaded, cached
 }
 
+func TestRemoveStaleTempFiles(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	url := "https://example.com/image.img"
+	shad := cacheDirectoryPath(cacheDir, url)
+	assert.NilError(t, os.MkdirAll(shad, 0o700))
+
+	data := filepath.Join(shad, "data")
+	part := filepath.Join(shad, "data.part")
+	legacy := filepath.Join(shad, "data.tmp.123.1")
+	for _, f := range []string{data, part, legacy} {
+		assert.NilError(t, os.WriteFile(f, []byte("x"), 0o644))
+	}
+
+	// No cache dir configured is a no-op.
+	assert.NilError(t, RemoveStaleTempFiles())
+
+	assert.NilError(t, RemoveStaleTempFiles(WithCacheDir(cacheDir)))
+
+	// The completed "data" file is kept; partial/temp files are removed.
+	_, err := os.Stat(data)
+	assert.NilError(t, err)
+	_, err = os.Stat(part)
+	assert.Assert(t, os.IsNotExist(err), "data.part should have been removed")
+	_, err = os.Stat(legacy)
+	assert.Assert(t, os.IsNotExist(err), "data.tmp.* should have been removed")
+}
+
 func TestRedownloadRemote(t *testing.T) {
 	remoteDir := t.TempDir()
 	ts := httptest.NewServer(http.FileServer(http.Dir(remoteDir)))


### PR DESCRIPTION
Add `downloader.RemoveStaleTempFiles`, which removes leftover "data.part" and legacy "data.tmp.*" files from the cache while keeping the completed "data" files. Each cache entry is locked before its partial files are removed, so a download in progress is never disturbed.

"limactl prune --keep-referred" now calls it after pruning unreferred entries, giving a non-nuclear way to reclaim space taken by interrupted downloads (e.g. after Ctrl-C) without dropping valid cached images.

Refs #5171