### PR TITLE
docs: add Community meetings section for CLOmonitor compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,13 @@ GUI:
 - `#lima` channel in the CNCF Slack
   - New account: <https://slack.cncf.io/>
   - Login: <https://cloud-native.slack.com/>
-- Zoom meetings (tentatively monthly)
-  - Meeting notes & agenda proposals: https://github.com/lima-vm/lima/discussions/categories/meetings
-  - Calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/lima
+
+### Community meetings
+
+We host a monthly community meeting on Zoom. Meeting notes and agenda proposals are tracked in GitHub Discussions.
+
+- Meeting notes & agenda proposals: https://github.com/lima-vm/lima/discussions/categories/meetings
+- Calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/lima
 
 ### Social media accounts
 


### PR DESCRIPTION
Fixes #5260

CLOmonitor expects README meeting information to match its regex checks. This adds a `### Community meetings` section with explicit monthly community meeting wording while keeping the existing calendar and discussion links.

Signed-off-by: Khashayar Ghafouri <engr.ghafouri@gmail.com>