### PR TITLE
pkg/ioutilx: move Windows path helpers to pkg/fsutil

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -25,8 +25,8 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/autostart"
 	"github.com/lima-vm/lima/v2/pkg/copytool"
 	"github.com/lima-vm/lima/v2/pkg/envutil"
+	"github.com/lima-vm/lima/v2/pkg/fsutil"
 	"github.com/lima-vm/lima/v2/pkg/instance"
-	"github.com/lima-vm/lima/v2/pkg/ioutilx"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limayaml"
 	"github.com/lima-vm/lima/v2/pkg/localpathutil"
@@ -784,9 +784,9 @@ func rsyncDirectory(ctx context.Context, cmd *cobra.Command, rsync copytool.Copy
 func mountDirFromWindowsDir(ctx context.Context, inst *limatype.Instance, dir string) (string, error) {
 	if inst.VMType == limatype.WSL2 {
 		distroName := "lima-" + inst.Name
-		return ioutilx.WindowsSubsystemPathForLinux(ctx, dir, distroName)
+		return fsutil.WindowsSubsystemPathForLinux(ctx, dir, distroName)
 	}
-	return ioutilx.WindowsSubsystemPath(ctx, dir)
+	return fsutil.WindowsSubsystemPath(ctx, dir)
 }
 
 func shellBashComplete(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/copytool/copytool.go
+++ b/pkg/copytool/copytool.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/lima-vm/lima/v2/pkg/ioutilx"
+	"github.com/lima-vm/lima/v2/pkg/fsutil"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/store"
 )
@@ -124,7 +124,7 @@ func parseCopyPaths(ctx context.Context, paths []string) ([]*Path, error) {
 		if runtime.GOOS == "windows" {
 			if filepath.IsAbs(path) {
 				var err error
-				path, err = ioutilx.WindowsSubsystemPath(ctx, path)
+				path, err = fsutil.WindowsSubsystemPath(ctx, path)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/fsutil/fsutil_unix.go
+++ b/pkg/fsutil/fsutil_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package fsutil
+
+import (
+	"context"
+	"errors"
+)
+
+// errWindowsPathConversionNotSupported is returned by the Windows path
+// conversion stubs below. Callers only invoke them behind a
+// runtime.GOOS == "windows" check, so this is never actually returned in
+// practice; it exists so the fsutil_windows.go API still compiles here.
+var errWindowsPathConversionNotSupported = errors.New("fsutil: Windows path conversion is not supported on this platform")
+
+// WindowsSubsystemPath is the non-Windows stub for the Windows-only
+// implementation in fsutil_windows.go.
+func WindowsSubsystemPath(_ context.Context, _ string) (string, error) {
+	return "", errWindowsPathConversionNotSupported
+}
+
+// WindowsSubsystemPathWithCygpath is the non-Windows stub for the
+// Windows-only implementation in fsutil_windows.go.
+func WindowsSubsystemPathWithCygpath(_ context.Context, _, _ string) (string, error) {
+	return "", errWindowsPathConversionNotSupported
+}
+
+// WindowsSubsystemPathForLinux is the non-Windows stub for the Windows-only
+// implementation in fsutil_windows.go.
+func WindowsSubsystemPathForLinux(_ context.Context, _, _ string) (string, error) {
+	return "", errWindowsPathConversionNotSupported
+}

--- a/pkg/fsutil/fsutil_windows.go
+++ b/pkg/fsutil/fsutil_windows.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package fsutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// WindowsSubsystemPath converts a Windows path to a Cygwin/MSYS form
+// (C:\Users\jan -> /c/Users/jan) via cygpath on PATH. A caller holding a
+// specific ssh toolchain should use WindowsSubsystemPathWithCygpath, which
+// runs that toolchain's own cygpath and respects its fstab.
+func WindowsSubsystemPath(ctx context.Context, orig string) (string, error) {
+	return WindowsSubsystemPathWithCygpath(ctx, "cygpath", orig)
+}
+
+// WindowsSubsystemPathWithCygpath converts a Windows path with the given
+// cygpathExe ("cygpath" for PATH, or an absolute path to bind the conversion
+// to one Cygwin install). When the cygpath binary is not found it falls back
+// to a native conversion of the absolute drive-letter case; a cygpath that
+// runs and fails returns its error, and non-drive-letter inputs (UNC, device,
+// extended-length) return an error.
+func WindowsSubsystemPathWithCygpath(ctx context.Context, cygpathExe, orig string) (string, error) {
+	out, err := exec.CommandContext(ctx, cygpathExe, filepath.ToSlash(orig)).CombinedOutput()
+	if err == nil {
+		return strings.TrimSpace(string(out)), nil
+	}
+	if !errors.Is(err, exec.ErrNotFound) && !errors.Is(err, fs.ErrNotExist) {
+		return "", fmt.Errorf("failed to run %#q on %#q: %#q: %w", cygpathExe, orig, strings.TrimSpace(string(out)), err)
+	}
+
+	logrus.WithError(err).Debugf("%#q not found for %#q, attempting native conversion", cygpathExe, orig)
+
+	return windowsSubsystemPathWithoutCygpath(orig)
+}
+
+func windowsSubsystemPathWithoutCygpath(orig string) (string, error) {
+	// The /c/... form this produces is the MSYS2 and Git-for-Windows
+	// convention; stock Cygwin defaults to /cygdrive/c/. Only an absolute
+	// drive-letter path ("C:\foo") has a well-defined form here. A
+	// drive-relative path ("C:foo") would become an unrelated absolute
+	// path, so reject it.
+	if !filepath.IsAbs(orig) {
+		return "", fmt.Errorf("cannot convert %#q to an MSYS-style path: input is not an absolute drive-letter path", orig)
+	}
+
+	// UNC path ("\\server\share\foo") is rejected here.
+	if vol := filepath.VolumeName(orig); len(vol) == 2 && vol[1] == ':' {
+		// orig[2:] starts with a separator for an absolute drive path
+		// (C:\foo, C:/foo); strip it so the result stays canonical.
+		tail := strings.TrimPrefix(filepath.ToSlash(orig[2:]), "/")
+		converted := "/" + strings.ToLower(vol[:1]) + "/" + tail
+		logrus.Debugf("native cygpath fallback: %#q -> %#q", orig, converted)
+		return converted, nil
+	}
+
+	return "", fmt.Errorf("cannot convert %#q to an MSYS-style path: input is not an absolute drive-letter path", orig)
+}
+
+// WindowsSubsystemPathForLinux converts a Windows path to the WSL form of
+// the given distro (e.g. C:\Users\jan -> /mnt/c/Users/jan) via wsl.exe.
+func WindowsSubsystemPathForLinux(ctx context.Context, orig, distro string) (string, error) {
+	out, err := exec.CommandContext(ctx, "wsl", "-d", distro, "--exec", "wslpath", filepath.ToSlash(orig)).CombinedOutput()
+	if err != nil {
+		logrus.WithError(err).Errorf("failed to convert path to mingw, maybe wsl command is not operational?")
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/pkg/fsutil/fsutil_windows_test.go
+++ b/pkg/fsutil/fsutil_windows_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright The Lima Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package ioutilx
+package fsutil
 
 import (
 	"strings"

--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -13,7 +13,7 @@ import (
 	"github.com/lima-vm/sshocker/pkg/reversesshfs"
 	"github.com/sirupsen/logrus"
 
-	"github.com/lima-vm/lima/v2/pkg/ioutilx"
+	"github.com/lima-vm/lima/v2/pkg/fsutil"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/sshutil"
 )
@@ -55,7 +55,7 @@ func (a *HostAgent) setupMount(ctx context.Context, m limatype.Mount) (*mount, e
 	resolvedLocation := m.Location
 	if runtime.GOOS == "windows" {
 		var err error
-		resolvedLocation, err = ioutilx.WindowsSubsystemPath(ctx, m.Location)
+		resolvedLocation, err = fsutil.WindowsSubsystemPath(ctx, m.Location)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ioutilx/ioutilx.go
+++ b/pkg/ioutilx/ioutilx.go
@@ -4,16 +4,10 @@
 package ioutilx
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
-	"os/exec"
-	"path/filepath"
-	"strings"
 
-	"github.com/sirupsen/logrus"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
@@ -49,64 +43,4 @@ func FromUTF16leToString(r io.Reader) (string, error) {
 	}
 
 	return string(out), nil
-}
-
-// WindowsSubsystemPath converts a Windows path to a Cygwin/MSYS form
-// (C:\Users\jan -> /c/Users/jan) via cygpath on PATH. A caller holding a
-// specific ssh toolchain should use WindowsSubsystemPathWithCygpath, which
-// runs that toolchain's own cygpath and respects its fstab.
-func WindowsSubsystemPath(ctx context.Context, orig string) (string, error) {
-	return WindowsSubsystemPathWithCygpath(ctx, "cygpath", orig)
-}
-
-// WindowsSubsystemPathWithCygpath converts a Windows path with the given
-// cygpathExe ("cygpath" for PATH, or an absolute path to bind the conversion
-// to one Cygwin install). When the cygpath binary is not found it falls back
-// to a native conversion of the absolute drive-letter case; a cygpath that
-// runs and fails returns its error, and non-drive-letter inputs (UNC, device,
-// extended-length) return an error.
-func WindowsSubsystemPathWithCygpath(ctx context.Context, cygpathExe, orig string) (string, error) {
-	out, err := exec.CommandContext(ctx, cygpathExe, filepath.ToSlash(orig)).CombinedOutput()
-	if err == nil {
-		return strings.TrimSpace(string(out)), nil
-	}
-	if !errors.Is(err, exec.ErrNotFound) && !errors.Is(err, fs.ErrNotExist) {
-		return "", fmt.Errorf("failed to run %#q on %#q: %#q: %w", cygpathExe, orig, strings.TrimSpace(string(out)), err)
-	}
-
-	logrus.WithError(err).Debugf("%#q not found for %#q, attempting native conversion", cygpathExe, orig)
-
-	return windowsSubsystemPathWithoutCygpath(orig)
-}
-
-func windowsSubsystemPathWithoutCygpath(orig string) (string, error) {
-	// The /c/... form this produces is the MSYS2 and Git-for-Windows
-	// convention; stock Cygwin defaults to /cygdrive/c/. Only an absolute
-	// drive-letter path ("C:\foo") has a well-defined form here. A
-	// drive-relative path ("C:foo") would become an unrelated absolute
-	// path, so reject it.
-	if !filepath.IsAbs(orig) {
-		return "", fmt.Errorf("cannot convert %#q to an MSYS-style path: input is not an absolute drive-letter path", orig)
-	}
-
-	// UNC path ("\\server\share\foo") is rejected here.
-	if vol := filepath.VolumeName(orig); len(vol) == 2 && vol[1] == ':' {
-		// orig[2:] starts with a separator for an absolute drive path
-		// (C:\foo, C:/foo); strip it so the result stays canonical.
-		tail := strings.TrimPrefix(filepath.ToSlash(orig[2:]), "/")
-		converted := "/" + strings.ToLower(vol[:1]) + "/" + tail
-		logrus.Debugf("native cygpath fallback: %#q -> %#q", orig, converted)
-		return converted, nil
-	}
-
-	return "", fmt.Errorf("cannot convert %#q to an MSYS-style path: input is not an absolute drive-letter path", orig)
-}
-
-func WindowsSubsystemPathForLinux(ctx context.Context, orig, distro string) (string, error) {
-	out, err := exec.CommandContext(ctx, "wsl", "-d", distro, "--exec", "wslpath", filepath.ToSlash(orig)).CombinedOutput()
-	if err != nil {
-		logrus.WithError(err).Errorf("failed to convert path to mingw, maybe wsl command is not operational?")
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
 }

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -26,8 +26,8 @@ import (
 	"github.com/pbnjay/memory"
 	"github.com/sirupsen/logrus"
 
+	"github.com/lima-vm/lima/v2/pkg/fsutil"
 	"github.com/lima-vm/lima/v2/pkg/instance/hostname"
-	"github.com/lima-vm/lima/v2/pkg/ioutilx"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
@@ -729,7 +729,7 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 			mountLocation := mount.Location
 			if runtime.GOOS == "windows" {
 				var err error
-				mountLocation, err = ioutilx.WindowsSubsystemPath(ctx, mountLocation)
+				mountLocation, err = fsutil.WindowsSubsystemPath(ctx, mountLocation)
 				if err != nil {
 					logrus.WithError(err).Warnf("Couldn't convert location %#q into mount target", mount.Location)
 				}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
 
-	"github.com/lima-vm/lima/v2/pkg/ioutilx"
+	"github.com/lima-vm/lima/v2/pkg/fsutil"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
@@ -240,7 +240,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Mounts = slices.Clone(y.Mounts)
 	expect.Mounts[0].MountPoint = ptr.Of(expect.Mounts[0].Location)
 	if runtime.GOOS == "windows" {
-		mountLocation, err := ioutilx.WindowsSubsystemPath(t.Context(), expect.Mounts[0].Location)
+		mountLocation, err := fsutil.WindowsSubsystemPath(t.Context(), expect.Mounts[0].Location)
 		if err == nil {
 			expect.Mounts[0].MountPoint = ptr.Of(mountLocation)
 		}
@@ -477,7 +477,7 @@ func TestFillDefault(t *testing.T) {
 	expect.Mounts = slices.Clone(d.Mounts)
 	expect.Mounts[0].MountPoint = ptr.Of(expect.Mounts[0].Location)
 	if runtime.GOOS == "windows" {
-		mountLocation, err := ioutilx.WindowsSubsystemPath(t.Context(), expect.Mounts[0].Location)
+		mountLocation, err := fsutil.WindowsSubsystemPath(t.Context(), expect.Mounts[0].Location)
 		if err == nil {
 			expect.Mounts[0].MountPoint = ptr.Of(mountLocation)
 		}

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/cpu"
 
-	"github.com/lima-vm/lima/v2/pkg/ioutilx"
+	"github.com/lima-vm/lima/v2/pkg/fsutil"
 	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/lockutil"
@@ -232,7 +232,7 @@ func PathForSSH(ctx context.Context, sshExe SSHExe, orig string) (string, error)
 		return orig, nil
 	}
 	if cygpathExe, ok := cygpathForSSH(sshExe); ok {
-		return ioutilx.WindowsSubsystemPathWithCygpath(ctx, cygpathExe, orig)
+		return fsutil.WindowsSubsystemPathWithCygpath(ctx, cygpathExe, orig)
 	}
 	return filepath.ToSlash(orig), nil
 }


### PR DESCRIPTION
Part of #5283.

Moves the Windows path-conversion helpers out of `pkg/ioutilx` into `pkg/fsutil`, per the issue's plan:

- `WindowsSubsystemPath`, `WindowsSubsystemPathWithCygpath`, `WindowsSubsystemPathForLinux` (+ the unexported cygpath-less fallback) → `pkg/fsutil/fsutil_windows.go`, compiled only on Windows via the filename suffix.
- `ReadAtMaximum` stays in `ioutilx` (per the issue), and the UTF16 helpers are deliberately **not** moved — their eventual home (`strutil`? `unicodeutil`?) is still an open question in the issue, so this PR doesn't preempt that call.

Because all six caller files are cross-platform and already gate these calls behind `runtime.GOOS == "windows"`, the symbols still need to resolve on non-Windows: `pkg/fsutil/fsutil_unix.go` (`//go:build !windows`) provides stub definitions returning an error, unreachable in practice — mirroring the existing `errNotSupported` pattern in `pkg/guestagent/timesync/timesync_others.go`. This keeps every caller's logic unchanged (only the import + `ioutilx.` → `fsutil.` prefix change) and no GOOS build breaks.

The Windows-only unit test moves alongside (`pkg/fsutil/fsutil_windows_test.go`, 98% rename). No forwarding shims were left in `ioutilx`, matching how prior moves in this area (7a5a207, 54db504) rewrote call sites directly.

## Verification

- `go build ./...` on darwin, `GOOS=linux`, and `GOOS=windows` — all clean
- `GOOS=windows go vet ./pkg/fsutil/...` + `go test -c ./pkg/fsutil/...` to compile-check the Windows-only files and test
- `go test` on all touched caller packages (copytool, hostagent, sshutil, limayaml, cmd/limactl) — ok
- `go vet ./...` clean; `golangci-lint run` on touched packages — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)