### PR TITLE
CI: factor Windows setup into composite actions; add plain-Windows jobs

### DIFF
--- a/.github/actions/windows_msys2_prep/action.yml
+++ b/.github/actions/windows_msys2_prep/action.yml
@@ -1,0 +1,24 @@
+name: 'windows msys2 prep'
+description: >
+  Adds C:\msys64\usr\bin to PATH and installs the MSYS2 packages the Windows
+  integration jobs need. The PATH prepend persists into subsequent job steps
+  via $GITHUB_PATH, so the test step can call cygpath / bash / pacman tools
+  directly without re-prepending. The Make step inherits the prepend too, so
+  make's $(shell find ...) finds GNU find instead of System32\FIND.EXE.
+runs:
+  using: composite
+  steps:
+  - name: Prepend MSYS2 to PATH and install test dependencies
+    shell: pwsh
+    # The value written to $GITHUB_PATH is the static literal C:\msys64\usr\bin,
+    # which is the canonical pattern for adding a directory to subsequent
+    # steps' PATH. No PR-controlled data reaches the env file.
+    run: | # zizmor: ignore[github-env]
+      $ErrorActionPreference = 'Stop'
+      Add-Content -Path $env:GITHUB_PATH -Value 'C:\msys64\usr\bin'
+      # rsync: without it the copy test skips its rsync backend, so the Windows
+      # path conversion that backend performs goes unexercised.
+      # openssh: keeps a Cygwin ssh ahead of %SystemRoot%\System32\OpenSSH, so
+      # these jobs cover the Cygwin toolchain and the plain jobs the native one.
+      & 'C:\msys64\usr\bin\pacman.exe' -Sy --noconfirm openbsd-netcat diffutils openssh rsync socat w3m
+      if ($LASTEXITCODE -ne 0) { throw "pacman failed: $LASTEXITCODE" }

--- a/.github/actions/windows_plain_build/action.yml
+++ b/.github/actions/windows_plain_build/action.yml
@@ -1,0 +1,26 @@
+name: 'windows plain build'
+description: >
+  Builds limactl.exe and the Linux/amd64 guest agent with `go build` on a
+  vanilla Windows host (no MSYS2 make / bash). The guest agent must be built
+  separately because limactl looks it up at
+  _output/share/lima/lima-guestagent.Linux-x86_64 when starting an instance,
+  and `go build ./cmd/limactl` does not produce that file.
+
+  Without make's -X ldflag pkg/version.Version keeps its "<unknown>" default.
+  Being unparsable, that passes every version comparison, which is what lets
+  default.yaml's minimumLimaVersion accept these builds.
+runs:
+  using: composite
+  steps:
+  - name: Build limactl and Linux/amd64 guest agent
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      go build -o _output\bin\limactl.exe .\cmd\limactl
+      if ($LASTEXITCODE -ne 0) { throw "limactl build failed: $LASTEXITCODE" }
+      New-Item -ItemType Directory -Force -Path _output\share\lima | Out-Null
+      $env:CGO_ENABLED = '0'
+      $env:GOOS = 'linux'
+      $env:GOARCH = 'amd64'
+      go build -o _output\share\lima\lima-guestagent.Linux-x86_64 .\cmd\lima-guestagent
+      if ($LASTEXITCODE -ne 0) { throw "lima-guestagent build failed: $LASTEXITCODE" }

