### PR TITLE
docs: fix deprecated Rosetta configuration reference

### DIFF
--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -427,7 +427,7 @@ os: null
 # DEPRECATED: Use vmOpts.qemu.cpuType instead. See the vmOpts.qemu.cpuType section above for configuration.
 cpuType:
 
-# DEPRECATED: Use vmOpts.vz.rosetta instead. See the vmOpts.qemu.cpuType section above for configuration.
+# DEPRECATED: Use vmOpts.vz.rosetta instead. See the vmOpts.vz.rosetta section above for configuration.
 rosetta:
   enabled: null
   binfmt: null


### PR DESCRIPTION
The deprecated `rosetta` key points readers to the QEMU CPU configuration section. Point it to the matching `vmOpts.vz.rosetta` section instead.

Validation:
- `limactl validate templates/default.yaml`
- `yamllint .`

Assisted-by: OpenAI Codex