### PR TITLE
block ssh ports on every guest IP, not just 0.0.0.0

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -246,18 +246,7 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 			break
 		}
 	}
-	rules := make([]limatype.PortForward, 0, 3+len(inst.Config.PortForwards))
-	// Block ports 22 and sshLocalPort on all IPs
-	for _, port := range []int{sshGuestPort, sshLocalPort} {
-		rule := limatype.PortForward{GuestIP: net.IPv4zero, GuestPort: port, Ignore: true}
-		limayaml.FillPortForwardDefaults(&rule, inst.Dir, inst.Config.User, inst.Param)
-		rules = append(rules, rule)
-	}
-	rules = append(rules, inst.Config.PortForwards...)
-	// Default forwards for all non-privileged ports from "127.0.0.1" and "::1"
-	rule := limatype.PortForward{}
-	limayaml.FillPortForwardDefaults(&rule, inst.Dir, inst.Config.User, inst.Param)
-	rules = append(rules, rule)
+	rules := portForwardRules(inst.Dir, inst.Config.User, inst.Param, sshLocalPort, inst.Config.PortForwards)
 
 	a := &HostAgent{
 		instConfig:        inst.Config,

--- a/pkg/hostagent/port.go
+++ b/pkg/hostagent/port.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/hostagent/events"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limayaml"
+	"github.com/lima-vm/lima/v2/pkg/ptr"
 )
 
 type portForwarder struct {
@@ -28,6 +29,26 @@ type portForwarder struct {
 const sshGuestPort = 22
 
 var IPv4loopback1 = limayaml.IPv4loopback1
+
+// portForwardRules returns the rules used by both forwarders: the SSH ports are
+// blocked on every guest IP, then the instance rules, then the default forward
+// for the remaining ports.
+func portForwardRules(instDir string, user limatype.User, param map[string]string, sshLocalPort int, instRules []limatype.PortForward) []limatype.PortForward {
+	rules := make([]limatype.PortForward, 0, 3+len(instRules))
+	for _, port := range []int{sshGuestPort, sshLocalPort} {
+		// GuestIPMustBeZero must be set explicitly. FillPortForwardDefaults would otherwise
+		// derive it from GuestIP and turn the rule into an exact 0.0.0.0 match, which leaves
+		// a guest listening on 127.0.0.1 or ::1 unblocked.
+		rule := limatype.PortForward{GuestIP: net.IPv4zero, GuestIPMustBeZero: ptr.Of(false), GuestPort: port, Ignore: true}
+		limayaml.FillPortForwardDefaults(&rule, instDir, user, param)
+		rules = append(rules, rule)
+	}
+	rules = append(rules, instRules...)
+	// Default forwards for all non-privileged ports from "127.0.0.1" and "::1"
+	rule := limatype.PortForward{}
+	limayaml.FillPortForwardDefaults(&rule, instDir, user, param)
+	return append(rules, rule)
+}
 
 func newPortForwarder(sshConfig *ssh.SSHConfig, sshAddressPort func() (string, int), rules []limatype.PortForward, ignore bool, vmType limatype.VMType, onEvent func(*events.PortForwardEvent)) *portForwarder {
 	return &portForwarder{

--- a/pkg/hostagent/port_test.go
+++ b/pkg/hostagent/port_test.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hostagent
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/guestagent/api"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+)
+
+func testPortForwarder(sshLocalPort int) *portForwarder {
+	return &portForwarder{
+		rules: portForwardRules("", limatype.User{}, nil, sshLocalPort, nil),
+	}
+}
+
+func TestPortForwardRulesBlockSSHOnEveryGuestIP(t *testing.T) {
+	const sshLocalPort = 60022
+	pf := testPortForwarder(sshLocalPort)
+	for _, guestIP := range []string{"0.0.0.0", "127.0.0.1", "::", "::1"} {
+		for _, port := range []int32{sshGuestPort, sshLocalPort} {
+			hostAddr, _ := pf.forwardingAddresses(&api.IPPort{Ip: guestIP, Port: port, Protocol: "tcp"})
+			assert.Equal(t, hostAddr, "", "guest %s:%d", guestIP, port)
+		}
+	}
+}
+
+func TestPortForwardRulesStillForwardOtherPorts(t *testing.T) {
+	pf := testPortForwarder(60022)
+	for _, guestIP := range []string{"0.0.0.0", "127.0.0.1", "::1"} {
+		hostAddr, _ := pf.forwardingAddresses(&api.IPPort{Ip: guestIP, Port: 8080, Protocol: "tcp"})
+		assert.Equal(t, hostAddr, "127.0.0.1:8080", "guest %s:8080", guestIP)
+	}
+}


### PR DESCRIPTION
The rules that block port 22 and sshLocalPort are built with GuestIP 0.0.0.0 and no explicit GuestIPMustBeZero, so FillPortForwardDefaults derives it as true and the rule ends up matching only a guest listener bound to 0.0.0.0. A guest that binds 127.0.0.1:22 or ::1:<sshLocalPort> falls through both deny rules and is then picked up by the default catch-all rule, which forwards it to the host, letting a compromised VM take over the host-local SSH endpoint that limactl shell talks to. The added test fails on master with `guest 127.0.0.1:22 -> 127.0.0.1:22` and passes here.

Setting GuestIPMustBeZero explicitly to false on the two deny rules keeps the exact-match semantics for user rules that ask for guestIP 0.0.0.0 while making these behave as the comment says. I pulled the rule construction out of New into portForwardRules so it could be tested; both forwarders read the same slice, so the one change covers the grpc and ssh paths.