### PR TITLE
Treat instances created before Lima v0.20 as older than any release

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -874,20 +874,27 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 	fixUpForPlainMode(y)
 }
 
-// ExistingLimaVersion returns empty if the instance was created with Lima prior to v0.20.
+// ExistingLimaVersion returns the version that created the instance, the empty string
+// for instances created before Lima v0.20 (which have no recorded version), or the
+// current version when the instance doesn't exist yet.
 func ExistingLimaVersion(instDir string) string {
 	if !IsExistingInstanceDir(instDir) {
 		return version.Version
 	}
 
 	limaVersionFile := filepath.Join(instDir, filenames.LimaVersion)
-	if b, err := os.ReadFile(limaVersionFile); err == nil {
+	b, err := os.ReadFile(limaVersionFile)
+	switch {
+	case err == nil:
 		return strings.TrimSpace(string(b))
-	} else if !errors.Is(err, os.ErrNotExist) {
+	case errors.Is(err, os.ErrNotExist):
+		// Instances created before Lima v0.20 have no version file. versionutil treats
+		// the empty string as older than any release.
+		return ""
+	default:
 		logrus.WithError(err).Warnf("Failed to read %#q", limaVersionFile)
+		return version.Version
 	}
-
-	return version.Version
 }
 
 func fixUpForPlainMode(y *limatype.LimaYAML) {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -25,7 +25,42 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/osutil"
 	"github.com/lima-vm/lima/v2/pkg/ptr"
+	"github.com/lima-vm/lima/v2/pkg/version"
 )
+
+func TestExistingLimaVersion(t *testing.T) {
+	t.Run("instance does not exist yet", func(t *testing.T) {
+		assert.Equal(t, ExistingLimaVersion(t.TempDir()), version.Version)
+	})
+
+	t.Run("version has been recorded", func(t *testing.T) {
+		instDir := createInstanceDir(t, map[string]string{filenames.LimaVersion: "1.2.3\n"})
+		assert.Equal(t, ExistingLimaVersion(instDir), "1.2.3")
+	})
+
+	// Instances created before Lima v0.20 have no lima-version file. Reporting the current
+	// version for them would move the guest home directory to a path that doesn't exist.
+	t.Run("instance predates the version file", func(t *testing.T) {
+		instDir := createInstanceDir(t, nil)
+		assert.Equal(t, ExistingLimaVersion(instDir), "")
+
+		user := osutil.LimaUser(t.Context(), ExistingLimaVersion(instDir), false, nil)
+		assert.Equal(t, user.HomeDir, "/home/{{.User}}.linux")
+	})
+}
+
+// createInstanceDir returns a directory that IsExistingInstanceDir recognizes as an
+// existing instance, populated with files.
+func createInstanceDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	instDir := t.TempDir()
+	// The host agent log is one of the files that identify an existing instance.
+	assert.NilError(t, os.WriteFile(filepath.Join(instDir, filenames.HostAgentStdoutLog), nil, 0o644))
+	for name, content := range files {
+		assert.NilError(t, os.WriteFile(filepath.Join(instDir, name), []byte(content), 0o644))
+	}
+	return instDir
+}
 
 func TestFillDefault(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)

--- a/pkg/osutil/user.go
+++ b/pkg/osutil/user.go
@@ -150,7 +150,10 @@ func LimaUser(ctx context.Context, limaVersion string, warn bool, guestOS *limat
 	}
 	// Make sure we return a pointer to a COPY of limaUser
 	u := *limaUser
-	limaVersionUnknown := limaVersion == "" || limaVersion == "<unknown>"
+	// "" and "<unknown>" both mean the version is unknown, but "" marks an instance created
+	// before Lima v0.20 and counts as old, while "<unknown>" is a development build assumed
+	// current.
+	limaVersionUnknown := limaVersion == "<unknown>"
 	if guestOS != nil && *guestOS == limatype.DARWIN {
 		u.HomeDir = "/Users/{{.User}}.guest"
 	} else if limaVersionUnknown || versionutil.GreaterEqual(limaVersion, "2.1.0") {

--- a/pkg/osutil/user_test.go
+++ b/pkg/osutil/user_test.go
@@ -30,6 +30,14 @@ func TestLimaUserAdminOld(t *testing.T) {
 	assert.Equal(t, user.Username, "admin")
 }
 
+// An empty version marks an instance created before Lima v0.20, which keeps the old home
+func TestLimaUserEmptyVersionIsOld(t *testing.T) {
+	currentUser.Username = fallbackUser
+	once = new(sync.Once)
+	user := LimaUser(t.Context(), "", false, nil)
+	assert.Equal(t, user.HomeDir, "/home/{{.User}}.linux")
+}
+
 func TestLimaUserInvalid(t *testing.T) {
 	currentUser.Username = "use@example.com"
 	once = new(sync.Once)


### PR DESCRIPTION
Instances created before Lima v0.20 have no `lima-version` file. FillDefault() treated the missing file as an empty version until commit 2076ff1d (v2.0.0-alpha.0), which made `ExistingLimaVersion()` report the current version instead. These old instances then get defaults meant for new ones.

QEMU instances switch from `reverse-sshfs` to `9p` mounts, and the guest home directory defaults to `/home/<user>.guest`, renamed from `/home/<user>.linux` in commit 4a10d927 (v2.1.0-beta.0). On `alpine-iso` instances with user-mode provisioning, `/home/<user>.guest` is missing because `/home` comes from the persistent data volume. Commit 032fc350 already restores the compatibility symlink after that mount, but this corrects the defaults at their source.

`versionutil` already treats the empty version as older than any release; `osutil.LimaUser` was the only consumer that read it as an unknown build and assumed the newest defaults.
