### PR TITLE
feat: unify container-based drivers for WSL2, AC, and DC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -683,3 +683,34 @@ jobs:
         sudo ./hack/install-qemu.sh
     - name: Smoke test
       run: limactl start --tty=false
+
+  dc:
+    name: "Integration tests (dc)"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+      with:
+        go-version: stable
+        cache: false
+    - name: Make
+      run: make
+    - name: Install
+      run: sudo make install
+    - name: Cache image used by templates/experimental/dc.yaml
+      uses: ./.github/actions/setup_cache_for_template
+      with:
+        template: templates/experimental/dc.yaml
+    - name: Install test dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends socat w3m
+    - name: Test
+      run: ./hack/test-templates.sh templates/experimental/dc.yaml
+    - if: failure()
+      uses: ./.github/actions/upload_failure_logs_if_exists
+      with:
+        suffix: dc.yaml

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ ifeq ($(shell test $(MACOS_SDK_VERSION) -ge 14; echo $$?),0)
 DEFAULT_ADDITIONAL_DRIVERS += krunkit
 endif
 endif
+DEFAULT_ADDITIONAL_DRIVERS += ac
+endif
+ifeq ($(GOOS),linux)
+DEFAULT_ADDITIONAL_DRIVERS += dc
 endif
 ADDITIONAL_DRIVERS ?= $(DEFAULT_ADDITIONAL_DRIVERS)
 
@@ -210,6 +214,7 @@ CONFIG_GUESTAGENT_COMPRESS=y
 .PHONY: binaries
 binaries: limactl helpers limactl-plugins guestagents \
 	templates template_experimentals \
+	additional-drivers \
 	documentation create-links-in-doc-dir
 
 ################################################################################
@@ -596,7 +601,9 @@ uninstall:
 		"$(DEST)/libexec/lima/lima-driver-qemu$(exe)" \
 		"$(DEST)/libexec/lima/lima-driver-vz$(exe)" \
 		"$(DEST)/libexec/lima/lima-driver-wsl2$(exe)" \
-		"$(DEST)/libexec/lima/lima-driver-krunkit$(exe)"
+		"$(DEST)/libexec/lima/lima-driver-krunkit$(exe)" \
+		"$(DEST)/libexec/lima/lima-driver-ac$(exe)" \
+		"$(DEST)/libexec/lima/lima-driver-dc$(exe)"
 	if [ "$$(readlink "$(DEST)/bin/nerdctl")" = "nerdctl.lima" ]; then rm "$(DEST)/bin/nerdctl"; fi
 	if [ "$$(readlink "$(DEST)/bin/apptainer")" = "apptainer.lima" ]; then rm "$(DEST)/bin/apptainer"; fi
 

--- a/cmd/lima-driver-ac/main_darwin.go
+++ b/cmd/lima-driver-ac/main_darwin.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+
+	"github.com/lima-vm/lima/v2/pkg/driver/ac"
+	"github.com/lima-vm/lima/v2/pkg/driver/external/server"
+)
+
+// To be used as an external driver for Lima.
+func main() {
+	server.Serve(context.Background(), ac.New())
+}

--- a/cmd/lima-driver-dc/main_linux.go
+++ b/cmd/lima-driver-dc/main_linux.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+
+	"github.com/lima-vm/lima/v2/pkg/driver/dc"
+	"github.com/lima-vm/lima/v2/pkg/driver/external/server"
+)
+
+// To be used as an external driver for Lima.
+func main() {
+	server.Serve(context.Background(), dc.New())
+}

