### PR TITLE
contain github symlink targets within the source repo

### DIFF
--- a/pkg/limatmpl/github.go
+++ b/pkg/limatmpl/github.go
@@ -41,6 +41,18 @@ func transformGitHubURL(ctx context.Context, input string) (string, error) {
 	repo := cmp.Or(parts[1], org)
 	filePath := strings.Join(parts[2:], "/")
 
+	// A `..` in REPO, PATH, or BRANCH collapses server-side and moves the fetch
+	// to an unrelated org. Redirect bodies re-enter here, so treat them as untrusted.
+	if repo == ".." {
+		return "", fmt.Errorf("repo %#q in github: URL %#q escapes the org", repo, input)
+	}
+	if escapesRepo(filePath) {
+		return "", fmt.Errorf("path %#q in github: URL %#q escapes the repository", filePath, input)
+	}
+	if escapesRepo(origBranch) {
+		return "", fmt.Errorf("branch %#q in github: URL %#q escapes the repository", origBranch, input)
+	}
+
 	if filePath == "" {
 		filePath = defaultFilename
 	} else {
@@ -75,7 +87,9 @@ func transformGitHubURL(ctx context.Context, input string) (string, error) {
 }
 
 func githubUserContentURL(org, repo, branch, filePath string) string {
-	return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", org, repo, branch, filePath)
+	// Emit a cleaned path so we never rely on the server to resolve `../`,
+	// even for in-repo segments that don't escape.
+	return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", org, repo, branch, path.Clean(filePath))
 }
 
 func getGitHubUserContent(ctx context.Context, org, repo, branch, filePath string) (*http.Response, error) {
@@ -168,10 +182,30 @@ func resolveGitHubSymlink(ctx context.Context, org, repo, branch, filePath, orig
 
 	// A symlink must be a single line (without trailing newline), no spaces, no colons
 	if !(content == "" || strings.ContainsAny(content, "\n :")) {
-		// symlink is relative to the directory of filePath
-		filePath = path.Join(path.Dir(filePath), content)
+		// symlink is relative to the directory of filePath, and must stay within the repo
+		filePath, err = symlinkTarget(filePath, content)
+		if err != nil {
+			return "", err
+		}
 	}
 	return githubUserContentURL(org, repo, branch, filePath), nil
+}
+
+// symlinkTarget resolves a symlink target relative to the directory of filePath.
+// It returns an error if the target escapes the repository root, so a symlink
+// cannot redirect the fetch to a different repository via `../` segments.
+func symlinkTarget(filePath, target string) (string, error) {
+	resolved := path.Join(path.Dir(filePath), target)
+	if escapesRepo(resolved) {
+		return "", fmt.Errorf("symlink target %#q in %#q escapes the repository", target, filePath)
+	}
+	return resolved, nil
+}
+
+// escapesRepo reports whether the cleaned path climbs above the repository root.
+func escapesRepo(p string) bool {
+	p = path.Clean(p)
+	return p == ".." || strings.HasPrefix(p, "../")
 }
 
 // resolveGitHubRedirect checks if a file at the given path is a github: URL to another file within the same repo.

--- a/pkg/limatmpl/github_test.go
+++ b/pkg/limatmpl/github_test.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package limatmpl
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSymlinkTarget(t *testing.T) {
+	t.Run("target in the same directory", func(t *testing.T) {
+		got, err := symlinkTarget("dir/config.yaml", "other.yaml")
+		assert.NilError(t, err)
+		assert.Equal(t, got, "dir/other.yaml")
+	})
+	t.Run("target relative to the repo root", func(t *testing.T) {
+		got, err := symlinkTarget(".lima.yaml", "sub/x.yaml")
+		assert.NilError(t, err)
+		assert.Equal(t, got, "sub/x.yaml")
+	})
+	t.Run("parent that stays within the repo", func(t *testing.T) {
+		got, err := symlinkTarget("dir/config.yaml", "../top.yaml")
+		assert.NilError(t, err)
+		assert.Equal(t, got, "top.yaml")
+	})
+	t.Run("parent from the repo root is rejected", func(t *testing.T) {
+		_, err := symlinkTarget(".lima.yaml", "../evil.yaml")
+		assert.ErrorContains(t, err, "escapes the repository")
+	})
+	t.Run("traversal to another repo is rejected", func(t *testing.T) {
+		_, err := symlinkTarget("dir/config.yaml", "../../../../torvalds/linux/master/README")
+		assert.ErrorContains(t, err, "escapes the repository")
+	})
+}
+
+func TestEscapesRepo(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		want bool
+	}{
+		{"", false}, // github:ORG has no PATH, and path.Clean("") is "."
+		{"x.yaml", false},
+		{"dir/../x.yaml", false},
+		{"..", true},
+		{"../x.yaml", true},
+		{"dir/../../x.yaml", true},
+	} {
+		assert.Equal(t, escapesRepo(tc.path), tc.want, "path %#q", tc.path)
+	}
+}
+
+// A `..` in REPO or PATH reaches transformGitHubURL from a github: redirect body,
+// which validateGitHubRedirect's prefix check alone does not contain.
+func TestTransformGitHubURLContainment(t *testing.T) {
+	t.Run("path climbing out of the repo is rejected", func(t *testing.T) {
+		_, err := transformGitHubURL(t.Context(), "lima-vm/lima/../../../torvalds/linux/master/evil.yaml")
+		assert.ErrorContains(t, err, "escapes the repository")
+	})
+	t.Run("repo of .. is rejected", func(t *testing.T) {
+		_, err := transformGitHubURL(t.Context(), "lima-vm/../../torvalds/linux/master/evil.yaml")
+		assert.ErrorContains(t, err, "escapes the org")
+	})
+	t.Run("branch climbing out of the repo is rejected", func(t *testing.T) {
+		_, err := transformGitHubURL(t.Context(), "lima-vm/lima/README.md@../../torvalds/linux/master")
+		assert.ErrorContains(t, err, "escapes the repository")
+	})
+	t.Run("redirect body leaving the org is rejected on re-entry", func(t *testing.T) {
+		redirect, err := validateGitHubRedirect("github:lima-vm/../../torvalds/linux/master/evil.yaml", "lima-vm", "main", "https://example.com/x")
+		assert.NilError(t, err)
+		// TransformCustomURL feeds the locator back in as the github: URL's opaque part.
+		_, err = transformGitHubURL(t.Context(), strings.TrimPrefix(redirect, "github:"))
+		assert.ErrorContains(t, err, "escapes the org")
+	})
+	t.Run("parent that stays within the repo is allowed", func(t *testing.T) {
+		got, err := transformGitHubURL(t.Context(), "lima-vm/lima/docs/../README.md@main")
+		assert.NilError(t, err)
+		assert.Equal(t, got, "https://raw.githubusercontent.com/lima-vm/lima/main/README.md")
+	})
+}

--- a/website/content/en/docs/templates/github.md
+++ b/website/content/en/docs/templates/github.md
@@ -74,7 +74,7 @@ FATA[0000] file "https://raw.githubusercontent.com/lima-vm/lima/master/.lima.yam
 
 ## Symbolic links
 
-Lima will check if the template file referenced by the `github:` URL is a symlink (or a text file whose content has no spaces, newlines, or colons). In that case it will treat the content as a relative path and return the address of that target file.
+Lima will check if the template file referenced by the `github:` URL is a symlink (or a text file whose content has no spaces, newlines, or colons). In that case it will treat the content as a relative path and return the address of that target file. The target must stay within the repository; Lima rejects one that climbs above the repo root via `../`.
 
 For example the `fedora` template is a symlink to `fedora-43.yaml`:
 
@@ -97,7 +97,7 @@ Org repos support two additional features that enable shorter URLs, even when th
 
 **Redirects:**
 
-In an org repo a template file can not only be a symlink, but also a text file containing a `github:` URL. The URL must point to the same GitHub org and must NOT include a `@TAG`. It will be used to replace the original URL.
+In an org repo a template file can not only be a symlink, but also a text file containing a `github:` URL. The URL must point to the same GitHub org and must NOT include a `@TAG`. It will be used to replace the original URL. Lima rejects a URL that uses `../` to climb out of the org.
 
 For example assume the `lima-vm` projects wants to support this URL:
 


### PR DESCRIPTION
resolveGitHubSymlink joins a github: template symlink body with path.Join and returns the raw.githubusercontent.com URL without a containment check, so a symlink whose body is `../../../../otherorg/otherrepo/x.yaml` collapses server-side into a 307 redirect to an unrelated repo that the redirect-following fetch then follows. That lets a symlink in a trusted-looking repo silently source a base/probe/provision file from attacker-controlled content, unlike the github: redirect path which already refuses to leave the org in validateGitHubRedirect. Reject a resolved target that climbs above the repo root so symlink resolution stays within the repository.