### PR TITLE
hostagent: support reverse-sshfs on plain Windows

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -59,6 +59,7 @@ type HostAgent struct {
 	instDir           string
 	instName          string
 	instSSHAddress    string
+	sshExe            sshutil.SSHExe
 	sshConfig         *ssh.SSHConfig
 	portForwarder     *portForwarder // legacy SSH port forwarder
 	grpcPortForwarder *portfwd.Forwarder
@@ -256,6 +257,7 @@ func New(ctx context.Context, instName string, stdout io.Writer, signalCh chan o
 		instDir:           inst.Dir,
 		instName:          instName,
 		instSSHAddress:    inst.SSHAddress,
+		sshExe:            sshExe,
 		sshConfig:         sshConfig,
 		driver:            limaDriver,
 		signalCh:          signalCh,

--- a/pkg/hostagent/mount.go
+++ b/pkg/hostagent/mount.go
@@ -8,18 +8,38 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/lima-vm/sshocker/pkg/reversesshfs"
 	"github.com/sirupsen/logrus"
 
-	"github.com/lima-vm/lima/v2/pkg/fsutil"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/sshutil"
 )
 
 type mount struct {
 	close func() error
+}
+
+// mountPathAndSftpServer returns location in the native path form, and the
+// sftp-server from sshExe's toolchain. Every driver gets the native form
+// because sshocker rewrites a Cygwin path to backslashes, which a Cygwin
+// ssh.exe then eats, leaving the server a path it cannot resolve. Both server
+// flavors accept the native form. The server is empty for the builtin driver,
+// which sshocker serves in-process, and when the toolchain ships none.
+func mountPathAndSftpServer(ctx context.Context, sshExe sshutil.SSHExe, driver, location string) (resolvedLocation, sftpServerBinary string) {
+	resolvedLocation = filepath.ToSlash(location)
+	if driver == limatype.SFTPDriverBuiltin {
+		return resolvedLocation, ""
+	}
+	sftpServerBinary = sshutil.SftpServerForSSH(ctx, sshExe)
+	if sftpServerBinary == "" {
+		logrus.Infof("reverse-sshfs: no sftp-server in the toolchain of %#q; falling back to a generic search, which may pick one that cannot resolve %#q", sshExe.Exe, resolvedLocation)
+	} else {
+		logrus.Debugf("reverse-sshfs: host path %#q resolved to %#q for sftp-server %#q", location, resolvedLocation, sftpServerBinary)
+	}
+	return resolvedLocation, sftpServerBinary
 }
 
 func (a *HostAgent) setupMounts(ctx context.Context) ([]*mount, error) {
@@ -53,12 +73,9 @@ func (a *HostAgent) setupMount(ctx context.Context, m limatype.Mount) (*mount, e
 	logrus.Infof("Mounting %#q on %#q", m.Location, *m.MountPoint)
 
 	resolvedLocation := m.Location
+	var sftpServerBinary string
 	if runtime.GOOS == "windows" {
-		var err error
-		resolvedLocation, err = fsutil.WindowsSubsystemPath(ctx, m.Location)
-		if err != nil {
-			return nil, err
-		}
+		resolvedLocation, sftpServerBinary = mountPathAndSftpServer(ctx, a.sshExe, *m.SSHFS.SFTPDriver, m.Location)
 	}
 
 	sshAddress, sshPort := a.sshAddressPort()
@@ -66,14 +83,15 @@ func (a *HostAgent) setupMount(ctx context.Context, m limatype.Mount) (*mount, e
 	// modifying HostAgent's sshConfig in case of Windows
 	sshConfig := *a.sshConfig
 	rsf := &reversesshfs.ReverseSSHFS{
-		Driver:              *m.SSHFS.SFTPDriver,
-		SSHConfig:           &sshConfig,
-		LocalPath:           resolvedLocation,
-		Host:                sshAddress,
-		Port:                sshPort,
-		RemotePath:          *m.MountPoint,
-		Readonly:            !(*m.Writable),
-		SSHFSAdditionalArgs: []string{"-o", sshfsOptions},
+		Driver:                  *m.SSHFS.SFTPDriver,
+		OpensshSftpServerBinary: sftpServerBinary,
+		SSHConfig:               &sshConfig,
+		LocalPath:               resolvedLocation,
+		Host:                    sshAddress,
+		Port:                    sshPort,
+		RemotePath:              *m.MountPoint,
+		Readonly:                !(*m.Writable),
+		SSHFSAdditionalArgs:     []string{"-o", sshfsOptions},
 	}
 	if runtime.GOOS == "windows" {
 		// cygwin/msys2 doesn't support full feature set over mux socket, this has at least 2 side effects:

--- a/pkg/hostagent/mount_windows_test.go
+++ b/pkg/hostagent/mount_windows_test.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hostagent
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/sshutil"
+)
+
+// TestMountPathAndSftpServer: the mount path stays native whatever the
+// toolchain, and the sftp-server comes from the toolchain, except under
+// builtin. A Cygwin path form would reach the server as backslashes a Cygwin
+// ssh.exe has eaten, so the Cygwin cases here assert the native form too.
+func TestMountPathAndSftpServer(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only path handling")
+	}
+	ctx := t.Context()
+
+	const location = `C:\Users\lima\shared`
+	const wantPath = "C:/Users/lima/shared"
+
+	// nativeToolchain writes an ssh.exe, plus a sibling sftp-server.exe when
+	// withSftpServer, and returns both paths. The production helpers expand
+	// the 8.3 short path (C:\Users\RUNNER~1\...) that t.TempDir() returns on
+	// GitHub Windows runners, so this fixture expands it too.
+	nativeToolchain := func(t *testing.T, withSftpServer bool) (sshExe, sftpExe string) {
+		t.Helper()
+		dir := t.TempDir()
+		resolved, err := filepath.EvalSymlinks(dir)
+		assert.NilError(t, err)
+		sshExe = filepath.Join(resolved, "ssh.exe")
+		assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+		if withSftpServer {
+			sftpExe = filepath.Join(resolved, "sftp-server.exe")
+			assert.NilError(t, os.WriteFile(sftpExe, nil, 0o644))
+		}
+		return sshExe, sftpExe
+	}
+
+	t.Run("sibling sftp-server pairs with the native path form", func(t *testing.T) {
+		sshExe, sftpExe := nativeToolchain(t, true)
+
+		gotPath, gotServer := mountPathAndSftpServer(ctx, sshutil.SSHExe{Exe: sshExe}, "", location)
+		assert.Equal(t, gotPath, wantPath)
+		assert.Equal(t, gotServer, sftpExe)
+	})
+
+	t.Run("no sibling sftp-server leaves detection to sshocker", func(t *testing.T) {
+		sshExe, _ := nativeToolchain(t, false)
+
+		gotPath, gotServer := mountPathAndSftpServer(ctx, sshutil.SSHExe{Exe: sshExe}, "", location)
+		assert.Equal(t, gotPath, wantPath)
+		assert.Equal(t, gotServer, "", "no sibling -> sshocker detects one itself")
+	})
+
+	t.Run("builtin driver gets no sftp-server", func(t *testing.T) {
+		sshExe, _ := nativeToolchain(t, true)
+
+		gotPath, gotServer := mountPathAndSftpServer(ctx, sshutil.SSHExe{Exe: sshExe}, limatype.SFTPDriverBuiltin, location)
+		assert.Equal(t, gotPath, wantPath)
+		assert.Equal(t, gotServer, "", "builtin serves the mount in-process")
+	})
+
+	t.Run("a Cygwin toolchain gets the native path under every driver", func(t *testing.T) {
+		sshExe, _ := nativeToolchain(t, false)
+		// cygpath.exe beside ssh.exe marks the toolchain as Cygwin.
+		assert.NilError(t, os.WriteFile(filepath.Join(filepath.Dir(sshExe), "cygpath.exe"), nil, 0o644))
+
+		for _, driver := range []string{"", limatype.SFTPDriverBuiltin, limatype.SFTPDriverOpenSSHSFTPServer} {
+			gotPath, _ := mountPathAndSftpServer(ctx, sshutil.SSHExe{Exe: sshExe}, driver, location)
+			assert.Equal(t, gotPath, wantPath, "driver %q: sshocker turns a Cygwin form into backslashes that a Cygwin ssh.exe eats", driver)
+		}
+	})
+
+	t.Run("explicit openssh-sftp-server driver pairs with the sibling", func(t *testing.T) {
+		sshExe, sftpExe := nativeToolchain(t, true)
+
+		gotPath, gotServer := mountPathAndSftpServer(ctx, sshutil.SSHExe{Exe: sshExe}, limatype.SFTPDriverOpenSSHSFTPServer, location)
+		assert.Equal(t, gotPath, wantPath)
+		assert.Equal(t, gotServer, sftpExe)
+	})
+}

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -230,8 +230,8 @@ func PathForSSH(ctx context.Context, sshExe SSHExe, orig string) (string, error)
 }
 
 // SftpServerForSSH returns the path of sftp-server binary from sshExe's toolchain,
-// so a locally-spawned sftp-server (reverse-sshfs) uses the same path form
-// PathForSSH produces. For Cygwin-based ssh the sibling cygpath resolves
+// so the server behind a reverse-sshfs mount comes from the same install as the
+// ssh driving it. For Cygwin-based ssh the sibling cygpath resolves
 // /usr/lib/ssh/sftp-server; for native OpenSSH it is sftp-server.exe beside
 // ssh.exe. Returns "" on non-Windows, empty input, or no match, leaving the
 // caller to fall back to its library's auto-detection.
@@ -244,20 +244,24 @@ func SftpServerForSSH(ctx context.Context, sshExe SSHExe) string {
 		if err != nil {
 			return ""
 		}
+		// Validate with LookPath, which appends the ".exe" that cygpath omits.
+		// Under the default driver sshocker resolves this path with LookPath as
+		// well and fails the mount when it does not resolve, so returning
+		// nothing beats returning a path it will reject.
 		candidate := strings.TrimSpace(string(out))
-		for _, p := range []string{candidate, candidate + ".exe"} {
-			if _, err := os.Stat(p); err == nil {
-				return p
-			}
+		sftpServer, err := exec.LookPath(candidate)
+		if err != nil {
+			logrus.WithError(err).Debugf("cannot use the sftp-server at %#q that cygpath resolved", candidate)
+			return ""
 		}
-		return ""
+		return sftpServer
 	}
 	path, ok := resolvedSSHPath(sshExe)
 	if !ok {
 		return ""
 	}
-	sftpServer := filepath.Join(filepath.Dir(path), "sftp-server.exe")
-	if _, err := os.Stat(sftpServer); err != nil {
+	sftpServer, err := exec.LookPath(filepath.Join(filepath.Dir(path), "sftp-server.exe"))
+	if err != nil {
 		return ""
 	}
 	return sftpServer

--- a/pkg/sshutil/sshutil_windows_test.go
+++ b/pkg/sshutil/sshutil_windows_test.go
@@ -7,10 +7,42 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
 )
+
+const (
+	fakeCygpathOutEnv  = "LIMA_TEST_FAKE_CYGPATH_OUT"
+	fakeCygpathFailure = "exit-non-zero"
+)
+
+// TestMain doubles as a fake cygpath.exe. With fakeCygpathOutEnv set it prints
+// that value and exits 0, or exits 1 when the value is fakeCygpathFailure, so a
+// test can copy this binary beside an ssh.exe and drive the Cygwin branch. An
+// empty value would not work as the failure signal, because Windows cannot
+// distinguish an empty environment variable from an unset one.
+//
+// It answers only the sftp-server probe and rejects any other command line. A
+// change to the arguments in SftpServerForSSH then breaks this test instead of
+// going unnoticed. A test driving a different cygpath call needs its own arm.
+func TestMain(m *testing.M) {
+	if out, ok := os.LookupEnv(fakeCygpathOutEnv); ok {
+		if want := []string{"-w", "/usr/lib/ssh/sftp-server"}; !slices.Equal(os.Args[1:], want) {
+			os.Stderr.WriteString("fake cygpath: got " + strings.Join(os.Args[1:], " ") +
+				", want " + strings.Join(want, " ") + "\n")
+			os.Exit(2)
+		}
+		if out == fakeCygpathFailure {
+			os.Exit(1)
+		}
+		os.Stdout.WriteString(out + "\n")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
 
 // TestPickCompleteSSHOnWindows: an ssh.exe missing scp.exe or
 // ssh-keygen.exe (MinGit's shape) is skipped for the next complete
@@ -123,6 +155,41 @@ func TestSftpServerForSSH(t *testing.T) {
 	})
 }
 
+// TestSftpServerForSSHCygwin: the Cygwin branch reports what the sibling
+// cygpath resolves, but only once that names an executable. cygpath omits the
+// .exe suffix, so the candidate reaches LookPath without one.
+func TestSftpServerForSSHCygwin(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only path handling")
+	}
+	ctx := t.Context()
+
+	t.Run("candidate without .exe resolves to the binary beside it", func(t *testing.T) {
+		sshExe := cygwinToolchain(t)
+		dir := filepath.Dir(sshExe)
+		sftpExe := filepath.Join(dir, "sftp-server.exe")
+		assert.NilError(t, os.WriteFile(sftpExe, nil, 0o644))
+		t.Setenv(fakeCygpathOutEnv, filepath.Join(dir, "sftp-server"))
+
+		assert.Equal(t, SftpServerForSSH(ctx, SSHExe{Exe: sshExe}), sftpExe)
+	})
+
+	t.Run("candidate that resolves to nothing returns empty", func(t *testing.T) {
+		sshExe := cygwinToolchain(t)
+		t.Setenv(fakeCygpathOutEnv, filepath.Join(filepath.Dir(sshExe), "sftp-server"))
+
+		assert.Equal(t, SftpServerForSSH(ctx, SSHExe{Exe: sshExe}), "",
+			"unresolvable candidate -> caller falls back to sshocker auto-detect")
+	})
+
+	t.Run("cygpath failure returns empty", func(t *testing.T) {
+		sshExe := cygwinToolchain(t)
+		t.Setenv(fakeCygpathOutEnv, fakeCygpathFailure)
+
+		assert.Equal(t, SftpServerForSSH(ctx, SSHExe{Exe: sshExe}), "")
+	})
+}
+
 // TestCompanionForSSH: a companion tool is resolved beside the selected
 // ssh.exe, and falls back to the bare name when no sibling exists.
 func TestCompanionForSSH(t *testing.T) {
@@ -151,6 +218,22 @@ func TestCompanionForSSH(t *testing.T) {
 	t.Run("empty input falls back to the bare name", func(t *testing.T) {
 		assert.Equal(t, companionForSSH(SSHExe{}, "ssh-keygen"), "ssh-keygen")
 	})
+}
+
+// cygwinToolchain writes an ssh.exe into a fresh directory, plus a cygpath.exe
+// that is a copy of this test binary, and returns the ssh.exe path.
+func cygwinToolchain(t *testing.T) string {
+	t.Helper()
+	dir := resolvedTempDir(t)
+	sshExe := filepath.Join(dir, "ssh.exe")
+	assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+
+	self, err := os.Executable()
+	assert.NilError(t, err)
+	binary, err := os.ReadFile(self)
+	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "cygpath.exe"), binary, 0o755))
+	return sshExe
 }
 
 // resolvedTempDir is t.TempDir() run through EvalSymlinks, matching what

