### PR TITLE
Extend the default timeout for Windows guest

### DIFF
--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -620,6 +620,12 @@ func startAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	if !cmd.Flags().Changed("timeout") && *inst.Config.OS == limatype.WINDOWS {
+		timeout = instance.WinDefaultWatchHostAgentEventsTimeout
+		logrus.Infof("Extended the default timeout to %v for Windows guest boot.", timeout)
+	}
+
 	if timeout > 0 {
 		ctx = instance.WithWatchHostAgentTimeout(ctx, timeout)
 	}

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -40,6 +40,10 @@ import (
 // to be running before timing out.
 const DefaultWatchHostAgentEventsTimeout = 10 * time.Minute
 
+// Since the initial boot of Windows usually takes longer than DefaultWatchHostAgentEventsTimeout,
+// use a windows-specific default timeout duration.
+const WinDefaultWatchHostAgentEventsTimeout = 30 * time.Minute
+
 type Prepared struct {
 	Driver              driver.Driver
 	GuestAgent          string

--- a/website/content/en/docs/usage/guests/windows.md
+++ b/website/content/en/docs/usage/guests/windows.md
@@ -36,4 +36,3 @@ For Windows server 2025, TPM emulation is disabled by default. However, there ar
 - QEMU is the only VM driver that supports Windows guests
 - Only plain mode is supported (no file mount, no dynamic port-forwarding)
 - Booting Windows 11 may occasionally fail. If it fails, please delete the instance and try it again from scratch.
-- Booting Windows 11 usually takes longer than default timeout (10 minutes). Please consider extending the timeout.(example: `--timeout=30m`)


### PR DESCRIPTION
<!-- Please read our contribution rules before submitting:

- Pull requests guide: https://lima-vm.io/docs/community/contributing/#sending-pull-requests
- AI usage policy: https://lima-vm.io/docs/community/contributing/#ai-contribution-rules

-->

## What This PR Changes
This PR extends the default timeout duration for Windows guest to 30 minutes, because the initial boot of Windows guests usually takes longer than the current default timeout setting (10min).
<!-- Explain the single problem this PR fixes, in your own words. -->

## Linked Issue (Required in most cases)
#5255 
<!-- Link the issue here. If your issue is not approved by a maintainer, don't expect your PR to be merged. -->

Closes #5255 

## How I Tested This
I tried booting Windows 11 VM on my Mac and confirmed that the initial booting completed.

## AI Usage
No
<!-- If you used AI tools, say which tool and how you used it. For example, `Assisted-by: AI_AGENT_NAME:VERSION [TOOL]` or `Co-Authored-By`-->