### PR TITLE
fix: only extend Windows guest timeout on initial boot

### DIFF
--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -622,8 +622,10 @@ func startAction(cmd *cobra.Command, args []string) error {
 	}
 
 	if !cmd.Flags().Changed("timeout") && *inst.Config.OS == limatype.WINDOWS {
-		timeout = instance.WinDefaultWatchHostAgentEventsTimeout
-		logrus.Infof("Extended the default timeout to %v for Windows guest boot.", timeout)
+		if _, err := os.Stat(filepath.Join(inst.Dir, filenames.WinDoneInstallation)); err != nil {
+			timeout = instance.WinDefaultWatchHostAgentEventsTimeout
+			logrus.Infof("Extended the default timeout to %v for Windows guest initial boot.", timeout)
+		}
 	}
 
 	if timeout > 0 {


### PR DESCRIPTION
<!-- Please read our contribution rules before submitting:

- Pull requests guide: https://lima-vm.io/docs/community/contributing/#sending-pull-requests
- AI usage policy: https://lima-vm.io/docs/community/contributing/#ai-contribution-rules

-->

## What This PR Changes

`limactl start` always stretches the default timeout from 10m to 30m for Windows guests(#5294),  even when just restarting an already-installed instance.   
This change only applies the 30m timeout on the inital boot, by checking for the `win-done-installation` marker file


## Linked Issue (Required in most cases)

Closes #5296 

## How I Tested This

I verified the branching logic end-to-end without a real Windows boot:
- Created a minimal `os: windows` \ `vmType: qemu` instance (dummy disk image, no real ISO).
- Ran `limactl start`: with no `win-done-installation` marker, the log shows the timeout was extended to 30m
- After creating the marker file and restarting, the extension log does not appear (default 10m timeout is used)


