### PR TITLE
feat(vz): add osOpts.Darwin.suppressFirstLoginSetup

### DIFF
--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -124,6 +124,16 @@ func templateArgs(ctx context.Context, bootScripts bool, instDir, name string, i
 		return nil, err
 	}
 	archive := "nerdctl-full.tgz"
+	var darwinOpts limatype.DarwinOpts
+	if *instConfig.OS == limatype.DARWIN {
+		if err := limayaml.Convert(instConfig.OsOpts[limatype.DARWIN], &darwinOpts, "osOpts.Darwin"); err != nil {
+			return nil, err
+		}
+	}
+	var suppressFirstLoginSetupPlist string
+	if darwinOpts.SuppressFirstLoginSetupPlist != nil {
+		suppressFirstLoginSetupPlist = *darwinOpts.SuppressFirstLoginSetupPlist
+	}
 	args := TemplateArgs{
 		Debug:              debugutil.Debug,
 		OS:                 *instConfig.OS,
@@ -153,6 +163,9 @@ func templateArgs(ctx context.Context, bootScripts bool, instDir, name string, i
 		Param:          instConfig.Param,
 		LegacyBIOS:     *instConfig.Firmware.LegacyBIOS,
 		TPM:            *instConfig.TPM,
+
+		SuppressFirstLoginSetup:      darwinOpts.SuppressFirstLoginSetup != nil && *darwinOpts.SuppressFirstLoginSetup,
+		SuppressFirstLoginSetupPlist: suppressFirstLoginSetupPlist,
 	}
 
 	firstUsernetIndex := limayaml.FirstUsernetIndex(instConfig)
@@ -408,6 +421,16 @@ func GenerateISO9660(ctx context.Context, drv driver.Driver, instDir, name strin
 	layout, err := ExecuteTemplateCIDataISO(args)
 	if err != nil {
 		return "", err
+	}
+
+	if args.SuppressFirstLoginSetup {
+		// Presence of this file (not any cloud-config key) is what tells the guest-side
+		// fakecloudinit to suppress first-login setup; an empty file means "use the
+		// guest's built-in plist template" rather than the content of this file.
+		layout = append(layout, iso9660util.Entry{
+			Path:   "setup-assistant.plist",
+			Reader: strings.NewReader(args.SuppressFirstLoginSetupPlist),
+		})
 	}
 
 	driverScripts, err := drv.BootScripts(ctx)

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -137,6 +137,8 @@ type TemplateArgs struct {
 	LegacyBIOS                      bool
 	IsWindowsServer                 bool
 	TPM                             bool
+	SuppressFirstLoginSetup         bool
+	SuppressFirstLoginSetupPlist    string // empty = use built-in plist
 }
 
 func (t *TemplateArgs) generateWindowsInitialPassword() error {

--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -65,6 +65,7 @@ var knownYamlProperties = []string{
 	"NestedVirtualization",
 	"Networks",
 	"OS",
+	"OsOpts",
 	"Param",
 	"Plain",
 	"PortForwards",

--- a/pkg/driver/vz/vz_driver_darwin.go
+++ b/pkg/driver/vz/vz_driver_darwin.go
@@ -66,6 +66,7 @@ var knownYamlProperties = []string{
 	"NestedVirtualization",
 	"Networks",
 	"OS",
+	"OsOpts",
 	"Param",
 	"Plain",
 	"PortForwards",

--- a/pkg/guestagent/fakecloudinit/fakecloudinit_darwin.go
+++ b/pkg/guestagent/fakecloudinit/fakecloudinit_darwin.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"text/template"
 
 	"github.com/goccy/go-yaml"
 	"github.com/sethvargo/go-password/password"
@@ -117,7 +118,7 @@ func processUserData(ctx context.Context, mnt string) error {
 		}
 	}
 	for _, u := range userData.Users {
-		if err := createUser(ctx, &u); err != nil {
+		if err := createUser(ctx, &u, mnt); err != nil {
 			errs = append(errs, fmt.Errorf("failed to create user %#q: %w", u.Name, err))
 		}
 	}
@@ -219,7 +220,119 @@ func populateHomeDir(ctx context.Context, uid int, homedir string) error {
 	return nil
 }
 
-func createUser(ctx context.Context, u *cloudinittypes.User) error {
+// setupAssistantPlistTemplate is the built-in com.apple.SetupAssistant.plist.
+// The Build/Version stamps are what macOS checks to decide whether setup is
+// already complete; without them macOS resets MiniBuddyLaunchReason to 13 on
+// first GUI login.
+const setupAssistantPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DidSeeAccessibility</key><true/>
+	<key>DidSeeActivationLock</key><true/>
+	<key>DidSeeAppStore</key><true/>
+	<key>DidSeeAppearanceSetup</key><true/>
+	<key>DidSeeApplePaySetup</key><true/>
+	<key>DidSeeCloudSetup</key><true/>
+	<key>DidSeeLockdownMode</key><true/>
+	<key>DidSeePrivacy</key><true/>
+	<key>DidSeeScreenTime</key><true/>
+	<key>DidSeeSetupSequence</key><true/>
+	<key>DidSeeSiriSetup</key><true/>
+	<key>DidSeeSyncSetup</key><true/>
+	<key>DidSeeSyncSetup2</key><true/>
+	<key>DidSeeTermsOfAddress</key><true/>
+	<key>DidSeeTouchIDSetup</key><true/>
+	<key>DidSeeiCloudLoginForStorageServices</key><true/>
+	<key>LastPreLoginTasksPerformedBuild</key><string>{{.Build}}</string>
+	<key>LastPreLoginTasksPerformedVersion</key><string>{{.Version}}</string>
+	<key>LastSeenAgeRangeSelectionProductVersion</key><string>{{.Version}}</string>
+	<key>LastSeenBuddyBuildVersion</key><string>{{.Build}}</string>
+	<key>LastSeenCloudProductVersion</key><string>{{.Version}}</string>
+	<key>LastSeenDiagnosticsProductVersion</key><string>{{.Version}}</string>
+	<key>MiniBuddyLaunchReason</key><integer>0</integer>
+	<key>MiniBuddyShouldLaunchToResumeSetup</key><false/>
+	<key>SkipExpressSettingsUpdating</key><true/>
+	<key>SkipFirstLoginOptimization</key><true/>
+</dict>
+</plist>
+`
+
+var setupAssistantPlistTmpl = template.Must(template.New("setupAssistantPlist").Parse(setupAssistantPlistTemplate))
+
+// suppressFirstLoginScreens writes the SetupAssistant and SoftwareUpdate
+// preference plists before first login, so macOS treats them as the guest's
+// initial state instead of resetting them at GUI login. A custom plist at
+// mnt/setup-assistant.plist overrides the built-in template if present.
+func suppressFirstLoginScreens(ctx context.Context, mnt string, uid int, homedir string) error {
+	prefsDir := filepath.Join(homedir, "Library/Preferences")
+	if err := os.MkdirAll(prefsDir, 0o700); err != nil {
+		return fmt.Errorf("failed to create Preferences dir %#q: %w", prefsDir, err)
+	}
+	if err := os.Chown(prefsDir, uid, -1); err != nil {
+		logrus.WithError(err).Warnf("Failed to chown Preferences dir %#q", prefsDir)
+	}
+
+	var setupAssistantPlist string
+	if customPlistPath := filepath.Join(mnt, "setup-assistant.plist"); mnt != "" {
+		if data, err := os.ReadFile(customPlistPath); err == nil && len(data) > 0 {
+			setupAssistantPlist = string(data)
+			logrus.Infof("Using custom SetupAssistant plist from %#q", customPlistPath)
+		}
+	}
+	if setupAssistantPlist == "" {
+		buildVersion := "unknown"
+		if out, err := exec.CommandContext(ctx, "sw_vers", "-buildVersion").Output(); err == nil {
+			buildVersion = strings.TrimSpace(string(out))
+		} else {
+			logrus.WithError(err).Warn("Failed to get build version from sw_vers")
+		}
+		productVersion := "unknown"
+		if out, err := exec.CommandContext(ctx, "sw_vers", "-productVersion").Output(); err == nil {
+			productVersion = strings.TrimSpace(string(out))
+		} else {
+			logrus.WithError(err).Warn("Failed to get product version from sw_vers")
+		}
+
+		var buf strings.Builder
+		data := struct{ Build, Version string }{Build: buildVersion, Version: productVersion}
+		if err := setupAssistantPlistTmpl.Execute(&buf, data); err != nil {
+			return fmt.Errorf("failed to render SetupAssistant plist template: %w", err)
+		}
+		setupAssistantPlist = buf.String()
+	}
+
+	saPlist := filepath.Join(prefsDir, "com.apple.SetupAssistant.plist")
+	if err := os.WriteFile(saPlist, []byte(setupAssistantPlist), 0o600); err != nil {
+		return fmt.Errorf("failed to write SetupAssistant plist %#q: %w", saPlist, err)
+	}
+	if err := os.Chown(saPlist, uid, -1); err != nil {
+		logrus.WithError(err).Warnf("Failed to chown SetupAssistant plist %#q", saPlist)
+	}
+
+	// defaults write (not os.WriteFile) so cfprefsd owns the domain; raw file
+	// writes get overwritten when softwareupdated rewrites the plist on first boot.
+	swPrefs := [][]string{
+		{"AutomaticCheckEnabled", "-bool", "true"},
+		{"AutomaticDownload", "-bool", "false"},
+		{"AutomaticallyInstallMacOSUpdates", "-bool", "false"},
+		{"ConfigDataInstall", "-bool", "true"},
+		{"CriticalUpdateInstall", "-bool", "false"},
+	}
+	for _, pref := range swPrefs {
+		args := append([]string{"write", "/Library/Preferences/com.apple.SoftwareUpdate"}, pref...)
+		cmd := exec.CommandContext(ctx, "defaults", args...)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			// Non-fatal: the dialog is annoying but does not block VM operation.
+			logrus.WithError(err).Warnf("Failed to set SoftwareUpdate pref %v (output=%#q)", pref[0], output)
+		}
+	}
+
+	logrus.Infof("Suppressed first-login setup screens for uid %d in %#q", uid, homedir)
+	return nil
+}
+
+func createUser(ctx context.Context, u *cloudinittypes.User, mnt string) error {
 	homedir := u.Homedir
 	if homedir == "" {
 		return fmt.Errorf("homedir is required for user %#q", u.Name)
@@ -279,6 +392,17 @@ func createUser(ctx context.Context, u *cloudinittypes.User) error {
 	// sysadminctl does not create the custom home directory
 	if err = populateHomeDir(ctx, uid, homedir); err != nil {
 		return fmt.Errorf("failed to populate home directory for user %#q: %w", u.Name, err)
+	}
+
+	// Presence of setup-assistant.plist on the cidata volume (not any cloud-config
+	// key) is what signals this feature is enabled -- see GenerateISO9660.
+	if _, statErr := os.Stat(filepath.Join(mnt, "setup-assistant.plist")); statErr == nil {
+		// Write first-login preference plists now, as root, before any GUI session starts.
+		// cfprefsd reads these fresh at first login so macOS does not reset them.
+		if err := suppressFirstLoginScreens(ctx, mnt, uid, homedir); err != nil {
+			// Non-fatal: SSH provisioning (configure.sh) can still handle it if needed.
+			logrus.WithError(err).Warnf("Failed to suppress first-login screens for user %#q", u.Name)
+		}
 	}
 
 	cmd = exec.CommandContext(ctx, "chmod", "700", homedir)

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -353,6 +353,14 @@ type WindowsOpts struct {
 	VirtioWin []File `yaml:"virtioWin,omitempty" json:"virtioWin,omitempty"`
 }
 
+type DarwinOpts struct {
+	// SuppressFirstLoginSetup suppresses macOS first-login wizard screens (Darwin guests only).
+	SuppressFirstLoginSetup *bool `yaml:"suppressFirstLoginSetup,omitempty" json:"suppressFirstLoginSetup,omitempty" jsonschema:"nullable"`
+	// SuppressFirstLoginSetupPlist overrides the built-in com.apple.SetupAssistant.plist content
+	// used by SuppressFirstLoginSetup. Ignored unless SuppressFirstLoginSetup is true.
+	SuppressFirstLoginSetupPlist *string `yaml:"suppressFirstLoginSetupPlist,omitempty" json:"suppressFirstLoginSetupPlist,omitempty" jsonschema:"nullable"`
+}
+
 func NewOS(osname string) OS {
 	switch osname {
 	case "linux":

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -350,6 +350,14 @@ type WindowsOpts struct {
 	VirtioWin []File `yaml:"virtioWin,omitempty" json:"virtioWin,omitempty"`
 }
 
+type DarwinOpts struct {
+	// SuppressFirstLoginSetup suppresses macOS first-login wizard screens (Darwin guests only).
+	SuppressFirstLoginSetup *bool `yaml:"suppressFirstLoginSetup,omitempty" json:"suppressFirstLoginSetup,omitempty" jsonschema:"nullable"`
+	// SuppressFirstLoginSetupPlist overrides the built-in com.apple.SetupAssistant.plist content
+	// used by SuppressFirstLoginSetup. Ignored unless SuppressFirstLoginSetup is true.
+	SuppressFirstLoginSetupPlist *string `yaml:"suppressFirstLoginSetupPlist,omitempty" json:"suppressFirstLoginSetupPlist,omitempty" jsonschema:"nullable"`
+}
+
 func NewOS(osname string) OS {
 	switch osname {
 	case "linux":

--- a/website/content/en/docs/usage/guests/macos.md
+++ b/website/content/en/docs/usage/guests/macos.md
@@ -33,6 +33,84 @@ limactl shell macos cat /Users/${USER}.guest/password
 - Password-less sudo is disabled, except for `/sbin/shutdown -h now` (see [Sudo](/docs/config/sudo/) — this is not currently configurable on macOS)
 - Several features are not implemented yet. See [Caveats](#caveats) below.
 
+## Advanced topics
+### Suppressing first-login setup screens
+| ⚡ Requirement | Lima >= 2.3, macOS >= (ADD VERSION HERE)  |
+|-------------------|-----------------------------|
+
+By default, macOS shows a series of setup wizard screens (Setup Assistant /
+mini-buddy) on the first GUI login. For automated or headless-style macOS VMs
+this is inconvenient. Set `osOpts.Darwin.suppressFirstLoginSetup` to have Lima
+pre-populate the relevant preference plists during provisioning, before any GUI
+session starts, so the setup screens are skipped automatically:
+
+```yaml
+osOpts:
+  Darwin:
+    suppressFirstLoginSetup: true
+```
+
+This writes `com.apple.SetupAssistant.plist` into the guest user's home
+directory and pre-configures `com.apple.SoftwareUpdate` system preferences so
+that the "Update Mac Automatically" dialog is also suppressed. The preferences
+are written as root (via the Lima guest agent) before first login, so macOS
+reads them as the authoritative initial state and does not reset them.
+
+**Default:** unset — setup screens are shown as normal.
+
+### Custom plist
+
+The built-in `com.apple.SetupAssistant.plist` template is shown below. At VM
+creation time, `<build>` is replaced with the output of `sw_vers -buildVersion`
+and `<version>` with `sw_vers -productVersion` from inside the guest. The
+version stamps are what macOS checks to decide whether setup is already
+complete — without them macOS resets `MiniBuddyLaunchReason` to 13 on first
+GUI login.
+
+```yaml
+osOpts:
+  Darwin:
+    suppressFirstLoginSetup: true
+    suppressFirstLoginSetupPlist: |
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+      	<key>DidSeeAccessibility</key><true/>
+      	<key>DidSeeActivationLock</key><true/>
+      	<key>DidSeeAppStore</key><true/>
+      	<key>DidSeeAppearanceSetup</key><true/>
+      	<key>DidSeeApplePaySetup</key><true/>
+      	<key>DidSeeCloudSetup</key><true/>
+      	<key>DidSeeLockdownMode</key><true/>
+      	<key>DidSeePrivacy</key><true/>
+      	<key>DidSeeScreenTime</key><true/>
+      	<key>DidSeeSetupSequence</key><true/>
+      	<key>DidSeeSiriSetup</key><true/>
+      	<key>DidSeeSyncSetup</key><true/>
+      	<key>DidSeeSyncSetup2</key><true/>
+      	<key>DidSeeTermsOfAddress</key><true/>
+      	<key>DidSeeTouchIDSetup</key><true/>
+      	<key>DidSeeiCloudLoginForStorageServices</key><true/>
+      	<key>LastPreLoginTasksPerformedBuild</key><string><build></string>
+      	<key>LastPreLoginTasksPerformedVersion</key><string><version></string>
+      	<key>LastSeenAgeRangeSelectionProductVersion</key><string><version></string>
+      	<key>LastSeenBuddyBuildVersion</key><string><build></string>
+      	<key>LastSeenCloudProductVersion</key><string><version></string>
+      	<key>LastSeenDiagnosticsProductVersion</key><string><version></string>
+      	<key>MiniBuddyLaunchReason</key><integer>0</integer>
+      	<key>MiniBuddyShouldLaunchToResumeSetup</key><false/>
+      	<key>SkipExpressSettingsUpdating</key><true/>
+      	<key>SkipFirstLoginOptimization</key><true/>
+      </dict>
+      </plist>
+```
+
+When `suppressFirstLoginSetupPlist` is supplied, it is used verbatim — no
+`<build>`/`<version>` substitution is performed. Copy and adapt the built-in
+template above, then supply the actual build and version strings for your
+target OS release if needed.
+
 ## Caveats
 - No support for turning off the video display.
 - No support for automatic port forwarding.

--- a/website/content/en/docs/usage/guests/macos.md
+++ b/website/content/en/docs/usage/guests/macos.md
@@ -33,6 +33,84 @@ limactl shell macos cat /Users/${USER}.guest/password
 - Password-less sudo is disabled, except for `/sbin/shutdown -h now` (see [Sudo](/docs/config/sudo/) — this is not currently configurable on macOS)
 - Several features are not implemented yet. See [Caveats](#caveats) below.
 
+## Advanced topics
+### Suppressing first-login setup screens
+| ⚡ Requirement | Lima >= 2.3, macOS >= 13.0  |
+|-------------------|-----------------------------|
+
+By default, macOS shows a series of setup wizard screens (Setup Assistant /
+mini-buddy) on the first GUI login. For automated or headless-style macOS VMs
+this is inconvenient. Set `osOpts.Darwin.suppressFirstLoginSetup` to have Lima
+pre-populate the relevant preference plists during provisioning, before any GUI
+session starts, so the setup screens are skipped automatically:
+
+```yaml
+osOpts:
+  Darwin:
+    suppressFirstLoginSetup: true
+```
+
+This writes `com.apple.SetupAssistant.plist` into the guest user's home
+directory and pre-configures `com.apple.SoftwareUpdate` system preferences so
+that the "Update Mac Automatically" dialog is also suppressed. The preferences
+are written as root (via the Lima guest agent) before first login, so macOS
+reads them as the authoritative initial state and does not reset them.
+
+**Default:** unset — setup screens are shown as normal.
+
+### Custom plist
+
+The built-in `com.apple.SetupAssistant.plist` template is shown below. At VM
+creation time, `<build>` is replaced with the output of `sw_vers -buildVersion`
+and `<version>` with `sw_vers -productVersion` from inside the guest. The
+version stamps are what macOS checks to decide whether setup is already
+complete — without them macOS resets `MiniBuddyLaunchReason` to 13 on first
+GUI login.
+
+```yaml
+osOpts:
+  Darwin:
+    suppressFirstLoginSetup: true
+    suppressFirstLoginSetupPlist: |
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+      	<key>DidSeeAccessibility</key><true/>
+      	<key>DidSeeActivationLock</key><true/>
+      	<key>DidSeeAppStore</key><true/>
+      	<key>DidSeeAppearanceSetup</key><true/>
+      	<key>DidSeeApplePaySetup</key><true/>
+      	<key>DidSeeCloudSetup</key><true/>
+      	<key>DidSeeLockdownMode</key><true/>
+      	<key>DidSeePrivacy</key><true/>
+      	<key>DidSeeScreenTime</key><true/>
+      	<key>DidSeeSetupSequence</key><true/>
+      	<key>DidSeeSiriSetup</key><true/>
+      	<key>DidSeeSyncSetup</key><true/>
+      	<key>DidSeeSyncSetup2</key><true/>
+      	<key>DidSeeTermsOfAddress</key><true/>
+      	<key>DidSeeTouchIDSetup</key><true/>
+      	<key>DidSeeiCloudLoginForStorageServices</key><true/>
+      	<key>LastPreLoginTasksPerformedBuild</key><string><build></string>
+      	<key>LastPreLoginTasksPerformedVersion</key><string><version></string>
+      	<key>LastSeenAgeRangeSelectionProductVersion</key><string><version></string>
+      	<key>LastSeenBuddyBuildVersion</key><string><build></string>
+      	<key>LastSeenCloudProductVersion</key><string><version></string>
+      	<key>LastSeenDiagnosticsProductVersion</key><string><version></string>
+      	<key>MiniBuddyLaunchReason</key><integer>0</integer>
+      	<key>MiniBuddyShouldLaunchToResumeSetup</key><false/>
+      	<key>SkipExpressSettingsUpdating</key><true/>
+      	<key>SkipFirstLoginOptimization</key><true/>
+      </dict>
+      </plist>
+```
+
+When `suppressFirstLoginSetupPlist` is supplied, it is used verbatim — no
+`<build>`/`<version>` substitution is performed. Copy and adapt the built-in
+template above, then supply the actual build and version strings for your
+target OS release if needed.
+
 ## Caveats
 - No support for turning off the video display.
 - No support for automatic port forwarding.


### PR DESCRIPTION
macOS VZ guests boot straight into the Setup Assistant ("mini-buddy") first-login wizard and sit there until someone clicks through it in the VM's GUI window -- Accessibility, Apple Pay, iCloud, Screen Time, Siri, Touch ID, Terms of Address, and more, plus a separate Software Update opt-in/out prompt on the same first login. Neither can currently be skipped, which blocks unattended macOS guest provisioning.

This adds an opt-in osOpts.Darwin.suppressFirstLoginSetup option. When set, fakecloudinit writes the per-user SetupAssistant plist and the system-wide SoftwareUpdate preferences as root during account creation, before the account's first login -- since the preferences exist before first login rather than being changed afterward, macOS treats them as the guest's actual initial state instead of resetting them. The built-in plist template queries sw_vers from inside the guest at provisioning time rather than hardcoding version strings, so it keeps working as the guest OS updates; a custom plist can be supplied instead via the option's `plist` field for anyone who wants different defaults.

This also switches the guest account-existence check from a filesystem test to an OpenDirectory (dscl) query, since other provisioning steps can pre-create a home directory before the account itself exists, which was making the filesystem check unreliable.

This is a Darwin-guest, VZ-driver-only feature.  It's opt-in only; without the setting, guest behavior doesn't change. It targets macOS 15/26 guests; macOS 27+ guests will have native provisioning support via VZMacGuestProvisioningOptions once that API is available on both host and guest, so this fills the gap until then.

Tested go build/go vet/go test/gofmt clean on this branch. Verified the osOpts.Darwin.suppressFirstLoginSetup config path end-to-end through YAML unmarshal into DarwinOpts via a direct test against the real limayaml. Also ran live end-to-end boot tests against real macOS 26.5 and macOS 15.6.1 VZ guests, each built with only this change applied and no other local patches: on both, with the option set, the guest's com.apple.SetupAssistant.plist and system-wide SoftwareUpdate preferences were confirmed written before first login with the guest's actual build/version substituted in, the SetupAssistant process never launched, and the VM booted straight to the standard login window instead of the first-login wizard.

Fixes #5186

Assisted-by: Claude Code (Sonnet 4.7 & Sonnet 5)
