### PR TITLE
Autoappend common tool directories to PATH

### DIFF
--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lima-vm/lima/v2/cmd/yq"
 	"github.com/lima-vm/lima/v2/pkg/debugutil"
 	"github.com/lima-vm/lima/v2/pkg/driver/external/server"
+	"github.com/lima-vm/lima/v2/pkg/envutil"
 	"github.com/lima-vm/lima/v2/pkg/fsutil"
 	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
 	"github.com/lima-vm/lima/v2/pkg/osutil"
@@ -45,6 +46,14 @@ func main() {
 			err := os.Setenv("PATH", strings.TrimSpace(extras)+string(filepath.ListSeparator)+p)
 			if err != nil {
 				logrus.Warning("Can't add extras to PATH, relying entirely on system PATH")
+			}
+		}
+		p := os.Getenv("PATH")
+		newPath := envutil.AppendDirsToPath(p, envutil.PlatformCommonToolDirs)
+		if newPath != p {
+			logrus.Info("Temporarily add the common tool (QEMU etc.) directories to PATH")
+			if err := os.Setenv("PATH", newPath); err != nil {
+				logrus.WithError(err).Warning("Can't add common tool directories to PATH, relying entirely on system PATH")
 			}
 		}
 	}

--- a/pkg/envutil/envutil_others.go
+++ b/pkg/envutil/envutil_others.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package envutil
+
+// PlatformCommonToolDirs contains the common tool installation directories required on the host platform.
+var PlatformCommonToolDirs = []string{}
+
+// AppendDirsToPath appends specified directories to pathEnv
+// Only existing directories that are not already in PATH are added.
+func AppendDirsToPath(_ string, _ []string) string {
+	return ""
+}

--- a/pkg/envutil/envutil_windows.go
+++ b/pkg/envutil/envutil_windows.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package envutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// PlatformCommonToolDirs contains the common tool installation directories required on the host platform.
+var PlatformCommonToolDirs = []string{
+	qemuDir(),
+	`C:\msys64\usr\bin`,
+}
+
+// qemuDir returns the default QEMU installation directories under %PROGRAMFILES%.
+func qemuDir() string {
+	programfiles, ok := os.LookupEnv("PROGRAMFILES")
+	if !ok {
+		programfiles = `C:\Program Files`
+	}
+	qemu := filepath.Join(programfiles, "QEMU")
+	return qemu
+}
+
+// AppendDirsToPath appends specified directories to pathEnv
+// Only existing directories that are not already in PATH are added.
+func AppendDirsToPath(pathEnv string, dirs []string) string {
+	seen := make(map[string]struct{})
+	for _, entry := range filepath.SplitList(pathEnv) {
+		seen[entry] = struct{}{}
+	}
+	for _, dir := range dirs {
+		st, err := os.Stat(dir)
+		if err != nil || !st.IsDir() {
+			continue
+		}
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+		seen[dir] = struct{}{}
+		pathEnv += string(filepath.ListSeparator) + dir
+	}
+	return pathEnv
+}

--- a/pkg/envutil/envutil_windows_test.go
+++ b/pkg/envutil/envutil_windows_test.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package envutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestAppendDirsToPath(t *testing.T) {
+	sep := string(filepath.ListSeparator)
+	existingDir := t.TempDir()
+	missingDir := filepath.Join(existingDir, "does-not-exist")
+	existingFile := filepath.Join(existingDir, "file.txt")
+	assert.NilError(t, os.WriteFile(existingFile, []byte("x"), 0o644))
+	dummyCurrentPath := filepath.Join("dummy1", "dummy2")
+
+	testCases := []struct {
+		name         string
+		originalPATH string
+		dirs         []string
+		expected     string
+	}{
+		{
+			name:         "existing directory is appended",
+			originalPATH: dummyCurrentPath,
+			dirs:         []string{existingDir},
+			expected:     dummyCurrentPath + sep + existingDir,
+		},
+		{
+			name:         "missing directory is not appended.",
+			originalPATH: dummyCurrentPath,
+			dirs:         []string{missingDir},
+			expected:     dummyCurrentPath,
+		},
+		{
+			name:         "file is not appended",
+			originalPATH: dummyCurrentPath,
+			dirs:         []string{existingFile},
+			expected:     dummyCurrentPath,
+		},
+		{
+			name:         "directory already in pathEnv is not appended again",
+			originalPATH: dummyCurrentPath + sep + existingDir,
+			dirs:         []string{existingDir},
+			expected:     dummyCurrentPath + sep + existingDir,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			got := AppendDirsToPath(test.originalPATH, test.dirs)
+			assert.Equal(t, got, test.expected)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Please read our contribution rules before submitting:

- Pull requests guide: https://lima-vm.io/docs/community/contributing/#sending-pull-requests
- AI usage policy: https://lima-vm.io/docs/community/contributing/#ai-contribution-rules

-->

## What This PR Changes
This PR appends tool directories commonly used in Windows host (e.g. QEMU etc.) to `PATH`.
This helps the common tool path automatically recognized.
<!-- Explain the single problem this PR fixes, in your own words. -->

## Linked Issue (Required in most cases)
#4820 
<!-- Link the issue here. If your issue is not approved by a maintainer, don't expect your PR to be merged. -->

Closes #4820 

## How I Tested This
Added unit tests in `envutil_test.go`.

## AI Usage
No
<!-- If you used AI tools, say which tool and how you used it. For example, `Assisted-by: AI_AGENT_NAME:VERSION [TOOL]` or `Co-Authored-By`-->