### PR TITLE
shell: measure the --sync directory depth on the host's own path

### DIFF
--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -213,23 +213,37 @@ func shellAction(cmd *cobra.Command, args []string) error {
 	if syncHostWorkdir && len(inst.Config.Mounts) > 0 {
 		return errors.New("cannot use `--sync` when the instance has host mounts configured, start the instance with `--mount-none` to disable mounts")
 	}
+	// A wsl2 guest already reaches the host directory through the /mnt automount,
+	// so `--sync` cannot isolate it from host files the way it does elsewhere.
+	if syncHostWorkdir && inst.VMType == limatype.WSL2 {
+		return errors.New("cannot use `--sync` with a wsl2 instance, the host directory is already visible in the guest")
+	}
 
 	// When workDir is explicitly set, the shell MUST have workDir as the cwd, or exit with an error.
 	//
 	// changeDirCmd := "cd workDir || exit 1"                  if workDir != ""
 	//              := "cd hostCurrentDir || cd hostHomeDir"   if workDir == ""
 	var changeDirCmd string
-	var hostCurrentDir string
+	// hostCurrentDirNative is the path as the host sees it. hostCurrentDir is the
+	// form the guest and the copy tool receive, which on Windows differs.
+	var hostCurrentDir, hostCurrentDirNative string
 	if syncDirVal != "" {
-		hostCurrentDir, err = filepath.Abs(syncDirVal)
-		if err == nil && runtime.GOOS == "windows" {
-			hostCurrentDir, err = mountDirFromWindowsDir(ctx, inst, hostCurrentDir)
-		}
+		hostCurrentDirNative, err = filepath.Abs(syncDirVal)
 	} else {
-		hostCurrentDir, err = hostCurrentDirectory(ctx, inst)
+		hostCurrentDirNative, err = os.Getwd()
+	}
+	if err == nil {
+		hostCurrentDir = hostCurrentDirNative
+		if runtime.GOOS == "windows" {
+			hostCurrentDir, err = mountDirFromWindowsDir(ctx, inst, hostCurrentDirNative)
+		}
 	}
 
 	if err != nil {
+		// An empty hostCurrentDir would reach rsync as the toolchain root.
+		if syncHostWorkdir {
+			return fmt.Errorf("failed to determine the host directory to sync: %w", err)
+		}
 		changeDirCmd = "false"
 		logrus.WithError(err).Warn("failed to get the current directory")
 	}
@@ -238,10 +252,19 @@ func shellAction(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("rsync is required for `--sync` but not found: %w", err)
 		}
 
-		srcWdDepth := len(strings.Split(hostCurrentDir, string(os.PathSeparator)))
+		// Measure the host's own path. The form hostCurrentDir carries on Windows
+		// adds one component (/c/...) or two (/cygdrive/c/...).
+		srcWdDepth := pathDepth(hostCurrentDirNative, runtime.GOOS == "windows")
 		if srcWdDepth < rsyncMinimumSrcDirDepth {
-			return fmt.Errorf("expected the depth of the host working directory (%#q) to be more than %d, only got %d (Hint: %s)",
-				hostCurrentDir, rsyncMinimumSrcDirDepth, srcWdDepth, "cd to a deeper directory")
+			return fmt.Errorf("expected the depth of the host working directory (%#q) to be at least %d, only got %d (Hint: %s)",
+				hostCurrentDirNative, rsyncMinimumSrcDirDepth, srcWdDepth, "cd to a deeper directory")
+		}
+		// rsync acts on hostCurrentDir, so measure that too: cygpath can report
+		// success without writing a path, and an fstab can map a deep directory
+		// onto a shallow one. It is always POSIX form, even on Windows.
+		if dstWdDepth := pathDepth(hostCurrentDir, false); dstWdDepth < rsyncMinimumSrcDirDepth {
+			return fmt.Errorf("expected the depth of the converted host working directory (%#q) to be at least %d, only got %d",
+				hostCurrentDir, rsyncMinimumSrcDirDepth, dstWdDepth)
 		}
 	}
 
@@ -745,12 +768,35 @@ func executeSSHForRsync(ctx context.Context, sshCmd exec.Cmd, sshLocalPort int, 
 	return nil
 }
 