--- a/.github/actions/windows_plain_host/action.yml
+++ b/.github/actions/windows_plain_host/action.yml
@@ -1,0 +1,183 @@
+name: 'windows plain host'
+description: >
+  Uninstalls MSYS2 and Git for Windows from the windows-2025 runner so the
+  job runs against a vanilla Windows toolchain: native OpenSSH from
+  %SystemRoot%\System32\OpenSSH, wsl.exe, and tar. Then verifies they are
+  gone across four layers (filesystem, PATH, binaries, registry) and that the
+  native OpenSSH client is there, so a runner-image change in either direction
+  fails the job loudly.
+
+  Destructive and irreversible: it also rewrites the Machine and User PATH in
+  the registry, so run it only on an ephemeral runner.
+
+  Run AFTER steps that need git CLI (checkout, windows_plain_templates) and
+  BEFORE the build / smoke test steps.
+runs:
+  using: composite
+  steps:
+  - name: Uninstall Git for Windows
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      $uninstaller = 'C:\Program Files\Git\unins000.exe'
+      if (Test-Path $uninstaller) {
+        Write-Host "Running Git for Windows Inno Setup uninstaller..."
+        & $uninstaller /VERYSILENT /NORESTART /SUPPRESSMSGBOXES
+        # The parent exits at once and Inno Setup finishes the work in a copy
+        # of itself under %TEMP%, named _iu*.tmp rather than unins000, so wait
+        # on both before wiping the leftover dir.
+        $deadline = (Get-Date).AddSeconds(120)
+        while ((Get-Date) -lt $deadline -and
+               (Get-Process -Name 'unins000', '_iu*' -ErrorAction SilentlyContinue)) {
+          Start-Sleep -Seconds 2
+        }
+      } else {
+        Write-Host "No Git for Windows uninstaller at $uninstaller; skipping."
+      }
+      foreach ($d in 'C:\Program Files\Git', 'C:\Program Files (x86)\Git') {
+        if (Test-Path $d) {
+          Write-Host "Removing leftover $d"
+          Remove-Item $d -Recurse -Force -ErrorAction SilentlyContinue
+        }
+      }
+      # The uninstaller forks, so its own exit status says nothing about the
+      # result. Discard it and let the verify step below be the gate.
+      exit 0
+
+  - name: Uninstall MSYS2 and standalone mingw
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      # MSYS2 on this runner image is an extracted tree, not a package, so
+      # "uninstall" means killing any process still mapping msys-2.0.dll
+      # then removing the dir. C:\mingw64 and C:\mingw32 are the same shape.
+      $procs = Get-Process | Where-Object {
+        try { $_.Modules.ModuleName -contains 'msys-2.0.dll' } catch { $false }
+      }
+      if ($procs) {
+        Write-Host "Stopping $($procs.Count) process(es) still mapping msys-2.0.dll"
+        $procs | Stop-Process -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 1
+      }
+      foreach ($d in 'C:\msys64', 'C:\tools\msys64', 'C:\msys32',
+                     'C:\mingw64', 'C:\mingw32') {
+        if (Test-Path $d) {
+          Write-Host "Removing $d"
+          Remove-Item $d -Recurse -Force -ErrorAction SilentlyContinue
+        }
+      }
+
+  - name: Scrub forbidden entries from Machine + User PATH
+    shell: pwsh
+    # The PATH= we publish here is the runner's own Machine + User PATH
+    # with a static deny-list of toolchain prefixes removed — no
+    # PR-controlled data reaches the env file.
+    run: | # zizmor: ignore[github-env]
+      $ErrorActionPreference = 'Stop'
+      # The uninstall removes the dirs, but the Machine/User PATH still has
+      # stale entries (C:\mingw64\bin stays registered). Rewrite both scopes
+      # so the verify step sees a clean host, then publish the combined PATH
+      # via $GITHUB_ENV, because registry changes do not reach the running
+      # runner process. $GITHUB_PATH entries from earlier steps are still
+      # prepended on top of this value, so the scrub cannot reach them.
+      $forbidden = '(?i)(msys|mingw|cygwin|\\Git\\(cmd|bin|usr))'
+      foreach ($scope in @('Machine','User')) {
+        $orig = [Environment]::GetEnvironmentVariable('Path', $scope)
+        if (-not $orig) { continue }
+        $cleaned = ($orig -split ';' | Where-Object { $_ -and ($_ -notmatch $forbidden) }) -join ';'
+        if ($cleaned -ne $orig) {
+          Write-Host "Scrubbing $scope PATH"
+          [Environment]::SetEnvironmentVariable('Path', $cleaned, $scope)
+        }
+      }
+      $machine = [Environment]::GetEnvironmentVariable('Path','Machine')
+      $user = [Environment]::GetEnvironmentVariable('Path','User')
+      $combined = (@($machine, $user) | Where-Object { $_ }) -join ';'
+      Add-Content -Path $env:GITHUB_ENV -Value "PATH=$combined"
+
+  - name: Verify host is vanilla Windows (no MSYS2 / Git for Windows / Cygwin)
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      # The PATH= published by the scrub step already applies to this step, so
+      # the inherited PATH is what later steps see. Check it as inherited
+      # rather than rebuilding it, which would only re-read the scrub's input.
+      $fail = @()
+
+      # --- Layer 1: filesystem ---
+      $fsForbidden = @(
+        'C:\msys64', 'C:\tools\msys64', 'C:\msys32',
+        'C:\Program Files\Git', 'C:\Program Files (x86)\Git',
+        'C:\mingw64', 'C:\mingw32',
+        'C:\cygwin', 'C:\cygwin64', 'C:\tools\cygwin'
+      )
+      foreach ($d in $fsForbidden) {
+        if (Test-Path $d) { $fail += "filesystem: $d still exists" }
+      }
+
+      # --- Layer 2: PATH (process + machine + user) ---
+      $pathRegex = '(?i)(msys|mingw|cygwin|\\Git\\(cmd|bin|usr))'
+      foreach ($scope in @('Process','Machine','User')) {
+        $p = [Environment]::GetEnvironmentVariable('Path', $scope)
+        if (-not $p) { continue }
+        foreach ($entry in $p -split ';') {
+          if ($entry -and ($entry -match $pathRegex)) {
+            $fail += ("PATH ({0}): {1}" -f $scope, $entry)
+          }
+        }
+      }
+
+      # --- Layer 3: smoking-gun binaries ---
+      # Any of these resolving on PATH means a toolchain is still reachable.
+      # bash is special: WSL ships %SystemRoot%\System32\bash.exe which is
+      # legitimately present on the wsl2 plain job, so allow only that path.
+      $forbiddenCmds = @('cygpath','pacman','mintty','git','git-bash','git-cmd')
+      foreach ($cmd in $forbiddenCmds) {
+        $g = Get-Command $cmd -ErrorAction SilentlyContinue
+        if ($g) { $fail += ("binary: {0} -> {1}" -f $cmd, $g.Source) }
+      }
+      $allowedBash = Join-Path $env:SystemRoot 'System32\bash.exe'
+      $bash = Get-Command bash -ErrorAction SilentlyContinue
+      if ($bash -and ($bash.Source -ne $allowedBash)) {
+        $fail += "binary: bash -> $($bash.Source) (only $allowedBash is allowed)"
+      }
+      $sh = Get-Command sh -ErrorAction SilentlyContinue
+      if ($sh) { $fail += "binary: sh -> $($sh.Source)" }
+
+      # --- Layer 4: registry uninstall keys ---
+      $uninstallRoots = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+        'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall'
+      )
+      foreach ($root in $uninstallRoots) {
+        if (-not (Test-Path $root)) { continue }
+        $keys = Get-ChildItem $root -ErrorAction SilentlyContinue
+        foreach ($k in $keys) {
+          $props = Get-ItemProperty $k.PSPath -ErrorAction SilentlyContinue
+          if ($props -and $props.DisplayName -and
+              ($props.DisplayName -match '(?i)(msys|git for windows|cygwin|mingw)')) {
+            $fail += ("registry: {0} -> DisplayName='{1}'" -f $k.PSPath, $props.DisplayName)
+          }
+        }
+      }
+
+      # --- Layer 5: the toolchain these jobs do need ---
+      # Missing ssh.exe fails the job with an opaque `exec: "ssh": executable
+      # file not found`; missing scp.exe or ssh-keygen.exe makes Lima fall
+      # back to a bare ssh lookup and fail later elsewhere; missing
+      # sftp-server.exe drops reverse-sshfs to the builtin driver, so the job
+      # stops covering what it was added to cover.
+      $opensshDir = Join-Path $env:SystemRoot 'System32\OpenSSH'
+      foreach ($exe in 'ssh.exe', 'scp.exe', 'ssh-keygen.exe', 'sftp-server.exe') {
+        $exePath = Join-Path $opensshDir $exe
+        if (-not (Test-Path $exePath)) { $fail += "missing: $exePath" }
+      }
+
+      if ($fail.Count -gt 0) {
+        Write-Host "Plain-Windows verification FAILED:" -ForegroundColor Red
+        $fail | ForEach-Object { Write-Host "  $_" }
+        Write-Error "Runner is not in the expected plain-Windows state; see the list above."
+        exit 1
+      }
+      Write-Host "Plain-Windows verification PASSED."

