### PR TITLE
Add parameter for Kubernetes apt-proxy (k8s)

### DIFF
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -53,14 +53,22 @@ provision:
     # Installing kubeadm, kubelet and kubectl
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
+    {{- if .Param.proxy }}
+    apt-get install -y --no-upgrade ca-certificates curl
+    {{- else}}
     apt-get install -y apt-transport-https ca-certificates curl
+    {{- end}}
     STABILITY="{{.Param.stability}}"
     {{if eq .Param.release "stable" }}
     RELEASE=$(curl -L -s https://dl.k8s.io/release/stable.txt | cut -d'.' -f1-2)
     {{else}}
     RELEASE="{{.Param.release}}"
     {{end}}
+    {{- if .Param.proxy }}
+    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] {{.Param.proxy}}/HTTPS///pkgs.k8s.io/core:/${STABILITY}:/${RELEASE}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+    {{- else}}
     echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/${STABILITY}:/${RELEASE}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+    {{- end}}
     curl -fsSL https://pkgs.k8s.io/core:/${STABILITY}:/${RELEASE}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     apt-get update
     apt-get install -y kubelet kubeadm kubectl && apt-mark hold kubelet kubeadm kubectl
@@ -243,6 +251,9 @@ message: |
   ------
   {{end -}}
 param:
+  # The proxy to use when pulling packages from k8s.io
+  # For a local proxy use for instance "http://host.lima.internal:3142"
+  proxy: ""
   # The mirror to use when pulling images from registry
   # For a local mirror use for instance "http://host.lima.internal:8080"
   mirror: ""


### PR DESCRIPTION
Now supports a parameter "proxy" for pulling packages from:

proxy: "http://host.lima.internal:3142"

A pull-through cache for pkgs.k8s.io (and the apt CDN) at:

https://github.com/afbjorklund/apt-proxy

Issue #5258

----

`apt-proxy -cachedir /var/tmp/packages -port 3142 &`

```
Hit:1 http://archive.ubuntu.com/ubuntu resolute InRelease
Hit:2 http://archive.ubuntu.com/ubuntu resolute-updates InRelease
Hit:3 http://archive.ubuntu.com/ubuntu resolute-backports InRelease
Hit:5 http://security.ubuntu.com/ubuntu resolute-security InRelease
Get:4 http://host.lima.internal:3142/HTTPS///pkgs.k8s.io/core:/stable:/v1.36/deb  InRelease [1227 B]
Get:6 http://host.lima.internal:3142/HTTPS///pkgs.k8s.io/core:/stable:/v1.36/deb  Packages [5666 B]
Get:1 http://host.lima.internal:3142/HTTPS///pkgs.k8s.io/core:/stable:/v1.36/deb  kubeadm 1.36.2-2.1 [12.6 MB]
Get:2 http://host.lima.internal:3142/HTTPS///pkgs.k8s.io/core:/stable:/v1.36/deb  kubectl 1.36.2-2.1 [11.8 MB]
Get:3 http://host.lima.internal:3142/HTTPS///pkgs.k8s.io/core:/stable:/v1.36/deb  kubernetes-cni 1.9.1-1.1 [39.0 MB]
Get:4 http://host.lima.internal:3142/HTTPS///pkgs.k8s.io/core:/stable:/v1.36/deb  kubelet 1.36.2-2.1 [13.4 MB]
```
