### PR TITLE
reject qemu packet exceeding the read buffer size

### DIFF
--- a/pkg/driver/vz/network_darwin.go
+++ b/pkg/driver/vz/network_darwin.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -103,6 +104,9 @@ func (c *qemuPacketConn) Read(b []byte) (n int, err error) {
 	if err := binary.Read(c.Conn, binary.BigEndian, &size); err != nil {
 		// Likely connection closed by peer.
 		return 0, err
+	}
+	if uint64(size) > uint64(len(b)) {
+		return 0, fmt.Errorf("packet size %d exceeds read buffer size %d", size, len(b))
 	}
 	return io.ReadFull(c.Conn, b[:size])
 }

--- a/pkg/driver/vz/network_darwin_test.go
+++ b/pkg/driver/vz/network_darwin_test.go
@@ -102,6 +102,28 @@ func TestDialQemu(t *testing.T) {
 	}
 }
 
+// TestQemuPacketConnReadOversize verifies that a packet whose size prefix
+// exceeds the caller's buffer returns an error instead of panicking on b[:size].
+func TestQemuPacketConnReadOversize(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	const bufSize = 1500
+	go func() {
+		hdr := make([]byte, 4)
+		binary.BigEndian.PutUint32(hdr, bufSize+1)
+		_, _ = server.Write(hdr)
+		_, _ = server.Write(make([]byte, bufSize+1))
+	}()
+
+	qemuConn := qemuPacketConn{Conn: client}
+	buf := make([]byte, bufSize)
+	n, err := qemuConn.Read(buf)
+	assert.Assert(t, err != nil, "expected an error for an oversize packet")
+	assert.Equal(t, n, 0, "no bytes should be reported on error")
+}
+
 // serveOneClient accepts one client and echo back received packets until a
 // "quit" packet is sent.
 func serveOneClient(listener *net.UnixListener) error {


### PR DESCRIPTION
1. qemuPacketConn.Read reads a uint32 size prefix from the QEMU packet socket and slices b[:size] without checking size against len(b).
2. a frame whose size prefix is larger than the read buffer (io.Copy in forwardPackets uses a 32 KiB buffer) makes the slice panic with an out-of-range and takes down the vz networking goroutine.
Return an error when size is larger than len(b), which the method already documents as a broken-protocol condition where the socket must be closed.