--- a/.github/actions/windows_plain_smoke_test/action.yml
+++ b/.github/actions/windows_plain_smoke_test/action.yml
@@ -1,0 +1,89 @@
+name: 'windows plain smoke test'
+description: >
+  Runs Lima's create / start / shell / copy / stop / delete cycle against a
+  given template on a plain Windows host. Each limactl invocation runs with
+  --debug so traces land in the workflow log, and on failure the workflow
+  dumps the instance's hostagent / serial logs so the run carries enough
+  context to diagnose without re-running.
+inputs:
+  template:
+    description: Path to the Lima template (e.g. .\templates\experimental\wsl2.yaml).
+    required: true
+  instance-name:
+    description: Name to use for the test instance.
+    required: false
+    default: plain
+  lima-home-suffix:
+    description: >
+      Suffix appended to runner.temp for LIMA_HOME (e.g. "plain-wsl2"). Must be
+      unique per job sharing a runner so concurrent jobs cannot collide.
+    required: true
+  vm-type:
+    description: >
+      Lima vmType to force via `--vm-type` (e.g. "qemu" or "wsl2"). When empty,
+      `limactl create` auto-selects, which on Windows prefers wsl2 over qemu
+      even when the template ships a disk image incompatible with wsl2.
+    required: false
+    default: ''
+runs:
+  using: composite
+  steps:
+  - name: Smoke test (create / start / shell / copy / stop / delete)
+    shell: pwsh
+    env:
+      LIMA_HOME: ${{ runner.temp }}\lima-${{ inputs.lima-home-suffix }}
+      INSTANCE: ${{ inputs.instance-name }}
+      TEMPLATE: ${{ inputs.template }}
+      VM_TYPE: ${{ inputs.vm-type }}
+    run: |
+      $ErrorActionPreference = 'Stop'
+      # $ErrorActionPreference does not propagate to native commands; wrap
+      # limactl so a non-zero exit aborts the whole script instead of
+      # silently continuing past the failure.
+      function Invoke-Limactl {
+        & .\_output\bin\limactl.exe --debug @args
+        if ($LASTEXITCODE -ne 0) { throw "limactl $($args -join ' ') exited $LASTEXITCODE" }
+      }
+      if (Test-Path $env:LIMA_HOME) { Remove-Item $env:LIMA_HOME -Recurse -Force }
+      New-Item -ItemType Directory -Path $env:LIMA_HOME | Out-Null
+      $createArgs = @('--tty=false', "--name=$env:INSTANCE")
+      if ($env:VM_TYPE) { $createArgs += "--vm-type=$env:VM_TYPE" }
+      $createArgs += $env:TEMPLATE
+      Invoke-Limactl create @createArgs
+      Invoke-Limactl start $env:INSTANCE
+      Invoke-Limactl shell --tty=false $env:INSTANCE -- uname -srm
+      'roundtrip' | Out-File -Encoding ascii "$env:LIMA_HOME\rt.txt"
+      Invoke-Limactl copy "$env:LIMA_HOME\rt.txt" "${env:INSTANCE}:/tmp/rt.txt"
+      Invoke-Limactl shell --tty=false $env:INSTANCE -- cat /tmp/rt.txt
+      # Cover the guest -> host direction too: it runs through different
+      # parseCopyPaths plumbing than the upload above.
+      Invoke-Limactl copy "${env:INSTANCE}:/tmp/rt.txt" "$env:LIMA_HOME\rt-back.txt"
+      # -Raw yields $null for an empty file, and $null.Trim() would throw
+      # before the mismatch message a zero-byte copy is meant to produce.
+      $back = "$(Get-Content "$env:LIMA_HOME\rt-back.txt" -Raw)".Trim()
+      if ($back -ne 'roundtrip') {
+        throw "round-trip mismatch: expected 'roundtrip', got '$back'"
+      }
+      Invoke-Limactl stop $env:INSTANCE
+      Invoke-Limactl delete --force $env:INSTANCE
+
+  - name: Dump Lima logs on failure
+    if: failure()
+    shell: pwsh
+    env:
+      LIMA_HOME: ${{ runner.temp }}\lima-${{ inputs.lima-home-suffix }}
+      INSTANCE: ${{ inputs.instance-name }}
+    run: |
+      $instDir = Join-Path $env:LIMA_HOME $env:INSTANCE
+      if (-not (Test-Path $instDir)) {
+        Write-Host "No instance directory at $instDir, nothing to dump."
+        exit 0
+      }
+      Get-ChildItem $instDir | Format-Table Name, Length, LastWriteTime
+      foreach ($name in 'ha.stdout.log','ha.stderr.log','serial.log','lima.yaml','ssh.config') {
+        $p = Join-Path $instDir $name
+        if (Test-Path $p) {
+          Write-Host ("===== {0} =====" -f $p)
+          Get-Content $p
+        }
+      }

