### PR TITLE
reject backslash parent-dir traversal in template locators

### DIFF
--- a/pkg/limatmpl/abs.go
+++ b/pkg/limatmpl/abs.go
@@ -126,8 +126,10 @@ func absPath(locator, basePath string) (string, error) {
 			return "", errors.New("basePath is empty")
 		case basePath == "-":
 			return "", errors.New("can't use relative paths when reading template from STDIN")
-		case strings.Contains(locator, "../"):
-			return "", fmt.Errorf("relative locator path %#q must not contain '../' segments", locator)
+		case strings.Contains(locator, "../") || strings.Contains(locator, `..\`):
+			// filepath.Join treats a backslash as a separator on Windows, so `..\` escapes the
+			// base directory just like `../`; reject both so the guard holds on every platform.
+			return "", fmt.Errorf("relative locator path %#q must not contain '..' path segments", locator)
 		case volumeLen != 0:
 			return "", fmt.Errorf("relative locator path %#q must not include a volume name", locator)
 		}

--- a/pkg/limatmpl/abs_test.go
+++ b/pkg/limatmpl/abs_test.go
@@ -246,7 +246,12 @@ func TestAbsPath(t *testing.T) {
 
 	t.Run("Relative paths must be underneath the basePath", func(t *testing.T) {
 		_, err = absPath("../foo", volume+"/root")
-		assert.ErrorContains(t, err, "'../'")
+		assert.ErrorContains(t, err, "'..'")
+	})
+
+	t.Run("Relative paths must not use backslash traversal", func(t *testing.T) {
+		_, err = absPath(`..\foo`, volume+"/root")
+		assert.ErrorContains(t, err, "'..'")
 	})
 
 	t.Run("locator must not be empty", func(t *testing.T) {


### PR DESCRIPTION
1. absPath, the helper that makes a template's base/provision/probes locators absolute, rejects relative locators containing `../` but not the backslash form `..\`.
2. filepath.Join treats `\` as a separator on Windows, so a relative locator like `..\..\x` escapes the base directory; on `limactl start` of a local template, embedAllScripts reads the resolved provision/probe file and inlines its contents into the config, so a downloaded template can read files outside its own directory.

Rejected `..\` in the same guard so the check holds on every platform. Added a regression case for the backslash form.