### PR TITLE
fix: remove stale Rosetta CDI symlink

### DIFF
--- a/pkg/driver/vz/boot.Linux/05-rosetta-volume.sh
+++ b/pkg/driver/vz/boot.Linux/05-rosetta-volume.sh
@@ -107,5 +107,5 @@ EOF
 else
 	# Remove CDI configuration for Rosetta AOT Caching
 	[ ! -f /etc/cdi/rosetta.yaml ] || rm /etc/cdi/rosetta.yaml
-	[ ! -d "${LIMA_CIDATA_HOME}/.config/cdi/rosetta.yaml" ] || rm "${LIMA_CIDATA_HOME}/.config/cdi/rosetta.yaml"
+	[ ! -L "${LIMA_CIDATA_HOME}/.config/cdi/rosetta.yaml" ] || rm "${LIMA_CIDATA_HOME}/.config/cdi/rosetta.yaml"
 fi


### PR DESCRIPTION
## Description

Remove the per-user Rosetta CDI configuration symlink when Rosetta AOT caching is unavailable.

The script creates the user configuration as a symlink to /etc/cdi/rosetta.yaml. Cleanup removes that target first, leaving a dangling symlink. The current -d test does not match it, while -L identifies the symlink and allows it to be removed.

## Testing

- bash syntax check
- ShellCheck 0.11.0
- shfmt 3.13.1
- Disposable dangling-symlink reproducer confirming -d misses the link and -L detects it after target removal

Assisted-by: OpenAI Codex