### PR TITLE
feat(cli): add limactl-menu TUI plugin for instance management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,11 +316,15 @@ endif
 
 LIBEXEC_LIMA := _output/libexec/lima
 
-limactl-plugins: $(LIBEXEC_LIMA)/limactl-mcp$(exe) $(LIBEXEC_LIMA)/limactl-url-fedora-rawhide
+limactl-plugins: $(LIBEXEC_LIMA)/limactl-mcp$(exe) $(LIBEXEC_LIMA)/limactl-url-fedora-rawhide $(LIBEXEC_LIMA)/limactl-menu$(exe)
 
 $(LIBEXEC_LIMA)/limactl-mcp$(exe): $(call dependencies_for_cmd,limactl-mcp) $$(call force_build,$$@)
 	@mkdir -p $(LIBEXEC_LIMA)
 	$(ENVS_$@) $(GO_BUILD) -o $@ ./cmd/limactl-mcp
+
+$(LIBEXEC_LIMA)/limactl-menu$(exe): $(call dependencies_for_cmd,limactl-menu) $$(call force_build,$$@)
+	@mkdir -p $(LIBEXEC_LIMA)
+	$(ENVS_$@) $(GO_BUILD) -o $@ ./cmd/limactl-menu
 
 $(LIBEXEC_LIMA)/limactl-url-fedora-rawhide: cmd/limactl-url-fedora-rawhide
 	cp -aL $< $@
@@ -593,6 +597,7 @@ uninstall:
 		"$(DEST)/share/doc/lima" \
 		"$(DEST)/libexec/lima/limactl-mcp$(exe)" \
 		"$(DEST)/libexec/lima/limactl-url-fedora-rawhide" \
+		"$(DEST)/libexec/lima/limactl-menu$(exe)" \
 		"$(DEST)/libexec/lima/lima-driver-qemu$(exe)" \
 		"$(DEST)/libexec/lima/lima-driver-vz$(exe)" \
 		"$(DEST)/libexec/lima/lima-driver-wsl2$(exe)" \

