### PR TITLE
Update windows.md to clarify the caveats for experimental Windows 11 guest support.

### DIFF
--- a/website/content/en/docs/usage/guests/windows.md
+++ b/website/content/en/docs/usage/guests/windows.md
@@ -35,3 +35,5 @@ For Windows server 2025, TPM emulation is disabled by default. However, there ar
 - For Windows 11 guest, you need to download the installer ISO manually from [here](https://www.microsoft.com/en-us/software-download/windows11)
 - QEMU is the only VM driver that supports Windows guests
 - Only plain mode is supported (no file mount, no dynamic port-forwarding)
+- Booting Windows 11 may occasionally fail. If it fails, please delete the instance and try it again from scratch.
+- Booting Windows 11 usually takes longer than default timeout (10 minutes). Please consider extending the timeout.(example: `--timeout=30m`)


### PR DESCRIPTION
<!-- Please read our contribution rules before submitting:

- Pull requests guide: https://lima-vm.io/docs/community/contributing/#sending-pull-requests
- AI usage policy: https://lima-vm.io/docs/community/contributing/#ai-contribution-rules

-->

## What This PR Changes
This PR adds two caveats to Windows 11 guest usage documentation. ([Documentation / Usage / Guest OS / Windows](https://lima-vm.io/docs/usage/guests/windows/))

At the moment, there are a few known limitations in Windows 11 VM behaviour that may affect user experience:
- Booting Windows 11 guest may fail occasionally.
- Booting Windows 11 tends to take longer than the default timeout of `limactl start`  

<!-- Explain the single problem this PR fixes, in your own words. -->

## Linked Issue (Required in most cases)
#5256
<!-- Link the issue here. If your issue is not approved by a maintainer, don't expect your PR to be merged. -->

## AI Usage
No
<!-- If you used AI tools, say which tool and how you used it. For example, `Assisted-by: AI_AGENT_NAME:VERSION [TOOL]` or `Co-Authored-By`-->