### PR TITLE
copytool: report a bad path instead of a missing tool

### DIFF
--- a/pkg/copytool/copytool.go
+++ b/pkg/copytool/copytool.go
@@ -62,23 +62,28 @@ func New(ctx context.Context, backend string, paths []string, opts *Options) (Co
 		if err != nil {
 			return nil, err
 		}
-
+		// Report a bad path as itself; IsAvailableOnGuest would reduce it to
+		// "rsync not available on guest(s)".
+		if _, err := parseCopyPaths(ctx, paths); err != nil {
+			return nil, err
+		}
 		if !rsync.IsAvailableOnGuest(ctx, paths) {
 			return nil, errors.New("rsync not available on guest(s)")
 		}
 		return rsync, nil
 	case BackendAuto:
-		var (
-			tool CopyTool
-			err  error
-		)
-
 		// For rsync, the source and destination cannot both be remote
-		if !hasRemoteSourceAndDestination(ctx, paths) {
-			tool, err = newRsyncTool(opts)
+		bothRemote, err := hasRemoteSourceAndDestination(ctx, paths)
+		if err != nil {
+			// A bad path is fatal for every backend, so report it here. Falling
+			// through to scp would replace it with "scp not found on host".
+			return nil, err
+		}
+		if !bothRemote {
+			rsync, err := newRsyncTool(opts)
 			if err == nil {
-				if tool.IsAvailableOnGuest(ctx, paths) {
-					return tool, nil
+				if rsync.IsAvailableOnGuest(ctx, paths) {
+					return rsync, nil
 				}
 				logrus.Debugf("rsync not available on guest(s), falling back to scp")
 			} else {
@@ -86,9 +91,11 @@ func New(ctx context.Context, backend string, paths []string, opts *Options) (Co
 			}
 		}
 
-		tool, err = newSCPTool(opts)
+		tool, err := newSCPTool(opts)
 		if err != nil {
-			return nil, fmt.Errorf("neither rsync nor scp found on host: %w", err)
+			// rsync may well have been found and rejected above, so name the
+			// outcome rather than guessing which tool is missing.
+			return nil, fmt.Errorf("no usable copy tool on host: %w", err)
 		}
 		return tool, nil
 	default:
@@ -96,10 +103,10 @@ func New(ctx context.Context, backend string, paths []string, opts *Options) (Co
 	}
 }
 
-func hasRemoteSourceAndDestination(ctx context.Context, paths []string) bool {
+func hasRemoteSourceAndDestination(ctx context.Context, paths []string) (bool, error) {
 	copyPaths, err := parseCopyPaths(ctx, paths)
 	if err != nil {
-		return true
+		return false, err
 	}
 
 	var hasRemoteSource, hasRemoteDestination bool
@@ -113,7 +120,7 @@ func hasRemoteSourceAndDestination(ctx context.Context, paths []string) bool {
 		}
 	}
 
-	return hasRemoteSource && hasRemoteDestination
+	return hasRemoteSource && hasRemoteDestination, nil
 }
 
 func parseCopyPaths(ctx context.Context, paths []string) ([]*Path, error) {

--- a/pkg/copytool/copytool_test.go
+++ b/pkg/copytool/copytool_test.go
@@ -44,3 +44,13 @@ func TestRsyncCommandEndsOptionParsing(t *testing.T) {
 	assert.Assert(t, sep != -1, "rsync args must contain the %#q separator: %v", "--", cmd.Args)
 	assert.Assert(t, slices.Index(cmd.Args, dashPath) > sep, "path %#q must come after %#q: %v", dashPath, "--", cmd.Args)
 }
+
+// TestNewAutoSurfacesPathError verifies that the default backend reports a bad
+// path as itself, rather than as a missing copy tool.
+func TestNewAutoSurfacesPathError(t *testing.T) {
+	t.Setenv("LIMA_HOME", t.TempDir())
+	paths := []string{"nonexistent-instance-for-test:/tmp/x", "/tmp/y"}
+
+	_, err := New(t.Context(), string(BackendAuto), paths, &Options{})
+	assert.ErrorContains(t, err, "instance `nonexistent-instance-for-test`")
+}

--- a/pkg/copytool/rsync.go
+++ b/pkg/copytool/rsync.go
@@ -36,6 +36,7 @@ func (t *rsyncTool) Name() string {
 func (t *rsyncTool) IsAvailableOnGuest(ctx context.Context, paths []string) bool {
 	copyPaths, err := parseCopyPaths(ctx, paths)
 	if err != nil {
+		// New() has already reported this to the user.
 		logrus.Debugf("failed to parse copy paths for rsync availability check: %v", err)
 		return false
 	}


### PR DESCRIPTION
A path naming an instance that does not exist reached the user as "neither rsync nor scp found on host", and as "rsync not available on guest(s)" under `--backend=rsync`. Both backends now report the parse error itself, and the auto backend's fallback message no longer guesses which tool is missing.

This is independent of the native Windows OpenSSH series, so it can merge in any order. But #5299 appends a test to the end of `pkg/copytool/copytool_test.go` too, so whichever lands second needs a rebase there.

## Console output

`-` is before the change, `+` is after. The last two commands run with `scp` removed from `$PATH`; the middle one still has `rsync`, the last has neither.

```diff
 $ limactl copy --backend=rsync nonexistent:/tmp/x /tmp/y
-FATA[0000] rsync not available on guest(s)
+FATA[0000] instance `nonexistent` does not exist, run `limactl create nonexistent` to create a new instance

 $ limactl copy nonexistent:/tmp/x /tmp/y
-FATA[0000] neither rsync nor scp found on host: scp not found on host: exec: "scp": executable file not found in $PATH
+FATA[0000] instance `nonexistent` does not exist, run `limactl create nonexistent` to create a new instance

 $ limactl copy /tmp/a /tmp/b
-FATA[0000] neither rsync nor scp found on host: scp not found on host: exec: "scp": executable file not found in $PATH
+FATA[0000] no usable copy tool on host: scp not found on host: exec: "scp": executable file not found in $PATH
```

With scp on the host, `limactl copy nonexistent:/tmp/x /tmp/y` already printed the instance error, from the copy command rather than from `New()`, so the auto backend looks the same there.

Assisted-by: Claude Opus 5
