### PR TITLE
Add parameter for Kubernetes apt-proxy (k3s)

### DIFF
--- a/templates/k3s.yaml
+++ b/templates/k3s.yaml
@@ -37,6 +37,10 @@ provision:
   script: |
     #!/bin/sh
     if [ ! -d /var/lib/rancher/k3s ]; then
+    {{- if .Param.proxy }}
+            INSTALL_K3S_ARTIFACT_URL={{.Param.proxy}}/HTTPS///github.com/k3s-io/k3s/releases/download
+            export INSTALL_K3S_ARTIFACT_URL
+    {{- end}}
     {{if not ( and .Param.url .Param.token )}}
             curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --write-kubeconfig-mode 644" sh -
     {{else}}
@@ -73,5 +77,8 @@ message: |
   ------
   {{end}}
 param:
+  # The proxy to use when downloading artifacts from k3s.io
+  # For a local proxy use for instance "http://host.lima.internal:3142"
+  proxy: ""
   url: ""
   token: ""


### PR DESCRIPTION
Now supports a parameter "proxy" for pulling packages from:

proxy: "http://host.lima.internal:3142"

It is not a deb package, but we can still use the apt-proxy.

Need a new URL instead of https_proxy, if we want caching...

Issue #5258

----

`apt-proxy -cachedir /var/tmp/packages -port 3142 &`


If using apt-cacher-ng, it needs to be configured to allow k3s:

```
PfilePatternEx: ^/k3s-io/k3s/releases/download/(v.*)/(sha256sum.*|k3s.*)$
```

Otherwise you will get an error, when trying to cache the k3s:

`403 Forbidden file type or location`