### PR TITLE
ci: Also run CI jobs on almalinux-9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -308,6 +308,7 @@ jobs:
         - fedora.yaml
         - archlinux.yaml
         - opensuse.yaml
+        - almalinux-9.yaml
         - docker.yaml
         - ../hack/test-templates/alpine-iso-9p-writable.yaml  # Covers alpine-iso.yaml
         - ../hack/test-templates/net-user-v2.yaml


### PR DESCRIPTION
## What This PR Changes

Make sure AlmaLinux-9 (which is among the canned Lima templates) continues to work.

FYI, the analog change actually fails for AlmaLinux-10 but that's a separate issue with the Lima mDNS script and its missing `kernel-modules-extra-$(uname -r)` dependency.

## How I Tested This

Passed the Lima Github CI matrix.
