### PR TITLE
sshutil: remove the unused IsSSHCygwin

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -139,14 +139,6 @@ var (
 	cygwinDetectCacheRW sync.RWMutex
 )
 
-// IsSSHCygwin reports whether sshExe is a Cygwin-based OpenSSH (Git for
-// Windows, MSYS2, Cygwin) rather than native Windows OpenSSH; always false
-// on non-Windows. See cygpathForSSH for the detection and caching.
-func IsSSHCygwin(sshExe SSHExe) bool {
-	_, ok := cygpathForSSH(sshExe)
-	return ok
-}
-
 // resolvedSSHPath returns the absolute, symlink-resolved path of sshExe's
 // binary — the directory Lima reads its companion tools from. It returns
 // ("", false) when a bare name does not resolve on PATH.

--- a/pkg/sshutil/sshutil_windows_test.go
+++ b/pkg/sshutil/sshutil_windows_test.go
@@ -70,7 +70,6 @@ func TestCygpathForSSH(t *testing.T) {
 		got, ok := cygpathForSSH(SSHExe{Exe: sshExe})
 		assert.Equal(t, ok, true, "ssh.exe next to cygpath.exe should be Cygwin")
 		assert.Equal(t, got, cygpathExe, "should return the sibling cygpath, not bare 'cygpath'")
-		assert.Equal(t, IsSSHCygwin(SSHExe{Exe: sshExe}), true)
 	})
 
 	t.Run("native", func(t *testing.T) {
@@ -81,7 +80,6 @@ func TestCygpathForSSH(t *testing.T) {
 		got, ok := cygpathForSSH(SSHExe{Exe: sshExe})
 		assert.Equal(t, ok, false, "ssh.exe with no sibling cygpath.exe should be native")
 		assert.Equal(t, got, "")
-		assert.Equal(t, IsSSHCygwin(SSHExe{Exe: sshExe}), false)
 	})
 
 	t.Run("empty", func(t *testing.T) {


### PR DESCRIPTION
`PathForSSH` was its only caller. It switched to `cygpathForSSH`, which returns the sibling cygpath it needs, and `IsSSHCygwin` has had no caller since it landed in #5205.

The two assertions dropped from `TestCygpathForSSH` re-checked the boolean that the `cygpathForSSH` assertion on the preceding line already covers, so coverage is unchanged.

Part of a series continuing the native Windows OpenSSH work from #5205 and #5270: #5298, #5299, #5300, #5301. They are independent and can merge in any order. #5298 and #5301 both touch `pkg/sshutil/sshutil.go`, in different functions, and apply cleanly in either order.
