### PR TITLE
hack: ignore SIGPIPE in test-port-forwarding.pl

### DIFF
--- a/hack/test-port-forwarding.pl
+++ b/hack/test-port-forwarding.pl
@@ -22,6 +22,10 @@ use JSON::PP;
 use Socket qw(inet_ntoa);
 use Sys::Hostname qw(hostname);
 
+# The socat we pipe a probe payload into can exit first when an `ignore:` rule
+# refuses the connection, and SIGPIPE would then kill the test mid-run.
+$SIG{PIPE} = 'IGNORE';
+
 my $connectionTimeout = 1; # seconds
 
 my $instance = shift;


### PR DESCRIPTION
The script writes each probe payload into a `| socat` pipe. For an `ignore:` rule the connection is meant to be refused, so socat can exit before the write reaches it, and the default SIGPIPE kills perl before it prints any per-forward result. The harness then reports port forwarding broken when its own probe was what died. Ten CI jobs failed this way between June 22 and July 24, spread over eight branches and eight templates.

Assisted-by: Claude Opus 5


<details>
<summary>All 10 recorded failures</summary>

Collected by a CI failure sweep over `lima-vm/lima`. Each entry is one failed job.

- [2026-06-22 — Integration tests (QEMU, Linux host) (fedora.yaml)](https://github.com/lima-vm/lima/actions/runs/27977879033/job/82800192017) on `fix/virtiofs-mount-path-with-spaces`
- [2026-06-26 — Integration tests (QEMU, Linux host) (debian.yaml)](https://github.com/lima-vm/lima/actions/runs/28244311717/job/83679092576) on `drop-sudo-host-services`
- [2026-07-05 — Integration tests (QEMU, Linux host) (docker.yaml)](https://github.com/lima-vm/lima/actions/runs/28737304645/job/85213696756) on `restrict-sudoers-group-5118`
- [2026-07-11 — Integration tests (QEMU, Linux host) (../hack/test-templates/test-misc.yaml)](https://github.com/lima-vm/lima/actions/runs/29150642057/job/86539492305) on `restrict-sudoers-group-5118`
- [2026-07-13 — Integration tests (QEMU, Linux host) (debian.yaml)](https://github.com/lima-vm/lima/actions/runs/29278850301/job/86914731454) on `feat/downloader-resume-partial-downloads`
- [2026-07-14 — Integration tests (QEMU, Linux host) (archlinux.yaml)](https://github.com/lima-vm/lima/actions/runs/29319012908/job/87039559684) on `master`
- [2026-07-14 — Integration tests (QEMU, Linux host) (fedora.yaml)](https://github.com/lima-vm/lima/actions/runs/29373476875/job/87221828950) on `improve-win11-performance`
- [2026-07-17 — Integration tests (QEMU, Linux host) (opensuse.yaml)](https://github.com/lima-vm/lima/actions/runs/29616993893/job/88004111363) on `windows-openssh-followup`
- [2026-07-21 — Integration tests (QEMU, Linux host) (alpine.yaml)](https://github.com/lima-vm/lima/actions/runs/29798108184/job/88533524709) on `master`
- [2026-07-24 — Integration tests (QEMU, Linux host) (../hack/test-templates/alpine-iso-9p-writable.yaml)](https://github.com/lima-vm/lima/actions/runs/30059747112/job/89378800419) on `dependabot/go_modules/github.com/mattn/go-isatty-0.0.23`

</details>
