### PR TITLE
docs: migrate Gemini CLI documentation to Antigravity CLI

### DIFF
--- a/website/content/en/docs/config/ai/outside/antigravity.md
+++ b/website/content/en/docs/config/ai/outside/antigravity.md
@@ -1,5 +1,5 @@
 ---
-title: Gemini
+title: Antigravity
 weight: 20
 
 ---
@@ -7,10 +7,10 @@ weight: 20
 | ⚡ Requirement | Lima >= 2.0 |
 |---------------|-------------|
 
-This page describes how to use Lima as an sandbox for [Google Gemini CLI](https://github.com/google-gemini/gemini-cli).
+This page describes how to use Lima as a sandbox for [Google Antigravity CLI](https://github.com/google-antigravity/antigravity-cli).
 
 ## Prerequisite
-In addition to Gemini and Lima, make sure that `limactl mcp` plugin is installed:
+In addition to Antigravity CLI and Lima, make sure that `limactl mcp` plugin is installed:
 
 ```console
 $ limactl mcp -v
@@ -28,11 +28,9 @@ limactl start --mount-only "$(pwd):w" default
 
 Drop the `:w` suffix if you do not want to allow writing to the mounted directory.
 
-2. Create `.gemini/extensions/lima/gemini-extension.json` as follows:
+2. Create `~/.gemini/antigravity-cli/mcp_config.json` as follows:
 ```json
 {
-  "name": "lima",
-  "version": "2.0.0",
   "mcpServers": {
     "lima": {
       "command": "limactl",
@@ -46,15 +44,18 @@ Drop the `:w` suffix if you do not want to allow writing to the mounted director
 }
 ```
 
-3. Modify `.gemini/settings.json` so as to disable Gemini CLI's [built-in tools](https://github.com/google-gemini/gemini-cli/tree/main/docs/tools)
-except ones that do not relate to local command execution and file I/O:
+3. Modify `~/.gemini/antigravity-cli/settings.json` to configure the permissions granted to Antigravity CLI. For example:
 ```json
 {
-  "coreTools": ["WebFetchTool", "WebSearchTool", "MemoryTool"]
+  "permissions": {
+    "allow": [],
+    "ask": [],
+    "deny": []
+  }
 }
 ```
 
 ## Usage
-Just run `gemini` in your project directory.
+Just run `agy` in your project directory.
 
-Gemini automatically recognizes the MCP tools provided by Lima.
+Antigravity CLI automatically recognizes the configured MCP server provided by Lima.

--- a/website/content/en/docs/examples/ai.md
+++ b/website/content/en/docs/examples/ai.md
@@ -51,6 +51,18 @@ lima vi "/home/${USER}.linux/.bash_profile"
 
 See also <https://github.com/Aider-AI/aider>.
 {{% /tab %}}
+{{% tab header="Antigravity" %}}
+```bash
+lima curl -fsSL https://antigravity.google/cli/install.sh | bash
+lima agy
+```
+
+Follow the guide shown in the first session for authentication.
+
+Authentication uses your browser (or an authorization URL when running over SSH), so no additional environment variable configuration is typically required.
+
+See also <https://github.com/google-antigravity/antigravity-cli>.
+{{% /tab %}}
 {{% tab header="Claude Code" %}}
 ```
 lima sudo snap install node --classic
@@ -82,22 +94,6 @@ lima vi "/home/${USER}.linux/.bash_profile"
 ```
 
 See also <https://github.com/openai/codex>.
-{{% /tab %}}
-{{% tab header="Gemini" %}}
-```
-lima sudo snap install node --classic
-lima sudo npm install -g @google/gemini-cli
-lima gemini
-```
-
-Follow the guide shown in the first session for authentication.
-
-Alternatively, you can set `export GEMINI_API_KEY...` via:
-```
-lima vi "/home/${USER}.linux/.bash_profile"
-```
-
-See also <https://github.com/google-gemini/gemini-cli>.
 {{% /tab %}}
 {{% tab header="GitHub Copilot" %}}
 ```
@@ -136,7 +132,7 @@ See also <https://github.com/anomalyco/opencode>.
  | ⚡ Requirement | Lima >= 2.1 |
  |----------------|-------------|
 
-The `--sync` flag for [`limactl shell`](../reference/limactl_shell) enables bidirectional synchronization of your host working directory with the guest VM. This is particularly useful when running AI agents (like Claude, Copilot, or Gemini) inside VMs to prevent them from accidentally modifying or breaking files on your host system.
+The `--sync` flag for [`limactl shell`](../reference/limactl_shell) enables bidirectional synchronization of your host working directory with the guest VM. This is particularly useful when running AI agents (like Claude, Copilot, or Antigravity) inside VMs to prevent them from accidentally modifying or breaking files on your host system.
 
 ### Comparison with `mount`
 


### PR DESCRIPTION
<!-- Please read our contribution rules before submitting:

- Pull requests guide: https://lima-vm.io/docs/community/contributing/#sending-pull-requests
- AI usage policy: https://lima-vm.io/docs/community/contributing/#ai-contribution-rules

-->

## What This PR Changes

Updates the AI documentation to reflect the migration from Gemini CLI to Antigravity CLI.

Specifically, this PR:
- Replaces the Gemini CLI setup instructions in the AI agents example with Antigravity CLI.
- Renames the dedicated configuration guide from `gemini.md` to `antigravity.md`.
- Updates the installation commands, CLI invocation (`agy`), documentation links, and MCP configuration to match the current Antigravity CLI documentation.
- Removes outdated Gemini-specific configuration and permissions references.

## Linked Issue (Required in most cases)

Closes #5249

## How I Tested This
N/A
## AI Usage

Assisted-by: ChatGPT (GPT-5.5) — used to cross-check the Antigravity CLI installation commands, MCP configuration, and documentation links against the official documentation. All changes were manually reviewed before submission.