### PR TITLE
cidata: write password.txt without a UTF-8 BOM

### DIFF
--- a/pkg/cidata/wincidata.TEMPLATE.d/first_logon.ps1
+++ b/pkg/cidata/wincidata.TEMPLATE.d/first_logon.ps1
@@ -14,7 +14,9 @@ $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 $newPassword = -join ((1..16) | ForEach-Object { $chars[(Get-Random -Maximum $chars.Length)] })
 
 # Store the password under the user directory so that user can know/change it.
-$newPassword | Out-File -FilePath "C:\Users\{{.User}}\password.txt" -Encoding utf8 -NoNewline
+# Use ASCII encoding to avoid the UTF-8 BOM that Windows PowerShell's `Out-File -Encoding utf8`
+# prepends; the generated password only contains ASCII characters.
+$newPassword | Out-File -FilePath "C:\Users\{{.User}}\password.txt" -Encoding ascii -NoNewline
 
 # Change the password
 $username = $env:USERNAME


### PR DESCRIPTION
<!-- Please read our contribution rules before submitting:

- Pull requests guide: https://lima-vm.io/docs/community/contributing/#sending-pull-requests
- AI usage policy: https://lima-vm.io/docs/community/contributing/#ai-contribution-rules

-->

## What This PR Changes

<!-- Explain the single problem this PR fixes, in your own words. -->
On Windows guests, `first_logon.ps1` writes the generated login password to `~/password.txt` with `Out-File -Encoding utf8`. Under Windows PowerShell 5.1 (the engine that runs during first logon) that encoding prepends a UTF-8 byte-order mark (`EF BB BF`) to the file, so the stored password is preceded by three stray bytes. Since the generated password only uses ASCII characters (`a-zA-Z0-9`), switching to `-Encoding ascii` writes the value with no BOM. This also matches the neighboring `boot.done` write on line 83, which already uses `-Encoding ascii`.

## Linked Issue (Required in most cases)

<!-- Link the issue here. If your issue is not approved by a maintainer, don't expect your PR to be merged. -->

Closes #5277

## How I Tested This

The change is confined to the Windows-guest cidata template, which is only exercised by booting a Windows guest, so I could not run it in this environment. I confirmed by inspection that Windows PowerShell's `Out-File -Encoding utf8` emits a BOM while `-Encoding ascii` does not, and that the password charset on line 13 is ASCII-only, so `ascii` encodes it losslessly.

## AI Usage

<!-- If you used AI tools, say which tool and how you used it. For example, `Assisted-by: AI_AGENT_NAME:VERSION [TOOL]` or `Co-Authored-By`-->