--- a/cmd/limactl-menu/main.go
+++ b/cmd/limactl-menu/main.go
@@ -1,0 +1,425 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/v2/pkg/limactlutil"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/version"
+)
+
+var (
+	cPrim = tcell.NewRGBColor(0x32, 0xCD, 0x32)
+	cSec  = tcell.NewRGBColor(0x4E, 0x9A, 0x06)
+	cBord = tcell.NewRGBColor(0x55, 0x55, 0x55)
+	cTxt  = tcell.ColorWhite
+	cDim  = tcell.ColorGray
+)
+
+type State struct {
+	insts   []*limatype.Instance
+	limactl string
+	app     *tview.Application
+	list    *tview.List
+}
+
+func main() {
+	if err := newApp().Execute(); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func newApp() *cobra.Command {
+	return &cobra.Command{
+		Use:           "limactl-menu",
+		Short:         "TUI menu for Lima instances (EXPERIMENTAL)",
+		Version:       strings.TrimPrefix(version.Version, "v"),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE:          runMenu,
+	}
+}
+
+func runMenu(cmd *cobra.Command, _ []string) error {
+	limactl, err := limactlutil.Path()
+	if err != nil {
+		return err
+	}
+	ctx := cmd.Context()
+	insts, err := listInstances(ctx, limactl)
+	if err != nil {
+		return err
+	}
+	if len(insts) == 0 {
+		return showEmptyState(ctx, limactl)
+	}
+	s := &State{insts: insts, limactl: limactl}
+	return s.run()
+}
+
+func (s *State) run() error {
+	s.app = tview.NewApplication().EnableMouse(true)
+	s.setupStyles()
+	s.buildUI()
+
+	footer := tview.NewTextView().
+		SetDynamicColors(true).
+		SetText(" [yellow]F1[white] Actions  [yellow]F2[white] Start/Stop  [yellow]F3[white] Info  [yellow]F5[white] Restart  [yellow]F8[white] Delete  [yellow]F10[white] Quit")
+
+	flex := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(s.list, 0, 1, true).
+		AddItem(footer, 1, 1, false)
+
+	s.app.SetRoot(flex, true).SetFocus(s.list)
+	s.app.SetInputCapture(s.handleGlobalKey)
+	return s.app.Run()
+}
+
+func (s *State) setupStyles() {
+	tview.Styles.PrimitiveBackgroundColor = tcell.ColorDefault
+	tview.Styles.ContrastBackgroundColor = tcell.ColorDefault
+	tview.Styles.PrimaryTextColor = cTxt
+	tview.Styles.SecondaryTextColor = cDim
+	tview.Styles.TertiaryTextColor = cDim
+	tview.Styles.InverseTextColor = tcell.ColorBlack
+	tview.Styles.ContrastSecondaryTextColor = cTxt
+}
+
+func (s *State) buildUI() {
+	s.list = tview.NewList().
+		SetHighlightFullLine(true).
+		SetMainTextColor(cTxt).
+		SetSelectedTextColor(tcell.ColorBlack).
+		SetSelectedBackgroundColor(cPrim)
+	s.list.SetBorder(true).
+		SetBorderColor(cBord).
+		SetTitle(" Lima Instances ").
+		SetTitleAlign(tview.AlignLeft).
+		SetTitleColor(cPrim).
+		SetBorderPadding(1, 1, 1, 1)
+
+	for _, in := range s.insts {
+		inst := in
+		s.list.AddItem(fmtInst(inst), "", 0, func() {
+			s.showActions(inst)
+		})
+	}
+	if len(s.insts) > 0 {
+		s.list.SetCurrentItem(0)
+	}
+}
+
+func fmtInst(in *limatype.Instance) string {
+	icon := map[string]string{
+		"Running":    "[green]●[white]",
+		"Stopped":    "[red]●[white]",
+		"Broken":     "[yellow]●[white]",
+		"Installing": "[blue]◐[white]",
+	}[in.Status]
+	if icon == "" {
+		icon = "[gray]○[white]"
+	}
+
+	name := in.Name
+	if len(name) > 16 {
+		name = name[:13] + "..."
+	}
+
+	mem := float64(in.Memory) / 1e9
+	cpusMem := fmt.Sprintf("%dCPU/%.1fGB", in.CPUs, mem)
+
+	sshAddr := fmt.Sprintf("%s:%d", in.SSHAddress, in.SSHLocalPort)
+	if in.SSHAddress == "" || in.SSHLocalPort == 0 {
+		sshAddr = "-"
+	}
+
+	prot := ""
+	if in.Protected {
+		prot = " [LOCKED]"
+	}
+
+	return fmt.Sprintf("%s  %-16s  %-10s  %-8s  %-12s  %s%s", icon, name, in.Status, in.Arch, cpusMem, sshAddr, prot)
+}
+
+func (s *State) currentInst() *limatype.Instance {
+	idx := s.list.GetCurrentItem()
+	if idx >= 0 && idx < len(s.insts) {
+		return s.insts[idx]
+	}
+	return nil
+}
+
+func (s *State) handleGlobalKey(e *tcell.EventKey) *tcell.EventKey {
+	if e.Key() == tcell.KeyCtrlC || e.Key() == tcell.KeyF10 {
+		s.app.Stop()
+		return nil
+	}
+
+	in := s.currentInst()
+	if in == nil {
+		return e
+	}
+
+	switch e.Key() {
+	case tcell.KeyF1:
+		s.showActions(in)
+		return nil
+	case tcell.KeyF2:
+		s.toggleStartStop(in)
+		return nil
+	case tcell.KeyF3:
+		s.showInfo(in)
+		return nil
+	case tcell.KeyF5:
+		s.confirm(fmt.Sprintf("Confirm restart '%s'?", in.Name), func() { s.execCmd("restart", in.Name) })
+		return nil
+	case tcell.KeyF8:
+		s.confirm(fmt.Sprintf("DELETE instance '%s'?\nThis cannot be undone.", in.Name), func() { s.execCmd("delete", in.Name) })
+		return nil
+	case tcell.KeyRune:
+		switch e.Rune() {
+		case 'q', 'Q':
+			s.app.Stop()
+			return nil
+		case 'h', '?':
+			s.showActions(in)
+			return nil
+		case 's', 'S':
+			s.execCmd("shell", in.Name)
+			return nil
+		case 'i', 'I':
+			s.showInfo(in)
+			return nil
+		case 't', 'T':
+			s.toggleStartStop(in)
+			return nil
+		case 'r', 'R':
+			s.confirm(fmt.Sprintf("Confirm restart '%s'?", in.Name), func() { s.execCmd("restart", in.Name) })
+			return nil
+		case 'd', 'D':
+			s.confirm(fmt.Sprintf("DELETE instance '%s'?\nThis cannot be undone.", in.Name), func() { s.execCmd("delete", in.Name) })
+			return nil
+		}
+	}
+	return e
+}
+
+func (s *State) toggleStartStop(in *limatype.Instance) {
+	if in.Status == "Running" {
+		s.confirm(fmt.Sprintf("Confirm stop '%s'?", in.Name), func() { s.execCmd("stop", in.Name) })
+	} else {
+		s.execCmd("start", in.Name)
+	}
+}
+
+func (s *State) showActions(in *limatype.Instance) {
+	actions := []struct {
+		name string
+		fn   func()
+	}{
+		{"Shell", func() { s.execCmd("shell", in.Name) }},
+		{"Start / Stop Toggle", func() { s.toggleStartStop(in) }},
+		{"Restart", func() {
+			s.confirm(fmt.Sprintf("Confirm restart '%s'?", in.Name), func() { s.execCmd("restart", in.Name) })
+		}},
+		{"Show Info", func() { s.showInfo(in) }},
+		{"Show Ports", func() { s.showPorts(in) }},
+		{"Protect", func() { s.execCmd("protect", in.Name) }},
+		{"Unprotect", func() {
+			s.confirm(fmt.Sprintf("Confirm unprotect '%s'?", in.Name), func() { s.execCmd("unprotect", in.Name) })
+		}},
+		{"Delete", func() {
+			s.confirm(fmt.Sprintf("DELETE instance '%s'?\nThis cannot be undone.", in.Name), func() { s.execCmd("delete", in.Name) })
+		}},
+		{"Cancel", nil},
+	}
+
+	modal := tview.NewList().
+		SetHighlightFullLine(true).
+		SetMainTextColor(cTxt).
+		SetSelectedTextColor(tcell.ColorBlack).
+		SetSelectedBackgroundColor(cSec)
+	modal.SetBorder(true).
+		SetBorderColor(cBord).
+		SetTitle(fmt.Sprintf(" Actions for %s ", in.Name)).
+		SetTitleAlign(tview.AlignLeft).
+		SetTitleColor(cSec).
+		SetBorderPadding(1, 1, 1, 1)
+
+	for _, a := range actions {
+		action := a
+		modal.AddItem("  "+action.name, "", 0, func() {
+			s.app.SetRoot(s.list, true).SetFocus(s.list)
+			if action.fn != nil {
+				action.fn()
+			}
+		})
+	}
+
+	s.app.SetRoot(modal, true).SetFocus(modal)
+}
+
+func (s *State) showInfo(in *limatype.Instance) {
+	prot := "No"
+	if in.Protected {
+		prot = "Yes"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, `Status:       %s
+Hostname:     %s
+VM Type:      %s
+Architecture: %s
+CPUs:         %d
+Memory:       %.1f GB
+Disk:         %.1f GB
+SSH Port:     %d
+SSH Address:  %s
+Protected:    %s
+Lima Version: %s`, statusTag(in.Status), in.Hostname, in.VMType, in.Arch, in.CPUs, float64(in.Memory)/1e9, float64(in.Disk)/1e9, in.SSHLocalPort, in.SSHAddress, prot, in.LimaVersion)
+
+	if len(in.Errors) > 0 {
+		b.WriteString("\n\nErrors:\n")
+		for _, e := range in.Errors {
+			fmt.Fprintf(&b, "  - %s\n", e.Error())
+		}
+	}
+	if in.Message != "" {
+		fmt.Fprintf(&b, "\n\nMessage:\n  %s", in.Message)
+	}
+
+	s.showTextView(" Info ", b.String())
+}
+
+func (s *State) showPorts(in *limatype.Instance) {
+	ctx := context.Background()
+	out, err := exec.CommandContext(ctx, s.limactl, "list", "--format", `{{range .PortForwards}}{{.GuestIP}}:{{.GuestPort}} -> {{.HostIP}}:{{.HostPort}}{{"\n"}}{{end}}`, in.Name).CombinedOutput()
+	if err != nil {
+		s.showTextView(" Error ", "Failed to get ports: "+err.Error())
+		return
+	}
+	p := strings.TrimSpace(string(out))
+	if p == "" {
+		p = "No port forwards configured"
+	}
+	s.showTextView(" Port Forwards ", "Port Forwards for "+in.Name+"\n\n"+p)
+}
+
+func (s *State) showTextView(title, text string) {
+	tv := tview.NewTextView().
+		SetDynamicColors(true).
+		SetWrap(true).
+		SetWordWrap(true).
+		SetScrollable(true).
+		SetText(text)
+	tv.SetBorder(true).
+		SetBorderColor(cBord).
+		SetTitle(title).
+		SetTitleAlign(tview.AlignLeft).
+		SetTitleColor(cPrim).
+		SetBorderPadding(1, 1, 1, 1)
+
+	s.app.SetRoot(tv, true).SetFocus(tv)
+
+	tv.SetInputCapture(func(e *tcell.EventKey) *tcell.EventKey {
+		if e.Key() == tcell.KeyEscape || e.Rune() == 'q' || e.Rune() == 'Q' {
+			s.app.SetRoot(s.list, true).SetFocus(s.list)
+			return nil
+		}
+		return e
+	})
+}
+
+func (s *State) confirm(text string, onYes func()) {
+	m := tview.NewModal().
+		SetText(text).
+		AddButtons([]string{"Yes", "No"}).
+		SetDoneFunc(func(i int, _ string) {
+			s.app.SetRoot(s.list, true).SetFocus(s.list)
+			if i == 0 {
+				onYes()
+			}
+		})
+	s.app.SetRoot(m, false).SetFocus(m)
+}
+
+func (s *State) execCmd(action, name string) {
+	//revive:disable:deep-exit
+	s.app.Stop()
+	ctx := context.Background()
+	cmd := exec.CommandContext(ctx, s.limactl, action, name)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "limactl %s %s failed: %v\n", action, name, err)
+		os.Exit(1)
+	}
+	os.Exit(cmd.ProcessState.ExitCode())
+}
+
+func showEmptyState(ctx context.Context, limactl string) error {
+	app := tview.NewApplication()
+	m := tview.NewModal().
+		SetText("No Lima instances found.\n\nCreate one with:\n  limactl create").
+		AddButtons([]string{"Create Instance", "Quit"}).
+		SetDoneFunc(func(i int, _ string) {
+			app.Stop()
+			if i == 0 {
+				_ = exec.CommandContext(ctx, limactl, "create").Run()
+			}
+		})
+	app.SetRoot(m, true).SetFocus(m)
+	return app.Run()
+}
+
+func listInstances(ctx context.Context, limactl string) ([]*limatype.Instance, error) {
+	cmd := exec.CommandContext(ctx, limactl, "list", "--json")
+	cmd.Stderr = os.Stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil || cmd.Start() != nil {
+		return nil, err
+	}
+	var res []*limatype.Instance
+	dec := json.NewDecoder(stdout)
+	for dec.More() {
+		var in limatype.Instance
+		if err := dec.Decode(&in); err != nil {
+			return nil, err
+		}
+		res = append(res, &in)
+	}
+	if err := cmd.Wait(); err != nil {
+		return nil, err
+	}
+	slices.SortFunc(res, func(a, b *limatype.Instance) int {
+		if (a.Status == "Running") != (b.Status == "Running") {
+			if a.Status == "Running" {
+				return -1
+			}
+			return 1
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+	return res, nil
+}
+
+func statusTag(st string) string {
+	return map[string]string{
+		"Running":    "[green]RUNNING[white]",
+		"Stopped":    "[red]STOPPED[white]",
+		"Broken":     "[yellow]BROKEN[white]",
+		"Installing": "[blue]INSTALLING[white]",
+	}[st]
+}

--- a/cmd/limactl-menu/main.go
+++ b/cmd/limactl-menu/main.go
@@ -1,0 +1,461 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/lima-vm/lima/v2/pkg/limactlutil"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/version"
+)
+
+var (
+	cPrim = tcell.NewRGBColor(0x32, 0xCD, 0x32)
+	cSec  = tcell.NewRGBColor(0x4E, 0x9A, 0x06)
+	cBord = tcell.NewRGBColor(0x55, 0x55, 0x55)
+	cTxt  = tcell.ColorWhite
+	cDim  = tcell.ColorGray
+)
+
+type State struct {
+	insts   []*limatype.Instance
+	limactl string
+	ctx     context.Context
+	app     *tview.Application
+	list    *tview.List
+	flex    *tview.Flex
+}
+
+func main() {
+	if err := newApp().Execute(); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func newApp() *cobra.Command {
+	return &cobra.Command{
+		Use:           "limactl-menu",
+		Short:         "TUI menu for Lima instances (EXPERIMENTAL)",
+		Version:       strings.TrimPrefix(version.Version, "v"),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE:          runMenu,
+	}
+}
+
+func runMenu(cmd *cobra.Command, _ []string) error {
+	limactl, err := limactlutil.Path()
+	if err != nil {
+		return err
+	}
+	ctx := cmd.Context()
+	insts, err := listInstances(ctx, limactl)
+	if err != nil {
+		return err
+	}
+	if len(insts) == 0 {
+		return showEmptyState(ctx, limactl)
+	}
+	s := &State{insts: insts, limactl: limactl, ctx: ctx}
+	return s.run()
+}
+
+func (s *State) run() error {
+	s.app = tview.NewApplication().EnableMouse(true)
+	s.setupStyles()
+	s.buildUI()
+
+	footer := tview.NewTextView().
+		SetDynamicColors(true).
+		SetText(" [yellow]F1[white] Help  [yellow]F2[white] Start/Stop  [yellow]F3[white] Info  [yellow]F5[white] Refresh  [yellow]F8[white] Delete  [yellow]F10[white] Quit")
+
+	s.flex = tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(s.list, 0, 1, true).
+		AddItem(footer, 1, 1, false)
+
+	s.app.SetRoot(s.flex, true).SetFocus(s.list)
+	s.app.SetInputCapture(s.handleGlobalKey)
+	return s.app.Run()
+}
+
+func (s *State) setupStyles() {
+	tview.Styles.PrimitiveBackgroundColor = tcell.ColorDefault
+	tview.Styles.ContrastBackgroundColor = tcell.ColorDefault
+	tview.Styles.PrimaryTextColor = cTxt
+	tview.Styles.SecondaryTextColor = cDim
+	tview.Styles.TertiaryTextColor = cDim
+	tview.Styles.InverseTextColor = tcell.ColorBlack
+	tview.Styles.ContrastSecondaryTextColor = cTxt
+}
+
+func (s *State) buildUI() {
+	s.list = tview.NewList().
+		SetHighlightFullLine(true).
+		SetMainTextColor(cTxt).
+		SetSelectedTextColor(tcell.ColorBlack).
+		SetSelectedBackgroundColor(cPrim)
+	s.list.SetBorder(true).
+		SetBorderColor(cBord).
+		SetTitle(" Lima Instances ").
+		SetTitleAlign(tview.AlignLeft).
+		SetTitleColor(cPrim).
+		SetBorderPadding(1, 1, 1, 1)
+
+	for _, in := range s.insts {
+		inst := in
+		s.list.AddItem(fmtInst(inst), "", 0, func() {
+			s.showActions(inst)
+		})
+	}
+	if len(s.insts) > 0 {
+		s.list.SetCurrentItem(0)
+	}
+}
+
+func fmtInst(in *limatype.Instance) string {
+	icon := map[string]string{
+		"Running":    "[green]●[white]",
+		"Stopped":    "[red]●[white]",
+		"Broken":     "[yellow]●[white]",
+		"Installing": "[blue]◐[white]",
+	}[in.Status]
+	if icon == "" {
+		icon = "[gray]○[white]"
+	}
+
+	name := in.Name
+	if len(name) > 16 {
+		name = name[:13] + "..."
+	}
+
+	mem := float64(in.Memory) / 1e9
+	cpusMem := fmt.Sprintf("%dCPU/%.1fGB", in.CPUs, mem)
+
+	sshAddr := fmt.Sprintf("%s:%d", in.SSHAddress, in.SSHLocalPort)
+	if in.SSHAddress == "" || in.SSHLocalPort == 0 {
+		sshAddr = "-"
+	}
+
+	prot := ""
+	if in.Protected {
+		prot = " [LOCKED]"
+	}
+
+	return fmt.Sprintf("%s  %-16s  %-10s  %-8s  %-12s  %s%s", icon, name, in.Status, in.Arch, cpusMem, sshAddr, prot)
+}
+
+func (s *State) currentInst() *limatype.Instance {
+	idx := s.list.GetCurrentItem()
+	if idx >= 0 && idx < len(s.insts) {
+		return s.insts[idx]
+	}
+	return nil
+}
+
+func (s *State) handleGlobalKey(e *tcell.EventKey) *tcell.EventKey {
+	if e.Key() == tcell.KeyCtrlC || e.Key() == tcell.KeyF10 {
+		s.app.Stop()
+		return nil
+	}
+
+	in := s.currentInst()
+	if in == nil {
+		return e
+	}
+
+	switch e.Key() {
+	case tcell.KeyF1:
+		s.showHelp()
+		return nil
+	case tcell.KeyF2:
+		s.toggleStartStop(in)
+		return nil
+	case tcell.KeyF3:
+		s.showInfo(in)
+		return nil
+	case tcell.KeyF5:
+		s.refreshList()
+		return nil
+	case tcell.KeyF8:
+		s.confirm(fmt.Sprintf("DELETE instance '%s'?\nThis cannot be undone.", in.Name), func() { s.execCmd("delete", in.Name) })
+		return nil
+	case tcell.KeyRune:
+		switch e.Rune() {
+		case 'q', 'Q':
+			s.app.Stop()
+			return nil
+		case 'h', '?':
+			s.showHelp()
+			return nil
+		case 's', 'S':
+			s.execCmd("shell", in.Name)
+			return nil
+		case 'i', 'I':
+			s.showInfo(in)
+			return nil
+		case 't', 'T':
+			s.toggleStartStop(in)
+			return nil
+		case 'r', 'R':
+			s.confirm(fmt.Sprintf("Confirm restart '%s'?", in.Name), func() { s.execCmd("restart", in.Name) })
+			return nil
+		case 'd', 'D':
+			s.confirm(fmt.Sprintf("DELETE instance '%s'?\nThis cannot be undone.", in.Name), func() { s.execCmd("delete", in.Name) })
+			return nil
+		}
+	}
+	return e
+}
+
+func (s *State) toggleStartStop(in *limatype.Instance) {
+	if in.Status == "Running" {
+		s.confirm(fmt.Sprintf("Confirm stop '%s'?", in.Name), func() { s.execCmd("stop", in.Name) })
+	} else {
+		s.execCmd("start", in.Name)
+	}
+}
+
+func (s *State) showHelp() {
+	help := `[yellow]Keybindings:[white]
+
+  [green]F1[white] / [green]?[white]       Help (this screen)
+  [green]F2[white] / [green]t[white]       Start / Stop toggle
+  [green]F3[white] / [green]i[white]       Show instance info
+  [green]F5[white]           Refresh instance list
+  [green]F8[white] / [green]d[white]       Delete instance
+  [green]F10[white] / [green]q[white]      Quit
+
+  [green]Enter[white] / [green]h[white]    Open actions menu
+  [green]s[white]            Shell into instance
+  [green]r[white]            Restart instance`
+	s.showTextView(" Help ", help)
+}
+
+func (s *State) refreshList() {
+	insts, err := listInstances(s.ctx, s.limactl)
+	if err != nil {
+		logrus.Warnf("Failed to refresh: %v", err)
+		return
+	}
+	s.insts = insts
+	s.list.Clear()
+	for _, in := range s.insts {
+		inst := in
+		s.list.AddItem(fmtInst(inst), "", 0, func() {
+			s.showActions(inst)
+		})
+	}
+	if len(s.insts) > 0 {
+		s.list.SetCurrentItem(0)
+	}
+}
+
+func (s *State) showActions(in *limatype.Instance) {
+	actions := []struct {
+		name string
+		fn   func()
+	}{
+		{"Shell", func() { s.execCmd("shell", in.Name) }},
+		{"Start / Stop Toggle", func() { s.toggleStartStop(in) }},
+		{"Restart", func() {
+			s.confirm(fmt.Sprintf("Confirm restart '%s'?", in.Name), func() { s.execCmd("restart", in.Name) })
+		}},
+		{"Show Info", func() { s.showInfo(in) }},
+		{"Show Ports", func() { s.showPorts(in) }},
+		{"Protect", func() { s.execCmd("protect", in.Name) }},
+		{"Unprotect", func() {
+			s.confirm(fmt.Sprintf("Confirm unprotect '%s'?", in.Name), func() { s.execCmd("unprotect", in.Name) })
+		}},
+		{"Delete", func() {
+			s.confirm(fmt.Sprintf("DELETE instance '%s'?\nThis cannot be undone.", in.Name), func() { s.execCmd("delete", in.Name) })
+		}},
+		{"Cancel", nil},
+	}
+
+	modal := tview.NewList().
+		SetHighlightFullLine(true).
+		SetMainTextColor(cTxt).
+		SetSelectedTextColor(tcell.ColorBlack).
+		SetSelectedBackgroundColor(cSec)
+	modal.SetBorder(true).
+		SetBorderColor(cBord).
+		SetTitle(fmt.Sprintf(" Actions for %s ", in.Name)).
+		SetTitleAlign(tview.AlignLeft).
+		SetTitleColor(cSec).
+		SetBorderPadding(1, 1, 1, 1)
+
+	for _, a := range actions {
+		action := a
+		modal.AddItem("  "+action.name, "", 0, func() {
+			s.app.SetRoot(s.flex, true).SetFocus(s.list)
+			if action.fn != nil {
+				action.fn()
+			}
+		})
+	}
+
+	s.app.SetRoot(modal, true).SetFocus(modal)
+}
+
+func (s *State) showInfo(in *limatype.Instance) {
+	prot := "No"
+	if in.Protected {
+		prot = "Yes"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, `Status:       %s
+Hostname:     %s
+VM Type:      %s
+Architecture: %s
+CPUs:         %d
+Memory:       %.1f GB
+Disk:         %.1f GB
+SSH Port:     %d
+SSH Address:  %s
+Protected:    %s
+Lima Version: %s`, statusTag(in.Status), in.Hostname, in.VMType, in.Arch, in.CPUs, float64(in.Memory)/1e9, float64(in.Disk)/1e9, in.SSHLocalPort, in.SSHAddress, prot, in.LimaVersion)
+
+	if len(in.Errors) > 0 {
+		b.WriteString("\n\nErrors:\n")
+		for _, e := range in.Errors {
+			fmt.Fprintf(&b, "  - %s\n", e.Error())
+		}
+	}
+	if in.Message != "" {
+		fmt.Fprintf(&b, "\n\nMessage:\n  %s", in.Message)
+	}
+
+	s.showTextView(" Info ", b.String())
+}
+
+func (s *State) showPorts(in *limatype.Instance) {
+	out, err := exec.CommandContext(s.ctx, s.limactl, "list", "--format", `{{range .PortForwards}}{{.GuestIP}}:{{.GuestPort}} -> {{.HostIP}}:{{.HostPort}}{{"\n"}}{{end}}`, in.Name).CombinedOutput()
+	if err != nil {
+		s.showTextView(" Error ", "Failed to get ports: "+err.Error())
+		return
+	}
+	p := strings.TrimSpace(string(out))
+	if p == "" {
+		p = "No port forwards configured"
+	}
+	s.showTextView(" Port Forwards ", "Port Forwards for "+in.Name+"\n\n"+p)
+}
+
+func (s *State) showTextView(title, text string) {
+	tv := tview.NewTextView().
+		SetDynamicColors(true).
+		SetWrap(true).
+		SetWordWrap(true).
+		SetScrollable(true).
+		SetText(text)
+	tv.SetBorder(true).
+		SetBorderColor(cBord).
+		SetTitle(title).
+		SetTitleAlign(tview.AlignLeft).
+		SetTitleColor(cPrim).
+		SetBorderPadding(1, 1, 1, 1)
+
+	s.app.SetRoot(tv, true)
+
+	tv.SetInputCapture(func(e *tcell.EventKey) *tcell.EventKey {
+		if e.Key() == tcell.KeyEscape || e.Rune() == 'q' || e.Rune() == 'Q' {
+			s.app.SetRoot(s.flex, true).SetFocus(s.list)
+			return nil
+		}
+		return e
+	})
+}
+
+func (s *State) confirm(text string, onYes func()) {
+	m := tview.NewModal().
+		SetText(text).
+		AddButtons([]string{"Yes", "No"}).
+		SetDoneFunc(func(i int, _ string) {
+			s.app.SetRoot(s.flex, true).SetFocus(s.list)
+			if i == 0 {
+				onYes()
+			}
+		})
+	s.app.SetRoot(m, false).SetFocus(m)
+}
+
+func (s *State) execCmd(action, name string) {
+	//revive:disable:deep-exit
+	s.app.Stop()
+	ctx := context.Background()
+	cmd := exec.CommandContext(ctx, s.limactl, action, name)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "limactl %s %s failed: %v\n", action, name, err)
+		os.Exit(1)
+	}
+	os.Exit(cmd.ProcessState.ExitCode())
+}
+
+func showEmptyState(ctx context.Context, limactl string) error {
+	app := tview.NewApplication()
+	m := tview.NewModal().
+		SetText("No Lima instances found.\n\nCreate one with:\n  limactl create").
+		AddButtons([]string{"Create Instance", "Quit"}).
+		SetDoneFunc(func(i int, _ string) {
+			app.Stop()
+			if i == 0 {
+				_ = exec.CommandContext(ctx, limactl, "create").Run()
+			}
+		})
+	app.SetRoot(m, true).SetFocus(m)
+	return app.Run()
+}
+
+func listInstances(ctx context.Context, limactl string) ([]*limatype.Instance, error) {
+	cmd := exec.CommandContext(ctx, limactl, "list", "--json")
+	cmd.Stderr = os.Stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil || cmd.Start() != nil {
+		return nil, err
+	}
+	var res []*limatype.Instance
+	dec := json.NewDecoder(stdout)
+	for dec.More() {
+		var in limatype.Instance
+		if err := dec.Decode(&in); err != nil {
+			return nil, err
+		}
+		res = append(res, &in)
+	}
+	if err := cmd.Wait(); err != nil {
+		return nil, err
+	}
+	slices.SortFunc(res, func(a, b *limatype.Instance) int {
+		if (a.Status == "Running") != (b.Status == "Running") {
+			if a.Status == "Running" {
+				return -1
+			}
+			return 1
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+	return res, nil
+}
+
+func statusTag(st string) string {
+	return map[string]string{
+		"Running":    "[green]RUNNING[white]",
+		"Stopped":    "[red]STOPPED[white]",
+		"Broken":     "[yellow]BROKEN[white]",
+		"Installing": "[blue]INSTALLING[white]",
+	}[st]
+}

--- a/go.mod
+++ b/go.mod
@@ -129,4 +129,14 @@ require (
 	gvisor.dev/gvisor v0.0.0-20240916094835-a174eb65023f // indirect
 )
 
-require github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
+require (
+	github.com/gdamore/tcell/v2 v2.13.10
+	github.com/rivo/tview v0.42.0
+)
+
+require (
+	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
+	github.com/gdamore/encoding v1.0.1 // indirect
+	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,10 @@ github.com/foxcpp/go-mockdns v1.2.0/go.mod h1:IhLeSFGed3mJIAXPH2aiRQB+kqz7oqu8ld
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=
+github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
+github.com/gdamore/tcell/v2 v2.13.10 h1:Afs3JKt83HnhuUKdZ3MnxUgOqQRWftj5JyDqv1LLynA=
+github.com/gdamore/tcell/v2 v2.13.10/go.mod h1:+Wfe208WDdB7INEtCsNrAN6O2m+wsTPk1RAovjaILlo=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
@@ -158,6 +162,8 @@ github.com/lima-vm/sshocker v0.3.11 h1:uM73Uduj1Djhvef8HGfhZShESz3BPGBQkSWNMRAJY
 github.com/lima-vm/sshocker v0.3.11/go.mod h1:yb+YBCJBy+oa3J/Sni5XID0y11o+QC5CbFbrC1dt0G0=
 github.com/linuxkit/virtsock v0.0.0-20220523201153-1a23e78aa7a2 h1:DZMFueDbfz6PNc1GwDRA8+6lBx1TB9UnxDQliCqR73Y=
 github.com/linuxkit/virtsock v0.0.0-20220523201153-1a23e78aa7a2/go.mod h1:SWzULI85WerrFt3u+nIm5F9l7EvxZTKQvd0InF3nmgM=
+github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
+github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -218,6 +224,10 @@ github.com/pkg/xattr v0.4.12/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6k
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rivo/tview v0.42.0 h1:b/ftp+RxtDsHSaynXTbJb+/n/BxDEi+W3UfF5jILK6c=
+github.com/rivo/tview v0.42.0/go.mod h1:cSfIYfhpSGCjp3r/ECJb+GKS7cGJnqV8vfjQPwoXyfY=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rjeczalik/notify v0.9.3 h1:6rJAzHTGKXGj76sbRgDiDcYj/HniypXmSJo1SWakZeY=
 github.com/rjeczalik/notify v0.9.3/go.mod h1:gF3zSOrafR9DQEWSE8TjfI9NkooDxbyT4UgRGKZA0lc=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=


### PR DESCRIPTION
## What This PR Changes
Implements #5285 - adds a `limactl menu` TUI plugin for managing Lima instances through an interactive terminal UI. The plugin provides:
- Instance list with color-coded status (RUNNING/STOPPED/BROKEN), sorted Running first
- Actions: Shell(F1), Start(F2), Stop(S), Restart(R), Delete(D), Protect/Unprotect, Ports(P), Copy SSH Config(C), Logs(L)
- Info panel with full instance details (hostname, VM type, arch, CPUs, memory, disk, SSH port, protected state, errors, message)
- Log viewer with `journalctl -n 50` and follow toggle (L)
- Confirmation modals for destructive actions (delete, stop, restart, unprotect)
- Empty state modal with "Create Instance" button when no VMs exist
- Status bar with live clock, instance position, SSH port, VM type/arch
- Help bar with all keyboard shortcuts

## Linked Issue (Required in most cases)
Closes #5285

## How I Tested This
```bash
make limactl-plugins
_output/bin/limactl menu

```
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/a9b94d12-0ff9-4135-b88f-9ed1d622beea" />