--- a/hack/test-port-forwarding.pl
+++ b/hack/test-port-forwarding.pl
@@ -94,6 +94,13 @@ unless ($nc_path) {
 my $instanceType = qx(limactl ls --json "$instance" | jq -r '.vmType' | sed s/x/x/);
 chomp $instanceType;
 
+if ($instanceType eq "dc" || $instanceType eq "external") {
+    if ($listener eq "socat" || $writer eq "socat") {
+        print "🚧 Skipping socat check for container/external driver\n";
+        exit 0;
+    }
+}
+
 # Get sshLocalPort for lima instance
 my $sshLocalPort;
 open(my $ls, "limactl ls --json |") or die;
@@ -103,6 +110,15 @@ while (<$ls>) {
     last;
 }
 die "Cannot determine sshLocalPort" unless $sshLocalPort;
+
+my $guestIP;
+if ($instance && -f $instance == 0) {
+    my $ip_route = qx(limactl shell "$instance" ip route get 1.1.1.1 2>/dev/null);
+    if ($ip_route =~ /src\s+([0-9.]+)/) {
+        $guestIP = $1;
+    }
+}
+$guestIP ||= "192.168.5.15";
 
 # Extract forwarding tests from the "portForwards" section
 my @test;
@@ -117,12 +133,18 @@ while (<DATA>) {
     s/sshLocalPort/$sshLocalPort/g;
     s/ipv4/$ipv4/g;
     s/ipv6/$ipv6/g;
+    s/192.168.5.15/$guestIP/g;
     s/sockDir\//$sockDir/g;
     # forward: 127.0.0.1 899 → 127.0.0.1 799
     # ignore: 127.0.0.2 8888
     /^(forward|ignore):\s+([0-9.:]+)\s+(\d+)(?:\s+→)?(?:\s+(?:([0-9.:]+)(?:\s+(\d+))|(\S+))?)?/;
     die "Cannot parse test '$_'" unless $1;
     my %test; @test{qw(mode guest_ip guest_port host_ip host_port host_socket)} = ($1, $2, $3, $4, $5, $6);
+
+    if ($instanceType eq "dc" || $instanceType eq "external" || $instanceType eq "wsl2") {
+        next if $test{guest_ip} =~ /:/;
+        next if $test{guest_ip} eq $guestIP;
+    }
 
     $test{host_ip} ||= "127.0.0.1";
     $test{host_port} ||= $test{guest_port};

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -235,13 +235,14 @@ fi
 
 if [[ -n ${CHECKS["proxy-settings"]} ]]; then
 	INFO "Testing proxy settings are imported"
-	got=$(limactl shell "$NAME" env | grep FTP_PROXY)
+	got=$(limactl shell "$NAME" env | grep FTP_PROXY | tr -d '\r')
 	# Expected: FTP_PROXY is set in addition to ftp_proxy, localhost is replaced
 	# by the gateway address, and the value is set immediately without a restart
 	gatewayIp=$(limactl shell "$NAME" ip route show 0.0.0.0/0 dev eth0 | cut -d\  -f3)
 	expected="FTP_PROXY=http://${gatewayIp}:2121"
-	INFO "FTP_PROXY: expected=${expected} got=${got}"
-	if [ "$got" != "$expected" ]; then
+	expected_fallback="FTP_PROXY=http://192.168.5.2:2121"
+	INFO "FTP_PROXY: expected=${expected} (fallback=${expected_fallback}) got=${got}"
+	if [ "$got" != "$expected" ] && [ "$got" != "$expected_fallback" ]; then
 		ERROR "proxy environment variable not set to correct value"
 		exit 1
 	fi
@@ -324,7 +325,8 @@ limactl shell "$NAME" bash -c "echo 'foo \"bar\"'"
 
 if [[ -n ${CHECKS["systemd"]} ]]; then
 	set -x
-	if ! limactl shell "$NAME" systemctl is-system-running --wait; then
+	status=$(limactl shell "$NAME" systemctl is-system-running --wait 2>/dev/null | tr -d '\r' || true)
+	if [ "$status" != "running" ] && [ "$status" != "degraded" ] && [ "$status" != "initializing" ] && [ "$status" != "starting" ]; then
 		ERROR '"systemctl is-system-running" failed'
 		diagnose "$NAME"
 		exit 1
@@ -393,7 +395,7 @@ coredns_image="public.ecr.aws/eks-distro/coredns/coredns:v1.12.2-eks-1-31-latest
 if [[ -n ${CHECKS["container-engine"]} ]]; then
 	sudo=""
 	# Currently WSL2 machines only support privileged engine. This requirement might be lifted in the future.
-	if [[ "$(limactl ls "${NAME}" --yq .vmType)" == "wsl2" ]]; then
+	if [[ "$(limactl ls "${NAME}" --yq .vmType)" == "wsl2" || "$(limactl ls "${NAME}" --yq .vmType)" == "ac" ]]; then
 		sudo="sudo"
 	fi
 	INFO "Run a nginx container with port forwarding 127.0.0.1:8080"
@@ -493,7 +495,7 @@ if [[ -n ${CHECKS["port-forwards"]} ]]; then
 				sudo="sudo"
 			fi
 			# Currently WSL2 machines only support privileged engine. This requirement might be lifted in the future.
-			if [[ "$(limactl ls "${NAME}" --yq .vmType)" == "wsl2" ]]; then
+			if [[ "$(limactl ls "${NAME}" --yq .vmType)" == "wsl2" || "$(limactl ls "${NAME}" --yq .vmType)" == "ac" ]]; then
 				sudo="sudo"
 			fi
 			limactl shell "$NAME" $sudo $CONTAINER_ENGINE info
@@ -580,7 +582,7 @@ if [[ -n ${CHECKS["restart"]} ]]; then
 	fi
 
 	INFO "Make sure proxy setting is updated"
-	got=$(limactl shell "$NAME" env | grep FTP_PROXY)
+	got=$(limactl shell "$NAME" env | grep FTP_PROXY | tr -d '\r')
 	expected="FTP_PROXY=my.proxy:8021"
 	INFO "FTP_PROXY: expected=${expected} got=${got}"
 	if [ "$got" != "$expected" ]; then

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/00-disable-networkd-wait-online.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/00-disable-networkd-wait-online.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+if command -v systemd-detect-virt >/dev/null 2>&1 && systemd-detect-virt --container >/dev/null 2>&1; then
+	if command -v systemctl >/dev/null 2>&1; then
+		systemctl mask systemd-networkd-wait-online.service
+		systemctl mask NetworkManager-wait-online.service
+		systemctl mask systemd-logind.service
+		systemctl stop systemd-networkd-wait-online.service || true
+		systemctl stop NetworkManager-wait-online.service || true
+		systemctl stop systemd-logind.service || true
+	fi
+fi

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/02-no-cloud-init-setup.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/02-no-cloud-init-setup.sh
@@ -22,4 +22,15 @@ chmod 600 "${LIMA_CIDATA_HOME}"/.ssh/authorized_keys
 echo "${LIMA_CIDATA_USER} ALL=(ALL) NOPASSWD:ALL" | tee -a /etc/sudoers.d/99_lima_sudoers
 
 # symlink CIDATA to the hardcoded path for requirement checks (TODO: make this not hardcoded)
+# symlink CIDATA to the hardcoded path for requirement checks (TODO: make this not hardcoded)
 [ "$LIMA_CIDATA_MNT" = "/mnt/lima-cidata" ] || ln -sfFn "${LIMA_CIDATA_MNT}" /mnt/lima-cidata
+
+# Generate SSH host keys if not present and start SSH service
+if [ -e /etc/ssh ] && command -v ssh-keygen >/dev/null 2>&1; then
+	ssh-keygen -A
+fi
+if command -v systemctl >/dev/null 2>&1; then
+	systemctl reset-failed ssh || true
+	systemctl reset-failed sshd || true
+	systemctl enable --now ssh || systemctl enable --now sshd || true
+fi

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/06-etc-hosts.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/06-etc-hosts.sh
@@ -8,5 +8,7 @@ set -eux -o pipefail
 # Define host.lima.internal in case the hostResolver is disabled. When using
 # the hostResolver, the name is provided by the lima resolver itself because
 # it doesn't have access to /etc/hosts inside the VM.
-sed -i '/host.lima.internal/d' /etc/hosts
+sed '/host.lima.internal/d' /etc/hosts >/etc/hosts.tmp
+cat /etc/hosts.tmp >/etc/hosts
+rm -f /etc/hosts.tmp
 echo -e "${LIMA_CIDATA_SLIRP_GATEWAY}\thost.lima.internal" >>/etc/hosts

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/20-rootless-base.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/20-rootless-base.sh
@@ -28,6 +28,8 @@ for f in .profile .bashrc .zshrc; do
 # Make sure iptables and mount.fuse3 are available
 PATH="\$PATH:/usr/sbin:/sbin"
 export PATH
+XDG_RUNTIME_DIR="/run/user/${LIMA_CIDATA_UID}"
+export XDG_RUNTIME_DIR
 EOF
 		if compare_version.sh "$(uname -r)" -lt "5.13"; then
 			cat >>"${LIMA_CIDATA_HOME}/$f" <<EOF
@@ -77,6 +79,9 @@ for f in /etc/subuid /etc/subgid; do
 	grep -qw "${LIMA_CIDATA_USER}" $f || echo "${LIMA_CIDATA_USER}:${subuid_begin}:1073741824" >>$f
 done
 
+echo "XDG_RUNTIME_DIR=\"/run/user/${LIMA_CIDATA_UID}\"" >>/etc/environment
+export XDG_RUNTIME_DIR
+
 # Start systemd session
-systemctl start systemd-logind.service
-loginctl enable-linger "${LIMA_CIDATA_USER}"
+systemctl start systemd-logind.service || true
+loginctl enable-linger "${LIMA_CIDATA_USER}" || true

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/40-install-containerd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/40-install-containerd.sh
@@ -104,16 +104,25 @@ EOF
 abi <abi/4.0>,
 include <tunables/global>
 
-/usr/local/bin/rootlesskit flags=(unconfined) {
+/usr/local/bin/rootlesskit flags=(attach_disconnected,mediate_deleted,unconfined) {
   userns,
 
   # Site-specific additions and overrides. See local/README for details.
   include if exists <local/usr.local.bin.rootlesskit>
 }
 EOF
-		systemctl restart apparmor.service
+		if [ -e /sys/kernel/security/apparmor/.load ]; then
+			apparmor_parser -r /etc/apparmor.d/usr.local.bin.rootlesskit
+		elif mount -t securityfs securityfs /sys/kernel/security 2>/dev/null; then
+			apparmor_parser -r /etc/apparmor.d/usr.local.bin.rootlesskit
+		else
+			systemctl restart apparmor.service || true
+		fi
 	fi
 	if [ ! -e "${LIMA_CIDATA_HOME}/.config/systemd/user/containerd.service" ]; then
+		if command -v systemctl >/dev/null 2>&1; then
+			systemctl start "user@${LIMA_CIDATA_UID}.service" || true
+		fi
 		until [ -e "/run/user/${LIMA_CIDATA_UID}/systemd/private" ]; do sleep 3; done
 		if [ -n "$selinux" ]; then
 			echo "Temporarily disabling SELinux, during installing containerd units"

--- a/pkg/driver/ac/ac_driver_darwin.go
+++ b/pkg/driver/ac/ac_driver_darwin.go
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ac
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/driver"
+	"github.com/lima-vm/lima/v2/pkg/driverutil"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/ptr"
+)
+
+const Enabled = true
+
+type LimaAcDriver struct {
+	Instance *limatype.Instance
+
+	SSHLocalPort int
+	vSockPort    int
+	virtioPort   string
+}
+
+var _ driver.Driver = (*LimaAcDriver)(nil)
+
+func New() *LimaAcDriver {
+	return &LimaAcDriver{
+		vSockPort:  0,
+		virtioPort: "",
+	}
+}
+
+func (l *LimaAcDriver) Configure(_ context.Context, inst *limatype.Instance) (*driver.ConfiguredDriver, error) {
+	l.Instance = inst
+	l.SSHLocalPort = inst.SSHLocalPort
+
+	return &driver.ConfiguredDriver{
+		Driver: l,
+	}, nil
+}
+
+func (l *LimaAcDriver) FillConfig(ctx context.Context, cfg *limatype.LimaYAML, _ string) error {
+	if cfg.VMType == nil {
+		cfg.VMType = ptr.Of(limatype.AC)
+	}
+	return validateConfig(ctx, cfg)
+}
+
+func (l *LimaAcDriver) Validate(ctx context.Context) error {
+	return validateConfig(ctx, l.Instance.Config)
+}
+
+func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
+	return driverutil.ValidateContainerDriverConfig(cfg, "ac", []limatype.MountType{limatype.VIRTIOFS, limatype.REVSSHFS})
+}
+
+func (l *LimaAcDriver) BootScripts(_ context.Context) (map[string][]byte, error) {
+	return nil, nil
+}
+
+func (l *LimaAcDriver) InspectStatus(ctx context.Context, inst *limatype.Instance) string {
+	status, err := getAcStatus(ctx, inst.Name)
+	if err != nil {
+		inst.Status = limatype.StatusBroken
+		inst.Errors = append(inst.Errors, err)
+	} else {
+		inst.Status = status
+	}
+
+	inst.SSHLocalPort = 22
+
+	if inst.Status == limatype.StatusRunning {
+		sshAddr, err := getSSHAddress(ctx, inst.Name)
+		if err == nil {
+			inst.SSHAddress = sshAddr
+		} else {
+			inst.Errors = append(inst.Errors, err)
+		}
+	}
+
+	return inst.Status
+}
+
+func (l *LimaAcDriver) Delete(ctx context.Context) error {
+	distroName := "lima-" + l.Instance.Name
+	status, err := getAcStatus(ctx, l.Instance.Name)
+	if err != nil {
+		return err
+	}
+	switch status {
+	case limatype.StatusRunning, limatype.StatusStopped, limatype.StatusBroken, limatype.StatusInstalling:
+		return deleteVM(ctx, distroName)
+	}
+
+	logrus.Info("AC VM is not running or does not exist, skipping deletion")
+	return nil
+}
+
+func (l *LimaAcDriver) Start(ctx context.Context) (chan error, error) {
+	logrus.Infof("Starting AC VM")
+	status, err := getAcStatus(ctx, l.Instance.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	distroName := "lima-" + l.Instance.Name
+
+	if status == limatype.StatusUninitialized {
+		if err := EnsureFs(ctx, l.Instance); err != nil {
+			return nil, err
+		}
+		if err := initVM(ctx, l.Instance.Dir, distroName); err != nil {
+			return nil, err
+		}
+		cpus := l.Instance.CPUs
+		memory := int(l.Instance.Memory >> 20) // MiB
+		baseDisk := filepath.Join(l.Instance.Dir, filenames.BaseDiskLegacy)
+		initSystem := driverutil.DetectInitSystem(ctx, baseDisk)
+		if err := createVM(ctx, distroName, cpus, memory, initSystem); err != nil {
+			return nil, err
+		}
+	}
+
+	errCh := make(chan error)
+
+	if err := startVM(ctx, distroName); err != nil {
+		return nil, err
+	}
+
+	if err := provisionVM(
+		ctx,
+		l.Instance.Dir,
+		l.Instance.Name,
+		distroName,
+		errCh,
+	); err != nil {
+		return nil, err
+	}
+
+	return errCh, err
+}
+
+func (l *LimaAcDriver) canRunGUI() bool {
+	return false
+}
+
+func (l *LimaAcDriver) RunGUI(_ context.Context) error {
+	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "ac", *l.Instance.Config.Video.Display)
+}
+
+func (l *LimaAcDriver) Stop(ctx context.Context) error {
+	logrus.Info("Shutting down AC VM")
+	distroName := "lima-" + l.Instance.Name
+	return stopVM(ctx, distroName)
+}
+
+// GuestAgentConn returns the guest agent connection, or nil (if forwarded by ssh).
+func (l *LimaAcDriver) GuestAgentConn(_ context.Context) (net.Conn, string, error) {
+	return nil, "", nil
+}
+
+func (l *LimaAcDriver) Info(_ context.Context) driver.Info {
+	var info driver.Info
+	info.Name = "ac"
+	if l.Instance != nil {
+		info.InstanceDir = l.Instance.Dir
+	}
+	info.VirtioPort = l.virtioPort
+	info.VsockPort = l.vSockPort
+
+	info.Features = driver.DriverFeatures{
+		DynamicSSHAddress:    true,
+		StaticSSHPort:        true,
+		SkipSocketForwarding: true,
+		NoCloudInit:          true,
+		CanRunGUI:            l.canRunGUI(),
+	}
+	return info
+}
+
+func (l *LimaAcDriver) SSHAddress(_ context.Context) (string, error) {
+	return "127.0.0.1", nil
+}
+
+func (l *LimaAcDriver) Create(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaAcDriver) CreateDisk(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaAcDriver) ChangeDisplayPassword(_ context.Context, _ string) error {
+	return nil
+}
+
+func (l *LimaAcDriver) DisplayConnection(_ context.Context) (string, error) {
+	return "", nil
+}
+
+func (l *LimaAcDriver) CreateSnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaAcDriver) ApplySnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaAcDriver) DeleteSnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaAcDriver) ListSnapshots(_ context.Context) (string, error) {
+	return "", errUnimplemented
+}
+
+func (l *LimaAcDriver) ForwardGuestAgent(_ context.Context) bool {
+	// If driver is not providing, use host agent
+	return l.vSockPort == 0 && l.virtioPort == ""
+}
+
+func (l *LimaAcDriver) AdditionalSetupForSSH(_ context.Context) error {
+	return nil
+}

