### PR TITLE
portfwd: reject guest ports with an unknown protocol

### DIFF
--- a/pkg/portfwd/forward.go
+++ b/pkg/portfwd/forward.go
@@ -98,6 +98,14 @@ func (fw *Forwarder) OnEvent(ctx context.Context, dialContext func(ctx context.C
 }
 
 func (fw *Forwarder) forwardingAddresses(guest *api.IPPort) (hostAddr, guestAddr string) {
+	// rule.Proto is limited to tcp, udp and any by limayaml validation, and the guest
+	// agent only ever reports tcp or udp. Without this check any other value would
+	// match none of the rules that name a protocol, so it would skip an `ignore` rule
+	// and then be forwarded by the catch-all rule the caller appends last.
+	if guest.Protocol != limatype.ProtoTCP && guest.Protocol != limatype.ProtoUDP {
+		logrus.Debugf("Not forwarding %s: unsupported protocol %#q", guest.HostString(), guest.Protocol)
+		return "", guest.HostString()
+	}
 	guestIP := net.ParseIP(guest.Ip)
 	for _, rule := range fw.rules {
 		if rule.GuestSocket != "" {

--- a/pkg/portfwd/forward_test.go
+++ b/pkg/portfwd/forward_test.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package portfwd
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/guestagent/api"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limayaml"
+)
+
+// testForwarder returns a forwarder configured to disable TCP forwarding, followed
+// by the catch-all rule that the host agent always appends last.
+func testForwarder() *Forwarder {
+	rules := []limatype.PortForward{
+		{GuestPortRange: [2]int{1, 65535}, Proto: limatype.ProtoTCP, Ignore: true},
+		{},
+	}
+	for i := range rules {
+		limayaml.FillPortForwardDefaults(&rules[i], "", limatype.User{}, nil)
+	}
+	return &Forwarder{rules: rules}
+}
+
+func TestForwardingAddressesRejectsUnknownProto(t *testing.T) {
+	fw := testForwarder()
+	for _, proto := range []string{"tcp6", "TCP", "any", ""} {
+		hostAddr, _ := fw.forwardingAddresses(&api.IPPort{Ip: "127.0.0.1", Port: 8080, Protocol: proto})
+		assert.Equal(t, hostAddr, "", "proto %#q", proto)
+	}
+}
+
+func TestForwardingAddressesHonorsIgnoredProto(t *testing.T) {
+	fw := testForwarder()
+	tcpAddr, _ := fw.forwardingAddresses(&api.IPPort{Ip: "127.0.0.1", Port: 8080, Protocol: limatype.ProtoTCP})
+	assert.Equal(t, tcpAddr, "")
+	udpAddr, _ := fw.forwardingAddresses(&api.IPPort{Ip: "127.0.0.1", Port: 8080, Protocol: limatype.ProtoUDP})
+	assert.Equal(t, udpAddr, "127.0.0.1:8080")
+}

--- a/pkg/portfwd/listener.go
+++ b/pkg/portfwd/listener.go
@@ -63,9 +63,9 @@ func (p *ClosableListeners) Forward(ctx context.Context, dialContext func(ctx co
 	protocol string, hostAddress string, guestAddress string,
 ) {
 	switch protocol {
-	case "tcp", "tcp6":
+	case "tcp":
 		go p.forwardTCP(ctx, dialContext, hostAddress, guestAddress)
-	case "udp", "udp6":
+	case "udp":
 		go p.forwardUDP(ctx, dialContext, hostAddress, guestAddress)
 	}
 }
@@ -74,7 +74,7 @@ func (p *ClosableListeners) Remove(_ context.Context, protocol, hostAddress, gue
 	logrus.Debugf("removing listener for hostAddress: %s, guestAddress: %s", hostAddress, guestAddress)
 	key := key(protocol, hostAddress, guestAddress)
 	switch protocol {
-	case "tcp", "tcp6":
+	case "tcp":
 		p.listenersRW.Lock()
 		defer p.listenersRW.Unlock()
 		listener, ok := p.listeners[key]
@@ -82,7 +82,7 @@ func (p *ClosableListeners) Remove(_ context.Context, protocol, hostAddress, gue
 			listener.Close()
 			delete(p.listeners, key)
 		}
-	case "udp", "udp6":
+	case "udp":
 		p.udpListenersRW.Lock()
 		defer p.udpListenersRW.Unlock()
 		listener, ok := p.udpListeners[key]


### PR DESCRIPTION
1. `forwardingAddresses` compares `rule.Proto` to the guest-reported protocol by exact string equality, so a value the rules never use (`tcp6`, `TCP`, `any`, empty) skips every rule that names a protocol and falls through to the catch-all rule, whose proto defaults to `any`.
2. `Forward` accepted `tcp6`/`udp6` as aliases, so the port that slipped past got a live host listener; `forwardTCP` keys it under `tcp` while `Remove` looks it up under `tcp6`, so a later `RemovedLocalPorts` never closes it.
3. Restricted the protocol to `tcp`/`udp` in `forwardingAddresses` (covers both event loops) and dropped the aliases.

To test: with `portForwards: [{guestPortRange: [1, 65535], proto: tcp, ignore: true}]` nothing is forwarded over TCP, but a guest reporting `Protocol: "tcp6"` on port 8080 gets `127.0.0.1:8080` bound on the host and logged as `Forwarding TCP6`. `go test ./pkg/portfwd/...` has the case; it returns `127.0.0.1:8080` without the change. `pkg/hostagent/port.go` drops non-tcp events explicitly, so the ssh forwarder is unaffected.