--- a/.github/actions/windows_plain_templates/action.yml
+++ b/.github/actions/windows_plain_templates/action.yml
@@ -1,0 +1,81 @@
+name: 'windows plain templates'
+description: >
+  Resolves Lima's template symlinks and copies templates/ to
+  _output/share/lima/templates/, replicating `make`'s TEMPLATES target without
+  needing MSYS2 / Git for Windows.
+
+  Several files under templates/ are git symlinks (mode 120000) pointing at
+  sibling files, and some chain (opensuse.yaml -> opensuse-leap.yaml ->
+  opensuse-leap-16.yaml). The working-tree representation varies: a runner
+  with Developer Mode (or admin) preserves them as NTFS symlinks; a plain
+  Windows checkout with core.symlinks=false writes 17-byte plaintext stubs.
+  Reading targets directly from git's object store makes resolution
+  independent of which representation the checkout used.
+
+  This action MUST run before windows_plain_host (which uninstalls Git for
+  Windows), because it shells out to `git ls-tree` and `git cat-file`.
+runs:
+  using: composite
+  steps:
+  - name: Install templates (replicating make's TEMPLATES target)
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      # windows_plain_host uninstalls git, so a job that runs this action after
+      # it would fail here with a bare not-found. Name the contract instead.
+      if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        throw "git not found; this action must run before windows_plain_host"
+      }
+      $srcRoot = 'templates'
+      $dstRoot = '_output\share\lima\templates'
+      if (Test-Path $dstRoot) { Remove-Item $dstRoot -Recurse -Force }
+      New-Item -ItemType Directory -Force -Path $dstRoot | Out-Null
+      Copy-Item -Path "$srcRoot\*" -Destination $dstRoot -Recurse -Force
+
+      $linkTargets = @{}
+      # Capture before iterating: a partial `git ls-tree` failure would let
+      # foreach run on truncated data, and later `git cat-file` calls would
+      # overwrite $LASTEXITCODE before the failure could be seen.
+      $lsTreeOutput = git ls-tree -r HEAD $srcRoot
+      if ($LASTEXITCODE -ne 0) { throw "git ls-tree failed: $LASTEXITCODE" }
+      foreach ($line in $lsTreeOutput) {
+        if ($line -notmatch '^120000\s') { continue }
+        $parts = $line -split "`t", 2
+        $sha = ($parts[0] -split '\s+')[2]
+        $posixPath = $parts[1]
+        # A failed cat-file writes only to stderr, so keep the value a string:
+        # $null.Trim() would throw ahead of the check below.
+        $target = "$(git cat-file blob $sha)".Trim()
+        if ($LASTEXITCODE -ne 0) { throw "git cat-file $sha failed: $LASTEXITCODE" }
+        $linkTargets[$posixPath] = $target
+      }
+
+      foreach ($posixPath in $linkTargets.Keys) {
+        $resolved = $posixPath
+        $depth = 0
+        while ($linkTargets.ContainsKey($resolved)) {
+          if ($depth++ -gt 16) { throw "Symlink chain too deep starting from $posixPath" }
+          $target = $linkTargets[$resolved]
+          $slash = $resolved.LastIndexOf('/')
+          $resolved = if ($slash -ge 0) { "$($resolved.Substring(0, $slash))/$target" } else { $target }
+          $segs = New-Object System.Collections.ArrayList
+          foreach ($s in ($resolved -split '/')) {
+            if ($s -eq '' -or $s -eq '.') { continue }
+            if ($s -eq '..') {
+              if ($segs.Count -gt 0) { $segs.RemoveAt($segs.Count - 1) | Out-Null }
+              continue
+            }
+            $segs.Add($s) | Out-Null
+          }
+          $resolved = $segs -join '/'
+        }
+        # Defensive: the '..' handling above silently underflows. Guard against
+        # a future symlink edit whose chain resolves outside templates/.
+        if (-not $resolved.StartsWith("$srcRoot/")) {
+          throw "Symlink $posixPath resolved to $resolved, which escapes $srcRoot/"
+        }
+        $srcFile = $resolved -replace '/', '\'
+        $dstFile = Join-Path '_output\share\lima' ($posixPath -replace '/', '\')
+        Write-Host "Resolving symlink: $posixPath -> $resolved"
+        Copy-Item -Force -Path $srcFile -Destination $dstFile
+      }

--- a/.github/actions/windows_qemu_install/action.yml
+++ b/.github/actions/windows_qemu_install/action.yml
@@ -1,0 +1,11 @@
+name: 'windows qemu install'
+description: Installs QEMU on the Windows runner via winget.
+runs:
+  using: composite
+  steps:
+  - name: Install QEMU
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      winget install --silent --accept-source-agreements --accept-package-agreements --disable-interactivity SoftwareFreedomConservancy.QEMU
+      if ($LASTEXITCODE -ne 0) { throw "winget install QEMU failed: $LASTEXITCODE" }

--- a/.github/actions/windows_wsl2_setup/action.yml
+++ b/.github/actions/windows_wsl2_setup/action.yml
@@ -1,0 +1,62 @@
+name: 'windows wsl2 setup'
+description: >
+  Enables WSL2 on the Windows runner and imports a dummy distro. The dummy
+  distro is required because `wsl --list --verbose` (called from Lima) fails
+  when no distro is installed -- see lima-vm/lima#1826. Starting with WSL2
+  2.5.7.0 the imported tarball must contain /bin/sh and /etc, hence the
+  scaffolding here.
+runs:
+  using: composite
+  steps:
+  - name: Enable WSL2
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      # PowerShell's $ErrorActionPreference does not propagate to native
+      # commands; check $LASTEXITCODE after every wsl invocation that
+      # gates the runner state.
+      wsl --set-default-version 2
+      if ($LASTEXITCODE -ne 0) { throw "wsl --set-default-version failed: $LASTEXITCODE" }
+      wsl --shutdown
+      if ($LASTEXITCODE -ne 0) { throw "wsl --shutdown failed: $LASTEXITCODE" }
+      # --update reaches a Microsoft update service that returns
+      # transient 403s; treat it as informational, like --status /
+      # --version / --list --online below.
+      wsl --update
+      wsl --status
+      wsl --version
+      wsl --list --online
+      # pwsh exits with the last command's status, and --list --online reaches
+      # that same service, so discard it to keep the four calls informational.
+      exit 0
+  - name: Install dummy WSL2 distro
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'Stop'
+      # Keep the scratch tarball and the distro disk under $RUNNER_TEMP so no
+      # untracked files land in the checked-out workspace.
+      $scratch = Join-Path $env:RUNNER_TEMP 'wsl2-dummy'
+      New-Item -ItemType Directory -Force -Path "$scratch\bin","$scratch\etc" | Out-Null
+      Set-Content -Path "$scratch\bin\sh" -Value ''
+      $tarball = Join-Path $env:RUNNER_TEMP 'wsl2-dummy.tar'
+      tar -cf $tarball --format ustar -C $scratch .
+      if ($LASTEXITCODE -ne 0) { throw "tar -cf $tarball failed: $LASTEXITCODE" }
+      # A fresh runner has no `dummy` to unregister; not checking $LASTEXITCODE
+      # is what makes that failure harmless. The call matters on a developer
+      # machine, where the import would otherwise fail on the second run.
+      wsl --unregister dummy
+      $distroDir = Join-Path $env:RUNNER_TEMP 'wsl2-dummy-distro'
+      New-Item -ItemType Directory -Force -Path $distroDir | Out-Null
+      # A composite action step cannot carry timeout-minutes, so bound the
+      # import here; it is the call that has hung on runners before.
+      # -ArgumentList joins its elements unquoted, so quote the two paths.
+      $p = Start-Process -FilePath wsl.exe -PassThru -NoNewWindow `
+        -ArgumentList '--import', 'dummy', "`"$distroDir`"", "`"$tarball`""
+      if (-not $p.WaitForExit(60000)) {
+        $p.Kill()
+        throw "wsl --import dummy timed out after 60s"
+      }
+      if ($p.ExitCode -ne 0) { throw "wsl --import dummy failed: $($p.ExitCode)" }
+      wsl --list --verbose
+      # Informational, like the listings in the step above.
+      exit 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,36 +145,11 @@ jobs:
     - name: Uninstall
       run: sudo make uninstall
 
-  windows:
+  windows-wsl2:
     name: "Windows tests (WSL2)"
     runs-on: windows-2025
     timeout-minutes: 30
     steps:
-    - name: Enable WSL2
-      run: |
-        wsl --set-default-version 2
-        wsl --shutdown
-        wsl --update
-        wsl --status
-        wsl --version
-        wsl --list --online
-    - name: Install WSL2 distro
-      timeout-minutes: 1
-      run: |
-        # FIXME: At least one distro has to be installed here,
-        # otherwise `wsl --list --verbose` (called from Lima) fails:
-        # https://github.com/lima-vm/lima/pull/1826#issuecomment-1729993334
-        # The distro image itself is not consumed by Lima.
-        # Starting with WSL2 version 2.5.7.0 the distro will be rejected
-        # if it doesn't contain /bin/sh and /etc.
-        # ------------------------------------------------------------------
-        mkdir dummy
-        mkdir dummy\bin
-        mkdir dummy\etc
-        echo "" >dummy\bin\sh
-        tar -cf dummy.tar --format ustar -C dummy .
-        wsl --import dummy $env:TEMP dummy.tar
-        wsl --list --verbose
     - name: Set gitconfig
       run: |
         git config --global core.autocrlf false
@@ -186,19 +161,19 @@ jobs:
       with:
         go-version: stable
         cache: false
+    - uses: ./.github/actions/windows_wsl2_setup
+    - uses: ./.github/actions/windows_msys2_prep
     - name: Unit tests
       run: go test -v ./...
     - name: Make
       run: make
     - name: Integration tests (WSL2, Windows host)
       run: |
-        $env:PATH = "$pwd\_output\bin;" + 'C:\msys64\usr\bin;' + $env:PATH
-        pacman -Sy --noconfirm openbsd-netcat diffutils socat w3m
-        $env:MSYS2_ENV_CONV_EXCL = 'HOME_HOST;HOME_GUEST;_LIMA_WINDOWS_EXTRA_PATH'
+        $env:PATH = "$pwd\_output\bin;" + $env:PATH
+        $env:MSYS2_ENV_CONV_EXCL = 'HOME_HOST;HOME_GUEST'
         $env:HOME_HOST = $(cygpath.exe "$env:USERPROFILE")
         $env:HOME_GUEST = "/mnt$env:HOME_HOST"
         $env:LIMACTL_CREATE_ARGS = '--vm-type=wsl2 --mount-type=wsl2 --containerd=system'
-        $env:_LIMA_WINDOWS_EXTRA_PATH = 'C:\Program Files\Git\usr\bin'
         bash.exe -c "./hack/test-templates.sh templates/experimental/wsl2.yaml"
 
   windows-qemu:
@@ -217,21 +192,92 @@ jobs:
       with:
         go-version: stable
         cache: false
+    - uses: ./.github/actions/windows_qemu_install
+    - uses: ./.github/actions/windows_msys2_prep
     - name: Make
       run: make
-    - name: Install QEMU
-      run: |
-        winget install --silent --accept-source-agreements --accept-package-agreements --disable-interactivity SoftwareFreedomConservancy.QEMU
     - name: Integration tests (QEMU, Windows host)
       run: |
-        $env:PATH = "$pwd\_output\bin;" + 'C:\msys64\usr\bin;' + 'C:\Program Files\QEMU;' + $env:PATH
-        pacman -Sy --noconfirm openbsd-netcat diffutils socat w3m
-        $env:MSYS2_ENV_CONV_EXCL = 'HOME_HOST;HOME_GUEST;_LIMA_WINDOWS_EXTRA_PATH'
+        $env:PATH = "$pwd\_output\bin;" + 'C:\Program Files\QEMU;' + $env:PATH
+        $env:MSYS2_ENV_CONV_EXCL = 'HOME_HOST;HOME_GUEST'
         $env:HOME_HOST = $(cygpath.exe "$env:USERPROFILE")
         $env:HOME_GUEST = "$env:HOME_HOST"
         $env:LIMACTL_CREATE_ARGS = '--vm-type=qemu'
-        $env:_LIMA_WINDOWS_EXTRA_PATH = 'C:\Program Files\Git\usr\bin'
         bash.exe -c "./hack/test-templates.sh templates/default.yaml"
+
+  windows-plain-wsl2:
+    # Smoke test that Lima's WSL2 driver works on a Windows host with only
+    # the bits that ship in a default Windows 10/11 install (native OpenSSH,
+    # wsl.exe, tar). Notably: no Git for Windows, no MSYS2, no cygpath, no
+    # Cygwin/MSYS2 ssh. Builds with `go build` (instead of `make`) and
+    # exercises the main commands in PowerShell. If this job ever needs to
+    # add MSYS2 / Git for Windows back to make a step pass, that means a new
+    # external-binary dependency was introduced and should be evaluated.
+    name: "Windows tests (WSL2, plain Windows host)"
+    runs-on: windows-2025
+    timeout-minutes: 30
+    steps:
+    - name: Set gitconfig
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+      with:
+        go-version: stable
+        cache: false
+    - uses: ./.github/actions/windows_wsl2_setup
+    # No windows_plain_templates here: wsl2.yaml carries no `base:`, so this
+    # job never reads the resolved template store that action builds.
+    - uses: ./.github/actions/windows_plain_host
+    - uses: ./.github/actions/windows_plain_build
+    - uses: ./.github/actions/windows_plain_smoke_test
+      with:
+        template: .\templates\experimental\wsl2.yaml
+        lima-home-suffix: plain-wsl2
+
+  windows-plain-qemu:
+    # Same shape as windows-plain-wsl2 but exercises the QEMU driver. Covers
+    # native OpenSSH selection and cygpath-free path translation without
+    # MSYS2 / Git-for-Windows on PATH. The reverse-sshfs mount starts through
+    # the native sftp-server, but its confirmation step fails on the runner
+    # and sshocker treats that as non-fatal, so the mount itself is uncovered.
+    name: "Windows tests (QEMU, plain Windows host)"
+    runs-on: windows-2025
+    timeout-minutes: 30
+    steps:
+    - name: Set gitconfig
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+      with:
+        go-version: stable
+        cache: false
+    - uses: ./.github/actions/windows_qemu_install
+    - uses: ./.github/actions/windows_plain_templates
+    - uses: ./.github/actions/windows_plain_host
+    # winget's QEMU manifest does not register a PATH entry, so add the
+    # install dir here, extending the scrubbed PATH= that windows_plain_host
+    # published through $GITHUB_ENV.
+    - name: Add QEMU to PATH
+      shell: pwsh
+      run: |
+        Add-Content -Path $env:GITHUB_ENV -Value "PATH=C:\Program Files\QEMU;$env:PATH"
+    - uses: ./.github/actions/windows_plain_build
+    - uses: ./.github/actions/windows_plain_smoke_test
+      with:
+        template: .\templates\default.yaml
+        lima-home-suffix: plain-qemu
+        # Force qemu: on Windows, `limactl create` auto-selects wsl2
+        # over qemu, and templates/default.yaml ships a cloud disk
+        # image that the wsl2 driver rejects.
+        vm-type: qemu
 
   qemu:
     name: "Integration tests (QEMU, macOS host)"

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -38,16 +38,6 @@ func main() {
 	}
 
 	yq.MaybeRunYQ()
-	if runtime.GOOS == "windows" {
-		extras, hasExtra := os.LookupEnv("_LIMA_WINDOWS_EXTRA_PATH")
-		if hasExtra && strings.TrimSpace(extras) != "" {
-			p := os.Getenv("PATH")
-			err := os.Setenv("PATH", strings.TrimSpace(extras)+string(filepath.ListSeparator)+p)
-			if err != nil {
-				logrus.Warning("Can't add extras to PATH, relying entirely on system PATH")
-			}
-		}
-	}
 	err := newApp().Execute()
 	server.Disconnect()
 	osutil.HandleExitError(err)

--- a/pkg/sshutil/sshutil_windows_test.go
+++ b/pkg/sshutil/sshutil_windows_test.go
@@ -51,6 +51,42 @@ func TestPickCompleteSSHOnWindows(t *testing.T) {
 		t.Setenv("PATH", mingit)
 		assert.Equal(t, pickCompleteSSHOnWindows(), nativeSSH)
 	})
