### PR TITLE
feat(image): add archVariant for x86-64-v3 image selection

### DIFF
--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -112,6 +112,8 @@ func RegisterCreate(cmd *cobra.Command, commentPrefix string) {
 
 	flags.String("image-variant", "", commentPrefix+"Image variant")
 
+	flags.String("arch-variant", "", commentPrefix+`Architecture variant (e.g. "v3" for x86-64-v3)`)
+
 	flags.String("containerd", "", commentPrefix+"containerd mode (user, system, user+system, none)")
 	_ = cmd.RegisterFlagCompletionFunc("containerd", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return []string{"user", "system", "user+system", "none"}, cobra.ShellCompDirectiveNoFileComp
@@ -397,6 +399,22 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool, params map[string]stri
 					return nil, errors.New("`--image-variant` must not be empty")
 				}
 				expr := fmt.Sprintf(`.images = [.images[] | select(.variant == %q)]`, variant)
+				return []string{expr}, nil
+			},
+			true,
+			false,
+		},
+		{
+			"arch-variant",
+			func(_ *flag.Flag) ([]string, error) {
+				archVariant, err := flags.GetString("arch-variant")
+				if err != nil {
+					return nil, err
+				}
+				if archVariant == "" {
+					return nil, errors.New("`--arch-variant` must not be empty")
+				}
+				expr := fmt.Sprintf(`.images = [.images[] | select(.archVariant == %q)]`, archVariant)
 				return []string{expr}, nil
 			},
 			true,

--- a/hack/update-template-almalinux.sh
+++ b/hack/update-template-almalinux.sh
@@ -69,6 +69,14 @@ function almalinux_url_spec_from_location() {
 	echo "${url_spec}"
 }
 
+# almalinux_limayaml_arch strips the x86-64 micro-architecture level suffix (e.g. the "_v2" in
+# x86_64_v2) so the emitted lima arch is the base x86_64; the level is carried separately in the
+# template's archVariant field. The URL/path and CHECKSUM lookups keep the original x86_64_v2.
+function almalinux_limayaml_arch() {
+	local arch=$1
+	echo "${arch%_v[0-9]}"
+}
+
 readonly almalinux_jq_filter_directory='"https://repo.almalinux.org/almalinux/\(.path_version)/cloud/\(.path_arch)/images/"'
 readonly almalinux_jq_filter_filename='"AlmaLinux-\(.major_version)-\(.target_vendor)-\(if .date then .major_minor_version + "-" + .date else "latest" end).\(.arch).\(.file_extension)"'
 
@@ -129,6 +137,7 @@ function almalinux_latest_image_entry_for_url_spec() {
 	filename=$(almalinux_image_filename_from_url_spec "${newer_url_spec}")
 	digest=$(awk "/${filename}/{print \"sha256:\"\$1}" "${downloaded_sha256sum}")
 	[[ -n ${digest} ]] || error_exit "Failed to get the SHA256 digest for ${filename}"
+	arch=$(almalinux_limayaml_arch "${arch}")
 	json_vars location arch digest
 }
 
@@ -151,7 +160,7 @@ function almalinux_image_entry_for_image_kernel() {
 			# shellcheck disable=SC2030
 			location=$(almalinux_location_from_url_spec "${url_spec}")
 			location=$(validate_url_without_redirect "${location}")
-			arch=$(jq -r '.path_arch' <<<"${url_spec}")
+			arch=$(almalinux_limayaml_arch "$(jq -r '.path_arch' <<<"${url_spec}")")
 			json_vars location arch
 		)
 	fi

--- a/hack/update-template-ubuntu.sh
+++ b/hack/update-template-ubuntu.sh
@@ -109,6 +109,15 @@ function ubuntu_image_url_try_replace_release_with_version() {
 	set -e
 }
 
+# ubuntu_limayaml_arch converts an Ubuntu image arch (e.g. amd64, amd64v3) to the lima.yaml arch.
+# The x86-64 micro-architecture level suffix (e.g. the "v3" in amd64v3) is stripped here because it is
+# carried separately in the template's archVariant field; the base arch (x86_64) is what lima matches.
+function ubuntu_limayaml_arch() {
+	local arch=$1
+	arch=${arch/#amd64v[0-9]/amd64}
+	limayaml_arch "${arch}"
+}
+
 # ubuntu_image_url_latest prints the latest image URL and its digest for the given flavor, version, arch, and path suffix.
 function ubuntu_image_url_latest() {
 	local flavor=$1 version=$2 arch=$3 path_suffix=$4 base_url ubuntu_downloaded_json jq_filter location_digest_release
@@ -129,7 +138,7 @@ function ubuntu_image_url_latest() {
 	read -r location digest release <<<"${location_digest_release}"
 	location=$(validate_url "${location}")
 	location=$(ubuntu_image_url_try_replace_release_with_version "${location}" "${release}" "${version}")
-	arch=$(limayaml_arch "${arch}")
+	arch=$(ubuntu_limayaml_arch "${arch}")
 	json_vars location arch digest
 }
 
@@ -151,7 +160,7 @@ function ubuntu_image_url_release() {
 		error_exit "The URL for ubuntu-${version}-${flavor}-cloudimg-${arch}${path_suffix} is not provided at ${ubuntu_base_urls[${flavor}]}."
 	location=$(validate_url "${base_url}${release}/release/ubuntu-${version}-${flavor}-cloudimg-${arch}${path_suffix}")
 	location=$(ubuntu_image_url_try_replace_release_with_version "${location}" "${release}" "${version}")
-	arch=$(limayaml_arch "${arch}")
+	arch=$(ubuntu_limayaml_arch "${arch}")
 	json_vars location arch
 }
 
@@ -180,7 +189,7 @@ function ubuntu_image_url_daily() {
 	read -r location digest version <<<"${location_digest_version}"
 	location=$(validate_url "${location}")
 	location=$(ubuntu_image_url_try_replace_release_with_version "${location}" "${codename}" "${version}")
-	arch=$(limayaml_arch "${arch}")
+	arch=$(ubuntu_limayaml_arch "${arch}")
 	json_vars location arch digest
 }
 
@@ -212,7 +221,7 @@ function ubuntu_image_url_current() {
 		error_exit "The URL for ubuntu-${version}-${products_flavor}-cloudimg-${arch}${path_suffix} is not provided at ${ubuntu_base_urls[${flavor}]}."
 	location=$(validate_url "${base_url}${path_prefix}${codename}/current/${codename}-${products_flavor}-cloudimg-${arch}${path_suffix}")
 	location=$(ubuntu_image_url_try_replace_release_with_version "${location}" "${codename}" "${version}")
-	arch=$(limayaml_arch "${arch}")
+	arch=$(ubuntu_limayaml_arch "${arch}")
 	json_vars location arch
 }
 

--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -303,7 +303,7 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 	}
 
 	for i, image := range cfg.Images {
-		if unknown := reflectutil.UnknownNonEmptyFields(image, "File", "Kernel", "Initrd", "Variant"); len(unknown) > 0 {
+		if unknown := reflectutil.UnknownNonEmptyFields(image, "File", "Kernel", "Initrd", "Variant", "ArchVariant"); len(unknown) > 0 {
 			logrus.Warnf("vmType %s: ignoring images[%d]: %+v", *cfg.VMType, i, unknown)
 		}
 	}

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -128,7 +128,7 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 			unsupportedVMImgRegex := regexp.MustCompile(`\.(qcow2|raw|img|iso|ipsw)(\.(gz|xz|bz2|zstd|zst))?$`)
 			squashfsRegex := regexp.MustCompile(`\.squashfs(\.(gz|xz|bz2|zstd|zst))?$`)
 			for i, image := range cfg.Images {
-				if unknown := reflectutil.UnknownNonEmptyFields(image, "File", "Variant"); len(unknown) > 0 {
+				if unknown := reflectutil.UnknownNonEmptyFields(image, "File", "Variant", "ArchVariant"); len(unknown) > 0 {
 					logrus.Warnf("Ignoring: vmType %s: images[%d]: %+v", *cfg.VMType, i, unknown)
 				}
 				if image.Arch == *cfg.Arch {

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -102,23 +102,28 @@ func Prepare(ctx context.Context, inst *limatype.Instance, guestAgent string) (*
 	initrd := filepath.Join(inst.Dir, filenames.Initrd)
 	if !osutil.FileExists(imagePath) && !osutil.FileExists(disk) {
 		var ensuredImage bool
-		var targetVariant string
+		var targetVariant, targetArchVariant string
 		var targetVariantSet bool
 		for _, img := range inst.Config.Images {
 			if img.Arch == *inst.Config.Arch {
 				targetVariant = img.Variant
+				targetArchVariant = img.ArchVariant
 				targetVariantSet = true
 				break
 			}
 		}
 
 		if len(inst.Config.Images) == 0 {
-			return nil, errors.New("no images are configured (did you set --image-variant to a value not present in the template?)")
+			return nil, errors.New("no images are configured (did you set --image-variant or --arch-variant to a value not present in the template?)")
 		}
 		errs := make([]error, len(inst.Config.Images))
 		for i, f := range inst.Config.Images {
 			if targetVariantSet && f.Variant != targetVariant {
 				errs[i] = fmt.Errorf("%w: variant mismatch (expected %q, got %q)", fileutils.ErrSkipped, targetVariant, f.Variant)
+				continue
+			}
+			if targetVariantSet && f.ArchVariant != targetArchVariant {
+				errs[i] = fmt.Errorf("%w: archVariant mismatch (expected %q, got %q)", fileutils.ErrSkipped, targetArchVariant, f.ArchVariant)
 				continue
 			}
 			if _, err := fileutils.DownloadFile(ctx, imagePath, f.File, true, "the image", *inst.Config.Arch, supportedImageFormats); err != nil {

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -151,10 +151,11 @@ type Kernel struct {
 }
 
 type Image struct {
-	File    `yaml:",inline"`
-	Kernel  *Kernel `yaml:"kernel,omitempty" json:"kernel,omitempty"`
-	Initrd  *File   `yaml:"initrd,omitempty" json:"initrd,omitempty"`
-	Variant string  `yaml:"variant,omitempty" json:"variant,omitempty"`
+	File        `yaml:",inline"`
+	Kernel      *Kernel `yaml:"kernel,omitempty" json:"kernel,omitempty"`
+	Initrd      *File   `yaml:"initrd,omitempty" json:"initrd,omitempty"`
+	Variant     string  `yaml:"variant,omitempty" json:"variant,omitempty"`
+	ArchVariant string  `yaml:"archVariant,omitempty" json:"archVariant,omitempty"`
 }
 
 type Disk struct {

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -1001,6 +1001,25 @@ images:
 	assert.Equal(t, y.Images[1].Variant, "minimal")
 }
 
+func TestUnmarshalImageArchVariant(t *testing.T) {
+	yamlBytes := []byte(`
+images:
+- location: "amd64-img.img"
+  arch: "x86_64"
+  variant: "server"
+- location: "amd64v3-img.img"
+  arch: "x86_64"
+  variant: "server"
+  archVariant: "v3"
+`)
+	var y limatype.LimaYAML
+	err := Unmarshal(yamlBytes, &y, "test")
+	assert.NilError(t, err)
+	assert.Equal(t, len(y.Images), 2)
+	assert.Equal(t, y.Images[0].ArchVariant, "")
+	assert.Equal(t, y.Images[1].ArchVariant, "v3")
+}
+
 func TestDefaultSelectedImageIsStandard(t *testing.T) {
 	// Verify that the default order of the images in the standard template
 	// places standard/server before minimal so standard users don't regress.

--- a/templates/_images/almalinux-10.yaml
+++ b/templates/_images/almalinux-10.yaml
@@ -2,6 +2,13 @@ images:
 - location: "https://repo.almalinux.org/almalinux/10.2/cloud/x86_64/images/AlmaLinux-10-GenericCloud-10.2-20260526.0.x86_64.qcow2"
   arch: "x86_64"
   digest: "sha256:47f2218668dd4776be140dd92fa3bea700be1766e2c7d88bdfd6a4b50f477b4d"
+# AlmaLinux 10 ships x86-64-v3 by default (x86_64) and offers x86-64-v2 for older
+# hardware. Still runs as x86_64, distinguished by archVariant.
+# Select it with `limactl start --arch-variant v2`.
+- location: "https://repo.almalinux.org/almalinux/10.2/cloud/x86_64_v2/images/AlmaLinux-10-GenericCloud-10.2-20260526.0.x86_64_v2.qcow2"
+  arch: "x86_64"
+  digest: "sha256:cd17bcbd7ac62a7f179c30fb24f5795c411d540650b4f060d2167859e2fd3d95"
+  archVariant: "v2"
 - location: "https://repo.almalinux.org/almalinux/10.2/cloud/aarch64/images/AlmaLinux-10-GenericCloud-10.2-20260526.0.aarch64.qcow2"
   arch: "aarch64"
   digest: "sha256:336c6861fe0ba9115af00f557ed1b09385a3525612dd0cb9cce7e0486f8e74a4"
@@ -16,6 +23,10 @@ images:
 
 - location: https://repo.almalinux.org/almalinux/10/cloud/x86_64/images/AlmaLinux-10-GenericCloud-latest.x86_64.qcow2
   arch: x86_64
+
+- location: https://repo.almalinux.org/almalinux/10/cloud/x86_64_v2/images/AlmaLinux-10-GenericCloud-latest.x86_64_v2.qcow2
+  arch: x86_64
+  archVariant: "v2"
 
 - location: https://repo.almalinux.org/almalinux/10/cloud/aarch64/images/AlmaLinux-10-GenericCloud-latest.aarch64.qcow2
   arch: aarch64

--- a/templates/_images/ubuntu-26.04.yaml
+++ b/templates/_images/ubuntu-26.04.yaml
@@ -5,6 +5,13 @@ images:
   arch: "x86_64"
   digest: "sha256:117816726abbdefc5ef3e38902e81a76f1c76c3610e709999d0885f9d5d9b477"
   variant: "server"
+# x86-64-v3 optimized image. Still runs as x86_64, distinguished by archVariant.
+# Select it with `limactl start --arch-variant v3`.
+- location: "https://cloud-images.ubuntu.com/releases/resolute/release-20260720/ubuntu-26.04-server-cloudimg-amd64v3.img"
+  arch: "x86_64"
+  digest: "sha256:2e7bc9471ec729b7d9ee59958258da6d3943c86b50b6c98d7dedb84cc6724bbf"
+  variant: "server"
+  archVariant: "v3"
 - location: "https://cloud-images.ubuntu.com/releases/resolute/release-20260720/ubuntu-26.04-server-cloudimg-arm64.img"
   arch: "aarch64"
   digest: "sha256:7bcf159e29ad0000bfed9c57875908c39268f5ed1257f4958fa6a9f5f60edd54"
@@ -31,6 +38,11 @@ images:
 - location: https://cloud-images.ubuntu.com/releases/resolute/release/ubuntu-26.04-server-cloudimg-amd64.img
   arch: x86_64
   variant: "server"
+
+- location: https://cloud-images.ubuntu.com/releases/resolute/release/ubuntu-26.04-server-cloudimg-amd64v3.img
+  arch: x86_64
+  variant: "server"
+  archVariant: "v3"
 
 - location: https://cloud-images.ubuntu.com/releases/resolute/release/ubuntu-26.04-server-cloudimg-arm64.img
   arch: aarch64

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -18,9 +18,11 @@ arch: null
 
 # OpenStack-compatible disk image.
 # Each image has a `location` URL for the disk image, an `arch` setting, an optional `digest`,
-# and an optional `variant` (e.g. "server", "minimal", "genericcloud").
+# an optional `variant` (e.g. "server", "minimal", "genericcloud"), and an optional `archVariant`
+# for the CPU micro-architecture level (e.g. "v3" for x86-64-v3; the image still runs as `arch`).
 # If multiple image variants are defined for the target architecture, the first one is used by default,
-# but they can be filtered using the `--image-variant` flag when running `limactl start` or `limactl create`.
+# but they can be filtered using the `--image-variant` and `--arch-variant` flags when running
+# `limactl start` or `limactl create`.
 # To specify a custom kernel and initial RAM disk, nest `kernel` and `initrd` under an image entry:
 #   - location: "https://example.com/image.qcow2"
 #     # kernel specifies a custom kernel to boot.


### PR DESCRIPTION
<!-- Please read our contribution rules before submitting:

- Pull requests guide: https://lima-vm.io/docs/community/contributing/#sending-pull-requests
- AI usage policy: https://lima-vm.io/docs/community/contributing/#ai-contribution-rules

-->

## What This PR Changes

Add an `archVariant` field on image entries, orthogonal to the existing distro `variant` (server/minimal), plus a `--arch-variant` flag to select it. Selection at start time filters by archVariant in parallel with variant, so the base image stays the default and `--arch-variant v3` picks the v3 image. The arch field is left untouched (no x86_64v3).

Wire up the variant entries and teach the update scripts to keep the vendor arch name (`amd64v3, x86_64_v2`) for the stream-JSON/CHECKSUM lookup while emitting `arch: x86_64` for lima:

  - Ubuntu 26.04: `amd64v3` image as `archVariant: v3`.
  - AlmaLinux 10: `x86_64_v2` image as `archVariant: v2` (AlmaLinux 10 ships x86-64-v3 by default and x86-64-v2 for older hardware).



<!-- Explain the single problem this PR fixes, in your own words. -->

## Linked Issue (Required in most cases)

<!-- Link the issue here. If your issue is not approved by a maintainer, don't expect your PR to be merged. -->

Closes #5160


## How I Tested This

  - Unit tests: `go test ./pkg/limayaml/... ./pkg/instance/... ./cmd/limactl/editflags/...` (added `TestUnmarshalImageArchVariant`).
  - Lint/format: `gofmt, shfmt, shellcheck, yamllint` all clean; `limactl generate-jsonschema` output includes the new archVariant field.
  - Functional check with `limactl create`:
    - `template:ubuntu-26.04 --arch-variant v3` reduces the resolved image list to the amd64v3 entries only; without the flag the base amd64 image is first and stays the default.
    - `template:almalinux-10 --arch-variant v2` reduces the list to the x86_64_v2 entries only; without the flag the default x86_64 (v3) image is first and stays the default.
  - Verified the update-script arch mapping in isolation: `amd64v3 / amd64v2 / amd64v4 and x86_64_v2` map to `x86_64`, while `riscv64` and the other arches are left untouched.


## AI Usage

<!-- If you used AI tools, say which tool and how you used it. For example, `Assisted-by: AI_AGENT_NAME:VERSION [TOOL]` or `Co-Authored-By`-->

Assisted-by: Claude Opus 4.8 [Claude Code]