### PR TITLE
fix: guard against nil instance Config in loadOrCreateInstance to stop limactl panic on invalid template

### DIFF
--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -284,6 +284,16 @@ func loadOrCreateInstance(cmd *cobra.Command, args []string, createOnly bool) (*
 		// store.Inspect() will validate the template name (in case it has been set to arg)
 		inst, err := store.Inspect(ctx, tmpl.Name)
 		if err == nil {
+			configErr := errors.Join(inst.Errors...)
+			if configErr != nil {
+				logrus.WithError(configErr).Errorf("Instance %q has configuration errors", tmpl.Name)
+			}
+			if inst.Config == nil {
+				if configErr != nil {
+					return nil, fmt.Errorf("instance %q has configuration errors: %w", tmpl.Name, configErr)
+				}
+				return nil, fmt.Errorf("instance %q has no configuration", tmpl.Name)
+			}
 			if createOnly {
 				return nil, fmt.Errorf("instance %#q already exists", tmpl.Name)
 			}

--- a/cmd/limactl/start_test.go
+++ b/cmd/limactl/start_test.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+)
+
+func TestLoadOrCreateInstance(t *testing.T) {
+	tests := []struct {
+		name            string
+		yaml            string
+		wantCPUs        int
+		wantErrContains []string
+	}{
+		{
+			name:     "valid configuration",
+			yaml:     "images: [{location: /}]\ncpus: 2\n",
+			wantCPUs: 2,
+		},
+		{
+			name: "invalid configuration",
+			yaml: "arch: [invalid\n",
+			wantErrContains: []string{
+				`instance "test" has configuration errors`,
+				"failed to unmarshal YAML",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limaDir := t.TempDir()
+			t.Setenv("LIMA_HOME", limaDir)
+			instanceDir := filepath.Join(limaDir, "test")
+			assert.NilError(t, os.MkdirAll(instanceDir, 0o700))
+			assert.NilError(t, os.WriteFile(filepath.Join(instanceDir, filenames.LimaYAML), []byte(tt.yaml), 0o600))
+
+			inst, err := loadOrCreateInstance(newTestStartCommand(t), []string{"test"}, false)
+			if len(tt.wantErrContains) > 0 {
+				for _, want := range tt.wantErrContains {
+					assert.ErrorContains(t, err, want)
+				}
+				assert.Assert(t, inst == nil)
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Assert(t, inst != nil)
+			assert.Assert(t, inst.Config != nil)
+			assert.Equal(t, *inst.Config.CPUs, tt.wantCPUs)
+		})
+	}
+}
+
+func newTestStartCommand(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := newStartCommand()
+	cmd.Flags().Bool("tty", false, "")
+	cmd.SetContext(t.Context())
+	return cmd
+}


### PR DESCRIPTION
## Summary
`store.Inspect` (pkg/store/instance.go) is designed to return an `*Instance` with `inst.Errors` populated and `inst.Config == nil` when YAML loading fails for any reason other than `os.ErrNotExist` (its doc comment says so, and `shellAction` already relies on this). `loadOrCreateInstance` in cmd/limactl/start.go calls `store.Inspect`, and on the `err == nil` branch immediately dereferences `inst.Config.Param` (via `editflags.YQExpressions(flags, false, inst.Config.Param)`) without checking `inst.Errors` or `inst.Config == nil`, which is the nil-pointer panic.

## Why this matters
`limactl` panics with a SIGSEGV nil-pointer dereference when it operates on an instance whose `lima.yaml` fails to unmarshal cleanly (an invalid/typo'd template). A MEMBER (jandubois) asked to keep the issue open, stating "limactl should not panic, regardless of the input data. It should produce meaningful validation errors instead." The original panic was in `shellAction` (cmd/limactl/shell.go:94, Lima 1.0.3); that call site has since been guarded on master. On 2026-07-08 dioput12 reproduced a still-live panic in Lima v2.1.4 at `loadOrCreateInstance` (cmd/limactl/start.go:290) triggered by an indentation typo under the `qemu` key, which logs "Non-strict YAML detected" and then crashes inside `loadOrCreateInstance`.

## Testing
- Happy path: an instance with a valid `lima.yaml` is loaded by `loadOrCreateInstance` and returns its config unchanged (no regression).
- Invalid-config path (the bug): set up a temp LIMA_HOME with an existing instance dir whose `lima.yaml` fails strict/normal unmarshal (unknown field / typo), call `loadOrCreateInstance` for that instance, and assert it returns a non-nil error mentioning configuration errors rather than panicking.
- Error path: confirm the returned error joins/reports the underlying `inst.Errors` so the user sees a meaningful validation message, and that `inst.Config == nil` is handled without a dereference.

Fixes #3103