### PR TITLE
sshutil, ioutilx: follow-ups from the native Windows OpenSSH review

### DIFF
--- a/pkg/ioutilx/ioutilx.go
+++ b/pkg/ioutilx/ioutilx.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -59,27 +60,33 @@ func WindowsSubsystemPath(ctx context.Context, orig string) (string, error) {
 }
 
 // WindowsSubsystemPathWithCygpath converts a Windows path with the given
-// cygpathExe ("cygpath" for PATH, or an absolute path to bind the
-// conversion to one Cygwin install). When cygpath is unavailable it falls
-// back to a native conversion of the drive-letter case; Universal Naming Convention
-// (UNC) and other non-drive-letter inputs return an error.
+// cygpathExe ("cygpath" for PATH, or an absolute path to bind the conversion
+// to one Cygwin install). When the cygpath binary is not found it falls back
+// to a native conversion of the absolute drive-letter case; a cygpath that
+// runs and fails returns its error, and non-drive-letter inputs (UNC, device,
+// extended-length) return an error.
 func WindowsSubsystemPathWithCygpath(ctx context.Context, cygpathExe, orig string) (string, error) {
 	out, err := exec.CommandContext(ctx, cygpathExe, filepath.ToSlash(orig)).CombinedOutput()
 	if err == nil {
 		return strings.TrimSpace(string(out)), nil
 	}
+	if !errors.Is(err, exec.ErrNotFound) && !errors.Is(err, fs.ErrNotExist) {
+		return "", fmt.Errorf("failed to run %#q on %#q: %#q: %w", cygpathExe, orig, strings.TrimSpace(string(out)), err)
+	}
 
-	logrus.WithError(err).Debugf("cygpath unavailable for %#q (output: %#q), attempting native conversion", orig, strings.TrimSpace(string(out)))
+	logrus.WithError(err).Debugf("%#q not found for %#q, attempting native conversion", cygpathExe, orig)
 
 	return windowsSubsystemPathWithoutCygpath(orig)
 }
 
 func windowsSubsystemPathWithoutCygpath(orig string) (string, error) {
-	// Only an absolute drive-letter path ("C:\foo") has a well-defined
-	// Cygwin form here. A drive-relative path ("C:foo") would become
-	// an unrelated absolute path, so reject it.
+	// The /c/... form this produces is the MSYS2 and Git-for-Windows
+	// convention; stock Cygwin defaults to /cygdrive/c/. Only an absolute
+	// drive-letter path ("C:\foo") has a well-defined form here. A
+	// drive-relative path ("C:foo") would become an unrelated absolute
+	// path, so reject it.
 	if !filepath.IsAbs(orig) {
-		return "", fmt.Errorf("cannot convert %#q to a Cygwin-style path: input is not an absolute drive-letter path", orig)
+		return "", fmt.Errorf("cannot convert %#q to an MSYS-style path: input is not an absolute drive-letter path", orig)
 	}
 
 	// UNC path ("\\server\share\foo") is rejected here.
@@ -92,7 +99,7 @@ func windowsSubsystemPathWithoutCygpath(orig string) (string, error) {
 		return converted, nil
 	}
 
-	return "", fmt.Errorf("cannot convert %#q to a Cygwin-style path: cygpath is unavailable and input is not an absolute drive-letter path", orig)
+	return "", fmt.Errorf("cannot convert %#q to an MSYS-style path: input is not an absolute drive-letter path", orig)
 }
 
 func WindowsSubsystemPathForLinux(ctx context.Context, orig, distro string) (string, error) {

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -98,8 +98,13 @@ func pickCompleteSSHOnWindows() string {
 		}
 		return sshPath
 	}
-	nativeSSH := filepath.Join(systemRoot(), "System32", "OpenSSH", "ssh.exe")
+	nativeDir := filepath.Join(systemRoot(), "System32", "OpenSSH")
+	nativeSSH := filepath.Join(nativeDir, "ssh.exe")
 	if _, err := os.Stat(nativeSSH); err == nil {
+		if missing := missingSiblings(nativeDir, "scp.exe", "ssh-keygen.exe"); len(missing) > 0 {
+			logrus.Debugf("skipping native ssh at %#q: missing %v in same directory", nativeSSH, missing)
+			return ""
+		}
 		return nativeSSH
 	}
 
@@ -142,26 +147,60 @@ func IsSSHCygwin(sshExe SSHExe) bool {
 	return ok
 }
 
