### PR TITLE
docs: document flaky CI runs and re-running failed jobs

### DIFF
--- a/website/content/en/docs/dev/testing/_index.md
+++ b/website/content/en/docs/dev/testing/_index.md
@@ -62,3 +62,13 @@ The tests about macOS-specific features (e.g., vz and vmnet) are still executed 
 
 Currently, the Intel version of macOS is used, as the ARM version of macOS on GitHub Actions still
 do not support nested virtualization.
+
+### Flaky runs
+
+CI is occasionally flaky, especially the integration tests on the slower macOS runners.
+A job can fail for reasons unrelated to the change under test, such as a timeout or a
+transient VM or network error.
+
+When this happens, the failed jobs can simply be re-run. Maintainers can re-run them from
+the GitHub Actions UI; contributors without write access can ask a maintainer to re-run the
+job, or push another commit to re-trigger the workflow.


### PR DESCRIPTION
## What

Adds a short "Flaky runs" note to the testing docs, as requested by @jandubois in the review of #4989 (tracked in #5266): CI is occasionally flaky, and failed jobs can simply be re-run.

## Details

Under the existing `## CI` section of `website/content/en/docs/dev/testing/_index.md`, this adds a `### Flaky runs` subsection noting that CI (especially the macOS integration tests, already described as "slow and flaky" just above) can fail for reasons unrelated to the change under test, and that the failed jobs can be re-run — by maintainers from the GitHub Actions UI, or by contributors re-triggering the workflow.

Closes #5266.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). It is a docs-only single-file change. DCO sign-off included.*
