### PR TITLE
Improve Windows 11 performance

### DIFF
--- a/pkg/cidata/wincidata.TEMPLATE.d/first_logon.ps1
+++ b/pkg/cidata/wincidata.TEMPLATE.d/first_logon.ps1
@@ -37,18 +37,11 @@ icacls $pubkeyLocation /inheritance:r
 icacls $pubkeyLocation /grant "SYSTEM:F"
 icacls $pubkeyLocation /grant "Administrators:F"
 
-# Install chocolatey for installing WinFSP.
-# WinFSP can be installed through winget as well, but currently winget is unstable in Windows Server Core
-# See: https://github.com/microsoft/winget-cli/discussions/5230
-Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-
-# Install WinFSP for VirtioFS
-C:\ProgramData\chocolatey\choco.exe install winfsp -y --pre
-
-# Create VirtioFs service from virtio-win, and enable it
-# By default, the host directory is mounted on Z:
-New-Service -Name VirtioFsSvc -BinaryPathName 'E:\viofs\2k25\amd64\virtiofs.exe' -DisplayName VirtioFsSvc -StartupType Automatic
-Start-Service -Name VirtioFsSvc
+# Finally, it creates a marker file. Host agent will check the file.
+$bootDoneDir = 'C:\ProgramData\Lima'
+New-Item -ItemType Directory -Path $bootDoneDir -Force | Out-Null
+$bootDoneFile = Join-Path $bootDoneDir 'lima-boot-done.txt'
+'done' | Out-File -FilePath $bootDoneFile -Encoding ascii -Force -NoNewline
 
 # Finish recording logs
 Stop-Transcript

--- a/pkg/cidata/wincidata.TEMPLATE.d/first_logon.ps1
+++ b/pkg/cidata/wincidata.TEMPLATE.d/first_logon.ps1
@@ -1,27 +1,63 @@
 $logfile = "C:\Users\{{.User}}\lima-setup.log"
+$globalStart = Get-Date
 
 # Record logs
 Start-Transcript -Path $logfile -Append
 
+Write-Output "Lima Setup Started at $globalStart"
+
+$sectionStart = Get-Date
 # We need to change password because the current password is specified in autounattend.xml, so all users/processes can see it.
-## Generate a random 16 character password.
-## Avoid special characters to minimize potential keyboard layout issue.
+# Generate a random 16 character password.
+# Avoid special characters to minimize potential keyboard layout issue.
 $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 $newPassword = -join ((1..16) | ForEach-Object { $chars[(Get-Random -Maximum $chars.Length)] })
 
-## Store the password under the user directory so that user can know/change it.
+# Store the password under the user directory so that user can know/change it.
 $newPassword | Out-File -FilePath "C:\Users\{{.User}}\password.txt" -Encoding utf8 -NoNewline
 
-## Change the password
+# Change the password
 $username = $env:USERNAME
 $newSecurePassword = ConvertTo-SecureString $newPassword -AsPlainText -Force
 Set-LocalUser -Name $username -Password $newSecurePassword
 
-# Install OpenSSH server, then enable it
-Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
-Start-Service sshd
-Set-Service -Name sshd -StartupType Automatic
+$elapsed = (Get-Date) - $sectionStart
+Write-Output "Password change completed in $($elapsed.TotalSeconds) seconds"
 
