### PR TITLE
hack: wait for the coredns forward before querying it

### DIFF
--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -415,7 +415,9 @@ if [[ -n ${CHECKS["container-engine"]} ]]; then
 		INFO "Run a coredns container with port forwarding 127.0.0.1:10053/udp"
 		limactl shell "$NAME" $sudo $CONTAINER_ENGINE pull --quiet ${coredns_image}
 		limactl shell "$NAME" $sudo $CONTAINER_ENGINE run -d --name coredns -p 127.0.0.1:10053:53/udp ${coredns_image}
-		dig @127.0.0.1 -p 10053 lima-vm.io
+		# Lima opens the host listener only after the guest agent has reported the
+		# published port, so the first query can arrive before it exists.
+		timeout 3m bash -euxc "until dig @127.0.0.1 -p 10053 lima-vm.io; do sleep 3; done"
 		limactl shell "$NAME" $sudo $CONTAINER_ENGINE rm -f coredns
 	fi
 


### PR DESCRIPTION
`test-templates.sh` fires `dig` at the forwarded UDP port the instant `nerdctl run -d` returns, while the `nginx` check just above waits with `until curl --retry-connrefused`. Lima opens the host listener only once the guest agent has reported the published port, so the query can arrive first and `dig` exits 9 under `set -e`. Ten CI jobs have died here since May 1, two of them on `master`, leaving aside one branch that had broken port forwarding.

Assisted-by: Claude Opus 5

<details>
<summary>All 29 recorded failures (10, plus 19 from one branch that was really broken)</summary>

Collected by a CI failure sweep over `lima-vm/lima`. Each entry is one failed job.

- [2026-05-01 — Integration tests (vz) (default.yaml)](https://github.com/lima-vm/lima/actions/runs/25208137318/job/73912737529) on `feat/sync-exclude-flags`
- [2026-05-22 — Integration tests (QEMU, macOS host)](https://github.com/lima-vm/lima/actions/runs/26313929490/job/77477909364) on `use_hashq`
- [2026-05-23 — Integration tests (QEMU, macOS host)](https://github.com/lima-vm/lima/actions/runs/26335567275/job/77753803269) on `use_hashq`
- [2026-05-23 — VMNet tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/26338105056/job/78198506849) on `lattice/qemu-stream-reconnect`
- [2026-05-25 — VMNet tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/26388974261/job/77673859005) on `use_hashq_part3`
- [2026-05-25 — VMNet tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/26421011888/job/77775568949) on `use_hashq_part3`
- [2026-05-26 — VMNet tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/26481946745/job/77980917308) on `figure-out-culprit-commit-containerd`
- [2026-05-28 — Integration tests (QEMU, macOS host)](https://github.com/lima-vm/lima/actions/runs/26569045804/job/78271159032) on `refactor/usestdlibvars`
- [2026-06-13 — Integration tests (vz) (default.yaml)](https://github.com/lima-vm/lima/actions/runs/27480636297/job/81227670004) on `master`
- [2026-07-22 — Integration tests (QEMU, Linux host) (archlinux.yaml)](https://github.com/lima-vm/lima/actions/runs/29924418413/job/88937773648) on `master`

`fix-nerdctl-rootlesskit` broke port forwarding for real across five commits, so its 19 hits are listed apart from the count above.

- [2026-05-24 — Integration tests (QEMU, macOS host)](https://github.com/lima-vm/lima/actions/runs/26362259176/job/77599745845)
- [2026-05-24 — VMNet tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/26362259176/job/77599745876)
- [2026-05-24 — Integration tests (QEMU, Linux host) (debian.yaml)](https://github.com/lima-vm/lima/actions/runs/26362259176/job/77599745904)
- [2026-05-24 — Integration tests (QEMU, Linux host) (fedora.yaml)](https://github.com/lima-vm/lima/actions/runs/26362259176/job/77599745909)
- [2026-05-24 — Integration tests (QEMU, Linux host) (../hack/test-templates/net-user-v2.yaml)](https://github.com/lima-vm/lima/actions/runs/26362259176/job/77599745917)
- [2026-05-24 — Integration tests (QEMU, Linux host) (../hack/test-templates/test-misc.yaml)](https://github.com/lima-vm/lima/actions/runs/26362259176/job/77599745939)
- [2026-05-24 — Integration tests (QEMU, Linux host) (opensuse.yaml)](https://github.com/lima-vm/lima/actions/runs/26362259176/job/77599745948)
- [2026-05-24 — Integration tests (QEMU, Linux host) (archlinux.yaml)](https://github.com/lima-vm/lima/actions/runs/26362259176/job/77599745956)
- [2026-05-24 — Integration tests (QEMU, macOS host)](https://github.com/lima-vm/lima/actions/runs/26372867832/job/77628012021)
- [2026-05-24 — VMNet tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/26372867832/job/77628012047)
- [2026-05-24 — Integration tests (QEMU, Linux host) (archlinux.yaml)](https://github.com/lima-vm/lima/actions/runs/26372867832/job/77628012048)
- [2026-05-24 — Integration tests (QEMU, Linux host) (debian.yaml)](https://github.com/lima-vm/lima/actions/runs/26372867832/job/77628012050)
- [2026-05-24 — Integration tests (QEMU, Linux host) (fedora.yaml)](https://github.com/lima-vm/lima/actions/runs/26372867832/job/77628012054)
- [2026-05-24 — Integration tests (QEMU, Linux host) (opensuse.yaml)](https://github.com/lima-vm/lima/actions/runs/26372867832/job/77628012055)
- [2026-05-24 — Integration tests (QEMU, Linux host) (../hack/test-templates/net-user-v2.yaml)](https://github.com/lima-vm/lima/actions/runs/26372867832/job/77628012057)
- [2026-05-24 — Integration tests (QEMU, Linux host) (../hack/test-templates/test-misc.yaml)](https://github.com/lima-vm/lima/actions/runs/26372867832/job/77628012081)
- [2026-05-25 — Integration tests (QEMU, macOS host)](https://github.com/lima-vm/lima/actions/runs/26396280879/job/77697603694)
- [2026-05-25 — Integration tests (QEMU, macOS host)](https://github.com/lima-vm/lima/actions/runs/26421907557/job/77778152737)
- [2026-05-25 — Integration tests (QEMU, macOS host)](https://github.com/lima-vm/lima/actions/runs/26422942586/job/77781041987)

</details>
