### PR TITLE
copytool: support native Windows OpenSSH

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -386,7 +386,6 @@ func shellAction(cmd *cobra.Command, args []string) error {
 		//   - Prevents error messages such as:
 		//     > mux_client_request_session: read from master failed: Connection reset by peer
 		//     > ControlSocket ....sock already exists, disabling multiplexing
-		// Only remove these options when writing the SSH config file and executing `limactl shell`, since multiplexing seems to work with port forwarding.
 		sshOpts = sshutil.SSHOptsRemovingControlPath(sshOpts)
 	}
 	sshArgs := append([]string{}, sshExe.Args...)

--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -302,7 +302,11 @@ if command -v rsync >/dev/null && limactl shell "$NAME" command -v rsync >/dev/n
 	testdir="$tmpdir/test-rsync-dir"
 	mkdir -p "$testdir"
 	echo "test content" >"$testdir/testfile.txt"
-	limactl cp --backend=rsync -r -v "$testdir" "$NAME":/tmp/
+	testdir_host=$testdir
+	if [ "${OS_HOST}" = "Msys" ]; then
+		testdir_host="$(cygpath -w "$testdir")"
+	fi
+	limactl cp --backend=rsync -r -v "$testdir_host" "$NAME":/tmp/
 	if ! limactl shell "$NAME" test -f /tmp/test-rsync-dir/testfile.txt; then
 		ERROR "rsync recursive copy failed"
 		exit 1

--- a/pkg/copytool/copytool.go
+++ b/pkg/copytool/copytool.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/lima-vm/lima/v2/pkg/fsutil"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/sshutil"
 	"github.com/lima-vm/lima/v2/pkg/store"
 )
 
