### PR TITLE
cidata: fix UTF-8 BOM in Windows guest password.txt

### DIFF
--- a/pkg/cidata/wincidata.TEMPLATE.d/first_logon.ps1
+++ b/pkg/cidata/wincidata.TEMPLATE.d/first_logon.ps1
@@ -14,7 +14,7 @@ $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 $newPassword = -join ((1..16) | ForEach-Object { $chars[(Get-Random -Maximum $chars.Length)] })
 
 # Store the password under the user directory so that user can know/change it.
-$newPassword | Out-File -FilePath "C:\Users\{{.User}}\password.txt" -Encoding utf8 -NoNewline
+[System.IO.File]::WriteAllText("C:\Users\{{.User}}\password.txt", $newPassword, (New-Object System.Text.UTF8Encoding $false))
 
 # Change the password
 $username = $env:USERNAME


### PR DESCRIPTION
## What This PR Changes

`Out-File -Encoding utf8` prepends a UTF-8 BOM to `password.txt`. Fixed by using `[System.IO.File]::WriteAllText()` with `UTF8Encoding($false)` instead.

## Linked Issue

Closes #5277

## How I Tested This

Not tested on an actual Windows guest, raced the code path (confirmed PS 5.1 via `autounattend.xml`, confirmed no other code reads `password.txt`). Can test if pointed to a way to spin up the guest.

## AI Usage

Assisted by: Claude Sonnet 5, used to investigate, I have reviewed and understood before submitting.