### PR TITLE
apfs: force the hdiutil detaches in TestChownIntegration

### DIFF
--- a/pkg/apfs/chown_darwin_test.go
+++ b/pkg/apfs/chown_darwin_test.go
@@ -42,7 +42,9 @@ func TestChownIntegration(t *testing.T) {
 
 	assert.NilError(t, os.WriteFile(filepath.Join(mntDir, "testfile.txt"), []byte("hello"), 0o644))
 
-	cmd = exec.CommandContext(ctx, "hdiutil", "detach", mntDir)
+	// -force, because Spotlight starts indexing the volume as soon as the file
+	// above is written, and an unforced eject fails with "Resource busy".
+	cmd = exec.CommandContext(ctx, "hdiutil", "detach", mntDir, "-force")
 	out, err = cmd.CombinedOutput()
 	assert.NilError(t, err, "hdiutil detach failed: %s", out)
 
@@ -58,7 +60,8 @@ func TestChownIntegration(t *testing.T) {
 	cmd = exec.CommandContext(ctx, "fsck_apfs", "-n", dev)
 	out, err = cmd.CombinedOutput()
 	assert.NilError(t, err, "fsck_apfs failed: %s", out)
-	cmd = exec.CommandContext(ctx, "hdiutil", "detach", dev)
+	// -force, because the device can still be busy right after fsck_apfs.
+	cmd = exec.CommandContext(ctx, "hdiutil", "detach", dev, "-force")
 	out, err = cmd.CombinedOutput()
 	assert.NilError(t, err, "hdiutil detach failed: %s", out)
 


### PR DESCRIPTION
`TestChownIntegration` ejects its scratch dmg twice with a bare `hdiutil detach`, and both ejects have failed in CI with "Resource busy", 8 times between May 1 and July 15. Spotlight indexes the volume as soon as the test writes to it, and the device can still be busy right after `fsck_apfs`. The cleanup detach at the end of the test already passes `-force`.

Assisted-by: Claude Opus 5


<details>
<summary>All 8 recorded failures</summary>

Collected by a CI failure sweep over `lima-vm/lima`. Each entry is one failed job. All in `Integration tests (QEMU, macOS host)`.

- [2026-05-01](https://github.com/lima-vm/lima/actions/runs/25208365163/job/73913437456) on `feat/sync-exclude-flags`
- [2026-05-01](https://github.com/lima-vm/lima/actions/runs/25224413248/job/73964288264) on `master`
- [2026-05-26](https://github.com/lima-vm/lima/actions/runs/26454190003/job/77883287732) on `grpc-port-forward-leak`
- [2026-06-10](https://github.com/lima-vm/lima/actions/runs/27283658724/job/80584773098) on `feat/ipv6`
- [2026-06-12](https://github.com/lima-vm/lima/actions/runs/27413454921/job/81020165633) on `opt-out-nopasswd`
- [2026-07-07](https://github.com/lima-vm/lima/actions/runs/28886965839/job/85689535750) on `master`
- [2026-07-11](https://github.com/lima-vm/lima/actions/runs/29141812976/job/86516292880) on `sbom`
- [2026-07-15](https://github.com/lima-vm/lima/actions/runs/29444851546/job/87452654254) on `master`

</details>
