### PR TITLE
verify cached image digest before raw conversion

### DIFF
--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -307,6 +307,19 @@ func getCached(ctx context.Context, localPath, remote string, o options) (*Resul
 				rawImgConvPath := filepath.Join(shad, "imgconv", "raw")
 				rawImgConvDigestPath := filepath.Join(shad, "imgconv", "raw.digest")
 
+				// The raw copy has a digest of its own, so o.expectedDigest is replaced
+				// below and the check at the end of this function then compares
+				// imgconv/raw.digest against a value read from that same file. When the
+				// cache entry carries no recorded digest there is nothing that has
+				// compared the caller's digest against any bytes yet, so do it here.
+				if o.expectedDigest != "" {
+					if _, err := os.Stat(shadDigest); err != nil {
+						if err := validateLocalFileDigest(shadData, o.expectedDigest); err != nil {
+							return nil, err
+						}
+					}
+				}
+
 				needConvert := false
 				if rawStat, err := os.Stat(rawImgConvPath); err != nil {
 					if errors.Is(err, os.ErrNotExist) {

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -591,3 +591,41 @@ func TestDownloadImageConversionCached(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, rawPath, r.CachePath)
 }
+
+func TestDownloadImageConversionCachedDigestMismatch(t *testing.T) {
+	_, err := exec.LookPath("qemu-img")
+	if err != nil {
+		t.Skipf("qemu-img does not seem installed: %v", err)
+	}
+
+	const lastModified = "Mon, 02 Jan 2006 15:04:05 GMT"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Last-Modified", lastModified)
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "cache")
+	remoteURL := ts.URL + "/test.qcow2"
+
+	// Pre-populate the cache the way a digest-less download does: "data" and
+	// "time", but no "<ALGO>.digest" file.
+	shad := cacheDirectoryPath(cacheDir, remoteURL)
+	assert.NilError(t, os.MkdirAll(shad, 0o700))
+	shadData := filepath.Join(shad, "data")
+	assert.NilError(t, exec.CommandContext(ctx, "qemu-img", "create", "-f", "qcow2", shadData, "64K").Run())
+	assert.NilError(t, os.WriteFile(filepath.Join(shad, "time"), []byte(lastModified), 0o644))
+
+	localPath := filepath.Join(tmpDir, "local")
+
+	// The cached image does not match the expected digest, so the download must fail
+	// even though the driver only supports raw and the image gets converted.
+	_, err = Download(ctx, localPath, remoteURL,
+		WithCacheDir(cacheDir),
+		WithDescription("image"),
+		WithImageFormats([]string{"raw"}),
+		WithExpectedDigest(digest.SHA256.FromString("unrelated")),
+	)
+	assert.ErrorContains(t, err, "expected digest")
+}


### PR DESCRIPTION
getCached replaces o.expectedDigest with the digest it computes for imgconv/raw, so the validateCachedDigest call that follows compares imgconv/raw.digest against a value read from that same file and can never fail. If the cache entry carries no <ALGO>.digest file, which is what a digest-less download leaves behind, nothing has checked the caller's digest against any bytes by that point, and the image is copied out with ValidatedDigest set. Hashing the cached original before the conversion branch takes over closes the gap, and the added test fails on the current tree where the cached image is accepted against an unrelated digest.