### PR TITLE
cidata: suppress the boot-done signal when a reboot is pending

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/00-reboot-if-required.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/00-reboot-if-required.sh
@@ -25,6 +25,7 @@ if command -v dnf >/dev/null 2>&1; then
 			dnf needs-restarting -r | tee "$logfile"
 			if [ "$?" = "1" ]; then
 				if grep -q "Reboot is required" "$logfile"; then
+					touch "$LIMA_REBOOT_REQUIRED"
 					systemctl reboot
 				fi
 			fi

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.essential.Linux/00-alpine-user-group.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.essential.Linux/00-alpine-user-group.sh
@@ -20,6 +20,7 @@ if [ "$LIMA_CIDATA_USER" != "alpine" ]; then
 		userdel alpine
 		rmdir /home/alpine
 		cloud-init clean --logs
+		touch "$LIMA_REBOOT_REQUIRED"
 		reboot
 	fi
 fi

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.sh
@@ -21,6 +21,12 @@ if [ "${UNAME}" != "Linux" ]; then
 fi
 rm -f "${RUN}/lima-boot-done"
 
+# A boot script that reboots the guest creates this file first, so that the rest
+# of this script knows the guest is on its way down.
+LIMA_REBOOT_REQUIRED="${RUN}/lima-reboot-required"
+export LIMA_REBOOT_REQUIRED
+rm -f "${LIMA_REBOOT_REQUIRED}"
+
 # shellcheck disable=SC2163
 while read -r line; do [ -n "$line" ] && export "$line"; done <"${LIMA_CIDATA_MNT}"/lima.env
 # shellcheck disable=SC2163
@@ -240,7 +246,14 @@ if [ "${UNAME}" != "Darwin" ] && [ "${LIMA_CIDATA_PASSWORDLESS_SUDO}" != "1" ]; 
 fi
 # Signal that provisioning is done. The instance ID changes on every boot,
 # so any value from a previous boot cycle will be different.
-echo "${LIMA_CIDATA_IID}" >"${RUN}/lima-boot-done"
+# A pending reboot suppresses the signal, because the reboot is asynchronous
+# and the host agent would otherwise call the guest ready while sshd is
+# already going down.
+if [ -e "${LIMA_REBOOT_REQUIRED}" ]; then
+	INFO "Not signaling boot completion because a boot script requested a reboot"
+else
+	echo "${LIMA_CIDATA_IID}" >"${RUN}/lima-boot-done"
+fi
 
 INFO "Exiting with code $CODE"
 exit "$CODE"

--- a/website/content/en/docs/dev/internals.md
+++ b/website/content/en/docs/dev/internals.md
@@ -236,7 +236,8 @@ The volume label is "cidata", as defined by [cloud-init NoCloud](https://docs.cl
 
 Boot scripts create the following marker files inside the guest at `/run/`:
 
-- `/run/lima-boot-done`: Written by `boot.sh` when provisioning is complete. Contains `LIMA_CIDATA_IID`.
+- `/run/lima-boot-done`: Written by `boot.sh` when provisioning is complete. Contains `LIMA_CIDATA_IID`. Not created when `/run/lima-reboot-required` exists.
+- `/run/lima-reboot-required`: Created by any boot script that is about to reboot the guest, with `touch "$LIMA_REBOOT_REQUIRED"` (`boot.sh` exports the variable). Empty. `boot.sh` then skips `/run/lima-boot-done`, so the host agent keeps waiting instead of calling the guest ready while sshd shuts down.
 - `/run/lima-ssh-ready`: Written by `boot.Linux/07-etc-environment.sh` when SSH is ready. Contains `LIMA_CIDATA_IID`.
 - `/run/lima-fuse-ready`: Written by `boot.Linux/35-setup-packages.sh` after fuse.conf is configured for `allow_other`. Contains `LIMA_CIDATA_IID`. Only created when `LIMA_CIDATA_MOUNTTYPE=reverse-sshfs`.
 


### PR DESCRIPTION
Two boot scripts reboot the guest partway through boot, the Alpine one after removing the image's built-in user and `00-reboot-if-required.sh` after a package upgrade. Both reboots are asynchronous, so `boot.sh` runs on to write `/run/lima-boot-done` and the host agent calls the instance ready while `sshd` is already stopping. A `limactl shell` issued right then gets its connection reset, which on July 18 killed `hack/test-templates.sh` on master under set -e.

The host agent retries the `boot-done` requirement for ten minutes, so waiting the reboot out costs nothing when the guest comes back.

Assisted-by: Claude Opus 5


<details>
<summary>The one recorded failure</summary>

Collected by a CI failure sweep over `lima-vm/lima`. Each entry is one failed job. All in `Integration tests (QEMU, Linux host) (alpine.yaml)`.

- [2026-07-18](https://github.com/lima-vm/lima/actions/runs/29664012302/job/88131299873) on `master`

</details>
