### PR TITLE
ci: run quick lints on docs-only PRs

### DIFF
--- a/.github/workflows/lint-quick.yml
+++ b/.github/workflows/lint-quick.yml
@@ -1,0 +1,44 @@
+name: lint-quick
+
+# These checks cover the whole tree, docs included, so this workflow runs
+# without the paths-ignore filter that test.yml uses to skip docs-only changes.
+on:
+  push:
+    branches:
+    - master
+    - 'release/**'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint-quick:
+    name: "Quick lints"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+      with:
+        go-version: stable
+        cache: false
+    - name: Run editorconfig-checker
+      run: make editorconfig-checker
+    - name: Run yamllint
+      run: make yamllint
+    - name: Run file and directory name linter
+      uses: ls-lint/action@02e380fe8733d499cbfc9e22276de5085508a5bd  # v2.3.1
+    - name: Check hyperlinks
+      uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2.9.0
+      with:
+        args: >-
+          --exclude https://img.shields.io
+          --exclude http://127.0.0.1:8080
+          --exclude https://github.com/lima-vm/lima/releases/download
+          --exclude https://xbarapp.com
+          --exclude https://api.github.com
+          README.md
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,31 +43,14 @@ jobs:
       run: make generate check-generated
     - name: Run nobin
       run: make nobin
-    - name: Run editorconfig-checker
-      run: make editorconfig-checker
-    - name: Run yamllint
-      run: make yamllint
     - name: Install shellcheck
       run: |
         sudo apt-get update
         sudo apt-get install -y shellcheck
-    - name: Run file and directory name linter
-      uses: ls-lint/action@02e380fe8733d499cbfc9e22276de5085508a5bd  # v2.3.1
     - name: Run shellcheck
       run: make shellcheck
     - name: Run shfmt
       run: make shfmt
-    - name: Check hyperlinks
-      uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2.9.0
-      with:
-        args: >-
-          --exclude https://img.shields.io
-          --exclude http://127.0.0.1:8080
-          --exclude https://github.com/lima-vm/lima/releases/download
-          --exclude https://xbarapp.com
-          --exclude https://api.github.com
-          README.md
-        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install go-licenses
       # TODO: move to `go tool` after upgrading to v2
       run: go install github.com/google/go-licenses@v1.6.0


### PR DESCRIPTION
The test workflow owns editorconfig-checker, yamllint, ls-lint, and the lychee hyperlink check, but its paths-ignore skips docs-only changes, so a docs PR can land a violation that only surfaces later, on the next code PR that runs the workflow against the whole tree.

Move those four into a new lint-quick workflow with no paths-ignore. Each of them covers files a docs-only PR touches. shellcheck, shfmt, and the Go/protobuf checks stay behind: they need extra tooling and have nothing to lint in the docs tree.

Closes #5272