+
+	t.Run("incomplete native install disqualifies it too", func(t *testing.T) {
+		fakeRoot := resolvedTempDir(t)
+		nativeDir := filepath.Join(fakeRoot, "System32", "OpenSSH")
+		assert.NilError(t, os.MkdirAll(nativeDir, 0o755))
+		assert.NilError(t, os.WriteFile(filepath.Join(nativeDir, "ssh.exe"), nil, 0o644))
+		t.Setenv("SystemRoot", fakeRoot)
+		t.Setenv("PATH", "")
+
+		assert.Equal(t, pickCompleteSSHOnWindows(), "",
+			"an ssh.exe without its companions never qualifies, wherever it lives")
+	})
+}
+
+// TestNewSSHExeFallsBackToPATH: when no directory holds a complete install,
+// NewSSHExe stops being selective and takes whatever `ssh` PATH resolves. The
+// binary it returns is therefore reachable only through PATH, which is why a
+// host check that only proves the files exist cannot show which ssh Lima runs.
+func TestNewSSHExeFallsBackToPATH(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only PATH walk")
+	}
+
+	partial := resolvedTempDir(t)
+	sshExe := filepath.Join(partial, "ssh.exe")
+	assert.NilError(t, os.WriteFile(sshExe, nil, 0o644))
+
+	t.Setenv("SystemRoot", resolvedTempDir(t))
+	t.Setenv("PATH", partial)
+	t.Setenv(EnvShellSSH, "")
+
+	assert.Equal(t, pickCompleteSSHOnWindows(), "", "the partial install must not qualify")
+
+	got, err := NewSSHExe()
+	assert.NilError(t, err)
+	assert.Equal(t, got.Exe, sshExe)
 }
 
 // TestCygpathForSSH: an ssh.exe next to cygpath.exe is Cygwin-based and