+
+$sectionStart = Get-Date
+# Install OpenSSH via MSI installer
+# Avoid using the OpenSSH.Server included in the OS because installing OpenSSH takes much longer than Win32-OpenSSH.
+$installer = "C:\Users\{{.User}}\openssh.msi"
+{{ $openSSHInstaller := "https://github.com/PowerShell/Win32-OpenSSH/releases/download/10.0.0.0p2-Preview/OpenSSH-Win64-v10.0.0.0.msi" -}}
+{{ $openSSHInstallerSHA256 := "ddec9c53864280759cf9f74791cefd387100e3946aa849a1c138a4ed1b96b7d9" -}}
+{{ if eq .Arch "aarch64" -}}
+{{ $openSSHInstaller = "https://github.com/PowerShell/Win32-OpenSSH/releases/download/10.0.0.0p2-Preview/OpenSSH-ARM64-v10.0.0.0.msi" -}}
+{{ $openSSHInstallerSHA256 = "7a17d0e22d004fb47ca4bfd8fef926fa305de4ebf70a6f3c7a29c39aabef0023" -}}
+{{ end -}}
+Invoke-WebRequest -Uri "{{ $openSSHInstaller }}" -OutFile $installer
+
+# Expected hash comes from https://github.com/powershell/win32-openssh/releases
+$expectedHash = "{{ $openSSHInstallerSHA256 }}".ToLower()
+$actualHash = (Get-FileHash -Path $installer -Algorithm SHA256).Hash.ToLower()
+
+# Verify the integrity of the downloaded installer before executing it.
+if ($actualHash -eq $expectedHash) {
+    Write-Output "OpenSSH SHA256 verification succeeded"
+}else{
+    Write-Output "OpenSSH SHA256 verification failed. Expected: ${expectedHash}, Actual: ${actualHash}"
+    Stop-Transcript
+    exit 1
+}
+
+msiexec /i $installer ADDLOCAL=Server
+[Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path",[System.EnvironmentVariableTarget]::Machine) + ';' + ${Env:ProgramFiles} + '\OpenSSH', [System.EnvironmentVariableTarget]::Machine)
+Get-Service -Name ssh*
+
+$elapsed = (Get-Date) - $sectionStart
+Write-Output "OpenSSH server installation completed in $($elapsed.TotalSeconds) seconds"
+
+$sectionStart = Get-Date
 # Modify firewall rule
 # Note that Windows server may have a firewall rule for SSH by default, but it doesn't work on my env.
 # So I remove and recreate the rule.
@@ -37,11 +73,18 @@ icacls $pubkeyLocation /inheritance:r
 icacls $pubkeyLocation /grant "SYSTEM:F"
 icacls $pubkeyLocation /grant "Administrators:F"
 
+$elapsed = (Get-Date) - $sectionStart
+Write-Output "SSH setting completed in $($elapsed.TotalSeconds) seconds"
+
 # Finally, it creates a marker file. Host agent will check the file.
 $bootDoneDir = 'C:\ProgramData\Lima'
 New-Item -ItemType Directory -Path $bootDoneDir -Force | Out-Null
 $bootDoneFile = Join-Path $bootDoneDir 'lima-boot-done.txt'
 'done' | Out-File -FilePath $bootDoneFile -Encoding ascii -Force -NoNewline
+
+
+$elapsed = (Get-Date) - $globalStart
+Write-Output "All works completed in $($elapsed.TotalSeconds) seconds"
 
 # Finish recording logs
 Stop-Transcript

--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -675,16 +675,24 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	}
 	if isoPresent {
 		args = appendArgsIfNoConflict(args, "-boot", "order=d,splash-time=0,menu=on")
-		// For aarch64, QEMU uses `virt` machine type but it doesn't recognize CDROM drive.
-		// In order to attach ISO files, we need to use USB devices instead.
-		if *y.OS == limatype.WINDOWS && *y.Arch == limatype.AARCH64 {
-			// Those two lines are necessary here, otherwise QEMU raises an error `No 'usb-bus' bus found for device 'usb-storage'`.
-			args = append(args, "-device", "qemu-xhci")
-			args = append(args, "-device", "usb-kbd")
-
-			args = append(args, "-drive", fmt.Sprintf("file=%s,if=none,id=cd0,format=raw,media=cdrom,readonly=on", isoPath))
-			args = append(args, "-device", "usb-storage,drive=cd0")
-		} else {
+		switch *y.OS {
+		case limatype.WINDOWS:
+			// We don't mount the ISO file if the Windows VM was already created before.
+			if isWindowsBootDone(cfg) {
+				break
+			}
+			// For aarch64, QEMU uses `virt` machine type but it doesn't recognize CDROM drive.
+			// In order to attach ISO files, we need to use USB devices instead.
+			if *y.Arch == limatype.AARCH64 {
+				// Those two lines are necessary here, otherwise QEMU raises an error `No 'usb-bus' bus found for device 'usb-storage'`.
+				args = append(args, "-device", "qemu-xhci")
+				args = append(args, "-device", "usb-kbd")
+				args = append(args, "-drive", fmt.Sprintf("file=%s,if=none,id=cd0,format=raw,media=cdrom,readonly=on", isoPath))
+				args = append(args, "-device", "usb-storage,drive=cd0")
+			} else {
+				args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,media=cdrom,readonly=on", isoPath))
+			}
+		default:
 			args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,media=cdrom,readonly=on", isoPath))
 		}
 	} else {
@@ -698,7 +706,8 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 
 	// virtio-win must be mounted before cidata.iso otherwise
 	// autounattend.xml can't find virtio drivers.
-	if *y.OS == limatype.WINDOWS && len(winOpts.VirtioWin) > 0 {
+	// The ISO file is not mounted if the VM was already created.
+	if *y.OS == limatype.WINDOWS && len(winOpts.VirtioWin) > 0 && !isWindowsBootDone(cfg) {
 		if *y.Arch == limatype.AARCH64 {
 			args = append(args, "-drive", fmt.Sprintf("file=%s,if=none,id=cd1,format=raw,media=cdrom,readonly=on", filepath.Join(cfg.InstanceDir, filenames.VirtioWin)))
 			args = append(args, "-device", "usb-storage,drive=cd1")
@@ -714,6 +723,10 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	// cloud-init
 	switch *y.OS {
 	case limatype.WINDOWS:
+		// cidata for Windows is not mounted if the VM was already created.
+		if isWindowsBootDone(cfg) {
+			break
+		}
 		// We can't use virtio-scsi for Windows's cidata, because autounattend in cidata installs virtio-win drivers.
 		// Until then, the VM can't detect virtio.
 		if *y.Arch == limatype.AARCH64 {
@@ -1361,4 +1374,16 @@ func hasHostCPU() bool {
 	}
 	// Not reached
 	return false
+}
+
+// isWindowsBootDone returns true if the Windows VM instance was already created and all installation was finished before.
+func isWindowsBootDone(cfg Config) bool {
+	if *cfg.LimaYAML.OS != limatype.WINDOWS {
+		return false
+	}
+
+	if _, err := os.Stat(filepath.Join(cfg.InstanceDir, filenames.WinDoneInstallation)); err != nil {
+		return false
+	}
+	return true
 }

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -602,6 +602,15 @@ func (a *HostAgent) startHostAgentRoutines(ctx context.Context) error {
 	if err := a.waitForRequirements("essential", essentialRequirements); err != nil {
 		errs = append(errs, err)
 	}
+
+	// Windows guest needs a marker file which shows all installation is done.
+	// In the next boot, Lima will not mount OS installer ISO file to prevent unexpected re-installation.
+	if *a.instConfig.OS == limatype.WINDOWS {
+		if _, err := os.Create(filepath.Join(a.instDir, filenames.WinDoneInstallation)); err != nil {
+			errs = append(errs, errors.New("failed to create a windows installation marker"))
+		}
+	}
+
 	if *a.instConfig.SSH.ForwardAgent {
 		if *a.instConfig.Plain {
 			logrus.Warn("Running in plain mode. Ignoring ssh.forwardAgent")

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -282,7 +282,7 @@ func (a *HostAgent) essentialWinRequirements() []requirement {
 	req = append(req,
 		requirement{
 			description: "ssh",
-			script:      `PowerShell.exe -c "echo 'ssh login succeeds.'"`,
+			script:      `PowerShell.exe -NoProfile -NonInteractive -Command "if (Test-Path -Path 'C:\ProgramData\Lima\lima-boot-done.txt' -PathType Leaf) { exit 0 } else { exit 1 }"`,
 			debugHint: `Failed to SSH into the guest.
 Make sure that the YAML field "ssh.localPort" is not used by other processes on the host.
 If any private key under ~/.ssh is protected with a passphrase, you need to have ssh-agent to be running.

--- a/pkg/limatype/filenames/filenames.go
+++ b/pkg/limatype/filenames/filenames.go
@@ -81,6 +81,9 @@ const (
 	// Swtpm is used for TPM emulation.
 	SwtpmSock = "swtpm.sock"
 	SwtpmDir  = "swtpm"
+
+	// Marker which indicates Windows OS installation completed.
+	WinDoneInstallation = "win-done-installation"
 )
 
 // Filenames used under a disk directory

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -91,6 +91,9 @@ TPM:
 - `swtpm.sock`: SWTPM (Software TPM Emulator) socket.
 - `swtpm`: A directory where TPM's state will be written.
 
+Installation Marker for Windows:
+- `win-done-installation`: An indicator showing whether Windows OS installation has completed.
+
 Guest agent:
 
 Each drivers use their own mode of communication


### PR DESCRIPTION
## What This PR Changes
Currently we have some problems on a Windows 11 guest
- Initial configuration takes time (around 20 minutes)
- Re-installation happens on the second boot

Ref: https://cloud-native.slack.com/archives/C0B1S09N04E/p1783932139851529

This PR fixes/relieves those problems. This PR has 2 commits:
1. A marker file is introduced. Lima doesn't mount OS installer ISO if the marker exists on a host. It prevents re-installation
2. Using https://github.com/powershell/win32-openssh for installing OpenSSH instead of Add-WindowsCapability command. Add-WindowsCapability command took over 10 minutes to install OpenSSH on my environment. On the other hand, Win32-OpenSSH just takes less than 30 seconds.

## How I Tested This
`./_output/bin/limactl start template:windows-11 --debug --timeout=30m` on my local. I tested both arm64 and amd64.
I also confirmed that the change doesn't break Windows server 2025.