### PR TITLE
pkg/ioutilx: move UTF-16 helpers to pkg/strutil

### DIFF
--- a/pkg/executil/command.go
+++ b/pkg/executil/command.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/lima-vm/lima/v2/pkg/ioutilx"
+	"github.com/lima-vm/lima/v2/pkg/strutil"
 )
 
 type options struct {
@@ -44,7 +44,7 @@ func RunUTF16leCommand(args []string, opts ...Opt) (string, error) {
 	outString := ""
 	out, err := cmd.CombinedOutput()
 	if out != nil {
-		s, err := ioutilx.FromUTF16leToString(bytes.NewReader(out))
+		s, err := strutil.FromUTF16leToString(bytes.NewReader(out))
 		if err != nil {
 			return "", fmt.Errorf("failed to convert output from UTF16 when running command %v, err: %w", args, err)
 		}

--- a/pkg/ioutilx/ioutilx.go
+++ b/pkg/ioutilx/ioutilx.go
@@ -7,9 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-
-	"golang.org/x/text/encoding/unicode"
-	"golang.org/x/text/transform"
 )
 
 // ReadAtMaximum reads n at maximum.
@@ -25,22 +22,4 @@ func ReadAtMaximum(r io.Reader, n int64) ([]byte, error) {
 		}
 	}
 	return b, err
-}
-
-// FromUTF16le returns an io.Reader for UTF16le data.
-// Windows uses little endian by default, use unicode.UseBOM policy to retrieve BOM from the text,
-// and unicode.LittleEndian as a fallback.
-func FromUTF16le(r io.Reader) io.Reader {
-	o := transform.NewReader(r, unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewDecoder())
-	return o
-}
-
-// FromUTF16leToString reads from Unicode 16 LE encoded data from an io.Reader and returns a string.
-func FromUTF16leToString(r io.Reader) (string, error) {
-	out, err := io.ReadAll(FromUTF16le(r))
-	if err != nil {
-		return "", err
-	}
-
-	return string(out), nil
 }

--- a/pkg/strutil/strutil.go
+++ b/pkg/strutil/strutil.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package strutil
+
+import (
+	"io"
+
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+)
+
+// FromUTF16le returns an io.Reader for UTF16le data.
+// Windows uses little endian by default, use unicode.UseBOM policy to retrieve BOM from the text,
+// and unicode.LittleEndian as a fallback.
+func FromUTF16le(r io.Reader) io.Reader {
+	return transform.NewReader(r, unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewDecoder())
+}
+
+// FromUTF16leToString reads from Unicode 16 LE encoded data from an io.Reader and returns a string.
+func FromUTF16leToString(r io.Reader) (string, error) {
+	out, err := io.ReadAll(FromUTF16le(r))
+	if err != nil {
+		return "", err
+	}
+
+	return string(out), nil
+}

--- a/pkg/strutil/strutil_test.go
+++ b/pkg/strutil/strutil_test.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package strutil
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestFromUTF16leToString(t *testing.T) {
+	// "Hi" in UTF-16LE without BOM
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint16(buf[0:], 'H')
+	binary.LittleEndian.PutUint16(buf[2:], 'i')
+
+	got, err := FromUTF16leToString(bytes.NewReader(buf))
+	assert.NilError(t, err)
+	assert.Equal(t, got, "Hi")
+}


### PR DESCRIPTION
## Summary
- Move `FromUTF16le` / `FromUTF16leToString` from `pkg/ioutilx` to new `pkg/strutil`
- Keep `ReadAtMaximum` in `pkg/ioutilx` (the ioutil-like helper)
- Update `pkg/executil` to use `strutil`

Continues #5283 after #5284 moved the Windows path helpers to `pkg/fsutil`.

## Test plan
- [x] `go test ./pkg/strutil/ ./pkg/executil/ ./pkg/ioutilx/`
- [ ] CI green


Made with [Cursor](https://cursor.com)