--- a/website/content/en/docs/config/environment-variables.md
+++ b/website/content/en/docs/config/environment-variables.md
@@ -147,20 +147,6 @@ This page documents the environment variables used in Lima.
   export LIMA_USERNET_RESOLVE_IP_ADDRESS_TIMEOUT=5
   ```
 
-### `_LIMA_WINDOWS_EXTRA_PATH`
-
-- **Description**: Additional directories which will be added to PATH by `limactl.exe` process to search for tools.
-  It is useful, when there is a need to prevent collisions between binaries available in active shell and ones
-  used by `limactl.exe` - injecting them only for the running process w/o altering PATH observed by user shell.
-  Is is Windows specific and does nothing for other platforms.
-- **Default**: unset
-- **Usage**:
-  ```bat
-  set _LIMA_WINDOWS_EXTRA_PATH=C:\Program Files\Git\usr\bin
-  ```
-- **Note**: It is an experimental setting and has no guarantees being ever promoted to stable. It may be removed
-  or changed at any stage of project development.
-
 ### `QEMU_SYSTEM_AARCH64`
 
 - **Description**: Path to the `qemu-system-aarch64` binary.

--- a/website/content/en/docs/releases/breaking.md
+++ b/website/content/en/docs/releases/breaking.md
@@ -3,6 +3,11 @@ title: Breaking changes
 weight: 20
 ---
 
+## v2.3.0
+- The experimental `_LIMA_WINDOWS_EXTRA_PATH` environment variable was removed. It prepended directories to
+  `limactl.exe`'s own PATH on Windows hosts, leaving the calling shell's PATH untouched. Put them on `PATH`
+  instead, or set `PATH` for the single call if you need to keep them out of your shell.
+
 ## v2.2.0
 - The default [`socket_vmnet` group](../config/network/vmnet.md) in `networks.yaml` was changed from `everyone` to
   `admin`. A non-admin user must set `group` to a group they belong to (e.g. `staff`).


### PR DESCRIPTION
Move the Windows runner setup out of `test.yml` into reusable composite actions, and add `windows-plain-{wsl2,qemu}` jobs that run Lima on a host with Git for Windows, MSYS2, and Cygwin removed. The plain-host action checks the toolchain is gone across filesystem, PATH, known binaries, and registry, and that the native OpenSSH client is present, so a runner-image change in either direction fails loudly instead of masking a regression.

With test.yml no longer setting `_LIMA_WINDOWS_EXTRA_PATH`, that env var loses its last user, so the implementation and its docs entry go too. It prepended `C:\Program Files\Git\usr\bin` to limactl's PATH, which is how the MSYS2 jobs got a Cygwin ssh.

The MSYS2 jobs install `openssh` in its place, so they keep exercising the Cygwin toolchain while the plain jobs exercise the native one. They also gain `rsync`. Without it `hack/test-templates.sh` skips its rsync copy backend instead of failing, so the path conversion that backend performs on Windows never runs.

The "windows" job id becomes "windows-wsl2". Its `name:` is unchanged, so required status checks are unaffected.

Note that the new plain-Windows jobs run `limactl copy` in both directions on a host with no Cygwin toolchain, which is what #5299 fixes, so expect them to fail until that lands.

A separate do-not-merge branch runs these jobs together with #5299, #5300, #5337, #5340 and #5341.

Assisted-by: Claude Opus 5
