### PR TITLE
docs: document the Windows host SSH toolchain

### DIFF
--- a/website/content/en/docs/config/environment-variables.md
+++ b/website/content/en/docs/config/environment-variables.md
@@ -214,3 +214,29 @@ This page documents the environment variables used in Lima.
   ```sh
   export QEMU_SYSTEM_X86_64=/usr/local/bin/qemu-system-x86_64
   ```
+
+### `SSH`
+
+- **Description**: Command to run in place of the `ssh` executable. The value is
+  split into shell tokens, so it can carry arguments as well as a path. Lima
+  sets its own `-F` on most invocations, and `limactl copy` drops the arguments
+  on its scp backend, so a path with no arguments is the reliable form.
+  Tokenization also reads `\` as an escape and splits on spaces. A Windows
+  path therefore needs quotes, and its backslashes survive only inside single
+  quotes; unquoted, `C:\Program Files\Git\usr\bin\ssh.exe` arrives as
+  `C:Program`.
+- **Default**: unset. Lima then searches `$PATH`, and on Windows falls back to
+  `%SystemRoot%\System32\OpenSSH`.
+- **Usage**:
+  ```sh
+  export SSH=/opt/homebrew/bin/ssh
+  ```
+  ```powershell
+  $env:SSH = "'C:\Program Files\Git\usr\bin\ssh.exe'"
+  ```
+- **Note**: On Windows this overrides the toolchain detection described under
+  [Windows toolchain]({{< ref "/docs/config/vmtype/wsl2#windows-toolchain" >}}).
+  Some paths still follow `PATH`, among them the guest mount point and
+  `limactl shell`'s working directory, so point `SSH` at the install that
+  comes first on `PATH`. `limactl guest-install` ignores this variable
+  altogether.

--- a/website/content/en/docs/config/vmtype/qemu.md
+++ b/website/content/en/docs/config/vmtype/qemu.md
@@ -11,6 +11,13 @@ Recommended QEMU version:
 - v8.2.1 or later (macOS)
 - v6.2.0 or later (Linux)
 
+On a Windows host, "qemu" needs an OpenSSH installation for its own `ssh`,
+`scp`, and `ssh-keygen`. Mounts there must be reverse-sshfs, because QEMU
+for Windows has no 9p support, and reverse-sshfs is the only thing in Lima
+that uses `sftp-server`. See
+[Windows toolchain]({{< ref "/docs/config/vmtype/wsl2#windows-toolchain" >}})
+for which binaries to install and how Lima chooses between them.
+
 An example configuration:
 {{< tabpane text=true >}}
 {{% tab header="CLI" %}}

--- a/website/content/en/docs/config/vmtype/wsl2.md
+++ b/website/content/en/docs/config/vmtype/wsl2.md
@@ -42,7 +42,7 @@ containerd:
 - "wsl2" currently doesn't support many of Lima's options. See [this file](https://github.com/lima-vm/lima/blob/master/pkg/wsl2/wsl_driver_windows.go#L19) for the latest supported options.
 - When running lima using "wsl2", `${LIMA_HOME}/<INSTANCE>/serial.log` will not contain kernel boot logs
 - WSL2 requires a `tar` formatted rootfs archive instead of a VM image. Standard VM disk images (like `.qcow2`, `.raw`, etc.) or `.squashfs` images cannot be natively imported by WSL2.
-- Windows doesn't ship with ssh.exe, gzip.exe, etc. which are used by Lima at various points. The easiest way around this is to run `winget install -e --id Git.MinGit` (winget is now built in to Windows as well), and add the resulting `C:\Program Files\Git\usr\bin\` directory to your path.
+- Lima unpacks a `.tar.gz` rootfs on its own, but a `.tar.xz`, `.tar.bz2`, or `.tar.zst` one needs the matching `xz`, `bzip2`, or `zstd` binary on your `PATH`, and Windows ships none of them.
 
 ### Rootfs Image Requirements & Building Custom Images
 
@@ -76,3 +76,39 @@ If you want to build and use your own custom rootfs, you can build it from a sta
    docker build -o type=tar,dest=custom-rootfs.tar .
    ```
 
+### Windows toolchain
+
+Windows 10 and 11 ship an OpenSSH client in `C:\Windows\System32\OpenSSH\`, and
+that's all the WSL2 driver needs.
+
+The QEMU driver's reverse-sshfs mounts also want `sftp-server.exe`, which
+belongs to OpenSSH Server, an [optional Feature on Demand](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse).
+Install it from an elevated PowerShell with
+`Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0`. Without it
+`sshocker` serves the mount in-process, so the mount still works. But pinning
+`sftpDriver: openssh-sftp-server` under a mount's [`sshfs`]({{< ref "/docs/config/mount#reverse-sshfs" >}})
+drops that fallback, and then the mount fails.
+
+[Git for Windows](https://gitforwindows.org/) (`winget install -e --id Git.Git`)
+is an alternative. Use the full installer; MinGit omits `scp.exe`,
+`ssh-keygen.exe`, and `cygpath.exe`. Add `C:\Program Files\Git\usr\bin\` to your
+`PATH` ahead of any other directory holding an `ssh.exe`; the installer's
+default adds only `cmd\`, which holds none of these binaries. `usr\bin` also
+carries `find.exe` and `sort.exe`, which shadow the Windows commands of those
+names.
+
+Order matters because Lima takes the first directory on `PATH` that holds
+`ssh.exe`, `scp.exe`, and `ssh-keygen.exe` together, and falls back to
+`System32\OpenSSH`. Lima then takes the `sftp-server` from that toolchain, and
+writes the key and socket paths it hands `ssh` in the form that toolchain
+expects. MSYS2 and Git for Windows get `cygpath`'s `/c/Users/USER`, stock
+Cygwin `/cygdrive/c/Users/USER`, and the native client `C:/Users/USER`.
+
+The [`SSH`]({{< ref "/docs/config/environment-variables#ssh" >}}) environment
+variable overrides that choice, but parts of Lima still follow `PATH`, so point
+both at the same install. A Cygwin toolchain in `SSH` with native OpenSSH
+leading `PATH` fails `limactl start`.
+
+A mount without an explicit `mountPoint` derives its guest path from `cygpath`
+on every load, so adding stock Cygwin to `PATH` can move an existing instance's
+mount inside the guest. Set `mountPoint` to pin it.

--- a/website/content/en/docs/installation/_index.md
+++ b/website/content/en/docs/installation/_index.md
@@ -11,6 +11,9 @@ Supported host OS:
 
 Prerequisite:
 - QEMU (Required, only if [QEMU]({{< ref "/docs/config/vmtype#qemu" >}}) driver is used)
+- An OpenSSH client on Windows hosts (Windows 10 and 11 ship one); see
+  [Windows toolchain]({{< ref "/docs/config/vmtype/wsl2#windows-toolchain" >}})
+  for when Lima needs more than the default install
 
 {{< tabpane text=true >}}
 


### PR DESCRIPTION
Document the host SSH toolchain now that Lima supports native Windows OpenSSH: which binaries ship by default, why to prefer full Git for Windows over MinGit, and how the Cygwin-vs-native path form is chosen. Also replaces the Known Issues bullet that claimed Windows ships no `ssh.exe`, since only `xz`, `bzip2`, and `zstd` rootfs archives still need an external binary.

This describes the state after #5299 and #5300 land, so it should merge after them. Merging it first would publish toolchain behaviour that master does not yet have.

`paths-ignore` in test.yml keeps the test workflow off this PR, but lint-quick.yml has no such filter and does run.
