### PR TITLE
hack: ignore the Ubuntu grubenv race in the systemd check

### DIFF
--- a/hack/test-templates.sh
+++ b/hack/test-templates.sh
@@ -325,9 +325,24 @@ limactl shell "$NAME" bash -c "echo 'foo \"bar\"'"
 if [[ -n ${CHECKS["systemd"]} ]]; then
 	set -x
 	if ! limactl shell "$NAME" systemctl is-system-running --wait; then
-		ERROR '"systemctl is-system-running" failed'
-		diagnose "$NAME"
-		exit 1
+		mapfile -t failed_units < <(limactl shell "$NAME" systemctl list-units --state=failed --plain --no-legend --no-pager | awk '{print $1}')
+		unexpected=()
+		for unit in "${failed_units[@]}"; do
+			case "${unit}" in
+			# Ubuntu's two grub units rewrite /boot/grub/grubenv concurrently through
+			# grub-editenv, so the loser dies on "invalid environment block". Lima
+			# controls neither unit.
+			grub-initrd-fallback.service | grub2-common.service) ;;
+			*) unexpected+=("${unit}") ;;
+			esac
+		done
+		if [[ ${#failed_units[@]} -gt 0 && ${#unexpected[@]} -eq 0 ]]; then
+			WARNING "Ignoring failed units that lima does not control: ${failed_units[*]}"
+		else
+			ERROR '"systemctl is-system-running" failed'
+			diagnose "$NAME"
+			exit 1
+		fi
 	fi
 	set +x
 fi


### PR DESCRIPTION
Ubuntu ships `grub-initrd-fallback.service` and `grub2-common.service`, which both rewrite `/boot/grub/grubenv` through `grub-editenv` with no ordering between them. The loser dies on "invalid environment block" and leaves the guest degraded, so `systemctl is-system-running` fails and takes the whole template test with it. Seventeen CI jobs failed this way between April 30 and July 12, four of them on `master`, and both units show up as the loser, which rules out a deterministic defect in the image.

A run still fails unless every failed unit is one of those two.

Assisted-by: Claude Opus 5


<details>
<summary>All 17 recorded failures</summary>

Collected by a CI failure sweep over `lima-vm/lima`. Each entry is one failed job.

- [2026-04-30 — Windows tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/25183689697/job/73835269598) on `fedora_templates`
- [2026-05-01 — Windows tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/25203580328/job/73899355115) on `docs/limactl-help-yq-limitations`
- [2026-05-01 — Windows tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/25225609804/job/73968301475) on `master`
- [2026-05-02 — Windows tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/25258785426/job/74062491455) on `fix-m4-gdb-sve`
- [2026-05-07 — Windows tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/25527271058/job/74925615328) on `fix/deterministic-boot-selection`
- [2026-05-07 — Integration tests (vz) (default.yaml)](https://github.com/lima-vm/lima/actions/runs/25528187158/job/74928455974) on `fix/deterministic-boot-selection`
- [2026-05-10 — Windows tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/25641713077/job/75263167617) on `Issue4606`
- [2026-05-17 — Windows tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/25999452018/job/76419819384) on `windows-native-ssh-no-cygpath`
- [2026-05-18 — Windows tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/26012415100/job/76455619904) on `windows-plain-ci`
- [2026-05-22 — VMNet tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/26304102660/job/77436319879) on `master`
- [2026-05-22 — VMNet tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/26313929490/job/77486353693) on `use_hashq`
- [2026-06-18 — Windows tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/27758103504/job/82125014328) on `dev`
- [2026-06-21 — Windows tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/27908804907/job/82582204384) on `master`
- [2026-06-27 — Windows tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/28300739736/job/83848451074) on `image-variant`
- [2026-07-03 — Integration tests (vz) (default.yaml)](https://github.com/lima-vm/lima/actions/runs/28635474066/job/84920789115) on `master`
- [2026-07-03 — Windows tests (QEMU)](https://github.com/lima-vm/lima/actions/runs/28685743124/job/85078000082) on `secure-vz-block-devices`
- [2026-07-12 — Integration tests (vz) (default.yaml)](https://github.com/lima-vm/lima/actions/runs/29190112880/job/86643168951) on `feat/downloader-resume-partial-downloads`

</details>