-func hostCurrentDirectory(ctx context.Context, inst *limatype.Instance) (string, error) {
-	hostCurrentDir, err := os.Getwd()
-	if err == nil && runtime.GOOS == "windows" {
-		hostCurrentDir, err = mountDirFromWindowsDir(ctx, inst, hostCurrentDir)
+// pathDepth counts the separator-delimited fields of an absolute path,
+// collapsing repeated separators. A trailing separator adds no field unless the
+// path is a bare root. Pass windows for a path in Windows form: elsewhere a
+// backslash is an ordinary filename character, and counting it as a separator
+// would score a directory just below the root deep enough to pass the guard.
+func pathDepth(path string, windows bool) int {
+	slashed := path
+	if windows {
+		slashed = strings.ReplaceAll(path, `\`, "/")
+		// An extended-length or device prefix spells a path the plain form also
+		// spells, so drop it before counting. The `UNC` token this leaves behind
+		// occupies the field the plain form's leading separator would.
+		if strings.HasPrefix(slashed, "//?/") || strings.HasPrefix(slashed, "//./") {
+			slashed = slashed[len("//?/"):]
+		}
 	}
-	return hostCurrentDir, err
+	// A separator run delimits one field. The two leading separators of a UNC
+	// path enclose one root, so counting both would clear the minimum depth for
+	// a share root.
+	for strings.Contains(slashed, "//") {
+		slashed = strings.ReplaceAll(slashed, "//", "/")
+	}
+	// filepath.Clean keeps the trailing separator of a root, so `\\server\share`
+	// and `\\server\share\` both reach here. Trim one that leaves a separator
+	// behind, which spares the bare roots "/" and `C:\`.
+	if trimmed := strings.TrimSuffix(slashed, "/"); strings.Contains(trimmed, "/") {
+		slashed = trimmed
+	}
+	return strings.Count(slashed, "/") + 1
 }
 
 func rsyncVersion(ctx context.Context) (*semver.Version, error) {

--- a/cmd/limactl/shell_test.go
+++ b/cmd/limactl/shell_test.go
@@ -9,6 +9,64 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+// TestPathDepth covers both host path forms, because `limactl shell --sync`
+// compares the depth against rsyncMinimumSrcDirDepth to refuse a directory too
+// close to the root. A Windows path must count the same as its Unix equivalent,
+// or the same threshold means two different things. The windows column is what
+// the call site passes for runtime.GOOS, so both platforms are covered wherever
+// this runs.
+func TestPathDepth(t *testing.T) {
+	tests := []struct {
+		path     string
+		windows  bool
+		expected int
+	}{
+		// A home directory sits at 3 on either platform, below the minimum of 4.
+		{"/Users/jan", false, 3},
+		{`C:\Users\jan`, true, 3},
+		{"/Users/jan/proj", false, 4},
+		{`C:\Users\jan\proj`, true, 4},
+		{"/", false, 2},
+		{`C:\`, true, 2},
+		// filepath.Abs normalises this form away before Lima ever sees it.
+		// Counting it anyway keeps the helper independent of the host separator.
+		{"C:/Users/jan/proj", true, 4},
+		// On Unix a backslash is an ordinary filename character. Counting it as
+		// a separator would score this single directory just below the root at
+		// 4 and pass the guard.
+		{`/x\y\z`, false, 2},
+		{`/foo\..\..\..\bar`, false, 2},
+		// The guard must refuse a share root and allow a directory inside it;
+		// counting both leading separators would pass the root.
+		{`\\server\share`, true, 3},
+		{`\\server\share\proj`, true, 4},
+		// Go's Clean keeps a separator run inside a UNC volume, and whether
+		// Windows collapses it earlier is unverified, so the guard collapses
+		// the run itself.
+		{`\\server\\share`, true, 3},
+		{`\\\server\share`, true, 3},
+		// An extended-length or device prefix spells a path the plain form
+		// also spells.
+		{`\\?\C:\`, true, 2},
+		{`\\?\C:\Users\jan\proj`, true, 4},
+		{`\\.\C:\`, true, 2},
+		{`\\?\UNC\server\share`, true, 3},
+		// filepath.Clean keeps a root's trailing separator and strips one below
+		// a root, so only the first form reaches Lima. Counting both alike
+		// keeps the trim from changing an ordinary path's depth.
+		{`\\server\share\`, true, 3},
+		{`C:\Users\jan\proj\`, true, 4},
+		// An empty path returns 1, so the guard refuses one if it ever reaches
+		// here.
+		{"", false, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, pathDepth(tt.path, tt.windows), tt.expected)
+		})
+	}
+}
+
 func TestParseRsyncStats(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/website/content/en/docs/examples/ai.md
+++ b/website/content/en/docs/examples/ai.md
@@ -190,6 +190,7 @@ limactl shell --sync . default
 - **rsync** must be installed on both host and guest
 - The host working directory must be at least 4 levels deep (e.g., `/Users/username/projects/myproject`)
 - The instance must not have any host mounts configured (use `--mount-none` when creating)
+- The instance must not use the `wsl2` VM type
 
 ## See also
 


### PR DESCRIPTION
`--sync` refuses a directory too close to the filesystem root, but on Windows it measured a path already converted to the `/c/...` form while still splitting on backslashes. Every directory counted as depth 1, so `--sync` could not run there at all. Measuring the native path keeps one threshold meaning the same thing everywhere.

Only Windows separates on a backslash. Elsewhere it is an ordinary filename character, and counting it as a separator would score a directory just below the root deep enough to pass, so the caller now says which form it holds rather than leaving it implied.

That guard was also the only thing stopping `--sync` when the conversion failed or returned nothing, because the empty string scored 1. Both now need their own error. An empty directory reaches rsync as the toolchain root, and with stdout not a terminal the sync back runs `--delete` against it unprompted.

A wsl2 guest already reaches the host directory through the `/mnt` automount, so `--sync` cannot isolate it from host files there. It now refuses that combination up front.

This is pre-existing and unrelated to the native Windows OpenSSH series. No test caught it because the BATS `--sync` tests run only on `ubuntu-24.04` and the Windows jobs never invoke `--sync`. Running BATS on Windows needs submodules, an rsync install, and a vm-type hook in `ensure_instance`, so that waits for the plain-Windows CI work.

Assisted-by: Claude Opus 5
