### PR TITLE
dependabot: group the codeql-action bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,5 +21,11 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  groups:
+    # codeql.yaml pins init and analyze to one SHA, so bumping them apart leaves
+    # the workflow on two versions until the second PR merges.
+    codeql-action:
+      patterns:
+      - "github/codeql-action*"
   cooldown:
     default-days: 7


### PR DESCRIPTION
Dependabot treats each codeql-action sub-path as its own dependency, so one upstream release opens three PRs. v4.37.2 arrived as #5351, #5352 and #5353.