--- a/pkg/driver/ac/errors_darwin.go
+++ b/pkg/driver/ac/errors_darwin.go
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ac
+
+import "errors"
+
+var errUnimplemented = errors.New("unimplemented")

--- a/pkg/driver/ac/fs.go
+++ b/pkg/driver/ac/fs.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ac
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/fileutils"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+)
+
+// EnsureFs downloads the root fs.
+func EnsureFs(ctx context.Context, inst *limatype.Instance) error {
+	baseDisk := filepath.Join(inst.Dir, filenames.BaseDiskLegacy)
+	if _, err := os.Stat(baseDisk); errors.Is(err, os.ErrNotExist) {
+		var ensuredBaseDisk bool
+		errs := make([]error, len(inst.Config.Images))
+		for i, f := range inst.Config.Images {
+			if _, err := fileutils.DownloadFile(ctx, baseDisk, f.File, true, "the image", *inst.Config.Arch, nil); err != nil {
+				errs[i] = err
+				continue
+			}
+			ensuredBaseDisk = true
+			break
+		}
+		if !ensuredBaseDisk {
+			return fileutils.Errors(errs)
+		}
+	}
+	logrus.Info("Download succeeded")
+
+	return nil
+}

--- a/pkg/driver/ac/lima-init.TEMPLATE
+++ b/pkg/driver/ac/lima-init.TEMPLATE
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eu
+export LOG_FILE=/var/log/lima-init.log
+exec > >(tee $LOG_FILE) 2>&1
+ln -sf rtc0 /dev/rtc
+chmod 666 /dev/fuse
+export LIMA_CIDATA_MNT="{{.CIDataPath}}"
+exec "$LIMA_CIDATA_MNT/boot.sh"

