### PR TITLE
sshutil: parse the Win32-OpenSSH version banner

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -632,7 +632,9 @@ func SSHOptsRemovingControlPath(opts []string) []string {
 }
 
 func ParseOpenSSHVersion(version []byte) *semver.Version {
-	regex := regexp.MustCompile(`(?m)^OpenSSH_(\d+\.\d+)(?:p(\d+))?\b`)
+	// Win32-OpenSSH banners: "OpenSSH_for_Windows_9.5p2", and older releases
+	// with a space before the version.
+	regex := regexp.MustCompile(`(?m)^OpenSSH(?:_for_Windows[_ ]|_)(\d+\.\d+)(?:p(\d+))?\b`)
 	matches := regex.FindSubmatch(version)
 	if len(matches) == 3 {
 		if len(matches[2]) == 0 {
@@ -640,6 +642,9 @@ func ParseOpenSSHVersion(version []byte) *semver.Version {
 		}
 		return semver.New(fmt.Sprintf("%s.%s", matches[1], matches[2]))
 	}
+	// A 0.0.0 return silently downgrades version-gated behavior, so log the
+	// unparsed banner for --debug traces.
+	logrus.Debugf("ParseOpenSSHVersion: no match in %q; returning 0.0.0", string(version))
 	return &semver.Version{}
 }
 

--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -54,6 +54,12 @@ func TestParseOpenSSHVersion(t *testing.T) {
 	// NixOS 25.05
 	assert.Check(t, ParseOpenSSHVersion([]byte(`command-line line 0: Unsupported option "gssapiauthentication"
 OpenSSH_10.0p2, OpenSSL 3.4.1 11 Feb 2025`)).Equal(*semver.New("10.0.2")))
+
+	// Native Windows OpenSSH (Win32-OpenSSH)
+	assert.Check(t, ParseOpenSSHVersion([]byte("OpenSSH_for_Windows_9.5p2, LibreSSL 3.8.2")).Equal(*semver.New("9.5.2")))
+
+	// Older Win32-OpenSSH, with a space before the version
+	assert.Check(t, ParseOpenSSHVersion([]byte("OpenSSH_for_Windows 9.5p2, LibreSSL 3.8.2")).Equal(*semver.New("9.5.2")))
 }
 
 func TestParseOpenSSHGSSAPISupported(t *testing.T) {


### PR DESCRIPTION
The regex required a digit right after `OpenSSH_`, so `OpenSSH_for_Windows_9.5p2` parsed as 0.0.0 and Lima treated a current install as ancient. That refused multi-instance `limactl copy` (gated at 8.0) and forced `LogLevel=QUIET` on `limactl shell` (gated at 8.9), which hides ssh errors.

Part of a series continuing the native Windows OpenSSH work from #5205 and #5270: #5298, #5299, #5300, #5301. They are independent and can merge in any order. #5298 and #5301 both touch `pkg/sshutil/sshutil.go`, in different functions, and apply cleanly in either order.
