### PR TITLE
end rsync option parsing before the copy paths

### DIFF
--- a/pkg/copytool/copytool_test.go
+++ b/pkg/copytool/copytool_test.go
@@ -4,6 +4,7 @@
 package copytool
 
 import (
+	"slices"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -24,4 +25,22 @@ func TestCommandDoesNotMutateOptions(t *testing.T) {
 
 	assert.Equal(t, tool.Options.Verbose, false, "Command() must not mutate stored Options.Verbose")
 	assert.Equal(t, tool.Options.Recursive, false, "Command() must not mutate stored Options.Recursive")
+}
+
+// TestRsyncCommandEndsOptionParsing verifies that a path starting with a dash is
+// passed after "--", so rsync cannot mistake it for an option such as --rsh.
+func TestRsyncCommandEndsOptionParsing(t *testing.T) {
+	tool, err := newRsyncTool(&Options{})
+	if err != nil {
+		t.Skip("rsync not found:", err)
+	}
+
+	const dashPath = "--rsh=touch pwned"
+	// Use local paths to avoid instance lookup
+	cmd, err := tool.Command(t.Context(), []string{dashPath, "/tmp/dst"}, nil)
+	assert.NilError(t, err)
+
+	sep := slices.Index(cmd.Args, "--")
+	assert.Assert(t, sep != -1, "rsync args must contain the %#q separator: %v", "--", cmd.Args)
+	assert.Assert(t, slices.Index(cmd.Args, dashPath) > sep, "path %#q must come after %#q: %v", dashPath, "--", cmd.Args)
 }

--- a/pkg/copytool/rsync.go
+++ b/pkg/copytool/rsync.go
@@ -168,6 +168,10 @@ func (t *rsyncTool) Command(ctx context.Context, paths []string, opts *Options) 
 		}
 	}
 
+	// End option parsing so a path starting with a dash is treated as a path,
+	// not as an rsync option. scp.go does the same.
+	rsyncArgs = append(rsyncArgs, "--")
+
 	for _, cp := range copyPaths {
 		if cp.IsRemote {
 			rsyncArgs = append(rsyncArgs, fmt.Sprintf("%s:%s", *cp.Instance.Config.User.Name+"@"+cp.Instance.SSHAddress, cp.Path))


### PR DESCRIPTION
The rsync backend appends the copy paths straight after the flag list, so rsync parses any path beginning with a dash as an option. A file named `--rsh=<cmd>` that reaches the argv, for instance through a shell glob over a directory the guest can write via a writable mount, overrides the `-e` we pass and rsync runs it on the host. The scp backend already ends its flags with `--`; this does the same for rsync, and the test checks the dashed path lands after the separator.