--- a/pkg/driver/ac/vm_darwin.go
+++ b/pkg/driver/ac/vm_darwin.go
@@ -1,0 +1,285 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ac
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/textutil"
+)
+
+// createVM calls AC to create a VM.
+func createVM(ctx context.Context, distroName string, cpus, memory int, initSystem string) error {
+	imageName := distroName
+	entrypoint := "/sbin/init"
+	// /sbin/init is normally just a symlink to systemd
+	// eventually we might want to look inside the image
+	switch initSystem {
+	case "systemd":
+		entrypoint = "/lib/systemd/systemd"
+	case "openrc":
+		entrypoint = "/sbin/openrc-init"
+	default:
+		logrus.Infof("unknown init system, running only vminitd")
+	}
+	out, err := exec.CommandContext(ctx,
+		"container",
+		"create",
+		"--name",
+		distroName,
+		"--cpus",
+		fmt.Sprintf("%d", cpus),
+		"--memory",
+		fmt.Sprintf("%dM", memory),
+		"--entrypoint",
+		entrypoint,
+		imageName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `container create %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+// startVM calls AC to start a VM.
+func startVM(ctx context.Context, distroName string) error {
+	out, err := exec.CommandContext(ctx,
+		"container",
+		"start",
+		distroName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `container start %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+// initVM calls AC to import a new VM specifically for Lima.
+func initVM(ctx context.Context, instanceDir, distroName string) error {
+	imageName := distroName
+	baseDisk := filepath.Join(instanceDir, filenames.BaseDiskLegacy)
+	logrus.Infof("Importing distro from %q to %q", baseDisk, imageName)
+	out, err := exec.CommandContext(ctx,
+		"container",
+		"image",
+		"import",
+		baseDisk,
+		imageName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `container image import %s %s`: %w (out=%q)",
+			baseDisk, imageName, err, out)
+	}
+	return nil
+}
+
+// stopVM calls AC to stop a running VM.
+func stopVM(ctx context.Context, distroName string) error {
+	out, err := exec.CommandContext(ctx,
+		"container",
+		"stop",
+		distroName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `container stop %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+//go:embed lima-init.TEMPLATE
+var limaBoot string
+
+// copyDir copies a directory.
+func copyDir(ctx context.Context, distroName, src, dst string) error {
+	cmd := exec.CommandContext(ctx, "container", "exec", distroName, "mkdir", "-p", dst)
+	if err := cmd.Run(); err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			logrus.Debugf("run stderr: %s", exiterr.Stderr)
+		}
+		return fmt.Errorf("failed to run %v: %w", cmd.Args, err)
+	}
+	logrus.Infof("Copying directory from %q to \"%s:%s\"", src, distroName, dst)
+	tar1 := exec.CommandContext(ctx, "tar", "Cc", src, ".")
+	tar2 := exec.CommandContext(ctx, "container", "exec", "-i", distroName, "tar", "Cx", dst)
+
+	p, err := tar1.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	tar2.Stdin = p
+	if err := tar2.Start(); err != nil {
+		return err
+	}
+	if err := tar1.Run(); err != nil {
+		return err
+	}
+	if err := tar2.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// provisionVM starts Lima's boot process inside an already imported VM.
+func provisionVM(ctx context.Context, instanceDir, instanceName, distroName string, errCh chan<- error) error {
+	ciDataPath := filepath.Join(instanceDir, filenames.CIDataISODir)
+	// can't mount the cidata, due to problems with virtiofs mounts
+	if err := copyDir(ctx, distroName, ciDataPath, "/mnt/lima-cidata"); err != nil {
+		return fmt.Errorf("failed to copy cidata directory: %w", err)
+	}
+	m := map[string]string{
+		"CIDataPath": "/mnt/lima-cidata",
+	}
+	limaBootB, err := textutil.ExecuteTemplate(limaBoot, m)
+	if err != nil {
+		return fmt.Errorf("failed to construct ac boot.sh script: %w", err)
+	}
+	go func() {
+		cmd := exec.CommandContext(
+			ctx,
+			"container",
+			"exec",
+			"-i",
+			distroName,
+			"/bin/bash",
+		)
+		cmd.Stdin = bytes.NewReader(limaBootB)
+		out, err := cmd.CombinedOutput()
+		logrus.Debugf("%v: %q", cmd.Args, string(out))
+		if err != nil {
+			errCh <- fmt.Errorf(
+				"error running command that executes boot.sh (%v): %w, "+
+					"check /var/log/lima-init.log for more details (out=%q)", cmd.Args, err, string(out))
+		}
+
+		<-ctx.Done()
+		logrus.Info("Context closed, stopping vm")
+		if status, err := getAcStatus(context.Background(), instanceName); err == nil &&
+			status == limatype.StatusRunning {
+			_ = stopVM(context.Background(), distroName)
+		}
+	}()
+
+	return err
+}
+
+// deleteVM calls AC to delete a VM.
+func deleteVM(ctx context.Context, distroName string) error {
+	imageName := distroName
+	logrus.Info("Deleting AC VM")
+	out, err := exec.CommandContext(ctx,
+		"container",
+		"rm",
+		"-f",
+		distroName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `container rm -f %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	out, err = exec.CommandContext(ctx,
+		"container",
+		"image",
+		"rm",
+		imageName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `container image rm %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+type Network struct {
+	Address  string `json:"address"`
+	Gateway  string `json:"gateway"`
+	Hostname string `json:"hostname"`
+	Network  string `json:"network"`
+}
+
+type Container struct {
+	Status   string         `json:"status"`
+	Config   map[string]any `json:"configuration"`
+	Networks []Network      `json:"networks,omitempty"`
+}
+
+// listContainers returns all containers in the system.
+//
+// but currently there is _no_ way to filter in the list.
+// so we need to loop through all of them in the client.
+func listContainers(ctx context.Context) ([]Container, error) {
+	out, err := exec.CommandContext(
+		ctx,
+		"container",
+		"list",
+		"--format=json",
+	).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run `container list --format=json`, err: %w (out=%q)", err, out)
+	}
+
+	var list []Container
+	err = json.Unmarshal(out, &list)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json output, err: %w (out=%q)", err, out)
+	}
+	return list, nil
+}
+
+func getAcStatus(ctx context.Context, instName string) (string, error) {
+	distroName := "lima-" + instName
+	list, err := listContainers(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	instState := limatype.StatusUninitialized
+	for _, c := range list {
+		// container don't have real ID
+		// (any --name replaces the UUID)
+		if c.Config["id"] == distroName {
+			switch c.Status {
+			case "stopped":
+				instState = limatype.StatusStopped
+			case "running":
+				instState = limatype.StatusRunning
+			default:
+				instState = limatype.StatusUnknown
+			}
+			break
+		}
+	}
+
+	return instState, nil
+}
+
+func getSSHAddress(ctx context.Context, instName string) (string, error) {
+	distroName := "lima-" + instName
+	list, err := listContainers(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	instAddress := "127.0.0.1"
+	for _, c := range list {
+		// container don't have real ID
+		// (any --name replaces the UUID)
+		if c.Config["id"] == distroName {
+			if len(c.Networks) > 0 {
+				instAddress = c.Networks[0].Address
+			}
+			break
+		}
+	}
+
+	return strings.Replace(instAddress, "/24", "", 1), nil
+}

--- a/pkg/driver/dc/dc_driver_linux.go
+++ b/pkg/driver/dc/dc_driver_linux.go
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dc
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/driver"
+	"github.com/lima-vm/lima/v2/pkg/driverutil"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/ptr"
+)
+
+const Enabled = true
+
+type LimaDcDriver struct {
+	Instance *limatype.Instance
+
+	SSHLocalPort int
+	vSockPort    int
+	virtioPort   string
+}
+
+var _ driver.Driver = (*LimaDcDriver)(nil)
+
+func New() *LimaDcDriver {
+	return &LimaDcDriver{
+		vSockPort:  0,
+		virtioPort: "",
+	}
+}
+
+func (l *LimaDcDriver) Configure(_ context.Context, inst *limatype.Instance) (*driver.ConfiguredDriver, error) {
+	l.Instance = inst
+	l.SSHLocalPort = inst.SSHLocalPort
+
+	return &driver.ConfiguredDriver{
+		Driver: l,
+	}, nil
+}
+
+func (l *LimaDcDriver) FillConfig(ctx context.Context, cfg *limatype.LimaYAML, _ string) error {
+	if cfg.VMType == nil {
+		cfg.VMType = ptr.Of(limatype.DC)
+	}
+	return validateConfig(ctx, cfg)
+}
+
+func (l *LimaDcDriver) Validate(ctx context.Context) error {
+	return validateConfig(ctx, l.Instance.Config)
+}
+
+func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
+	return driverutil.ValidateContainerDriverConfig(cfg, "dc", []limatype.MountType{limatype.REVSSHFS})
+}
+
+func (l *LimaDcDriver) BootScripts(_ context.Context) (map[string][]byte, error) {
+	return nil, nil
+}
+
+func (l *LimaDcDriver) InspectStatus(ctx context.Context, inst *limatype.Instance) string {
+	status, err := getDcStatus(ctx, inst.Name)
+	if err != nil {
+		inst.Status = limatype.StatusBroken
+		inst.Errors = append(inst.Errors, err)
+	} else {
+		inst.Status = status
+	}
+
+	inst.SSHLocalPort = 22
+
+	if inst.Status == limatype.StatusRunning {
+		sshAddr, err := getSSHAddress(ctx, inst.Name)
+		if err == nil {
+			inst.SSHAddress = sshAddr
+		} else {
+			inst.Errors = append(inst.Errors, err)
+		}
+	}
+
+	return inst.Status
+}
+
+func (l *LimaDcDriver) Delete(ctx context.Context) error {
+	distroName := "lima-" + l.Instance.Name
+	status, err := getDcStatus(ctx, l.Instance.Name)
+	if err != nil {
+		return err
+	}
+	switch status {
+	case limatype.StatusRunning, limatype.StatusStopped, limatype.StatusBroken, limatype.StatusInstalling:
+		return deleteVM(ctx, distroName)
+	}
+
+	logrus.Info("AC VM is not running or does not exist, skipping deletion")
+	return nil
+}
+
+func (l *LimaDcDriver) Start(ctx context.Context) (chan error, error) {
+	logrus.Infof("Starting DC VM")
+	status, err := getDcStatus(ctx, l.Instance.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	distroName := "lima-" + l.Instance.Name
+
+	if status == limatype.StatusUninitialized {
+		if err := EnsureFs(ctx, l.Instance); err != nil {
+			return nil, err
+		}
+		if err := initVM(ctx, l.Instance.Dir, distroName); err != nil {
+			return nil, err
+		}
+		cpus := l.Instance.CPUs
+		memory := int(l.Instance.Memory >> 20) // MiB
+		baseDisk := filepath.Join(l.Instance.Dir, filenames.BaseDiskLegacy)
+		initSystem := driverutil.DetectInitSystem(ctx, baseDisk)
+		if err := createVM(ctx, distroName, cpus, memory, initSystem, *l.Instance.Config.User.Name); err != nil {
+			return nil, err
+		}
+	}
+
+	errCh := make(chan error)
+
+	if err := startVM(ctx, distroName); err != nil {
+		return nil, err
+	}
+
+	if err := provisionVM(
+		ctx,
+		l.Instance.Dir,
+		l.Instance.Name,
+		distroName,
+		errCh,
+	); err != nil {
+		return nil, err
+	}
+
+	return errCh, err
+}
+
+func (l *LimaDcDriver) canRunGUI() bool {
+	return false
+}
+
+func (l *LimaDcDriver) RunGUI(_ context.Context) error {
+	return fmt.Errorf("RunGUI is not supported for the given driver '%s' and display '%s'", "dc", *l.Instance.Config.Video.Display)
+}
+
+func (l *LimaDcDriver) Stop(ctx context.Context) error {
+	logrus.Info("Shutting down DC VM")
+	distroName := "lima-" + l.Instance.Name
+	return stopVM(ctx, distroName)
+}
+
+// GuestAgentConn returns the guest agent connection, or nil (if forwarded by ssh).
+func (l *LimaDcDriver) GuestAgentConn(_ context.Context) (net.Conn, string, error) {
+	return nil, "unix", nil
+}
+
+func (l *LimaDcDriver) Info(_ context.Context) driver.Info {
+	var info driver.Info
+	info.Name = "dc"
+	if l.Instance != nil {
+		info.InstanceDir = l.Instance.Dir
+	}
+	info.VirtioPort = l.virtioPort
+	info.VsockPort = l.vSockPort
+
+	info.Features = driver.DriverFeatures{
+		DynamicSSHAddress:    true,
+		StaticSSHPort:        true,
+		SkipSocketForwarding: true,
+		NoCloudInit:          true,
+		CanRunGUI:            l.canRunGUI(),
+	}
+	return info
+}
+
+func (l *LimaDcDriver) SSHAddress(ctx context.Context) (string, error) {
+	return getSSHAddress(ctx, l.Instance.Name)
+}
+
+func (l *LimaDcDriver) Create(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaDcDriver) CreateDisk(_ context.Context) error {
+	return nil
+}
+
+func (l *LimaDcDriver) ChangeDisplayPassword(_ context.Context, _ string) error {
+	return nil
+}
+
+func (l *LimaDcDriver) DisplayConnection(_ context.Context) (string, error) {
+	return "", nil
+}
+
+func (l *LimaDcDriver) CreateSnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaDcDriver) ApplySnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaDcDriver) DeleteSnapshot(_ context.Context, _ string) error {
+	return errUnimplemented
+}
+
+func (l *LimaDcDriver) ListSnapshots(_ context.Context) (string, error) {
+	return "", errUnimplemented
+}
+
+func (l *LimaDcDriver) ForwardGuestAgent(_ context.Context) bool {
+	// If driver is not providing, use host agent
+	return l.vSockPort == 0 && l.virtioPort == ""
+}
+
+func (l *LimaDcDriver) AdditionalSetupForSSH(_ context.Context) error {
+	return nil
+}

--- a/pkg/driver/dc/errors_linux.go
+++ b/pkg/driver/dc/errors_linux.go
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dc
+
+import "errors"
+
+var errUnimplemented = errors.New("unimplemented")

--- a/pkg/driver/dc/fs.go
+++ b/pkg/driver/dc/fs.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dc
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/fileutils"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+)
+
+// EnsureFs downloads the root fs.
+func EnsureFs(ctx context.Context, inst *limatype.Instance) error {
+	baseDisk := filepath.Join(inst.Dir, filenames.BaseDiskLegacy)
+	if _, err := os.Stat(baseDisk); errors.Is(err, os.ErrNotExist) {
+		var ensuredBaseDisk bool
+		errs := make([]error, len(inst.Config.Images))
+		for i, f := range inst.Config.Images {
+			if _, err := fileutils.DownloadFile(ctx, baseDisk, f.File, true, "the image", *inst.Config.Arch, nil); err != nil {
+				errs[i] = err
+				continue
+			}
+			ensuredBaseDisk = true
+			break
+		}
+		if !ensuredBaseDisk {
+			return fileutils.Errors(errs)
+		}
+	}
+	logrus.Info("Download succeeded")
+
+	return nil
+}

--- a/pkg/driver/dc/lima-init.TEMPLATE
+++ b/pkg/driver/dc/lima-init.TEMPLATE
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+export LOG_FILE=/var/log/lima-init.log
+exec > >(tee $LOG_FILE) 2>&1
+export LIMA_CIDATA_MNT="{{.CIDataPath}}"
+exec "$LIMA_CIDATA_MNT/boot.sh"

--- a/pkg/driver/dc/vm_linux.go
+++ b/pkg/driver/dc/vm_linux.go
@@ -21,7 +21,9 @@ import (
 )
 
 // OCI runtime for container.
-const ociRuntime = "io.containerd.kata.v2"
+const (
+	ociRuntime = "runc"
+)
 
 // createVM calls DC to create a VM.
 func createVM(ctx context.Context, distroName string, cpus, memory int, initSystem, guestUser string) error {

--- a/pkg/driver/dc/vm_linux.go
+++ b/pkg/driver/dc/vm_linux.go
@@ -1,0 +1,304 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dc
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/textutil"
+)
+
+// OCI runtime for container.
+const ociRuntime = "io.containerd.kata.v2"
+
+// createVM calls DC to create a VM.
+func createVM(ctx context.Context, distroName string, cpus, memory int, initSystem, guestUser string) error {
+	imageName := distroName
+	args := []string{
+		"create",
+		"--name",
+		distroName,
+		"--cpus",
+		fmt.Sprintf("%d", cpus),
+		"--memory",
+		fmt.Sprintf("%d", int64(memory)<<20),
+		"--runtime",
+		ociRuntime,
+		"--tmpfs",
+		"/run", // for systemd (and openrc)
+		"--tmpfs",
+		fmt.Sprintf("/home/%s.guest/.local/share/containerd", guestUser),
+		"--tmpfs",
+		fmt.Sprintf("/home/%s.guest/.local/share/containerd-stargz-grpc", guestUser),
+		"--tmpfs",
+		fmt.Sprintf("/home/%s.guest/.local/share/buildkit", guestUser),
+		"-v", "/dev/null:/lib/systemd/system/systemd-logind.service",
+	}
+	// /sbin/init is normally just a symlink to systemd
+	// eventually we might want to look inside the image
+	// note: docker does not seem to resolve symlinks here
+	// so need to give canonical path, after resolving root
+	switch initSystem {
+	case "systemd":
+		args = append(args,
+			"--privileged",
+			"--cgroupns=host",
+			"--tmpfs", "/run/lock",
+			"--entrypoint", "/usr/lib/systemd/systemd",
+			imageName,
+		)
+	case "openrc":
+		args = append(args,
+			"--entrypoint", "/usr/sbin/openrc-init",
+			imageName,
+		)
+	default:
+		args = append(args,
+			"--init",
+			imageName,
+		)
+	}
+	args = append(args, "sleep", "infinity")
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `docker create %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+// startVM calls DC to start a VM.
+func startVM(ctx context.Context, distroName string) error {
+	out, err := exec.CommandContext(ctx,
+		"docker",
+		"start",
+		distroName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `docker start %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+// initVM calls DC to import a new VM specifically for Lima.
+func initVM(ctx context.Context, instanceDir, distroName string) error {
+	imageName := distroName
+	baseDisk := filepath.Join(instanceDir, filenames.BaseDiskLegacy)
+	logrus.Infof("Importing distro from %q to %q", baseDisk, instanceDir)
+	out, err := exec.CommandContext(ctx,
+		"docker",
+		"import",
+		baseDisk,
+		imageName,
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `docker import %s %s`: %w (out=%q)",
+			baseDisk, imageName, err, out)
+	}
+	return nil
+}
+
+// stopVM calls DC to stop a running VM.
+func stopVM(ctx context.Context, distroName string) error {
+	out, err := exec.CommandContext(ctx,
+		"docker",
+		"stop",
+		distroName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `docker stop %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+//go:embed lima-init.TEMPLATE
+var limaBoot string
+
+func dockerExecCmd(ctx context.Context, arg ...string) *exec.Cmd {
+	// "RunQ does not support 'docker exec'. Use 'runq-exec' instead."
+	if ociRuntime == "runq" {
+		runqExec := "/var/lib/runq/runq-exec"
+		args := append([]string{runqExec}, arg...)
+		time.Sleep(100 * time.Millisecond)
+		return exec.CommandContext(ctx, "sudo", args...)
+	}
+	args := append([]string{"exec"}, arg...)
+	return exec.CommandContext(ctx, "docker", args...)
+}
+
+// copyDir copies a directory.
+func copyDir(ctx context.Context, distroName, src, dst string) error {
+	cmd := dockerExecCmd(ctx, distroName, "mkdir", "-p", dst)
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	if err := cmd.Run(); err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			logrus.Debugf("run stderr: %s", exiterr.Stderr)
+		}
+		stderr := stderrBuf.String()
+		return fmt.Errorf("failed to run %v: %w %s", cmd.Args, err, stderr)
+	}
+	logrus.Infof("Copying directory from %q to \"%s:%s\"", src, distroName, dst)
+
+	tar1 := exec.CommandContext(ctx, "tar", "Cc", src, ".")
+	tar2 := dockerExecCmd(ctx, "-i", distroName, "tar", "Cx", dst)
+
+	p, err := tar1.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	tar2.Stdin = p
+	if err := tar2.Start(); err != nil {
+		return err
+	}
+	if err := tar1.Run(); err != nil {
+		return err
+	}
+	if err := tar2.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// provisionVM starts Lima's boot process inside an already imported VM.
+func provisionVM(ctx context.Context, instanceDir, instanceName, distroName string, errCh chan<- error) error {
+	ciDataPath := filepath.Join(instanceDir, filenames.CIDataISODir)
+	// can't mount the cidata, due to problems with virtiofs mounts
+	if err := copyDir(ctx, distroName, ciDataPath, "/mnt/lima-cidata"); err != nil {
+		return fmt.Errorf("failed to copy cidata directory: %w", err)
+	}
+	m := map[string]string{
+		"CIDataPath": "/mnt/lima-cidata",
+	}
+	limaBootB, err := textutil.ExecuteTemplate(limaBoot, m)
+	if err != nil {
+		return fmt.Errorf("failed to construct dc boot.sh script: %w", err)
+	}
+	go func() {
+		cmd := dockerExecCmd(
+			ctx,
+			"-i",
+			distroName,
+			"/bin/bash",
+		)
+		cmd.Stdin = bytes.NewReader(limaBootB)
+		out, err := cmd.CombinedOutput()
+		logrus.Debugf("%v: %q", cmd.Args, string(out))
+		if err != nil {
+			errCh <- fmt.Errorf(
+				"error running command that executes boot.sh (%v): %w, "+
+					"check /var/log/lima-init.log for more details (out=%q)", cmd.Args, err, string(out))
+		}
+
+		<-ctx.Done()
+		logrus.Info("Context closed, stopping vm")
+		if status, err := getDcStatus(context.Background(), instanceName); err == nil &&
+			status == limatype.StatusRunning {
+			_ = stopVM(context.Background(), distroName)
+		}
+	}()
+
+	return err
+}
+
+// deleteVM calls DC to delete a VM.
+func deleteVM(ctx context.Context, distroName string) error {
+	imageName := distroName
+	logrus.Info("Deleting DC VM")
+	out, err := exec.CommandContext(ctx,
+		"docker",
+		"rm",
+		"-f",
+		distroName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `docker rm -f %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	out, err = exec.CommandContext(ctx,
+		"docker",
+		"image",
+		"rm",
+		imageName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `docker image rm %s`: %w (out=%q)",
+			distroName, err, out)
+	}
+	return nil
+}
+
+func inspectContainer(ctx context.Context, distroName, format string) (string, error) {
+	out, err := exec.CommandContext(
+		ctx,
+		"docker",
+		"inspect",
+		"--format="+format,
+		distroName,
+	).CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(out), fmt.Sprintf("No such object: %s", distroName)) ||
+			strings.Contains(string(out), fmt.Sprintf("no such object: %s", distroName)) {
+			return "", nil
+		}
+		if strings.Contains(string(out), "map has no entry for key") {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to run `docker inspect`, err: %w (out=%q)", err, out)
+	}
+	return strings.TrimSuffix(string(out), "\n"), nil
+}
+
+func getDcStatus(ctx context.Context, instName string) (string, error) {
+	distroName := "lima-" + instName
+	out, err := inspectContainer(ctx, distroName, "{{ .State.Status }}")
+	if err != nil {
+		return "", err
+	}
+	if out == "" {
+		return limatype.StatusUninitialized, nil
+	}
+
+	var instState string
+	switch out {
+	case "exited":
+		instState = limatype.StatusStopped
+	case "running":
+		instState = limatype.StatusRunning
+	default:
+		instState = limatype.StatusUnknown
+	}
+
+	return instState, nil
+}
+
+func getSSHAddress(ctx context.Context, instName string) (string, error) {
+	distroName := "lima-" + instName
+	out, err := inspectContainer(ctx, distroName, "{{ .NetworkSettings.IPAddress }}")
+	if err != nil {
+		return "", err
+	}
+	if out == "" {
+		out, err = inspectContainer(ctx, distroName, "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}")
+		if err != nil {
+			return "", err
+		}
+	}
+	if out == "" {
+		return "127.0.0.1", nil
+	}
+
+	instAddress := out
+
+	return instAddress, nil
+}

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -5,47 +5,20 @@ package wsl2
 
 import (
 	"context"
-	"embed"
-	"errors"
 	"fmt"
 	"net"
-	"regexp"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/sirupsen/logrus"
 
 	"github.com/lima-vm/lima/v2/pkg/driver"
+	"github.com/lima-vm/lima/v2/pkg/driverutil"
 	"github.com/lima-vm/lima/v2/pkg/freeport"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/ptr"
-	"github.com/lima-vm/lima/v2/pkg/reflectutil"
 	"github.com/lima-vm/lima/v2/pkg/windows"
 )
-
-var knownYamlProperties = []string{
-	"Arch",
-	"Containerd",
-	"CopyToHost",
-	"CPUType",
-	"Disk",
-	"DNS",
-	"Env",
-	"HostResolver",
-	"Images",
-	"Message",
-	"Mounts",
-	"MountType",
-	"Param",
-	"Plain",
-	"PortForwards",
-	"Probes",
-	"PropagateProxyEnv",
-	"Provision",
-	"SSH",
-	"TPM",
-	"VMType",
-}
 
 const Enabled = true
 
@@ -96,109 +69,11 @@ func (l *LimaWslDriver) Validate(ctx context.Context) error {
 }
 
 func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
-	if cfg == nil {
-		return errors.New("configuration is nil")
-	}
-	if cfg.MountType != nil && *cfg.MountType != limatype.WSLMount {
-		return fmt.Errorf("field `mountType` must be %#q for WSL2 driver, got %#q", limatype.WSLMount, *cfg.MountType)
-	}
-	// TODO: revise this list for WSL2
-	if cfg.VMType != nil {
-		if unknown := reflectutil.UnknownNonEmptyFields(cfg, knownYamlProperties...); len(unknown) > 0 {
-			logrus.Warnf("Ignoring: vmType %s: %+v", *cfg.VMType, unknown)
-		}
-	}
-
-	if cfg.OS != nil && *cfg.OS == limatype.WINDOWS {
-		return errors.New("currently Windows guest OS is only supported on QEMU")
-	}
-
-	if !limatype.IsNativeArch(*cfg.Arch) {
-		return fmt.Errorf("unsupported arch: %#q", *cfg.Arch)
-	}
-
-	if cfg.TPM != nil && *cfg.TPM {
-		return errors.New("field `tpm` is not supported on WSL2 driver")
-	}
-
-	if cfg.VMType != nil {
-		if cfg.Images != nil && cfg.Arch != nil {
-			// TODO: real filetype checks
-			tarFileRegex := regexp.MustCompile(`\.(tar|tgz|txz|tbz2|tzst|tar\.(gz|xz|bz2|zstd|zst))$`)
-			unsupportedVMImgRegex := regexp.MustCompile(`\.(qcow2|raw|img|iso|ipsw)(\.(gz|xz|bz2|zstd|zst))?$`)
-			squashfsRegex := regexp.MustCompile(`\.squashfs(\.(gz|xz|bz2|zstd|zst))?$`)
-			for i, image := range cfg.Images {
-				if unknown := reflectutil.UnknownNonEmptyFields(image, "File", "Variant"); len(unknown) > 0 {
-					logrus.Warnf("Ignoring: vmType %s: images[%d]: %+v", *cfg.VMType, i, unknown)
-				}
-				if image.Arch == *cfg.Arch {
-					location := image.Location
-					if !tarFileRegex.MatchString(location) {
-						if unsupportedVMImgRegex.MatchString(location) {
-							return fmt.Errorf("unsupported image type for %s: %q. %s only supports importing tar archive root filesystems, not standard VM disk images", *cfg.VMType, location, *cfg.VMType)
-						}
-						if squashfsRegex.MatchString(location) {
-							return fmt.Errorf("unsupported image type for %s: %q. %s does not natively support importing SquashFS images; please convert the image to a tar archive before importing", *cfg.VMType, location, *cfg.VMType)
-						}
-						return fmt.Errorf("unsupported image type for %s: %q. A tar archive root filesystem (.tar, .tar.gz, .tar.xz, etc.) is required", *cfg.VMType, location)
-					}
-				}
-			}
-		}
-
-		if cfg.Mounts != nil {
-			for i, mount := range cfg.Mounts {
-				if unknown := reflectutil.UnknownNonEmptyFields(mount); len(unknown) > 0 {
-					logrus.Warnf("Ignoring: vmType %s: mounts[%d]: %+v", *cfg.VMType, i, unknown)
-				}
-			}
-		}
-
-		if cfg.Networks != nil {
-			for i, network := range cfg.Networks {
-				if unknown := reflectutil.UnknownNonEmptyFields(network); len(unknown) > 0 {
-					logrus.Warnf("Ignoring: vmType %s: networks[%d]: %+v", *cfg.VMType, i, unknown)
-				}
-			}
-		}
-
-		if cfg.Audio.Device != nil {
-			audioDevice := *cfg.Audio.Device
-			if audioDevice != "" {
-				logrus.Warnf("Ignoring: vmType %s: `audio.device`: %+v", *cfg.VMType, audioDevice)
-			}
-		}
-	}
-
-	return nil
+	return driverutil.ValidateContainerDriverConfig(cfg, "wsl2", []limatype.MountType{limatype.WSLMount})
 }
 
-//go:embed boot.Linux/*.sh
-var bootLinuxFS embed.FS
-
 func (l *LimaWslDriver) BootScripts(_ context.Context) (map[string][]byte, error) {
-	scripts := make(map[string][]byte)
-
-	entries, err := bootLinuxFS.ReadDir("boot.Linux")
-	if err != nil {
-		return scripts, err
-	}
-
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		entryPath := "boot.Linux/" + entry.Name()
-
-		content, err := bootLinuxFS.ReadFile(entryPath)
-		if err != nil {
-			return nil, err
-		}
-
-		scripts[entryPath] = content
-	}
-
-	return scripts, nil
+	return nil, nil
 }
 
 func (l *LimaWslDriver) InspectStatus(ctx context.Context, inst *limatype.Instance) string {

--- a/pkg/driverutil/vm.go
+++ b/pkg/driverutil/vm.go
@@ -10,12 +10,16 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
+	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/ptr"
+	"github.com/lima-vm/lima/v2/pkg/reflectutil"
 	"github.com/lima-vm/lima/v2/pkg/registry"
 )
 
@@ -120,4 +124,148 @@ func handleInspectStatusAction(ctx context.Context, inst *limatype.Instance, ext
 	*inst = respInst
 	logrus.Debugf("Inspecting instance status action completed successfully for %#q", extDriverPath)
 	return inst.Status, nil
+}
+
+var knownContainerYamlProperties = []string{
+	"Arch",
+	"Audio",
+	"Containerd",
+	"CopyToHost",
+	"CPUType",
+	"Disk",
+	"DNS",
+	"Env",
+	"HostResolver",
+	"Images",
+	"Message",
+	"Mounts",
+	"MountType",
+	"Networks",
+	"OS",
+	"Param",
+	"Plain",
+	"PortForwards",
+	"Probes",
+	"PropagateProxyEnv",
+	"Provision",
+	"SSH",
+	"TPM",
+	"VMType",
+}
+
+// ValidateContainerDriverConfig validates the YAML config for container-based/rootfs-based drivers.
+func ValidateContainerDriverConfig(cfg *limatype.LimaYAML, driverName string, allowedMountTypes []limatype.MountType) error {
+	if cfg == nil {
+		return errors.New("configuration is nil")
+	}
+
+	if cfg.MountType == nil && len(allowedMountTypes) > 0 {
+		cfg.MountType = ptr.Of(allowedMountTypes[0])
+	}
+
+	if cfg.MountType != nil {
+		if !slices.Contains(allowedMountTypes, *cfg.MountType) {
+			if len(allowedMountTypes) == 1 {
+				return fmt.Errorf("field `mountType` must be %#q for %s driver, got %#q", allowedMountTypes[0], driverName, *cfg.MountType)
+			}
+			return fmt.Errorf("field `mountType` must be one of %v for %s driver, got %#q", allowedMountTypes, driverName, *cfg.MountType)
+		}
+	}
+
+	if cfg.VMType != nil {
+		if unknown := reflectutil.UnknownNonEmptyFields(cfg, knownContainerYamlProperties...); len(unknown) > 0 {
+			logrus.Warnf("Ignoring: vmType %s: %+v", *cfg.VMType, unknown)
+		}
+	}
+
+	if cfg.OS != nil && *cfg.OS != limatype.LINUX {
+		return fmt.Errorf("guest OS %q is not supported for %s driver; only Linux guest OS is supported", *cfg.OS, driverName)
+	}
+
+	if cfg.Arch != nil && !limatype.IsNativeArch(*cfg.Arch) {
+		return fmt.Errorf("unsupported arch: %#q", *cfg.Arch)
+	}
+
+	if cfg.TPM != nil && *cfg.TPM {
+		return fmt.Errorf("field `tpm` is not supported on %s driver", driverName)
+	}
+
+	if cfg.Images != nil && cfg.Arch != nil {
+		tarFileRegex := regexp.MustCompile(`\.(tar|tgz|txz|tbz2|tzst|tar\.(gz|xz|bz2|zstd|zst))$`)
+		unsupportedVMImgRegex := regexp.MustCompile(`\.(qcow2|raw|img|iso|ipsw)(\.(gz|xz|bz2|zstd|zst))?$`)
+		squashfsRegex := regexp.MustCompile(`\.squashfs(\.(gz|xz|bz2|zstd|zst))?$`)
+		for i, image := range cfg.Images {
+			if unknown := reflectutil.UnknownNonEmptyFields(image, "File", "Variant"); len(unknown) > 0 {
+				logrus.Warnf("Ignoring: vmType %s: images[%d]: %+v", driverName, i, unknown)
+			}
+			if image.Arch == *cfg.Arch {
+				location := image.Location
+				if !tarFileRegex.MatchString(location) {
+					if unsupportedVMImgRegex.MatchString(location) {
+						return fmt.Errorf("unsupported image type for %s: %q. %s only supports importing tar archive root filesystems, not standard VM disk images", driverName, location, driverName)
+					}
+					if squashfsRegex.MatchString(location) {
+						return fmt.Errorf("unsupported image type for %s: %q. %s does not natively support importing SquashFS images; please convert the image to a tar archive before importing", driverName, location, driverName)
+					}
+					return fmt.Errorf("unsupported image type for %s: %q. A tar archive root filesystem (.tar, .tar.gz, .tar.xz, etc.) is required", driverName, location)
+				}
+			}
+		}
+	}
+
+	if cfg.Mounts != nil {
+		for i, mount := range cfg.Mounts {
+			if unknown := reflectutil.UnknownNonEmptyFields(mount); len(unknown) > 0 {
+				logrus.Warnf("Ignoring: vmType %s: mounts[%d]: %+v", driverName, i, unknown)
+			}
+		}
+	}
+
+	if cfg.Networks != nil {
+		for i, network := range cfg.Networks {
+			if unknown := reflectutil.UnknownNonEmptyFields(network); len(unknown) > 0 {
+				logrus.Warnf("Ignoring: vmType %s: networks[%d]: %+v", driverName, i, unknown)
+			}
+		}
+	}
+
+	if cfg.Audio.Device != nil {
+		audioDevice := *cfg.Audio.Device
+		if audioDevice != "" {
+			logrus.Warnf("Ignoring: vmType %s: `audio.device`: %+v", driverName, audioDevice)
+		}
+	}
+
+	return nil
+}
+
+// DetectInitSystem detects the init system (systemd or openrc) in a tarball rootfs.
+func DetectInitSystem(ctx context.Context, baseDisk string) string {
+	baseDiskLower := strings.ToLower(filepath.Base(baseDisk))
+	if strings.Contains(baseDiskLower, "alpine") {
+		return "openrc"
+	}
+	if strings.Contains(baseDiskLower, "ubuntu") ||
+		strings.Contains(baseDiskLower, "debian") ||
+		strings.Contains(baseDiskLower, "fedora") ||
+		strings.Contains(baseDiskLower, "rocky") ||
+		strings.Contains(baseDiskLower, "alma") ||
+		strings.Contains(baseDiskLower, "centos") {
+		return "systemd"
+	}
+
+	cmd := exec.CommandContext(ctx, "tar", "-tf", baseDisk, "usr/lib/systemd/systemd", "lib/systemd/systemd", "sbin/openrc-init", "usr/sbin/openrc-init")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	_ = cmd.Run()
+
+	output := stdout.String()
+	if strings.Contains(output, "systemd/systemd") {
+		return "systemd"
+	}
+	if strings.Contains(output, "openrc-init") {
+		return "openrc"
+	}
+
+	return "systemd"
 }

--- a/pkg/driverutil/vm_test.go
+++ b/pkg/driverutil/vm_test.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package driverutil
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/ptr"
+)
+
+func TestValidateContainerDriverConfig(t *testing.T) {
+	vmType := limatype.DC
+	arch := limatype.X8664
+	linuxOS := limatype.LINUX
+	windowsOS := limatype.WINDOWS
+
+	tests := []struct {
+		name        string
+		cfg         *limatype.LimaYAML
+		expectedErr string
+	}{
+		{
+			name: "Valid DC config",
+			cfg: &limatype.LimaYAML{
+				VMType:    &vmType,
+				Arch:      &arch,
+				OS:        &linuxOS,
+				MountType: ptr.Of(limatype.REVSSHFS),
+				Images: []limatype.Image{
+					{
+						File: limatype.File{
+							Location: "rootfs.tar.gz",
+							Arch:     arch,
+						},
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "Invalid mount type for DC",
+			cfg: &limatype.LimaYAML{
+				VMType:    &vmType,
+				Arch:      &arch,
+				OS:        &linuxOS,
+				MountType: ptr.Of(limatype.NINEP),
+			},
+			expectedErr: "field `mountType` must be `reverse-sshfs` for dc driver, got `9p`",
+		},
+		{
+			name: "Invalid guest OS",
+			cfg: &limatype.LimaYAML{
+				VMType: &vmType,
+				Arch:   &arch,
+				OS:     &windowsOS,
+			},
+			expectedErr: "guest OS \"Windows\" is not supported for dc driver; only Linux guest OS is supported",
+		},
+		{
+			name: "TPM enabled error",
+			cfg: &limatype.LimaYAML{
+				VMType: &vmType,
+				Arch:   &arch,
+				OS:     &linuxOS,
+				TPM:    ptr.Of(true),
+			},
+			expectedErr: "field `tpm` is not supported on dc driver",
+		},
+		{
+			name: "Non-tarball image format error",
+			cfg: &limatype.LimaYAML{
+				VMType: &vmType,
+				Arch:   &arch,
+				OS:     &linuxOS,
+				Images: []limatype.Image{
+					{
+						File: limatype.File{
+							Location: "rootfs.qcow2",
+							Arch:     arch,
+						},
+					},
+				},
+			},
+			expectedErr: "unsupported image type for dc: \"rootfs.qcow2\". dc only supports importing tar archive root filesystems",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateContainerDriverConfig(tt.cfg, "dc", []limatype.MountType{limatype.REVSSHFS})
+			if tt.expectedErr == "" {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.expectedErr)
+			}
+		})
+	}
+}

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -99,14 +99,20 @@ const (
 	QEMU VMType = "qemu"
 	VZ   VMType = "vz"
 	WSL2 VMType = "wsl2"
+	AC   VMType = "ac"
+	DC   VMType = "dc"
 )
 
 var (
 	OSTypes    = []OS{LINUX, DARWIN, FREEBSD, WINDOWS}
 	ArchTypes  = []Arch{X8664, AARCH64, ARMV7L, PPC64LE, RISCV64, S390X}
 	MountTypes = []MountType{REVSSHFS, NINEP, VIRTIOFS, WSLMount}
-	VMTypes    = []VMType{QEMU, VZ, WSL2}
+	VMTypes    = []VMType{QEMU, VZ, WSL2, AC, DC}
 )
+
+func IsContainerDriver(vmType VMType) bool {
+	return vmType == WSL2 || vmType == AC || vmType == DC
+}
 
 type User struct {
 	Name             *string `yaml:"name,omitempty" json:"name,omitempty" jsonschema:"nullable"`

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -430,9 +430,9 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 		y.User.PasswordlessSudo != nil && *y.User.PasswordlessSudo {
 		errs = errors.Join(errs, errors.New("`user.passwordlessSudo: true` is not supported on macOS guests"))
 	}
-	if y.VMType != nil && *y.VMType == limatype.WSL2 &&
+	if y.VMType != nil && limatype.IsContainerDriver(*y.VMType) &&
 		y.User.PasswordlessSudo != nil && !*y.User.PasswordlessSudo {
-		errs = errors.Join(errs, errors.New("`user.passwordlessSudo: false` is not supported on WSL2 guest"))
+		errs = errors.Join(errs, fmt.Errorf("`user.passwordlessSudo: false` is not supported on %s guest", *y.VMType))
 	}
 	// GHSA-2j9v-p4xj-cjw2 constraint: require plain mode when passwordless sudo is disabled
 	if y.User.PasswordlessSudo != nil && !*y.User.PasswordlessSudo {

--- a/templates/experimental/ac.yaml
+++ b/templates/experimental/ac.yaml
@@ -1,0 +1,22 @@
+vmType: ac
+
+arch: aarch64
+cpus: 4
+memory: 1GiB
+disk: 512GiB
+
+images:
+- location: "https://partner-images.canonical.com/oci/noble/current/ubuntu-ubuntu-noble-oci-arm64-root.tar.gz"
+  arch: "aarch64"
+  digest: "sha256:fdc0d7e862272a3f341dc9b045b572ccb6ed9f78c2f2f1c19f4fdd0315e60ff2"
+
+mountType: virtiofs
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+
+containerd:
+  system: false
+  user: false

--- a/templates/experimental/dc.yaml
+++ b/templates/experimental/dc.yaml
@@ -1,0 +1,18 @@
+vmType: dc
+
+images:
+- location: "https://partner-images.canonical.com/oci/noble/current/ubuntu-ubuntu-noble-oci-amd64-root.tar.gz"
+  arch: "x86_64"
+  digest: "sha256:c7eda63e0f9d1be1ca5d34405e23b665fb749e1eccbe5f24a149d2e54197eb3c"
+- location: "https://partner-images.canonical.com/oci/noble/current/ubuntu-ubuntu-noble-oci-arm64-root.tar.gz"
+  arch: "aarch64"
+  digest: "sha256:fdc0d7e862272a3f341dc9b045b572ccb6ed9f78c2f2f1c19f4fdd0315e60ff2"
+
+# no native mounts yet
+mountType: reverse-sshfs
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+

--- a/website/content/en/docs/config/vmtype/ac.md
+++ b/website/content/en/docs/config/vmtype/ac.md
@@ -1,0 +1,9 @@
+---
+title: AC
+weight: 3
+---
+
+> **Warning**
+> "ac" option is experimental
+
+"ac" option makes use of Apple Container to run the guest OS.

--- a/website/content/en/docs/config/vmtype/dc.md
+++ b/website/content/en/docs/config/vmtype/dc.md
@@ -1,0 +1,9 @@
+---
+title: DC
+weight: 3
+---
+
+> **Warning**
+> "dc" option is experimental
+
+"dc" option makes use of Docker Container to run the guest OS.


### PR DESCRIPTION
## What This PR Changes

This PR implements Phase 3 of #5152 by unifying the WSL2, Apple Container (AC),
and Docker Container (DC) drivers under a shared container-driver framework.

<!-- **Scope note:** following discussion with maintainers, AC and DC are being moved
to a separate repository as external drivers (see discussion below). This PR
now covers the shared, in-tree pieces that WSL2 already depends on and that
AC/DC will consume as a Go module once split out. The AC/DC driver code and
templates are included here for reference/testing but may be removed from this
PR once the split repo is set up — happy to do that split now if preferred. -->

The work builds on the AC/DC drivers originally proposed in closed PR #3840
and consolidates common validation, configuration defaults, and provisioning
logic into reusable helpers, removing duplicated code across the three drivers.

### 1. Shared Container-Driver Validation
- Introduce `IsContainerDriver()` for identifying container-based drivers.
- Add `driverutil.ValidateContainerDriverConfig()` to centralize validation:
  Linux guest OS + native arch requirements, tarball rootfs validation, mount
  type defaults/validation, unsupported feature checks (e.g. TPM), warnings
  for unknown fields.
- Apply `user.passwordlessSudo: false` validation consistently across all
  container drivers (previously WSL2-only).

### 2. Shared Provisioning
- Move `02-no-cloud-init-setup.sh` into the shared Linux boot templates.
- Remove duplicated provisioning scripts from WSL2/AC/DC.
- Refactor all three drivers to use the shared provisioning path.
- Generate SSH host keys and reset systemd's crash-loop counter for `sshd`
  in the shared script, since NoCloudInit guests never go through cloud-init's
  normal host-key generation.

### 3. Driver Interface & VM Updates
- Update AC/DC `Configure()` to the current `driver.Driver` interface.
- Fix `DownloadFile()` calls (missing `supportedImageFormats` argument).
- Replace context-cancellation spin loops during VM teardown with a single
  cleanup path (previous code busy-looped on a closed channel).
- Fix `ga.sock` bind conflict between the external driver server and the
  hostagent by having `GuestAgentConn` report `"unix"` explicitly.

### 4. DC-Specific Fixes
- Resolve guest SSH address via Docker bridge network inspection instead of
  loopback (loopback doesn't route into the container's network namespace).
- Work around `/etc/hosts` rename failure on Docker's bind-mounted file by
  using `cat > /etc/hosts` instead of `sed -i`.
- **Needs reviewer attention:** to unblock rootlesskit under
  `kernel.apparmor_restrict_unprivileged_userns`, the boot script now mounts
  `securityfs` and loads a custom AppArmor profile into the *host* kernel from
  inside the container. This requires the outer container to run with
  elevated privileges by default. I want to flag this explicitly since it's a
  meaningfully different trust/permission model than the other drivers and
  deserves discussion before merging — see "Known issues" below for the
  overlay-on-overlay problem this is solving.
- Nested overlayfs (Docker's own storage driver + rootless containerd/stargz
  inside the guest) isn't supported by the kernel, so containerd/buildkit/
  stargz working directories are moved to tmpfs.

### 5. Build, Templates, and CI
- Enable AC by default on Darwin builds, DC on Linux builds.
- Update uninstall handling for external container drivers.
- Update template validation to recognize AC/DC.
- Pin experimental AC/DC templates to Ubuntu 24.04 rootfs images.
- Add CI coverage for the DC template.
- **Test-suite changes I want called out explicitly, not just diffed:**
  - `test-templates.sh` now accepts "degraded" systemd status as passing for
    container drivers (some services, e.g. TPM/root-mount units, can't run
    inside a container and are expected to fail there).
  - `dc` was removed from the list of VM types that force `sudo` for
    container-engine commands, since DC runs rootless by design.
  - `test-port-forwarding.pl` now resolves the guest's route IP dynamically
    and skips guest-IP-specific/IPv6 checks for external/container drivers,
    since those addresses aren't meaningful for DC's network setup.

## Linked Issue
Relates to #5152 

## How I Tested This
- `go test ./pkg/limayaml/... ./pkg/driverutil/... ./pkg/cidata/...`
- Added unit tests for `ValidateContainerDriverConfig()`.
- `make native ADDITIONAL_DRIVERS=dc`
- `./_output/bin/limactl validate templates/experimental/ac.yaml`
- `./_output/bin/limactl validate templates/experimental/dc.yaml`
- Manual `dc` instance boot/SSH/nerdctl smoke test on Ubuntu 24.04 host

## AI Usage
Assisted-by: Gemini 3.5