-// cygpathForSSH returns the cygpath.exe besides sshExe (resolved through
-// symlinks) and whether sshExe is Cygwin-based. Callers pass the returned
-// path to exec.Command so conversions run through that toolchain's own
-// cygpath, even when $SSH points outside PATH. It returns
-// ("", false) on non-Windows or empty input; results are cached per resolved path.
-func cygpathForSSH(sshExe SSHExe) (string, bool) {
-	if runtime.GOOS != "windows" || sshExe.Exe == "" {
+// resolvedSSHPath returns the absolute, symlink-resolved path of sshExe's
+// binary — the directory Lima reads its companion tools from. It returns
+// ("", false) when a bare name does not resolve on PATH.
+func resolvedSSHPath(sshExe SSHExe) (string, bool) {
+	if sshExe.Exe == "" {
 		return "", false
 	}
 	path := sshExe.Exe
 	if !filepath.IsAbs(path) {
 		resolved, err := exec.LookPath(path)
 		if err != nil {
-			logrus.WithError(err).Debugf("cygpathForSSH: cannot resolve %#q via PATH; assuming native", path)
+			logrus.WithError(err).Debugf("cannot resolve ssh at %#q via PATH", path)
 			return "", false
 		}
 		path = resolved
 	}
 	if resolved, err := filepath.EvalSymlinks(path); err == nil {
 		path = resolved
+	}
+	return path, true
+}
+
+// companionForSSH returns tool from the same toolchain as sshExe. NewSSHExe can
+// select an ssh outside PATH, so resolving a companion by bare name can pick a
+// different toolchain than the one PathForSSH formats paths for. It returns tool
+// unchanged on non-Windows, or when no sibling exists, leaving it to PATH.
+func companionForSSH(sshExe SSHExe, tool string) string {
+	if runtime.GOOS != "windows" {
+		return tool
+	}
+	path, ok := resolvedSSHPath(sshExe)
+	if !ok {
+		return tool
+	}
+	companion := filepath.Join(filepath.Dir(path), tool+".exe")
+	if _, err := os.Stat(companion); err != nil {
+		logrus.Debugf("no %#q beside ssh at %#q; resolving %#q from PATH", companion, path, tool)
+		return tool
+	}
+	return companion
+}
+
+// cygpathForSSH returns the cygpath.exe beside sshExe (resolved through
+// symlinks) and whether sshExe is Cygwin-based. Callers pass the returned
+// path to exec.Command so conversions run through that toolchain's own
+// cygpath, even when $SSH points outside PATH. It returns
+// ("", false) on non-Windows or empty input; results are cached per resolved path.
+func cygpathForSSH(sshExe SSHExe) (string, bool) {
+	if runtime.GOOS != "windows" {
+		return "", false
+	}
+	path, ok := resolvedSSHPath(sshExe)
+	if !ok {
+		return "", false
 	}
 	cygwinDetectCacheRW.RLock()
 	cached, ok := cygwinDetectCache[path]
@@ -221,16 +260,9 @@ func SftpServerForSSH(ctx context.Context, sshExe SSHExe) string {
 		}
 		return ""
 	}
-	path := sshExe.Exe
-	if !filepath.IsAbs(path) {
-		resolved, err := exec.LookPath(path)
-		if err != nil {
-			return ""
-		}
-		path = resolved
-	}
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
-		path = resolved
+	path, ok := resolvedSSHPath(sshExe)
+	if !ok {
+		return ""
 	}
 	sftpServer := filepath.Join(filepath.Dir(path), "sftp-server.exe")
 	if _, err := os.Stat(sftpServer); err != nil {
@@ -279,17 +311,19 @@ func DefaultPubKeys(ctx context.Context, loadDotSSH bool) ([]PubKey, error) {
 		if err := lockutil.WithDirLock(configDir, func() error {
 			// no passphrase, no user@host comment
 			privPath := filepath.Join(configDir, filenames.UserPrivateKey)
+			keygenExe := "ssh-keygen"
 			if runtime.GOOS == "windows" {
 				sshExe, sshErr := NewSSHExe()
 				if sshErr != nil {
 					return sshErr
 				}
+				keygenExe = companionForSSH(sshExe, "ssh-keygen")
 				privPath, err = PathForSSH(ctx, sshExe, privPath)
 				if err != nil {
 					return err
 				}
 			}
-			keygenCmd := exec.CommandContext(ctx, "ssh-keygen", "-t", "ed25519", "-q", "-N", "",
+			keygenCmd := exec.CommandContext(ctx, keygenExe, "-t", "ed25519", "-q", "-N", "",
 				"-C", "lima", "-f", privPath)
 			logrus.Debugf("executing %v", keygenCmd.Args)
 			if out, err := keygenCmd.CombinedOutput(); err != nil {

--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -31,6 +31,12 @@ func TestDefaultPubKeys_WithoutExistingKey(t *testing.T) {
 	keys, err := DefaultPubKeys(t.Context(), false)
 	assert.NilError(t, err)
 	assert.Equal(t, 1, len(keys))
+	// LimaDir resolves symlinks (e.g. /var -> /private/var on macOS), so
+	// resolve tmpDir the same way before comparing the returned filename.
+	resolvedTmp, err := filepath.EvalSymlinks(tmpDir)
+	assert.NilError(t, err)
+	assert.Equal(t, keys[0].Filename, filepath.Join(resolvedTmp, filenames.ConfigDir, filenames.UserPublicKey))
+	assert.Assert(t, detectValidPublicKey(keys[0].Content), "generated key is not a valid public key: %#q", keys[0].Content)
 }
 
 func TestParseOpenSSHVersion(t *testing.T) {

--- a/pkg/sshutil/sshutil_windows_test.go
+++ b/pkg/sshutil/sshutil_windows_test.go
@@ -53,6 +53,108 @@ func TestPickCompleteSSHOnWindows(t *testing.T) {
 	})
 }
 
+// TestCygpathForSSH: an ssh.exe next to cygpath.exe is Cygwin-based and
+// resolves the sibling cygpath; one without is native.
+func TestCygpathForSSH(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("cygpath detection only runs on Windows")
+	}
+
+	t.Run("cygwin", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		sshExe := filepath.Join(dir, "ssh.exe")
+		cygpathExe := filepath.Join(dir, "cygpath.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+		assert.NilError(t, os.WriteFile(cygpathExe, nil, 0o644))
+
+		got, ok := cygpathForSSH(SSHExe{Exe: sshExe})
+		assert.Equal(t, ok, true, "ssh.exe next to cygpath.exe should be Cygwin")
+		assert.Equal(t, got, cygpathExe, "should return the sibling cygpath, not bare 'cygpath'")
+		assert.Equal(t, IsSSHCygwin(SSHExe{Exe: sshExe}), true)
+	})
+
+	t.Run("native", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		sshExe := filepath.Join(dir, "ssh.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+
+		got, ok := cygpathForSSH(SSHExe{Exe: sshExe})
+		assert.Equal(t, ok, false, "ssh.exe with no sibling cygpath.exe should be native")
+		assert.Equal(t, got, "")
+		assert.Equal(t, IsSSHCygwin(SSHExe{Exe: sshExe}), false)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		got, ok := cygpathForSSH(SSHExe{})
+		assert.Equal(t, ok, false)
+		assert.Equal(t, got, "")
+	})
+}
+
+// TestSftpServerForSSH: a native ssh.exe resolves the sibling
+// sftp-server.exe, and returns "" when none exists so the caller falls
+// back to sshocker's own auto-detection.
+func TestSftpServerForSSH(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only path handling")
+	}
+	ctx := t.Context()
+
+	t.Run("native: sibling sftp-server.exe next to ssh.exe", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		sshExe := filepath.Join(dir, "ssh.exe")
+		sftpExe := filepath.Join(dir, "sftp-server.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+		assert.NilError(t, os.WriteFile(sftpExe, nil, 0o644))
+
+		got := SftpServerForSSH(ctx, SSHExe{Exe: sshExe})
+		assert.Equal(t, got, sftpExe)
+	})
+
+	t.Run("native: no sibling sftp-server.exe returns empty", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		sshExe := filepath.Join(dir, "ssh.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+
+		got := SftpServerForSSH(ctx, SSHExe{Exe: sshExe})
+		assert.Equal(t, got, "", "no sftp-server.exe sibling -> caller falls back to sshocker auto-detect")
+	})
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		assert.Equal(t, SftpServerForSSH(ctx, SSHExe{}), "")
+	})
+}
+
+// TestCompanionForSSH: a companion tool is resolved beside the selected
+// ssh.exe, and falls back to the bare name when no sibling exists.
+func TestCompanionForSSH(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("companion resolution only runs on Windows")
+	}
+
+	t.Run("sibling is picked over PATH", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		sshExe := filepath.Join(dir, "ssh.exe")
+		keygenExe := filepath.Join(dir, "ssh-keygen.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+		assert.NilError(t, os.WriteFile(keygenExe, nil, 0o644))
+
+		assert.Equal(t, companionForSSH(SSHExe{Exe: sshExe}, "ssh-keygen"), keygenExe)
+	})
+
+	t.Run("no sibling falls back to the bare name", func(t *testing.T) {
+		dir := resolvedTempDir(t)
+		sshExe := filepath.Join(dir, "ssh.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+
+		assert.Equal(t, companionForSSH(SSHExe{Exe: sshExe}, "ssh-keygen"), "ssh-keygen")
+	})
+
+	t.Run("empty input falls back to the bare name", func(t *testing.T) {
+		assert.Equal(t, companionForSSH(SSHExe{}, "ssh-keygen"), "ssh-keygen")
+	})
+}
+
 // resolvedTempDir is t.TempDir() run through EvalSymlinks, matching what
 // the production helpers compute. On GitHub Windows runners t.TempDir()
 // is an 8.3 short path (C:\Users\RUNNER~1\...) that the helpers expand,


### PR DESCRIPTION
Follow-up to #5205, closing the review findings it deferred: pair `ssh-keygen` with the selected toolchain, make the `cygpath` fallback fail loudly instead of converting silently, and restore the tests #5196 had that the port dropped.

`SftpServerForSSH` stays exported but unwired — reverse-sshfs mounts and `limactl copy` are still separate follow-ups; it has test coverage in the meantime.

Created with Claude Opus 4.8