@@ -88,7 +88,9 @@ func New(ctx context.Context, backend string, paths []string, opts *Options) (Co
 
 		tool, err = newSCPTool(opts)
 		if err != nil {
-			return nil, fmt.Errorf("neither rsync nor scp found on host: %w", err)
+			// rsync may well have been found and rejected above, so name the
+			// outcome rather than guessing which tool is missing.
+			return nil, fmt.Errorf("no usable copy tool on host: %w", err)
 		}
 		return tool, nil
 	default:
@@ -116,21 +118,40 @@ func hasRemoteSourceAndDestination(ctx context.Context, paths []string) bool {
 	return hasRemoteSource && hasRemoteDestination
 }
 
+// sshOptsForInstance returns the ssh options for copying to or from inst. The
+// rsync availability probe and the rsync command must both use it, or the probe
+// rejects a working install. On Windows it drops connection multiplexing, since
+// native OpenSSH has none and Cygwin ssh's is unreliable for scp and rsync.
+//
+// toolPath names the binary whose path form the options take. scp hands them to
+// the ssh beside itself, while rsync hands them to the ssh it names with -e.
+func sshOptsForInstance(ctx context.Context, sshExe sshutil.SSHExe, toolPath string, inst *limatype.Instance) ([]string, error) {
+	if runtime.GOOS == "windows" {
+		return sshutil.SSHOptsWithoutMultiplexing(ctx, sshExe, toolPath, *inst.Config.User.Name, false)
+	}
+	return sshutil.SSHOpts(ctx, sshExe, inst.Dir, *inst.Config.User.Name, false, false, false, false)
+}
+
 func parseCopyPaths(ctx context.Context, paths []string) ([]*Path, error) {
 	var copyPaths []*Path
 
 	for _, path := range paths {
 		cp := &Path{}
 		if runtime.GOOS == "windows" {
+			// Classify absolute paths before the ":" split, so a drive letter
+			// is not read as an instance name. Drive-relative "C:foo" is not
+			// absolute, so single-letter instance names still work.
+			//
+			// The path stays in native form here. scp and rsync can come from
+			// different toolchains, so each backend formats it for the binary
+			// that consumes it.
 			if filepath.IsAbs(path) {
-				var err error
-				path, err = fsutil.WindowsSubsystemPath(ctx, path)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				path = filepath.ToSlash(path)
+				cp.Path = path
+				cp.IsRemote = false
+				copyPaths = append(copyPaths, cp)
+				continue
 			}
+			path = filepath.ToSlash(path)
 		}
 
 		parts := strings.SplitN(path, ":", 2)

--- a/pkg/copytool/copytool_test.go
+++ b/pkg/copytool/copytool_test.go
@@ -4,10 +4,19 @@
 package copytool
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"slices"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/sshutil"
 )
 
 // TestCommandDoesNotMutateOptions verifies that passing opts to Command() does not
@@ -43,4 +52,163 @@ func TestRsyncCommandEndsOptionParsing(t *testing.T) {
 	sep := slices.Index(cmd.Args, "--")
 	assert.Assert(t, sep != -1, "rsync args must contain the %#q separator: %v", "--", cmd.Args)
 	assert.Assert(t, slices.Index(cmd.Args, dashPath) > sep, "path %#q must come after %#q: %v", dashPath, "--", cmd.Args)
+}
+
+// TestParseCopyPathsWindowsDriveLetter locks in the split between Windows
+// absolute paths, which are local, and drive-relative paths like "C:foo.txt",
+// which must stay instance "C" so single-letter instance names keep working.
+func TestParseCopyPathsWindowsDriveLetter(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only path handling")
+	}
+	t.Setenv("LIMA_HOME", t.TempDir())
+	ctx := t.Context()
+
+	// Absolute drive-letter paths are local, and keep the native form the
+	// backends convert for their own tool.
+	for _, p := range []string{`C:\foo`, `C:/foo`} {
+		cps, err := parseCopyPaths(ctx, []string{p})
+		assert.NilError(t, err)
+		assert.Equal(t, len(cps), 1)
+		assert.Equal(t, cps[0].IsRemote, false, "%q must be a local path", p)
+		assert.Equal(t, cps[0].Path, p, "%q must reach the backend unconverted", p)
+	}
+
+	// "C:foo" is drive-relative (not absolute). It must reach the
+	// instance-lookup branch as instance "C" path "foo" and fail at
+	// store.Inspect with an instance-not-found error.
+	_, err := parseCopyPaths(ctx, []string{"C:foo"})
+	assert.ErrorContains(t, err, "instance `C`")
+	assert.ErrorContains(t, err, "does not exist")
+
+	// Explicit instance:path behaves the same.
+	_, err = parseCopyPaths(ctx, []string{"nonexistent-instance-for-test:/tmp/x"})
+	assert.ErrorContains(t, err, "instance `nonexistent-instance-for-test`")
+	assert.ErrorContains(t, err, "does not exist")
+}
+
+// looksRemoteToRsync reports whether rsync would read arg as host:path, which it
+// does for any colon before the first slash.
+func looksRemoteToRsync(arg string) bool {
+	colon := strings.Index(arg, ":")
+	slash := strings.Index(arg, "/")
+	return colon >= 0 && (slash < 0 || colon < slash)
+}
+
+// TestRsyncCommandLocalPathForm locks in that local operands reach rsync as
+// paths. Windows has no native rsync, so a drive letter would be read as a
+// hostspec and the transfer would fail.
+func TestRsyncCommandLocalPathForm(t *testing.T) {
+	// Nothing beside this path, so the conversion takes its in-process
+	// fallback and the expected operand holds with or without a Cygwin install.
+	tool := &rsyncTool{toolPath: filepath.Join(t.TempDir(), "rsync"), Options: &Options{}}
+
+	src, dst := "/tmp/src", "/tmp/dst"
+	wantSrc, wantDst := src, dst
+	if runtime.GOOS == "windows" {
+		src, dst = `C:\src`, `C:\dst`
+		wantSrc, wantDst = "/c/src", "/c/dst"
+	}
+
+	cmd, err := tool.Command(t.Context(), []string{src, dst}, nil)
+	assert.NilError(t, err)
+
+	operands := cmd.Args[len(cmd.Args)-2:]
+	assert.Equal(t, operands[0], wantSrc)
+	assert.Equal(t, operands[1], wantDst)
+	for _, arg := range operands {
+		assert.Assert(t, !looksRemoteToRsync(arg), "rsync reads %q as host:path", arg)
+	}
+}
+
+// TestSCPCommandLocalPathForm locks in that local operands reach scp in the
+// form its own toolchain reads. Native Windows OpenSSH takes a drive letter,
+// which a Cygwin scp would read as a hostspec instead.
+func TestSCPCommandLocalPathForm(t *testing.T) {
+	limaHome := t.TempDir()
+	t.Setenv("LIMA_HOME", limaHome)
+	// CommonOpts requires the internal identity to exist.
+	configDir := filepath.Join(limaHome, "_config")
+	assert.NilError(t, os.MkdirAll(configDir, 0o700))
+	assert.NilError(t, os.WriteFile(filepath.Join(configDir, filenames.UserPrivateKey), nil, 0o600))
+
+	// Nothing beside this path, so the conversion takes its native fallback and
+	// the expected operand holds with or without a Cygwin install.
+	tool := &scpTool{
+		toolPath: filepath.Join(t.TempDir(), "scp"),
+		sshExe:   sshutil.SSHExe{Exe: "ssh"},
+		Options:  &Options{},
+	}
+
+	src, dst := "/tmp/src", "/tmp/dst"
+	wantSrc, wantDst := src, dst
+	if runtime.GOOS == "windows" {
+		src, dst = `C:\src`, `C:\dst`
+		wantSrc, wantDst = "C:/src", "C:/dst"
+	}
+
+	// Two local operands, so no instance lookup and no host-specific options.
+	cmd, err := tool.Command(t.Context(), []string{src, dst}, nil)
+	assert.NilError(t, err)
+
+	operands := cmd.Args[len(cmd.Args)-2:]
+	assert.Equal(t, operands[0], wantSrc)
+	assert.Equal(t, operands[1], wantDst)
+
+	// scp hands IdentityFile to the ssh beside itself, so it must carry scp's
+	// path form, which is not always the form of the ssh Lima selected.
+	var identityFile string
+	for _, arg := range cmd.Args {
+		if strings.HasPrefix(arg, "IdentityFile=") {
+			identityFile = arg
+		}
+	}
+	assert.Assert(t, identityFile != "", "no IdentityFile option: %v", cmd.Args)
+	if runtime.GOOS == "windows" {
+		// Pin the whole value: the Cygwin form carries no backslash either, so
+		// a laxer check would pass even if the form followed sshExe again.
+		// LimaConfigDir resolves symlinks, which on Windows runners also expands
+		// the 8.3 temp path, so build the expectation from the same helper.
+		resolvedConfigDir, err := dirnames.LimaConfigDir()
+		assert.NilError(t, err)
+		want := "IdentityFile='" + filepath.ToSlash(filepath.Join(resolvedConfigDir, filenames.UserPrivateKey)) + "'"
+		assert.Equal(t, identityFile, want)
+	}
+}
+
+// TestSSHOptsForInstanceMultiplexing locks in the multiplexing policy shared by
+// the rsync availability probe and the rsync and scp commands.
+func TestSSHOptsForInstanceMultiplexing(t *testing.T) {
+	limaHome := t.TempDir()
+	t.Setenv("LIMA_HOME", limaHome)
+	// CommonOpts requires the internal identity to exist.
+	configDir := filepath.Join(limaHome, "_config")
+	assert.NilError(t, os.MkdirAll(configDir, 0o700))
+	assert.NilError(t, os.WriteFile(filepath.Join(configDir, filenames.UserPrivateKey), nil, 0o600))
+
+	name := "test-instance"
+	inst := &limatype.Instance{
+		// Only the control socket path derives from Dir, and nothing opens it.
+		// Keep it short: SSHOpts rejects a socket path over UNIX_PATH_MAX, which
+		// the temp directory on macOS exceeds on its own.
+		Dir:    filepath.Join("/tmp", name),
+		Config: &limatype.LimaYAML{User: limatype.User{Name: &name}},
+	}
+
+	opts, err := sshOptsForInstance(t.Context(), sshutil.SSHExe{Exe: "ssh"}, "ssh", inst)
+	assert.NilError(t, err)
+	assert.Assert(t, slices.Contains(opts, "User="+name), "opts: %v", opts)
+
+	var mux []string
+	for _, o := range opts {
+		if strings.HasPrefix(o, "ControlMaster") || strings.HasPrefix(o, "ControlPath") || strings.HasPrefix(o, "ControlPersist") {
+			mux = append(mux, o)
+		}
+	}
+	if runtime.GOOS == "windows" {
+		// Native OpenSSH cannot multiplex, and Cygwin ssh's is unreliable.
+		assert.Equal(t, len(mux), 0, "Windows must not multiplex: %v", mux)
+	} else {
+		assert.Equal(t, len(mux), 3, "other platforms multiplex: %v", opts)
+	}
 }

--- a/pkg/copytool/rsync.go
+++ b/pkg/copytool/rsync.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	"al.essio.dev/pkg/shellescape"
 	"github.com/sirupsen/logrus"
 
+	"github.com/lima-vm/lima/v2/pkg/fsutil"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/sshutil"
 )
