### PR TITLE
Create the guest home symlink after the data volume is mounted

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/05-guest-home.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/05-guest-home.sh
@@ -7,6 +7,11 @@ set -eu
 
 # The default guest home directory is "/home/${LIMA_CIDATA_USER}.guest" since Lima 2.1.0.
 # The path was previously "/home/${LIMA_CIDATA_USER}.linux".
+#
+# This must run after 04-persistent-data-volume.sh has mounted /home from the data
+# volume, and after the WSL2 driver has created the user in 02-no-cloud-init-setup.sh.
+# Symlinking earlier either targets a home directory that doesn't exist yet, or creates
+# the symlink on the ramdisk, where the data volume immediately hides it.
 if [ -d "/home/${LIMA_CIDATA_USER}.guest" ] && [ ! -e "/home/${LIMA_CIDATA_USER}.linux" ]; then
 	ln -s "${LIMA_CIDATA_USER}.guest" "/home/${LIMA_CIDATA_USER}.linux"
 fi


### PR DESCRIPTION
The symlink never reached an existing Alpine instance, where `/home` is mounted from a persistent data volume, and it was never created at all on WSL2, where the driver creates the user later, in `02-no-cloud-init-setup.sh`.

Note: this PR renames `00-guest-home.sh` → `05-guest-home.sh`