--- a/website/content/en/docs/config/mount.md
+++ b/website/content/en/docs/config/mount.md
@@ -59,6 +59,12 @@ The default value of `sftpDriver` has been set to "openssh-sftp-server" since Li
 such as `/usr/libexec/sftp-server` is detected on the host.
 Lima prior to v0.10 had used "builtin" as the SFTP driver.
 
+On Windows, unless `sftpDriver` is "builtin", Lima first looks for an sftp-server in the toolchain of the
+`ssh.exe` it selected, either `sftp-server.exe` beside a native OpenSSH or `/usr/lib/ssh/sftp-server` for a
+Cygwin-based one. Only if that finds nothing does the generic search apply.
+This matters when a Cygwin-based OpenSSH (Git for Windows, MSYS2) and the native Windows OpenSSH are both
+installed. The host path handed to the server is always the native `C:/Users/USER` form, which both kinds resolve.
+
 #### Caveats
 - A mount is disabled when the SSH connection was shut down.
 - A compromised `sshfs` process in the guest may have access to unexposed host directories.


### PR DESCRIPTION
The sftp-server that serves a mount and the host path handed to it now come from one install, the one holding the ssh.exe Lima selected at startup. Otherwise sshocker picks an sftp-server off PATH that may come from a different toolchain than the one the path was converted for, and cannot resolve what it is given.

The builtin driver instead gets the native form, because sshocker serves that one in-process, where a Cygwin path resolves to the wrong directory.

#5299 also touches `pkg/sshutil/sshutil.go`, `pkg/sshutil/sshutil_windows_test.go`, and `pkg/hostagent/hostagent.go`, in different places; the two apply cleanly in either order.

The Windows CI runner uses MSYS2 / Git for Windows, so it exercises the Cygwin path. End-to-end validation on a plain Windows host, with no Cygwin toolchain present, arrives with the plain-Windows CI jobs in #5342.

Assisted-by: Claude Opus 5