@@ -63,7 +66,7 @@ func checkRsyncOnGuest(ctx context.Context, inst *limatype.Instance) bool {
 		logrus.Debugf("failed to create SSH executable: %v", err)
 		return false
 	}
-	sshOpts, err := sshutil.SSHOpts(ctx, sshExe, inst.Dir, *inst.Config.User.Name, false, false, false, false)
+	sshOpts, err := sshOptsForInstance(ctx, sshExe, sshExe.Exe, inst)
 	if err != nil {
 		logrus.Debugf("failed to get SSH options for rsync check: %v", err)
 		return false
@@ -82,10 +85,41 @@ func checkRsyncOnGuest(ctx context.Context, inst *limatype.Instance) bool {
 	return err == nil
 }
 
+// pathForRsync formats a host path for the rsync binary t will run. Windows
+// has no native rsync build, so any rsync is Cygwin- or MSYS-based and reads a
+// colon before the first slash as host:path; the sibling cygpath applies that
+// install's own fstab. Without that sibling the conversion falls back to the
+// MSYS form, which a stock Cygwin rsync resolves under its own install root
+// rather than the drive.
+func (t *rsyncTool) pathForRsync(ctx context.Context, orig string) (string, error) {
+	if runtime.GOOS != "windows" || !filepath.IsAbs(orig) {
+		return orig, nil
+	}
+	// Resolve here rather than in newRsyncTool, which would also change the
+	// binary exec runs and the argv[0] it sees.
+	toolPath := t.toolPath
+	if resolved, err := filepath.EvalSymlinks(toolPath); err == nil {
+		toolPath = resolved
+	}
+	cygpathExe := filepath.Join(filepath.Dir(toolPath), "cygpath.exe")
+	return fsutil.WindowsSubsystemPathWithCygpath(ctx, cygpathExe, orig)
+}
+
 func (t *rsyncTool) Command(ctx context.Context, paths []string, opts *Options) (*exec.Cmd, error) {
 	copyPaths, err := parseCopyPaths(ctx, paths)
 	if err != nil {
 		return nil, err
+	}
+
+	// Format before the trailing-slash handling below, which decides whether
+	// rsync copies a directory or its contents.
+	for _, cp := range copyPaths {
+		if cp.IsRemote {
+			continue
+		}
+		if cp.Path, err = t.pathForRsync(ctx, cp.Path); err != nil {
+			return nil, err
+		}
 	}
 
 	effectiveOpts := t.Options
@@ -123,7 +157,7 @@ func (t *rsyncTool) Command(ctx context.Context, paths []string, opts *Options) 
 				if err != nil {
 					return nil, err
 				}
-				sshOpts, err := sshutil.SSHOpts(ctx, sshExe, cp.Instance.Dir, *cp.Instance.Config.User.Name, false, false, false, false)
+				sshOpts, err := sshOptsForInstance(ctx, sshExe, sshExe.Exe, cp.Instance)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/copytool/scp.go
+++ b/pkg/copytool/scp.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/coreos/go-semver/semver"
 
@@ -17,15 +18,22 @@ import (
 
 type scpTool struct {
 	toolPath string
+	sshExe   sshutil.SSHExe
 	Options  *Options
 }
 
 func newSCPTool(opts *Options) (*scpTool, error) {
-	path, err := exec.LookPath("scp")
+	// scp must come from the same toolchain as the ssh whose path form it
+	// receives, and NewSSHExe can select an ssh that PATH would not.
+	sshExe, err := sshutil.NewSSHExe()
+	if err != nil {
+		return nil, fmt.Errorf("ssh not found on host: %w", err)
+	}
+	path, err := exec.LookPath(sshutil.CompanionForSSH(sshExe, "scp"))
 	if err != nil {
 		return nil, fmt.Errorf("scp not found on host: %w", err)
 	}
-	return &scpTool{toolPath: path, Options: opts}, nil
+	return &scpTool{toolPath: path, sshExe: sshExe, Options: opts}, nil
 }
 
 func (t *scpTool) Name() string {
@@ -66,12 +74,22 @@ func (t *scpTool) Command(ctx context.Context, paths []string, opts *Options) (*
 		scpFlags = append(scpFlags, effectiveOpts.AdditionalArgs...)
 	}
 
-	// this assumes that ssh and scp come from the same place, but scp has no -V
-	sshExeForVersion, err := sshutil.NewSSHExe()
-	if err != nil {
-		return nil, err
+	// scp has no -V, so the version comes from t.sshExe, which is scp's own
+	// toolchain unless that install shipped no scp.
+	legacySSH := sshutil.DetectOpenSSHVersion(ctx, t.sshExe).LessThan(*semver.New("8.0.0"))
+
+	// Only absolute paths carry a drive letter to convert; a relative path is
+	// already in a form both toolchains accept. Key the form to scp itself,
+	// which parses these operands: it usually comes from the same toolchain as
+	// t.sshExe, but falls back to PATH when that install ships no scp.
+	for _, cp := range copyPaths {
+		if cp.IsRemote || !filepath.IsAbs(cp.Path) {
+			continue
+		}
+		if cp.Path, err = sshutil.PathForTool(ctx, t.toolPath, cp.Path); err != nil {
+			return nil, err
+		}
 	}
-	legacySSH := sshutil.DetectOpenSSHVersion(ctx, sshExeForVersion).LessThan(*semver.New("8.0.0"))
 
 	for _, cp := range copyPaths {
 		if cp.IsRemote {
@@ -98,24 +116,18 @@ func (t *scpTool) Command(ctx context.Context, paths []string, opts *Options) (*
 	if len(instances) == 1 {
 		// Only one (instance) host is involved; we can use the instance-specific
 		// arguments such as ControlPath.  This is preferred as we can multiplex
-		// sessions without re-authenticating (MaxSessions permitting).
+		// sessions without re-authenticating (MaxSessions permitting), except on
+		// Windows.
 		for _, inst := range instances {
-			sshExe, err := sshutil.NewSSHExe()
-			if err != nil {
-				return nil, err
-			}
-			sshOpts, err = sshutil.SSHOpts(ctx, sshExe, inst.Dir, *inst.Config.User.Name, false, false, false, false)
+			sshOpts, err = sshOptsForInstance(ctx, t.sshExe, t.toolPath, inst)
 			if err != nil {
 				return nil, err
 			}
 		}
 	} else {
 		// Copying among multiple hosts; we can't pass in host-specific options.
-		sshExe, err := sshutil.NewSSHExe()
-		if err != nil {
-			return nil, err
-		}
-		sshOpts, err = sshutil.CommonOpts(ctx, sshExe, false)
+		// CommonOpts carries no multiplexing options to begin with.
+		sshOpts, err = sshutil.CommonOpts(ctx, t.sshExe, t.toolPath, false)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -302,7 +302,7 @@ func writeSSHConfigFile(sshPath, instName, instDir, instSSHAddress string, sshLo
 		//   - Prevents error messages such as:
 		//     > mux_client_request_session: read from master failed: Connection reset by peer
 		//     > ControlSocket ....sock already exists, disabling multiplexing
-		// Only remove these options when writing the SSH config file and executing `limactl shell`, since multiplexing seems to work with port forwarding.
+		// The sshConfig the hostagent builds from the same options keeps them.
 		sshOpts = sshutil.SSHOptsRemovingControlPath(sshOpts)
 	}
 	if err := sshutil.Format(b, sshPath, instName, sshutil.FormatConfig,
@@ -571,7 +571,6 @@ func (a *HostAgent) startHostAgentRoutines(ctx context.Context) error {
 	}
 	a.cleanUp(func() error {
 		// Skip ExitMaster when the control socket does not exist.
-		// On Windows, the ControlMaster is used only for SSH port forwarding.
 		if !sshutil.IsControlMasterExisting(a.instDir) {
 			return nil
 		}

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -133,24 +133,24 @@ func missingSiblings(dir string, siblings ...string) []string {
 }
 
 var (
-	// cygwinDetectCache maps a resolved ssh path to its sibling cygpath.exe,
-	// or "" when that ssh is not Cygwin-based. Each path is probed once.
+	// cygwinDetectCache maps a resolved tool path to its sibling cygpath.exe,
+	// or "" when that tool is not Cygwin-based. Each path is probed once.
 	cygwinDetectCache   = map[string]string{}
 	cygwinDetectCacheRW sync.RWMutex
 )
 
-// resolvedSSHPath returns the absolute, symlink-resolved path of sshExe's
-// binary — the directory Lima reads its companion tools from. It returns
+// resolvedToolPath returns the absolute, symlink-resolved path of toolExe's
+// binary, whose directory Lima reads its companion tools from. It returns
 // ("", false) when a bare name does not resolve on PATH.
-func resolvedSSHPath(sshExe SSHExe) (string, bool) {
-	if sshExe.Exe == "" {
+func resolvedToolPath(toolExe SSHExe) (string, bool) {
+	if toolExe.Exe == "" {
 		return "", false
 	}
-	path := sshExe.Exe
+	path := toolExe.Exe
 	if !filepath.IsAbs(path) {
 		resolved, err := exec.LookPath(path)
 		if err != nil {
-			logrus.WithError(err).Debugf("cannot resolve ssh at %#q via PATH", path)
+			logrus.WithError(err).Debugf("cannot resolve tool at %#q via PATH", path)
 			return "", false
 		}
 		path = resolved
@@ -161,15 +161,15 @@ func resolvedSSHPath(sshExe SSHExe) (string, bool) {
 	return path, true
 }
 
-// companionForSSH returns tool from the same toolchain as sshExe. NewSSHExe can
+// CompanionForSSH returns tool from the same toolchain as sshExe. NewSSHExe can
 // select an ssh outside PATH, so resolving a companion by bare name can pick a
 // different toolchain than the one PathForSSH formats paths for. It returns tool
 // unchanged on non-Windows, or when no sibling exists, leaving it to PATH.
-func companionForSSH(sshExe SSHExe, tool string) string {
+func CompanionForSSH(sshExe SSHExe, tool string) string {
 	if runtime.GOOS != "windows" {
 		return tool
 	}
-	path, ok := resolvedSSHPath(sshExe)
+	path, ok := resolvedToolPath(sshExe)
 	if !ok {
 		return tool
 	}
@@ -181,16 +181,17 @@ func companionForSSH(sshExe SSHExe, tool string) string {
 	return companion
 }
 
-// cygpathForSSH returns the cygpath.exe beside sshExe (resolved through
-// symlinks) and whether sshExe is Cygwin-based. Callers pass the returned
-// path to exec.Command so conversions run through that toolchain's own
-// cygpath, even when $SSH points outside PATH. It returns
-// ("", false) on non-Windows or empty input; results are cached per resolved path.
-func cygpathForSSH(sshExe SSHExe) (string, bool) {
+// cygpathForSSH returns the cygpath.exe beside toolExe (resolved through
+// symlinks) and whether toolExe is Cygwin-based. PathForTool passes non-ssh
+// binaries here too. Callers pass the returned path to exec.Command so
+// conversions run through that toolchain's own cygpath, even when $SSH points
+// outside PATH. It returns ("", false) on non-Windows or empty input; results
+// are cached per resolved path.
+func cygpathForSSH(toolExe SSHExe) (string, bool) {
 	if runtime.GOOS != "windows" {
 		return "", false
 	}
-	path, ok := resolvedSSHPath(sshExe)
+	path, ok := resolvedToolPath(toolExe)
 	if !ok {
 		return "", false
 	}
@@ -202,10 +203,10 @@ func cygpathForSSH(sshExe SSHExe) (string, bool) {
 	}
 	cygpathExe := filepath.Join(filepath.Dir(path), "cygpath.exe")
 	if _, err := os.Stat(cygpathExe); err != nil {
-		logrus.Debugf("ssh at %#q detected as native Windows OpenSSH (no cygpath.exe alongside)", path)
+		logrus.Debugf("tool at %#q detected as native Windows OpenSSH (no cygpath.exe alongside)", path)
 		cygpathExe = ""
 	} else {
-		logrus.Debugf("ssh at %#q detected as Cygwin-based (found %#q alongside)", path, cygpathExe)
+		logrus.Debugf("tool at %#q detected as Cygwin-based (found %#q alongside)", path, cygpathExe)
 	}
 	cygwinDetectCacheRW.Lock()
 	cygwinDetectCache[path] = cygpathExe
@@ -219,11 +220,23 @@ func cygpathForSSH(sshExe SSHExe) (string, bool) {
 // Windows, MSYS2) gets a /c/Users/... form from the sibling cygpath, which
 // respects the toolchain's fstab; native Windows OpenSSH gets forward
 // slashes (C:/Users/...), which native ssh, ssh-keygen, and scp accept.
+// It is a convenience wrapper for callers holding an SSHExe; PathForTool takes
+// the binary's path directly.
 func PathForSSH(ctx context.Context, sshExe SSHExe, orig string) (string, error) {
+	return PathForTool(ctx, sshExe.Exe, orig)
+}
+
+// PathForTool is PathForSSH keyed to an arbitrary binary, for a tool that Lima
+// resolves separately from ssh. Pass the tool's own path so the form follows
+// the toolchain that reads it, whether the tool parses the path itself or hands
+// it to the ssh beside it. Callers whose tool is Cygwin-based on every
+// Windows host should convert through cygpath directly instead: the native form
+// this returns as a fallback would be wrong for them.
+func PathForTool(ctx context.Context, toolPath, orig string) (string, error) {
 	if runtime.GOOS != "windows" {
 		return orig, nil
 	}
-	if cygpathExe, ok := cygpathForSSH(sshExe); ok {
+	if cygpathExe, ok := cygpathForSSH(SSHExe{Exe: toolPath}); ok {
 		return fsutil.WindowsSubsystemPathWithCygpath(ctx, cygpathExe, orig)
 	}
 	return filepath.ToSlash(orig), nil
@@ -252,7 +265,7 @@ func SftpServerForSSH(ctx context.Context, sshExe SSHExe) string {
 		}
 		return ""
 	}
-	path, ok := resolvedSSHPath(sshExe)
+	path, ok := resolvedToolPath(sshExe)
 	if !ok {
 		return ""
 	}
@@ -309,8 +322,10 @@ func DefaultPubKeys(ctx context.Context, loadDotSSH bool) ([]PubKey, error) {
 				if sshErr != nil {
 					return sshErr
 				}
-				keygenExe = companionForSSH(sshExe, "ssh-keygen")
-				privPath, err = PathForSSH(ctx, sshExe, privPath)
+				keygenExe = CompanionForSSH(sshExe, "ssh-keygen")
+				// ssh-keygen parses this path, and it falls back to PATH when
+				// the selected ssh ships none, so key the form to keygenExe.
+				privPath, err = PathForTool(ctx, keygenExe, privPath)
 				if err != nil {
 					return err
 				}
@@ -386,7 +401,11 @@ var sshInfo struct {
 //
 // The result always contains the IdentityFile option.
 // The result never contains the Port option.
-func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, error) {
+//
+// Path options take toolPath's form, for the binary that ends up reading them.
+// scp hands its options to the ssh beside itself, which need not be sshExe.
+// Version detection still runs against sshExe, since only ssh reports a version.
+func CommonOpts(ctx context.Context, sshExe SSHExe, toolPath string, useDotSSH bool) ([]string, error) {
 	configDir, err := dirnames.LimaConfigDir()
 	if err != nil {
 		return nil, err
@@ -397,7 +416,7 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 		return nil, err
 	}
 	var opts []string
-	idf, err := identityFileEntry(ctx, sshExe, privateKeyPath)
+	idf, err := identityFileEntry(ctx, toolPath, privateKeyPath)
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +451,7 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 				// Fail on permission-related and other path errors
 				return nil, err
 			}
-			idf, err = identityFileEntry(ctx, sshExe, privateKeyPath)
+			idf, err = identityFileEntry(ctx, toolPath, privateKeyPath)
 			if err != nil {
 				return nil, err
 			}
@@ -484,9 +503,9 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 	return opts, nil
 }
 
-func identityFileEntry(ctx context.Context, sshExe SSHExe, privateKeyPath string) (string, error) {
+func identityFileEntry(ctx context.Context, toolPath, privateKeyPath string) (string, error) {
 	if runtime.GOOS == "windows" {
-		privateKeyPath, err := PathForSSH(ctx, sshExe, privateKeyPath)
+		privateKeyPath, err := PathForTool(ctx, toolPath, privateKeyPath)
 		if err != nil {
 			return "", err
 		}
@@ -568,13 +587,15 @@ func RemoveStaleControlMaster(ctx context.Context, instDir string) (bool, error)
 	return existed, nil
 }
 
-// SSHOpts adds the following options to CommonOptions: User, ControlMaster, ControlPath, ControlPersist.
+// SSHOpts adds the following options to CommonOpts: User, ControlMaster,
+// ControlPath, ControlPersist, and whichever of ForwardAgent, ForwardX11, and
+// ForwardX11Trusted the caller asks for.
 func SSHOpts(ctx context.Context, sshExe SSHExe, instDir, username string, useDotSSH, forwardAgent, forwardX11, forwardX11Trusted bool) ([]string, error) {
 	controlSock := filepath.Join(instDir, filenames.SSHSock)
 	if len(controlSock) >= osutil.UnixPathMax {
 		return nil, fmt.Errorf("socket path %#q is too long: >= UNIX_PATH_MAX=%d", controlSock, osutil.UnixPathMax)
 	}
-	opts, err := CommonOpts(ctx, sshExe, useDotSSH)
+	opts, err := SSHOptsWithoutMultiplexing(ctx, sshExe, sshExe.Exe, username, useDotSSH)
 	if err != nil {
 		return nil, err
 	}
@@ -587,7 +608,6 @@ func SSHOpts(ctx context.Context, sshExe SSHExe, instDir, username string, useDo
 		controlPath = fmt.Sprintf(`ControlPath='%s'`, controlSock)
 	}
 	opts = append(opts,
-		fmt.Sprintf("User=%s", username), // guest and host have the same username, but we should specify the username explicitly (#85)
 		"ControlMaster=auto",
 		controlPath,
 		"ControlPersist=yes",
@@ -602,6 +622,22 @@ func SSHOpts(ctx context.Context, sshExe SSHExe, instDir, username string, useDo
 		opts = append(opts, "ForwardX11Trusted=yes")
 	}
 	return opts, nil
+}
+
+// SSHOptsWithoutMultiplexing returns CommonOpts plus an explicit User, adding
+// neither multiplexing nor forwarding options. Use it for invocations that
+// cannot share a control socket: native Windows OpenSSH has no multiplexing,
+// and Cygwin ssh's is unreliable. It builds no control path, so the caller also
+// escapes the socket length limit SSHOpts enforces.
+// Path options take toolPath's form; pass sshExe.Exe unless another binary
+// receives the options, as described on CommonOpts.
+func SSHOptsWithoutMultiplexing(ctx context.Context, sshExe SSHExe, toolPath, username string, useDotSSH bool) ([]string, error) {
+	opts, err := CommonOpts(ctx, sshExe, toolPath, useDotSSH)
+	if err != nil {
+		return nil, err
+	}
+	// guest and host have the same username, but we should specify the username explicitly (#85)
+	return append(opts, fmt.Sprintf("User=%s", username)), nil
 }
 
 // SSHArgsFromOpts returns ssh args from opts.

--- a/pkg/sshutil/sshutil_windows_test.go
+++ b/pkg/sshutil/sshutil_windows_test.go
@@ -137,7 +137,7 @@ func TestCompanionForSSH(t *testing.T) {
 		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
 		assert.NilError(t, os.WriteFile(keygenExe, nil, 0o644))
 
-		assert.Equal(t, companionForSSH(SSHExe{Exe: sshExe}, "ssh-keygen"), keygenExe)
+		assert.Equal(t, CompanionForSSH(SSHExe{Exe: sshExe}, "ssh-keygen"), keygenExe)
 	})
 
 	t.Run("no sibling falls back to the bare name", func(t *testing.T) {
@@ -145,11 +145,11 @@ func TestCompanionForSSH(t *testing.T) {
 		sshExe := filepath.Join(dir, "ssh.exe")
 		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
 
-		assert.Equal(t, companionForSSH(SSHExe{Exe: sshExe}, "ssh-keygen"), "ssh-keygen")
+		assert.Equal(t, CompanionForSSH(SSHExe{Exe: sshExe}, "ssh-keygen"), "ssh-keygen")
 	})
 
 	t.Run("empty input falls back to the bare name", func(t *testing.T) {
-		assert.Equal(t, companionForSSH(SSHExe{}, "ssh-keygen"), "ssh-keygen")
+		assert.Equal(t, CompanionForSSH(SSHExe{}, "ssh-keygen"), "ssh-keygen")
 	})
 }
 


### PR DESCRIPTION
On Windows, `limactl copy` converted host paths to the Cygwin/MSYS form no matter which tool would consume them, and it passed ControlMaster options unconditionally. Native OpenSSH cannot use that path form and has no multiplexing, so scp failed with `getsockname failed`.

The two backends need different path forms, so every path now takes the form of the binary that reads it. Both also skip multiplexing on Windows.

Part of the native Windows OpenSSH series. It can merge in any order, except that #5337 appends to the same test file, so whichever lands second needs a trivial rebase there. The Windows jobs exercise only the Cygwin scp path, because the runners carry no rsync of their own. That coverage and validation on a plain Windows host both arrive with the CI jobs in #5342.

Assisted-by: Claude Opus 5
