### PR TITLE
docs: clarify community meeting information

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ GUI:
 - `#lima` channel in the CNCF Slack
   - New account: <https://slack.cncf.io/>
   - Login: <https://cloud-native.slack.com/>
-- Zoom meetings (tentatively monthly)
+- Community meetings on Zoom (tentatively monthly)
   - Meeting notes & agenda proposals: https://github.com/lima-vm/lima/discussions/categories/meetings
   - Calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/lima
 

--- a/website/content/en/docs/community/_index.md
+++ b/website/content/en/docs/community/_index.md
@@ -13,7 +13,7 @@ The GitHub repo of Lima can be found at <https://github.com/lima-vm/lima>.
   - New account: <https://slack.cncf.io/>
   - Login: <https://cloud-native.slack.com/>
 
-- Zoom meetings (tentatively monthly)
+- Community meetings on Zoom (tentatively monthly)
   - Meeting notes & agenda proposals: https://github.com/lima-vm/lima/discussions/categories/meetings
   - Calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/lima
 


### PR DESCRIPTION
## Summary

- Rename the Zoom meeting entry to identify it as a community meeting.
- Keep the README and website community page synchronized.

The updated wording matches CLOMonitor's community-meeting detection pattern.

Fixes #5260.

## Validation

- Verified the CLOMonitor community-meeting regular expression matches both updated files.
- `git diff --check`

The repository's codespell check was not run locally because codespell is not installed; it will run in GitHub Actions.
