### PR TITLE
reject invalid guest ip or protocol in forwardingAddresses

### DIFF
--- a/pkg/hostagent/port.go
+++ b/pkg/hostagent/port.go
@@ -83,6 +83,13 @@ func hostAddress(rule limatype.PortForward, guest *api.IPPort) string {
 
 func (pf *portForwarder) forwardingAddresses(guest *api.IPPort) (hostAddr, guestAddr string) {
 	guestIP := net.ParseIP(guest.Ip)
+	// guest.Ip and guest.Protocol arrive from the guest agent over gRPC and are
+	// otherwise untrusted. Drop entries that are not a valid ip / known protocol so
+	// raw guest bytes never reach the forwarded address, the host logs, or the
+	// port-forward events that limactl prints to the user's terminal.
+	if guestIP == nil || (guest.Protocol != "tcp" && guest.Protocol != "udp") {
+		return "", ""
+	}
 	for _, rule := range pf.rules {
 		if rule.GuestSocket != "" {
 			continue

--- a/pkg/hostagent/port_test.go
+++ b/pkg/hostagent/port_test.go
@@ -36,3 +36,19 @@ func TestPortForwardRulesStillForwardOtherPorts(t *testing.T) {
 		assert.Equal(t, hostAddr, "127.0.0.1:8080", "guest %s:8080", guestIP)
 	}
 }
+
+func TestForwardingAddressesRejectsUntrustedGuestFields(t *testing.T) {
+	pf := testPortForwarder(60022)
+	// Ip and Protocol are proto3 strings supplied by the guest agent; a hostile
+	// value must not be forwarded or returned as the guest address, otherwise the
+	// bytes reach the host logs and the events limactl prints.
+	for _, guest := range []*api.IPPort{
+		{Ip: "127.0.0.1\x1b]0;pwned\x07", Port: 8080, Protocol: "tcp"},
+		{Ip: "not-an-ip", Port: 8080, Protocol: "tcp"},
+		{Ip: "127.0.0.1", Port: 8080, Protocol: "tcp\nforwarding evil"},
+	} {
+		hostAddr, guestAddr := pf.forwardingAddresses(guest)
+		assert.Equal(t, hostAddr, "", "ip=%q proto=%q", guest.Ip, guest.Protocol)
+		assert.Equal(t, guestAddr, "", "ip=%q proto=%q", guest.Ip, guest.Protocol)
+	}
+}

--- a/pkg/portfwd/forward.go
+++ b/pkg/portfwd/forward.go
@@ -99,6 +99,13 @@ func (fw *Forwarder) OnEvent(ctx context.Context, dialContext func(ctx context.C
 
 func (fw *Forwarder) forwardingAddresses(guest *api.IPPort) (hostAddr, guestAddr string) {
 	guestIP := net.ParseIP(guest.Ip)
+	// guest.Ip and guest.Protocol arrive from the guest agent over gRPC and are
+	// otherwise untrusted. Drop entries that are not a valid ip / known protocol so
+	// raw guest bytes never reach the forwarded address, the host logs, or the
+	// port-forward events that limactl prints to the user's terminal.
+	if guestIP == nil || (guest.Protocol != "tcp" && guest.Protocol != "udp") {
+		return "", ""
+	}
 	for _, rule := range fw.rules {
 		if rule.GuestSocket != "" {
 			continue

--- a/pkg/portfwd/forward_test.go
+++ b/pkg/portfwd/forward_test.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package portfwd
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/guestagent/api"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limayaml"
+)
+
+func testForwarder() *Forwarder {
+	rule := limatype.PortForward{}
+	limayaml.FillPortForwardDefaults(&rule, "", limatype.User{}, nil)
+	return NewPortForwarder([]limatype.PortForward{rule}, false, false, nil)
+}
+
+func TestForwardingAddressesForwardsValidPort(t *testing.T) {
+	fw := testForwarder()
+	hostAddr, _ := fw.forwardingAddresses(&api.IPPort{Ip: "127.0.0.1", Port: 8080, Protocol: "tcp"})
+	assert.Equal(t, hostAddr, "127.0.0.1:8080")
+}
+
+func TestForwardingAddressesRejectsUntrustedGuestFields(t *testing.T) {
+	fw := testForwarder()
+	// Ip and Protocol are proto3 strings supplied by the guest agent; a hostile
+	// value must not be forwarded or returned as the guest address, otherwise the
+	// bytes reach the host logs and the events limactl prints.
+	for _, guest := range []*api.IPPort{
+		{Ip: "127.0.0.1\x1b]0;pwned\x07", Port: 8080, Protocol: "tcp"},
+		{Ip: "not-an-ip", Port: 8080, Protocol: "tcp"},
+		{Ip: "127.0.0.1", Port: 8080, Protocol: "tcp\nforwarding evil"},
+	} {
+		hostAddr, guestAddr := fw.forwardingAddresses(guest)
+		assert.Equal(t, hostAddr, "", "ip=%q proto=%q", guest.Ip, guest.Protocol)
+		assert.Equal(t, guestAddr, "", "ip=%q proto=%q", guest.Ip, guest.Protocol)
+	}
+}


### PR DESCRIPTION
## What This PR Changes

The port forwarders read `api.IPPort` values off the guest-agent event stream. `forwardingAddresses` (in `pkg/portfwd/forward.go` and `pkg/hostagent/port.go`) hands the guest-supplied `Ip` back as `guest.HostString()`, and the forwarders copy `guest.Protocol` straight into `PortForwardEvent`. `net.ParseIP` was only used for rule matching, so an `Ip` that never parses still rides the catch-all rule through to the address, and both strings then land in the host-agent log and the events that `limactl watch`/`start` print to the terminal. A compromised guest can put escape sequences or forged log lines in `Ip` or `Protocol` and inject them into the operator console.

This validates the guest `Ip` and `Protocol` at the top of both `forwardingAddresses` functions (`Ip` must parse, `Protocol` must be `tcp` or `udp` per the proto contract) and drops anything else before it reaches the address, logs, or events.

## Linked Issue (Required in most cases)

No separate issue filed; this is a hardening fix for the guest-to-host trust boundary in the port forwarders. Happy to open one if you'd prefer to track it separately.

## How I Tested This

`go test ./pkg/portfwd/ ./pkg/hostagent/` (added regression tests in both packages that feed hostile `Ip`/`Protocol` values and assert no host or guest address is produced), plus `go build ./...`, `gofmt`, and `go vet`.

## AI Usage

None.
