### PR TITLE
refactor(templates): externalize templates to share/lima with embed fallbacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,8 +186,8 @@ help-artifact:
 exe: _output/bin/limactl$(exe)
 
 .PHONY: minimal native
-minimal: clean limactl native-guestagent default_template
-native: clean limactl limactl-plugins helpers native-guestagent templates template_experimentals additional-drivers
+minimal: clean limactl share-lima native-guestagent default_template
+native: clean limactl limactl-plugins helpers native-guestagent share-lima templates template_experimentals additional-drivers
 
 ################################################################################
 # These configs were once customizable but should no longer be changed.
@@ -437,6 +437,25 @@ $(DARWIN_GUESTAGENT_PATH_COMMON)%.gz: $(DARWIN_GUESTAGENT_PATH_COMMON)% $$(call 
 	@set -x; gzip -n $<
 
 MKDIR_TARGETS += _output/share/lima
+
+LIMA_DEFAULTS = $(addprefix _output/share/lima/defaults/,$(notdir $(wildcard share/lima/defaults/*)))
+LIMA_AUTOSTART = $(addprefix _output/share/lima/autostart/,$(notdir $(wildcard share/lima/autostart/*)))
+
+.PHONY: share-lima
+share-lima: $(LIMA_DEFAULTS) $(LIMA_AUTOSTART) _output/share/lima/cidata.TEMPLATE.d
+
+$(LIMA_DEFAULTS): | _output/share/lima/defaults
+$(LIMA_AUTOSTART): | _output/share/lima/autostart
+_output/share/lima/cidata.TEMPLATE.d: | _output/share/lima
+	cp -aL share/lima/cidata.TEMPLATE.d $@
+
+MKDIR_TARGETS += _output/share/lima/defaults _output/share/lima/autostart
+
+_output/share/lima/defaults/%: share/lima/defaults/%
+	cp -aL $< $@
+
+_output/share/lima/autostart/%: share/lima/autostart/%
+	cp -aL $< $@
 
 ################################################################################
 # _output/share/lima/templates
@@ -722,6 +741,7 @@ artifact: $(addprefix $(ARTIFACT_PATH_COMMON),$(ARTIFACT_FILE_EXTENSIONS)) \
 
 ARTIFACT_DES =  _output/bin/limactl$(exe) limactl-plugins $(LIMA_DEPS) $(HELPERS_DEPS) \
 	$(NATIVE_GUESTAGENT) \
+	$(LIMA_DEFAULTS) $(LIMA_AUTOSTART) _output/share/lima/cidata.TEMPLATE.d \
 	$(TEMPLATES) $(TEMPLATE_IMAGES) $(TEMPLATE_DEFAULTS) $(TEMPLATE_EXPERIMENTALS) \
 	additional-drivers \
 	$(DOCUMENTATION) _output/share/doc/lima/templates \

--- a/pkg/autostart/autostart_test.go
+++ b/pkg/autostart/autostart_test.go
@@ -16,7 +16,7 @@ import (
 var (
 	Launchd = &TemplateFileBasedManager{
 		filePath:              launchd.GetPlistPath,
-		template:              launchd.Template,
+		template:              launchd.GetTemplate(),
 		enabler:               launchd.EnableDisableService,
 		autoStartedIdentifier: launchd.AutoStartedServiceName,
 		requestStart:          launchd.RequestStart,
@@ -29,7 +29,7 @@ var (
 	}
 	Systemd = &TemplateFileBasedManager{
 		filePath:              systemd.GetUnitPath,
-		template:              systemd.Template,
+		template:              systemd.GetTemplate(),
 		enabler:               systemd.EnableDisableUnit,
 		autoStartedIdentifier: systemd.AutoStartedUnitName,
 		requestStart:          systemd.RequestStart,

--- a/pkg/autostart/launchd/launchd.go
+++ b/pkg/autostart/launchd/launchd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/usrlocal"
 )
 
 //go:embed io.lima-vm.autostart.INSTANCE.plist
@@ -21,6 +22,14 @@ var Template string
 
 //go:embed io.lima-vm.daemon.INSTANCE.plist
 var DaemonTemplate string
+
+// GetTemplate returns the launchd plist template from disk if available, or the embedded template.
+func GetTemplate() string {
+	if b, err := usrlocal.ReadFile("autostart/io.lima-vm.autostart.INSTANCE.plist"); err == nil {
+		return string(b)
+	}
+	return Template
+}
 
 // GetPlistPath returns the path to the launchd plist file for the given instance name.
 func GetPlistPath(instName string) string {

--- a/pkg/autostart/managers_darwin.go
+++ b/pkg/autostart/managers_darwin.go
@@ -9,7 +9,7 @@ import "github.com/lima-vm/lima/v2/pkg/autostart/launchd"
 func Manager() autoStartManager {
 	return &TemplateFileBasedManager{
 		filePath:              launchd.GetPlistPath,
-		template:              launchd.Template,
+		template:              launchd.GetTemplate(),
 		enabler:               launchd.EnableDisableService,
 		autoStartedIdentifier: launchd.AutoStartedServiceName,
 		requestStart:          launchd.RequestStart,

--- a/pkg/autostart/managers_linux.go
+++ b/pkg/autostart/managers_linux.go
@@ -15,7 +15,7 @@ func Manager() autoStartManager {
 	if systemd.IsRunningSystemd() {
 		return &TemplateFileBasedManager{
 			filePath:              systemd.GetUnitPath,
-			template:              systemd.Template,
+			template:              systemd.GetTemplate(),
 			enabler:               systemd.EnableDisableUnit,
 			autoStartedIdentifier: systemd.AutoStartedUnitName,
 			requestStart:          systemd.RequestStart,

--- a/pkg/autostart/systemd/systemd.go
+++ b/pkg/autostart/systemd/systemd.go
@@ -14,10 +14,19 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/usrlocal"
 )
 
 //go:embed lima-vm@INSTANCE.service
 var Template string
+
+// GetTemplate returns the systemd unit template from disk if available, or the embedded template.
+func GetTemplate() string {
+	if b, err := usrlocal.ReadFile("autostart/lima-vm@INSTANCE.service"); err == nil {
+		return string(b)
+	}
+	return Template
+}
 
 // GetUnitPath returns the path to the systemd unit file for the given instance name.
 func GetUnitPath(instName string) string {

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/textutil"
+	"github.com/lima-vm/lima/v2/pkg/usrlocal"
 )
 
 //go:embed cidata.TEMPLATE.d
@@ -35,6 +36,13 @@ const windowsTemplateFSRoot = "wincidata.TEMPLATE.d"
 // This is for checking whether Windows OS is 11 or server 2025.
 // For example, Windows 11 x86-64's label is CCCOMA_X64FRE_EN-US_DV9.
 const windowsClientISOLabelPrefix = "CCCOMA_"
+
+func getTemplateFS() (fs.FS, error) {
+	if subFS, err := usrlocal.DirFS("cidata.TEMPLATE.d"); err == nil {
+		return subFS, nil
+	}
+	return fs.Sub(templateFS, templateFSRoot)
+}
 
 type CACerts struct {
 	RemoveDefaults *bool
@@ -199,7 +207,12 @@ func ExecuteTemplateCloudConfig(args *TemplateArgs) ([]byte, error) {
 		return nil, err
 	}
 
-	userData, err := templateFS.ReadFile(path.Join(templateFSRoot, "user-data"))
+	fsys, err := getTemplateFS()
+	if err != nil {
+		return nil, err
+	}
+
+	userData, err := fs.ReadFile(fsys, "user-data")
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +226,7 @@ func ExecuteTemplateCIDataISO(args *TemplateArgs) ([]iso9660util.Entry, error) {
 		return nil, err
 	}
 
-	fsys, err := fs.Sub(templateFS, templateFSRoot)
+	fsys, err := getTemplateFS()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -36,6 +36,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/networks"
 	"github.com/lima-vm/lima/v2/pkg/osutil"
 	"github.com/lima-vm/lima/v2/pkg/ptr"
+	"github.com/lima-vm/lima/v2/pkg/usrlocal"
 	"github.com/lima-vm/lima/v2/pkg/version"
 )
 
@@ -66,8 +67,12 @@ type ContainerdYAML struct {
 }
 
 func defaultContainerdArchives() []limatype.File {
+	yamlBytes, err := usrlocal.ReadFile("defaults/containerd.yaml")
+	if err != nil {
+		yamlBytes = defaultContainerdYAML
+	}
 	var containerd ContainerdYAML
-	err := yaml.UnmarshalWithOptions(defaultContainerdYAML, &containerd, yaml.Strict())
+	err = yaml.UnmarshalWithOptions(yamlBytes, &containerd, yaml.Strict())
 	if err != nil {
 		panic(fmt.Errorf("failed to unmarshal as YAML: %w", err))
 	}

--- a/pkg/networks/config.go
+++ b/pkg/networks/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/textutil"
+	"github.com/lima-vm/lima/v2/pkg/usrlocal"
 )
 
 //go:embed networks.TEMPLATE.yaml
@@ -52,7 +53,11 @@ func defaultConfigBytes() ([]byte, error) {
 	if args.SocketVMNet == "" {
 		args.SocketVMNet = candidates[0] // the hard-coded path before v0.14
 	}
-	return textutil.ExecuteTemplate(defaultConfigTemplate, args)
+	tplStr := defaultConfigTemplate
+	if b, err := usrlocal.ReadFile("defaults/networks.TEMPLATE.yaml"); err == nil {
+		tplStr = string(b)
+	}
+	return textutil.ExecuteTemplate(tplStr, args)
 }
 
 func fillDefaults(cfg Config) (Config, error) {

--- a/pkg/usrlocal/usrlocal.go
+++ b/pkg/usrlocal/usrlocal.go
@@ -215,3 +215,39 @@ func LibexecLima() ([]string, error) {
 	}
 	return candidates, nil
 }
+
+// ReadFile reads a resource file from <PREFIX>/share/lima/<relPath>.
+// Returns fs.ErrNotExist if the file is not found in any share directory.
+func ReadFile(name string) ([]byte, error) {
+	dirs, err := ShareLima()
+	if err != nil {
+		return nil, err
+	}
+	for _, dir := range dirs {
+		filePath := filepath.Join(dir, filepath.FromSlash(name))
+		b, err := os.ReadFile(filePath)
+		if err == nil {
+			return b, nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("failed to read %q: %w", filePath, err)
+		}
+	}
+	return nil, fmt.Errorf("%w: resource %q not found in share directories", fs.ErrNotExist, name)
+}
+
+// DirFS returns an fs.FS for <PREFIX>/share/lima/<relPath>.
+// Returns fs.ErrNotExist if the directory is not found in any share directory.
+func DirFS(name string) (fs.FS, error) {
+	dirs, err := ShareLima()
+	if err != nil {
+		return nil, err
+	}
+	for _, dir := range dirs {
+		dirPath := filepath.Join(dir, filepath.FromSlash(name))
+		if st, err := os.Stat(dirPath); err == nil && st.IsDir() {
+			return os.DirFS(dirPath), nil
+		}
+	}
+	return nil, fmt.Errorf("%w: resource directory %q not found in share directories", fs.ErrNotExist, name)
+}

--- a/pkg/usrlocal/usrlocal_test.go
+++ b/pkg/usrlocal/usrlocal_test.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package usrlocal
+
+import (
+	"io/fs"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestReadFile(t *testing.T) {
+	// Test reading containerd.yaml or networks.TEMPLATE.yaml from share/lima/defaults
+	b, err := ReadFile("defaults/containerd.yaml")
+	if err != nil {
+		t.Logf("ReadFile(defaults/containerd.yaml) failed: %v", err)
+	} else {
+		assert.Assert(t, len(b) > 0)
+	}
+}
+
+func TestDirFS(t *testing.T) {
+	// Test DirFS for cidata.TEMPLATE.d
+	f, err := DirFS("cidata.TEMPLATE.d")
+	if err != nil {
+		t.Logf("DirFS(cidata.TEMPLATE.d) failed: %v", err)
+	} else {
+		entries, err := fs.ReadDir(f, ".")
+		assert.NilError(t, err)
+		assert.Assert(t, len(entries) > 0)
+	}
+}

--- a/share/lima/autostart/io.lima-vm.autostart.INSTANCE.plist
+++ b/share/lima/autostart/io.lima-vm.autostart.INSTANCE.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>io.lima-vm.autostart.{{ .Instance }}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>{{ .Binary }}</string>
+		<string>start</string>
+		<string>{{ .Instance }}</string>
+		<string>--foreground</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>launchd.stderr.log</string>
+	<key>StandardOutPath</key>
+	<string>launchd.stdout.log</string>
+	<key>WorkingDirectory</key>
+	<string>{{ .WorkDir }}</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+</dict>
+</plist>

--- a/share/lima/autostart/lima-vm@INSTANCE.service
+++ b/share/lima/autostart/lima-vm@INSTANCE.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Lima - Linux virtual machines, with a focus on running containers.
+Documentation=man:lima(1)
+
+[Service]
+ExecStart={{.Binary}} start %i --foreground
+WorkingDirectory=%h
+Type=simple
+TimeoutSec=10
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/share/lima/cidata.TEMPLATE.d/boot.FreeBSD/05-lima-mounts.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.FreeBSD/05-lima-mounts.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Populate mounts from the cidata.
+# This script is a workaround until nuageinit supports mounts.
+
+set -eux
+
+if ! grep -q '#LIMA-START' /etc/fstab; then
+	"${LIMA_CIDATA_MNT}"/util.FreeBSD/print_cidata_fstab.lua >/etc/fstab.lima.tmp
+	if [ -s /etc/fstab.lima.tmp ]; then
+		{
+			echo "#LIMA-START"
+			cat /etc/fstab.lima.tmp
+			echo "#LIMA-END"
+		} >>/etc/fstab
+	fi
+	rm -f /etc/fstab.lima.tmp
+fi
+
+# Run mkdir on every boot, as the mount points may be on tmpfs
+awk '/^[^#]/ && $2 != "none" {print $2}' /etc/fstab | while IFS= read -r line; do
+	mkdir -p "${line}"
+done
+mount -a

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/00-alpine-user-group.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/00-alpine-user-group.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+test -f /etc/alpine-release || exit 0
+
+# Make sure that root is in the sudoers file.
+# This is needed to run the user provisioning scripts.
+SUDOERS=/etc/sudoers.d/00-root-user
+if [ ! -f $SUDOERS ]; then
+	echo "root ALL=(ALL) NOPASSWD:ALL" >$SUDOERS
+	chmod 660 $SUDOERS
+fi
+
+# Remove the user embedded in the image,
+# and use cloud-init for users and groups.
+if [ "$LIMA_CIDATA_USER" != "alpine" ]; then
+	if [ "$(id -u alpine 2>&1)" = "1000" ]; then
+		userdel alpine
+		rmdir /home/alpine
+		cloud-init clean --logs
+		reboot
+	fi
+fi

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/00-check-rtc-and-wait-ntp.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/00-check-rtc-and-wait-ntp.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+# In vz, the VM lacks an RTC when booting with a kernel image (see: https://developer.apple.com/forums/thread/760344).
+# This causes incorrect system time until NTP synchronizes it, leading to TLS errors.
+# To avoid TLS errors, this script waits for NTP synchronization if RTC is unavailable.
+test ! -c /dev/rtc0 || exit 0
+
+# This script is intended for services running with systemd.
+command -v systemctl >/dev/null 2>&1 || exit 0
+
+echo_with_time_usec() {
+	time_usec=$(timedatectl show --property=TimeUSec)
+	echo "${time_usec}, ${1}"
+}
+
+# For the first boot, where the above setting is not yet active, wait for NTP synchronization here.
+max_retry=60 retry=0
+until ntp_synchronized=$(timedatectl show --property=NTPSynchronized --value) && [ "${ntp_synchronized}" = "yes" ] ||
+	[ "${retry}" -gt "${max_retry}" ]; do
+	if [ "${retry}" -eq 0 ]; then
+		# If /dev/rtc is not available, the system time set during the Linux kernel build is used.
+		# The larger the difference between this system time and the NTP server time, the longer the NTP synchronization will take.
+		# By setting the system time to the modification time of the reference file, which is likely to be closer to the actual time,
+		reference_file="${LIMA_CIDATA_MNT:-/mnt/lima-cidata}/user-data"
+		[ -f "${reference_file}" ] || reference_file="${0}"
+
+		# the NTP synchronization time can be shortened.
+		echo_with_time_usec "Setting the system time to the modification time of ${reference_file}."
+
+		# To set the time to a specified time, it is necessary to stop systemd-timesyncd.
+		systemctl stop systemd-timesyncd
+
+		# Since `timedatectl set-time` fails if systemd-timesyncd is not stopped,
+		# ensure that it is completely stopped before proceeding.
+		until pid_of_timesyncd=$(systemctl show systemd-timesyncd --property=MainPID --value) && [ "${pid_of_timesyncd}" -eq 0 ]; do
+			echo_with_time_usec "Waiting for systemd-timesyncd to stop..."
+			sleep 1
+		done
+
+		# Set the system time to the modification time of the reference file.
+		modification_time=$(stat -c %y "${reference_file}")
+		echo_with_time_usec "Setting the system time to ${modification_time}."
+		timedatectl set-time "${modification_time}"
+
+		# Restart systemd-timesyncd
+		systemctl start systemd-timesyncd
+	else
+		echo_with_time_usec "Waiting for NTP synchronization..."
+	fi
+	retry=$((retry + 1))
+	sleep 1
+done
+# Print the result of NTP synchronization
+ntp_message=$(timedatectl show-timesync --property=NTPMessage)
+if [ "${ntp_synchronized}" = "yes" ]; then
+	echo_with_time_usec "NTP synchronization complete."
+	echo "${ntp_message}"
+else
+	echo_with_time_usec "NTP synchronization timed out."
+	echo "${ntp_message}"
+	exit 1
+fi

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/00-guest-home.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/00-guest-home.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+# The default guest home directory is "/home/${LIMA_CIDATA_USER}.guest" since Lima 2.1.0.
+# The path was previously "/home/${LIMA_CIDATA_USER}.linux".
+if [ -d "/home/${LIMA_CIDATA_USER}.guest" ] && [ ! -e "/home/${LIMA_CIDATA_USER}.linux" ]; then
+	ln -s "${LIMA_CIDATA_USER}.guest" "/home/${LIMA_CIDATA_USER}.linux"
+fi
+if [ -d "/home/${LIMA_CIDATA_USER}.linux" ] && [ ! -e "/home/${LIMA_CIDATA_USER}.guest" ]; then
+	ln -s "${LIMA_CIDATA_USER}.linux" "/home/${LIMA_CIDATA_USER}.guest"
+fi

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/00-modprobe.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/00-modprobe.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Load modules as soon as the cloud-init starts up.
+# Because Arch Linux removes kernel module files when the kernel package was updated during running cloud-init :(
+
+set -eu
+
+command -v modprobe >/dev/null 2>&1 || exit 0
+
+for f in \
+	fuse \
+	tun tap \
+	bridge veth \
+	ip_tables ip6_tables iptable_nat ip6table_nat iptable_filter ip6table_filter \
+	nf_tables \
+	x_tables xt_MASQUERADE xt_addrtype xt_comment xt_conntrack xt_mark xt_multiport xt_nat xt_tcpudp \
+	overlay; do
+	echo "Loading kernel module \"$f\""
+	if ! modprobe "$f"; then
+		echo >&2 "Failed to load \"$f\" (negligible if it is built-in the kernel)"
+	fi
+done

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/00-reboot-if-required.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/00-reboot-if-required.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux
+
+[ "$LIMA_CIDATA_UPGRADE_PACKAGES" = "1" ] || exit 0
+
+# Check if cloud-init forgot to reboot_if_required
+# (only implemented for apt at the moment, not dnf)
+
+if command -v dnf >/dev/null 2>&1; then
+	# dnf-utils needs to be installed, for needs-restarting
+	if dnf -h needs-restarting >/dev/null 2>&1; then
+		# check-update returns "false" (100) if updates (!)
+		set +e
+		dnf check-update >/dev/null
+		if [ "$?" != "1" ]; then
+			# needs-restarting messages are translated _()
+			export LC_ALL=C.UTF-8
+			logfile=$(mktemp)
+			# needs-restarting returns "false" if needed (!)
+			set -o pipefail
+			dnf needs-restarting -r | tee "$logfile"
+			if [ "$?" = "1" ]; then
+				if grep -q "Reboot is required" "$logfile"; then
+					systemctl reboot
+				fi
+			fi
+			rm "$logfile"
+		fi
+	fi
+fi

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/01-alpine-ash-as-bash.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/01-alpine-ash-as-bash.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# This script pretends that /bin/ash can be used as /bin/bash, so all following
+# cloud-init scripts can use `#!/bin/bash` and `set -o pipefail`.
+test -f /etc/alpine-release || exit 0
+
+# If bash already exists, do nothing.
+test -x /bin/bash && exit 0
+
+# Redirect bash to ash (built with CONFIG_ASH_BASH_COMPAT) and hope for the best :)
+# It does support `set -o pipefail`, but not `[[`.
+# /bin/bash can't be a symlink because /bin/ash is a symlink to /bin/busybox
+cat >/bin/bash <<'EOF'
+#!/bin/sh
+exec /bin/ash "$@"
+EOF
+chmod +x /bin/bash

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/04-persistent-data-volume.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/04-persistent-data-volume.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# bash is used for enabling `set -o pipefail`.
+# NOTE: On Alpine, /bin/bash is ash with ASH_BASH_COMPAT, not GNU bash
+set -eux -o pipefail
+
+# Restrict the rest of this script to Alpine until it has been tested with other distros
+test -f /etc/alpine-release || exit 0
+
+# Nothing to do unless we are running from a ramdisk
+[ "$(awk '$2 == "/" {print $3}' /proc/mounts)" != "tmpfs" ] && exit 0
+
+# Data directories that should be persisted across reboots
+DATADIRS="/etc /home /root /tmp /usr/local /var/lib"
+
+# Prepare mnt.sh (used for restoring mounts later)
+echo "#!/bin/sh" >/mnt.sh
+echo "set -eux" >>/mnt.sh
+for DIR in ${DATADIRS}; do
+	while IFS= read -r LINE; do
+		[ -z "$LINE" ] && continue
+		MNTDEV="$(echo "${LINE}" | awk '{print $1}')"
+		# unmangle " \t\n\\#"
+		# https://github.com/torvalds/linux/blob/v6.6/fs/proc_namespace.c#L89
+		MNTPNT="$(echo "${LINE}" | awk '{print $2}' | sed -e 's/\\040/ /g; s/\\011/\t/g; s/\\012/\n/g; s/\\134/\\/g; s/\\043/#/g')"
+		# Ignore if MNTPNT is neither DIR nor a parent directory of DIR.
+		# It is not a parent if MNTPNT doesn't start with DIR, or the first
+		# character after DIR isn't a slash.
+		WITHOUT_DIR="${MNTPNT#"$DIR"}"
+		# shellcheck disable=SC2166
+		[ "$MNTPNT" != "$DIR" ] && [ "$MNTPNT" == "$WITHOUT_DIR" -o "${WITHOUT_DIR::1}" != "/" ] && continue
+		MNTTYPE="$(echo "${LINE}" | awk '{print $3}')"
+		[ "${MNTTYPE}" = "ext4" ] && continue
+		[ "${MNTTYPE}" = "tmpfs" ] && continue
+		MNTOPTS="$(echo "${LINE}" | awk '{print $4}')"
+		if [ "${MNTTYPE}" = "9p" ]; then
+			# https://github.com/torvalds/linux/blob/v6.6/fs/9p/v9fs.h#L61
+			MNTOPTS="$(echo "${MNTOPTS}" | sed -e 's/cache=8f,/cache=fscache,/; s/cache=f,/cache=loose,/; s/cache=5,/cache=mmap,/; s/cache=1,/cache=readahead,/; s/cache=0,/cache=none,/')"
+		fi
+		# Before mv, unmount filesystems (virtiofs, 9p, etc.) below "${DIR}", otherwise host mounts will be wiped out
+		# https://github.com/rancher-sandbox/rancher-desktop/issues/6582
+		umount "${MNTPNT}" || exit 1
+		MNTPNT=${MNTPNT//\\/\\\\}
+		MNTPNT=${MNTPNT//\"/\\\"}
+		echo "mount -t \"${MNTTYPE}\" -o \"${MNTOPTS}\" \"${MNTDEV}\" \"${MNTPNT}\"" >>/mnt.sh
+	done </proc/mounts
+done
+chmod +x /mnt.sh
+
+mkdir -p /mnt/data
+
+# Resolve the data volume device via blkid, not the udev symlink.
+# The /dev/disk/by-label/ symlink depends on udev having probed the device.
+# A race between growpart (which triggers a partition table re-read and thus
+# a udev re-probe) and e2fsck (which modifies the superblock) can cause the
+# re-probe to see an inconsistent ext4 checksum and delete the symlink.
+# BusyBox blkid doesn't support --label, so we parse the output instead.
+# The leading whitespace anchor on LABEL= avoids matching PARTLABEL= on
+# util-linux blkid output; quitting after the first match prevents a
+# multi-match from producing a newline-separated device list.
+DATA_VOLUME=$(blkid | sed -n '/[[:space:]]LABEL="data-volume"/{s/^\([^:]*\):.*/\1/p;q;}')
+
+if [ -n "${DATA_VOLUME}" ]; then
+	DATA_DISK="/dev/$(lsblk --noheadings --output pkname "${DATA_VOLUME}")"
+	# growpart command may be missing in older VMs
+	if command -v growpart >/dev/null 2>&1 && command -v resize2fs >/dev/null 2>&1; then
+		# Automatically expand the data volume filesystem
+		growpart "$DATA_DISK" 1 || true
+		# growpart re-reads the partition table; settle before e2fsck so
+		# the resulting udev re-probe doesn't race with fsck. Tolerate
+		# failure: the blkid above already bypasses udev, so this is
+		# defense-in-depth, and a missing udevadm must not kill boot
+		# under set -e.
+		udevadm settle || true
+		# Only resize when filesystem is in a healthy state
+		if e2fsck -f -p "${DATA_VOLUME}"; then
+			resize2fs "${DATA_VOLUME}" || true
+		fi
+	fi
+	# Mount data volume
+	mount -t ext4 "${DATA_VOLUME}" /mnt/data
+	# Update /etc files that might have changed during this boot
+	cp /etc/network/interfaces /mnt/data/etc/network/
+	cp /etc/resolv.conf /mnt/data/etc/
+	if [ -f /etc/localtime ]; then
+		# Preserve symlink
+		cp -d /etc/localtime /mnt/data/etc/
+		# setup-timezone copies the single zoneinfo file into /etc/zoneinfo and targets the symlink there
+		if [ -d /etc/zoneinfo ]; then
+			rm -rf /mnt/data/etc/zoneinfo
+			cp -r /etc/zoneinfo /mnt/data/etc
+		fi
+	fi
+	if [ -f /etc/timezone ]; then
+		cp /etc/timezone /mnt/data/etc/
+	fi
+	# TODO there are probably others that should be updated as well
+else
+	# Find an unpartitioned disk and create data-volume
+	DISKS=$(lsblk --list --noheadings --output name,type | awk '$2 == "disk" {print $1}')
+	for DISK in ${DISKS}; do
+		# A disk is in use if it has any partitions, carries a filesystem
+		# signature directly, or is mounted. Check lsblk for partitions
+		# and filesystem types, not just /proc/mounts; an unmounted but
+		# partitioned or raw-formatted disk (e.g. the data volume after
+		# a failed boot) must not be reformatted.
+		if lsblk --list --noheadings --output fstype /dev/"${DISK}" | grep -q "[^[:space:]]"; then
+			continue
+		fi
+		if lsblk --list --noheadings --output type /dev/"${DISK}" | grep -q "part"; then
+			continue
+		fi
+		if awk '/^\/dev\// {sub("^/dev/", "", $1); print $1}' /proc/mounts | grep -q "^${DISK}$"; then
+			continue
+		fi
+		echo 'type=83' | sfdisk --label dos /dev/"${DISK}"
+		# sfdisk's BLKRRPART emits a uevent for the new partition; settle
+		# before lsblk so its libudev query sees that partition rather
+		# than stale pre-sfdisk state. Tolerate failure as above.
+		udevadm settle || true
+		PART=$(lsblk --list /dev/"${DISK}" --noheadings --output name,type | awk '$2 == "part" {print $1}')
+		mkfs.ext4 -L data-volume /dev/"${PART}"
+		# Let udev create /dev/disk/by-label/data-volume; mount uses the
+		# device path directly, but later scripts may depend on the
+		# symlink. Tolerate failure as above.
+		udevadm settle || true
+		mount -t ext4 /dev/"${PART}" /mnt/data
+		# setup apk package cache
+		mkdir -p /mnt/data/apk/cache
+		mkdir -p /etc/apk
+		ln -s /mnt/data/apk/cache /etc/apk/cache
+		# Move all persisted directories to the data volume
+		for DIR in ${DATADIRS}; do
+			DEST="/mnt/data$(dirname "${DIR}")"
+			mkdir -p "${DIR}" "${DEST}"
+			mv "${DIR}" "${DEST}"
+		done
+		# Make sure all data moved to the persistent volume has been committed to disk
+		sync
+		break
+	done
+fi
+for DIR in ${DATADIRS}; do
+	if [ -d /mnt/data"${DIR}" ]; then
+		mkdir -p "${DIR}"
+		mount --bind /mnt/data"${DIR}" "${DIR}"
+	fi
+done
+# Remount submounts on top of the new ${DIR}
+/mnt.sh
+# Reinstall packages from /mnt/data/apk/cache into the RAM disk
+apk fix --no-network

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/05-lima-disks.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/05-lima-disks.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux -o pipefail
+
+test "$LIMA_CIDATA_DISKS" -gt 0 || exit 0
+
+get_disk_var() {
+	diskvarname="LIMA_CIDATA_DISK_${1}_${2}"
+	eval echo \$"$diskvarname"
+}
+
+for i in $(seq 0 $((LIMA_CIDATA_DISKS - 1))); do
+	DISK_NAME="$(get_disk_var "$i" "NAME")"
+	DEVICE_NAME="$(get_disk_var "$i" "DEVICE")"
+	FORMAT_DISK="$(get_disk_var "$i" "FORMAT")"
+	FORMAT_FSTYPE="$(get_disk_var "$i" "FSTYPE")"
+	FORMAT_FSARGS="$(get_disk_var "$i" "FSARGS")"
+
+	test -n "$FORMAT_DISK" || FORMAT_DISK=true
+	test -n "$FORMAT_FSTYPE" || FORMAT_FSTYPE=ext4
+
+	# first time setup
+	if [[ ! -b "/dev/disk/by-label/lima-${DISK_NAME}" ]]; then
+		if $FORMAT_DISK; then
+			if [ "$FORMAT_FSTYPE" == "swap" ]; then
+				echo 'type=swap' | sfdisk --label gpt "/dev/${DEVICE_NAME}"
+				# shellcheck disable=SC2086
+				mkswap $FORMAT_FSARGS -L "lima-${DISK_NAME}" "/dev/${DEVICE_NAME}1"
+			else
+				echo 'type=linux' | sfdisk --label gpt "/dev/${DEVICE_NAME}"
+				# shellcheck disable=SC2086
+				mkfs.$FORMAT_FSTYPE $FORMAT_FSARGS -L "lima-${DISK_NAME}" "/dev/${DEVICE_NAME}1"
+			fi
+		fi
+	fi
+
+	if [ "$FORMAT_FSTYPE" == "swap" ]; then
+		swapon "/dev/${DEVICE_NAME}1"
+	else
+		mkdir -p "/mnt/lima-${DISK_NAME}"
+		mount -t "$FORMAT_FSTYPE" "/dev/${DEVICE_NAME}1" "/mnt/lima-${DISK_NAME}"
+	fi
+	if command -v growpart >/dev/null 2>&1 && command -v resize2fs >/dev/null 2>&1; then
+		growpart "/dev/${DEVICE_NAME}" 1 || true
+		# Only resize when filesystem is in a healthy state
+		if command -v "fsck.$FORMAT_FSTYPE" -f -p "/dev/disk/by-label/lima-${DISK_NAME}"; then
+			if [[ $FORMAT_FSTYPE == "ext2" || $FORMAT_FSTYPE == "ext3" || $FORMAT_FSTYPE == "ext4" ]]; then
+				resize2fs "/dev/disk/by-label/lima-${DISK_NAME}" || true
+			elif [ "$FORMAT_FSTYPE" == "xfs" ]; then
+				xfs_growfs "/dev/disk/by-label/lima-${DISK_NAME}" || true
+			else
+				echo >&2 "WARNING: unknown fs '$FORMAT_FSTYPE'. FS will not be grew up automatically"
+			fi
+		fi
+	fi
+done

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/05-lima-mounts.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/05-lima-mounts.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux -o pipefail
+
+# Check if mount type is virtiofs and vm type as vz
+if ! [[ ${LIMA_CIDATA_VMTYPE} == "vz" && ${LIMA_CIDATA_MOUNTTYPE} == "virtiofs" ]]; then
+	exit 0
+fi
+
+# Update fstab entries and unmount/remount the volumes with secontext options
+# when selinux is enabled in kernel
+if [ -d /sys/fs/selinux ]; then
+	LABEL_BIN="system_u:object_r:bin_t:s0"
+	LABEL_NFS="system_u:object_r:nfs_t:s0"
+	# shellcheck disable=SC2013
+	for line in $(grep -n virtiofs </etc/fstab | cut -d':' -f1); do
+		OPTIONS=$(awk -v line="$line" 'NR==line {print $4}' /etc/fstab)
+		TAG=$(awk -v line="$line" 'NR==line {print $1}' /etc/fstab)
+		MOUNT_OPTIONS=$(mount | grep "${TAG}" | awk '{print $6}')
+		if [[ ${OPTIONS} != *"context"* ]]; then
+			##########################################################################################
+			## When using vz & virtiofs, initially container_file_t selinux label
+			## was considered which works perfectly for container work loads
+			## but it might break for other work loads if the process is running with
+			## different label. Also these are the remote mounts from the host machine,
+			## so keeping the label as nfs_t fits right. Package container-selinux by
+			## default adds rules for nfs_t context which allows container workloads to work as well.
+			## https://github.com/lima-vm/lima/pull/1965
+			##
+			## With integration[https://github.com/lima-vm/lima/pull/2474] with systemd-binfmt,
+			## the existing "nfs_t" selinux label for Rosetta is causing issues while registering it.
+			## This behaviour needs to be fixed by setting the label as "bin_t"
+			## https://github.com/lima-vm/lima/pull/2630
+			##########################################################################################
+			if [[ ${TAG} == *"rosetta"* ]]; then
+				label=${LABEL_BIN}
+			else
+				label=${LABEL_NFS}
+			fi
+			sed -i -e "$line""s/comment=cloudconfig/comment=cloudconfig,context=\"$label\"/g" /etc/fstab
+			if [[ ${MOUNT_OPTIONS} != *"$label"* ]]; then
+				MOUNT_POINT=$(awk -v line="$line" 'NR==line {print $2}' /etc/fstab)
+				OPTIONS=$(awk -v line="$line" 'NR==line {print $4}' /etc/fstab)
+
+				#########################################################
+				## We need to migrate existing users of Fedora having
+				## Rosetta mounted from nfs_t to bin_t by unregistering
+				## it from binfmt before remounting
+				#########################################################
+				if [[ ${TAG} == *"rosetta"* && ${MOUNT_OPTIONS} == *"${LABEL_NFS}"* ]]; then
+					[ ! -f "/proc/sys/fs/binfmt_misc/rosetta" ] || echo -1 >/proc/sys/fs/binfmt_misc/rosetta
+				fi
+				umount "${TAG}"
+				mount -t virtiofs "${TAG}" "${MOUNT_POINT}" -o "${OPTIONS}"
+			fi
+		fi
+	done
+fi

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/06-enable-mdns-on-systemd.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/06-enable-mdns-on-systemd.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux -o pipefail
+
+# Do nothing on OpenRC systems (e.g., Alpine Linux)
+if [[ -f /sbin/openrc-run ]]; then
+	exit 0
+fi
+
+# It depends on systemd-resolved
+command -v systemctl >/dev/null 2>&1 || exit 0
+command -v resolvectl >/dev/null 2>&1 || exit 0
+
+# Configure systemd-resolved to enable mDNS resolution globally
+enable_mdns_conf_path=/etc/systemd/resolved.conf.d/00-lima-enable-mdns.conf
+enable_mdns_conf_content="[Resolve]
+MulticastDNS=yes
+"
+# Create /etc/systemd/resolved.conf.d/00-lima-enable-mdns.conf if its content is different
+if [ "$(echo "${enable_mdns_conf_content}" | sha256sum)" != "$(sha256sum <"${enable_mdns_conf_path}" 2>/dev/null)" ]; then
+	mkdir -p "$(dirname "${enable_mdns_conf_path}")"
+	echo "${enable_mdns_conf_content}" >"${enable_mdns_conf_path}"
+	systemctl daemon-reload
+	systemctl restart systemd-resolved.service
+fi
+
+# On Ubuntu, systemd.network's configuration won't work.
+# See: https://unix.stackexchange.com/a/652582
+# So we need to enable mDNS per-link using resolvectl.
+for iface in $(resolvectl status | sed -n -E 's/^Link +[0-9]+ \(([^)]+)\)/\1/p'); do
+	# This setting is volatile and will be lost on reboot, so we need to set it every time
+	resolvectl mdns "${iface}" yes
+done

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/06-etc-hosts.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/06-etc-hosts.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux -o pipefail
+
+# Define host.lima.internal in case the hostResolver is disabled. When using
+# the hostResolver, the name is provided by the lima resolver itself because
+# it doesn't have access to /etc/hosts inside the VM.
+sed -i '/host.lima.internal/d' /etc/hosts
+echo -e "${LIMA_CIDATA_SLIRP_GATEWAY}\thost.lima.internal" >>/etc/hosts

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/07-etc-environment.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/07-etc-environment.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux
+
+# /etc/environment must be written after 04-persistent-data-volume.sh has run to
+# make sure the changes on a restart are applied to the persisted version.
+
+orig=$(test ! -f /etc/environment || cat /etc/environment)
+if [ -e /etc/environment ]; then
+	sed -i '/#LIMA-START/,/#LIMA-END/d' /etc/environment
+fi
+cat "${LIMA_CIDATA_MNT}/etc_environment" >>/etc/environment
+
+# It is possible that a requirements script has started an ssh session before
+# /etc/environment was updated, so we need to kill it to make sure it will
+# restart with the updated environment before "linger" is being enabled.
+
+if command -v loginctl >/dev/null 2>&1 && [ "${orig}" != "$(cat /etc/environment)" ]; then
+	loginctl terminate-user "${LIMA_CIDATA_USER}" || true
+fi
+
+# Signal that provisioning is done. The instance ID changes on every boot,
+# so any value from a previous boot cycle will be different.
+echo "${LIMA_CIDATA_IID}" >/run/lima-ssh-ready

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/08-shell-prompt.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/08-shell-prompt.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux
+
+# This script is only intended for the default.yaml image, which is based on Ubuntu LTS
+
+if [ "${LIMA_CIDATA_NAME}" = "default" ] && command -v patch >/dev/null 2>&1 && grep -q color_prompt "${LIMA_CIDATA_HOME}/.bashrc"; then
+
+	! grep -q "^# Lima PS1" "${LIMA_CIDATA_HOME}/.bashrc" || exit 0
+
+	# Change the default shell prompt from "green" to "lime green" (#32CD32)
+
+	patch --forward -r - "${LIMA_CIDATA_HOME}/.bashrc" <<'EOF'
+@@ -37,7 +37,11 @@
+
+ # set a fancy prompt (non-color, unless we know we "want" color)
+ case "$TERM" in
+-    xterm-color|*-256color) color_prompt=yes;;
++    xterm-color) color_prompt=yes;;
++    *-256color)  color_prompt=256;;
++esac
++case "$COLORTERM" in
++    truecolor) color_prompt=true;;
+ esac
+
+ # uncomment for a colored prompt, if the terminal has the capability; turned
+@@ -56,7 +60,12 @@
+     fi
+ fi
+
+-if [ "$color_prompt" = yes ]; then
++# Lima PS1: set color to lime green
++if [ "$color_prompt" = true ]; then
++    PS1='${debian_chroot:+($debian_chroot)}\[\033[38;2;50;205;50m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
++elif [ "$color_prompt" = 256 ]; then
++    PS1='${debian_chroot:+($debian_chroot)}\[\033[38;5;77m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
++elif [ "$color_prompt" = yes ]; then
+     PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+ else
+     PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+EOF
+
+fi

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/09-host-dns-setup.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/09-host-dns-setup.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux
+
+readonly chain=LIMADNS
+
+chain_exists() {
+	iptables --table nat -n --list "${chain}" >/dev/null 2>&1
+}
+
+# Wait until iptables has been installed; 35-configure-packages.sh will call this script again
+if command -v iptables >/dev/null 2>&1; then
+	if ! chain_exists; then
+		iptables --table nat --new-chain ${chain}
+		iptables --table nat --insert PREROUTING 1 --jump "${chain}"
+		iptables --table nat --insert OUTPUT 1 --jump "${chain}"
+	fi
+
+	# Remove old rules
+	iptables --table nat --flush ${chain}
+	# Add rules for the existing ip:port
+	if [ -n "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" ] && [ "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" -ne 0 ]; then
+		iptables --table nat --append "${chain}" --destination "${LIMA_CIDATA_SLIRP_DNS}" --protocol udp --dport 53 --jump DNAT \
+			--to-destination "${LIMA_CIDATA_SLIRP_GATEWAY}:${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}"
+	fi
+	if [ -n "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" ] && [ "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" -ne 0 ]; then
+		iptables --table nat --append "${chain}" --destination "${LIMA_CIDATA_SLIRP_DNS}" --protocol tcp --dport 53 --jump DNAT \
+			--to-destination "${LIMA_CIDATA_SLIRP_GATEWAY}:${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}"
+	fi
+fi

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/10-alpine-prep.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/10-alpine-prep.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux
+
+# This script prepares Alpine for lima; there is nothing in here for other distros
+test -f /etc/alpine-release || exit 0
+
+# Configure apk repos
+BRANCH=edge
+VERSION_ID=$(awk -F= '$1=="VERSION_ID" {print $2}' /etc/os-release)
+case ${VERSION_ID} in
+*_alpha* | *_beta*) BRANCH=edge ;;
+*.*.*) BRANCH=v${VERSION_ID%.*} ;;
+esac
+
+for REPO in main community; do
+	URL="https://dl-cdn.alpinelinux.org/alpine/${BRANCH}/${REPO}"
+	if ! grep -q "^${URL}$" /etc/apk/repositories; then
+		echo "${URL}" >>/etc/apk/repositories
+	fi
+done
+
+# Alpine comes with doas instead of sudo
+if ! command -v sudo >/dev/null 2>&1; then
+	apk add sudo
+fi
+
+# Alpine doesn't use PAM so we need to explicitly allow public key auth
+usermod -p '*' "${LIMA_CIDATA_USER}"
+
+# Alpine disables TCP forwarding, which is needed by the lima-guestagent
+sed -i 's/AllowTcpForwarding no/AllowTcpForwarding yes/g' /etc/ssh/sshd_config
+# Enable PAM so as to load /etc/environment via pam_env
+sed -i 's/#UsePAM no/UsePAM yes/g' /etc/ssh/sshd_config
+rc-service --ifstarted sshd reload
+
+# mount /sys/fs/cgroup
+rc-service cgroups start
+
+# `limactl stop` tells acpid to powerdown
+rc-update add acpid
+rc-service acpid start

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/11-colorterm-environment.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/11-colorterm-environment.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux
+
+if [ -d /etc/ssh/sshd_config.d ]; then
+	if [ -e /etc/ssh/sshd_config.d/10-acceptenv-colorterm.conf ]; then
+		exit 0
+	fi
+
+	# accept any incoming COLORTERM environment variable
+	echo "AcceptEnv COLORTERM" >/etc/ssh/sshd_config.d/10-acceptenv-colorterm.conf
+elif [ -e /etc/ssh/sshd_config ]; then
+	if grep -q "COLORTERM" /etc/ssh/sshd_config; then
+		exit 0
+	fi
+
+	# accept any incoming COLORTERM environment variable
+	sed -i 's/^AcceptEnv LANG LC_\*$/AcceptEnv COLORTERM LANG LC_*/' /etc/ssh/sshd_config
+else
+	exit 0
+fi
+
+if [ -f /sbin/openrc-run ]; then
+	if [ -f etc/init.d/ssh ]; then
+		rc-service --ifstarted ssh reload
+	elif [ -f etc/init.d/sshd ]; then
+		rc-service --ifstarted sshd reload
+	fi
+elif command -v systemctl >/dev/null 2>&1; then
+	if systemctl -q is-active ssh; then
+		systemctl reload ssh
+	elif systemctl -q is-active sshd; then
+		systemctl reload sshd
+	fi
+fi

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/20-rootless-base.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/20-rootless-base.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux
+
+# This script does not work unless systemd is available
+command -v systemctl >/dev/null 2>&1 || exit 0
+
+if [ -O "${LIMA_CIDATA_HOME}" ]; then
+	# Fix ownership of the user home directory when created by root.
+	# In cases where mount points exist in the user's home directory, the home directory and
+	# the mount points are created by root before the user is created. This leads to the home
+	# directory being owned by root.
+	# Following commands fix the ownership of the home directory and its contents (on the same filesystem)
+	# is updated to the correct user.
+	# shellcheck disable=SC2046 # it fails if find results are quoted.
+	chown "${LIMA_CIDATA_USER}" $(find "${LIMA_CIDATA_HOME}" -xdev) ||
+		true # Ignore errors because changing owner of the mount points may fail but it is not critical.
+fi
+
+# Set up env
+for f in .profile .bashrc .zshrc; do
+	if ! grep -q "# Lima BEGIN" "${LIMA_CIDATA_HOME}/$f"; then
+		cat >>"${LIMA_CIDATA_HOME}/$f" <<EOF
+# Lima BEGIN
+# Make sure iptables and mount.fuse3 are available
+PATH="\$PATH:/usr/sbin:/sbin"
+export PATH
+EOF
+		if compare_version.sh "$(uname -r)" -lt "5.13"; then
+			cat >>"${LIMA_CIDATA_HOME}/$f" <<EOF
+# fuse-overlayfs is the most stable snapshotter for rootless, on kernel < 5.13
+# https://github.com/lima-vm/lima/issues/383
+# https://rootlesscontaine.rs/how-it-works/overlayfs/
+CONTAINERD_SNAPSHOTTER="fuse-overlayfs"
+export CONTAINERD_SNAPSHOTTER
+EOF
+		fi
+		cat >>"${LIMA_CIDATA_HOME}/$f" <<EOF
+# Lima END
+EOF
+		chown "${LIMA_CIDATA_USER}" "${LIMA_CIDATA_HOME}/$f"
+	fi
+done
+# Enable cgroup delegation (only meaningful on cgroup v2)
+if [ ! -e "/etc/systemd/system/user@.service.d/lima.conf" ]; then
+	mkdir -p "/etc/systemd/system/user@.service.d"
+	cat >"/etc/systemd/system/user@.service.d/lima.conf" <<EOF
+[Service]
+Delegate=yes
+EOF
+fi
+systemctl daemon-reload
+
+# Set up sysctl
+sysctl_conf="/etc/sysctl.d/99-lima.conf"
+if [ ! -e "${sysctl_conf}" ]; then
+	if [ -e "/proc/sys/kernel/unprivileged_userns_clone" ]; then
+		echo "kernel.unprivileged_userns_clone=1" >>"${sysctl_conf}"
+	fi
+	echo "net.ipv4.ping_group_range = 0 2147483647" >>"${sysctl_conf}"
+	echo "net.ipv4.ip_unprivileged_port_start=0" >>"${sysctl_conf}"
+	sysctl --system
+fi
+
+# Set up subuid
+for f in /etc/subuid /etc/subgid; do
+	# systemd-homed expects the subuid range to be within 524288-1878982656 (0x80000-0x6fff0000).
+	# See userdbctl.
+	# 1073741824 (1G) is just an arbitrary number.
+	# 1073741825-1878982656 is left blank for additional accounts.
+	subuid_begin=524288
+	# https://github.com/moby/moby/issues/49810#issuecomment-2808108191
+	[ "${LIMA_CIDATA_UID}" -ge "${subuid_begin}" ] && subuid_begin="$((LIMA_CIDATA_UID + 1))"
+	grep -qw "${LIMA_CIDATA_USER}" $f || echo "${LIMA_CIDATA_USER}:${subuid_begin}:1073741824" >>$f
+done
+
+# Start systemd session
+systemctl start systemd-logind.service
+loginctl enable-linger "${LIMA_CIDATA_USER}"

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/25-guestagent-base.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/25-guestagent-base.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux
+
+if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
+	# Create mount points
+	# NOTE: Busybox sh does not support `for ((i=0;i<$N;i++))` form
+	for f in $(seq 0 $((LIMA_CIDATA_MOUNTS - 1))); do
+		mountpointvar="LIMA_CIDATA_MOUNTS_${f}_MOUNTPOINT"
+		mountpoint="$(eval echo \$"$mountpointvar")"
+		mkdir -p "${mountpoint}"
+		gid=$(id -g "${LIMA_CIDATA_USER}")
+		chown "${LIMA_CIDATA_UID}:${gid}" "${mountpoint}"
+	done
+fi
+
+# Install or update the guestagent binary
+mkdir -p "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin
+guestagent_updated=false
+if [ "$(sha256sum <"${LIMA_CIDATA_MNT}"/lima-guestagent)" = "$(sha256sum <"${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/lima-guestagent 2>/dev/null)" ]; then
+	echo "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}/bin/lima-guestagent is up-to-date"
+else
+	install -m 755 "${LIMA_CIDATA_MNT}"/lima-guestagent "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/lima-guestagent
+	guestagent_updated=true
+fi
+
+# Launch the guestagent service
+if [ -f /sbin/openrc-run ]; then
+	print_config() {
+		# Convert .env to conf.d by wrapping values in double quotes.
+		# Split the variable and value at the first "=" to handle cases where the value contains additional "=" characters.
+		sed -E 's/^([^=]+)=(.*)/\1="\2"/' "${LIMA_CIDATA_MNT}/lima.env"
+	}
+	print_script() {
+		# the openrc lima-guestagent service script
+		cat <<-'EOF'
+			#!/sbin/openrc-run
+			supervisor=supervise-daemon
+
+			log_file="${log_file:-/var/log/${RC_SVCNAME}.log}"
+			err_file="${err_file:-${log_file}}"
+			log_mode="${log_mode:-0644}"
+			log_owner="${log_owner:-root:root}"
+
+			supervise_daemon_args="${supervise_daemon_opts:---stderr \"${err_file}\" --stdout \"${log_file}\"}"
+
+			name="lima-guestagent"
+			description="Forward ports to the lima-hostagent"
+
+			command=${LIMA_CIDATA_GUEST_INSTALL_PREFIX}/bin/lima-guestagent
+			command_args="daemon --debug=${LIMA_CIDATA_DEBUG} --vsock-port \"${LIMA_CIDATA_VSOCK_PORT}\" --virtio-port \"${LIMA_CIDATA_VIRTIO_PORT}\""
+			command_background=true
+			pidfile="/run/lima-guestagent.pid"
+		EOF
+	}
+	if [ "${guestagent_updated}" = "false" ] &&
+		[ "$(print_config | sha256sum)" = "$(sha256sum </etc/conf.d/lima-guestagent 2>/dev/null)" ] &&
+		[ "$(print_script | sha256sum)" = "$(sha256sum </etc/init.d/lima-guestagent 2>/dev/null)" ]; then
+		echo "lima-guestagent service already up-to-date"
+		exit 0
+	fi
+
+	print_config >/etc/conf.d/lima-guestagent
+	print_script >/etc/init.d/lima-guestagent
+	chmod 755 /etc/init.d/lima-guestagent
+
+	rc-update add lima-guestagent default
+	rc-service --ifstarted lima-guestagent restart # restart if running, otherwise do nothing
+	rc-service --ifstopped lima-guestagent start   # start if not running, otherwise do nothing
+else
+	# Remove legacy systemd service
+	rm -f "${LIMA_CIDATA_HOME}/.config/systemd/user/lima-guestagent.service"
+
+	if [ "${LIMA_CIDATA_VSOCK_PORT}" != "0" ]; then
+		sudo "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/lima-guestagent install-systemd --debug="${LIMA_CIDATA_DEBUG}" --guestagent-updated="${guestagent_updated}" --vsock-port "${LIMA_CIDATA_VSOCK_PORT}"
+	elif [ "${LIMA_CIDATA_VIRTIO_PORT}" != "" ]; then
+		sudo "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/lima-guestagent install-systemd --debug="${LIMA_CIDATA_DEBUG}" --guestagent-updated="${guestagent_updated}" --virtio-port "${LIMA_CIDATA_VIRTIO_PORT}"
+	else
+		sudo "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/lima-guestagent install-systemd --debug="${LIMA_CIDATA_DEBUG}" --guestagent-updated="${guestagent_updated}"
+	fi
+fi

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/30-install-packages.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/30-install-packages.sh
@@ -1,0 +1,231 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux
+
+INSTALL_IPTABLES=0
+if [ "${LIMA_CIDATA_CONTAINERD_SYSTEM}" = 1 ] || [ "${LIMA_CIDATA_CONTAINERD_USER}" = 1 ]; then
+	INSTALL_IPTABLES=1
+fi
+if [ "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" -ne 0 ] || [ "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" -ne 0 ]; then
+	INSTALL_IPTABLES=1
+fi
+
+# Install minimum dependencies
+# Run any user provided dependency scripts first
+if [ -d "${LIMA_CIDATA_MNT}"/provision.dependency ]; then
+	echo "Detected dependency provisioning scripts, running before default dependency installation"
+	CODE=0
+	for f in "${LIMA_CIDATA_MNT}"/provision.dependency/*; do
+		if ! "$f"; then
+			CODE=1
+		fi
+	done
+	if [ $CODE != 0 ]; then
+		exit "$CODE"
+	fi
+fi
+
+# apt-get detected through the first bytes of apt-get binary to ensure we're
+# matching to an actual binary and not a wrapper script. This case is an issue
+# on OpenSuse which wraps its own package manager in to a script named apt-get
+# to mimic certain options but doesn't offer full parameters compatibility
+# See : https://github.com/lima-vm/lima/pull/1014
+if [ "${LIMA_CIDATA_SKIP_DEFAULT_DEPENDENCY_RESOLUTION}" = 1 ]; then
+	echo "LIMA_CIDATA_SKIP_DEFAULT_DEPENDENCY_RESOLUTION is set, skipping regular dependency installation"
+	exit 0
+fi
+
+REMOUNT_VIRTIOFS=0
+
+if head -c 4 "$(command -v apt-get)" | grep -qP '\x7fELF' >/dev/null 2>&1; then
+	pkgs=""
+	if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
+		if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ] && ! command -v sshfs >/dev/null 2>&1; then
+			pkgs="${pkgs} sshfs"
+		fi
+	fi
+	if [ "${INSTALL_IPTABLES}" = 1 ] && [ ! -e /usr/sbin/iptables ]; then
+		pkgs="${pkgs} iptables"
+	fi
+	if [ "${LIMA_CIDATA_CONTAINERD_USER}" = 1 ] && ! command -v newuidmap >/dev/null 2>&1; then
+		pkgs="${pkgs} uidmap fuse3 dbus-user-session"
+	fi
+	if ! command -v rsync >/dev/null 2>&1; then
+		pkgs="${pkgs} rsync"
+	fi
+	if [ -n "${pkgs}" ]; then
+		DEBIAN_FRONTEND=noninteractive
+		export DEBIAN_FRONTEND
+		apt-get update
+		# shellcheck disable=SC2086
+		apt-get install -y --no-upgrade --no-install-recommends -q ${pkgs}
+	fi
+elif command -v dnf >/dev/null 2>&1; then
+	pkgs=""
+	extrapkgs=""
+	if ! command -v tar >/dev/null 2>&1; then
+		pkgs="${pkgs} tar"
+	fi
+	if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
+		if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ] && ! command -v sshfs >/dev/null 2>&1; then
+			# fuse-sshfs is not included in EL
+			extrapkgs="${extrapkgs} fuse-sshfs"
+		fi
+	fi
+	if [ "${INSTALL_IPTABLES}" = 1 ] && [ ! -e /usr/sbin/iptables ]; then
+		pkgs="${pkgs} iptables"
+	fi
+	if [ "${LIMA_CIDATA_CONTAINERD_USER}" = 1 ]; then
+		if ! command -v newuidmap >/dev/null 2>&1; then
+			pkgs="${pkgs} shadow-utils"
+		fi
+		if ! command -v mount.fuse3 >/dev/null 2>&1; then
+			pkgs="${pkgs} fuse3"
+		fi
+	fi
+	if ! command -v rsync >/dev/null 2>&1; then
+		pkgs="${pkgs} rsync"
+	fi
+	if [ -n "${pkgs}" ] || [ -n "${extrapkgs}" ]; then
+		dnf_install_flags="-y --setopt=install_weak_deps=False"
+		epel_install_flags=""
+		if grep -q "Oracle Linux Server release 8" /etc/system-release; then
+			# repo flag instead of enable repo to reduce metadata syncing on slow Oracle repos
+			dnf_install_flags="${dnf_install_flags} --repo ol8_baseos_latest --repo ol8_codeready_builder"
+		elif grep -q "release 8" /etc/system-release; then
+			dnf_install_flags="${dnf_install_flags} --enablerepo powertools"
+		elif grep -q "Oracle Linux Server release 9" /etc/system-release; then
+			# shellcheck disable=SC2086
+			dnf install ${dnf_install_flags} oracle-epel-release-el9
+			dnf config-manager --disable ol9_developer_EPEL >/dev/null 2>&1
+			epel_install_flags="${epel_install_flags} --enablerepo ol9_developer_EPEL"
+		elif grep -q "Oracle Linux Server release 10" /etc/system-release; then
+			oraclelinux_version="$(awk '{print $5}' /etc/system-release)"
+			oraclelinux_version_major=$(echo "$oraclelinux_version" | cut -d. -f1)
+			oraclelinux_version_minor=$(echo "$oraclelinux_version" | cut -d. -f2)
+			oraclelinux_epel_repo="ol${oraclelinux_version_major}_u${oraclelinux_version_minor}_developer_EPEL"
+			# shellcheck disable=SC2086
+			dnf install ${dnf_install_flags} oracle-epel-release-el${oraclelinux_version_major}
+			dnf config-manager --disable "$oraclelinux_epel_repo" >/dev/null 2>&1 || true
+			epel_install_flags="${epel_install_flags} --enablerepo $oraclelinux_epel_repo"
+		elif grep -q -E "release (9|10)" /etc/system-release; then
+			# shellcheck disable=SC2086
+			dnf install ${dnf_install_flags} epel-release
+			# Disable the OpenH264 repository as well, by default
+			dnf config-manager --disable epel\* >/dev/null 2>&1
+			epel_install_flags="${epel_install_flags} --enablerepo epel"
+		fi
+		if grep -q "Oracle Linux Server" /etc/system-release && [ "${LIMA_CIDATA_MOUNTTYPE}" = "virtiofs" ]; then
+			# Enable repositories like "ol9_UEKR7"
+			for repo in $(dnf -q repolist | awk '/UEK/NR>1{print $1}'); do
+				epel_install_flags="${epel_install_flags} --enablerepo ${repo}"
+			done
+			extrapkgs="${extrapkgs} kernel-uek-modules-$(uname -r)"
+			REMOUNT_VIRTIOFS=1
+		fi
+		if [ -n "${pkgs}" ]; then
+			# shellcheck disable=SC2086
+			dnf install ${dnf_install_flags} ${pkgs}
+		fi
+		if [ -n "${extrapkgs}" ]; then
+			# shellcheck disable=SC2086
+			dnf install ${dnf_install_flags} ${epel_install_flags} ${extrapkgs}
+		fi
+	fi
+	if [ "${LIMA_CIDATA_CONTAINERD_USER}" = 1 ] && [ ! -e /usr/bin/fusermount ]; then
+		# Workaround for https://github.com/containerd/stargz-snapshotter/issues/340
+		ln -s fusermount3 /usr/bin/fusermount
+	fi
+elif command -v yum >/dev/null 2>&1; then
+	echo "DEPRECATED: CentOS7 and others RHEL-like version 7 are unsupported and might be removed or stop to work in future lima releases"
+	pkgs=""
+	yum_install_flags="-y"
+	if ! rpm -ql epel-release >/dev/null 2>&1; then
+		yum install ${yum_install_flags} epel-release
+	fi
+	if ! command -v tar >/dev/null 2>&1; then
+		pkgs="${pkgs} tar"
+	fi
+	if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ] && ! command -v sshfs >/dev/null 2>&1; then
+		pkgs="${pkgs} fuse-sshfs"
+	fi
+	if [ "${INSTALL_IPTABLES}" = 1 ] && [ ! -e /usr/sbin/iptables ]; then
+		pkgs="${pkgs} iptables"
+	fi
+	if [ "${LIMA_CIDATA_CONTAINERD_USER}" = 1 ]; then
+		if ! command -v newuidmap >/dev/null 2>&1; then
+			pkgs="${pkgs} shadow-utils"
+		fi
+		if ! command -v mount.fuse3 >/dev/null 2>&1; then
+			pkgs="${pkgs} fuse3"
+		fi
+	fi
+	if ! command -v rsync >/dev/null 2>&1; then
+		pkgs="${pkgs} rsync"
+	fi
+	if [ -n "${pkgs}" ]; then
+		# shellcheck disable=SC2086
+		yum install ${yum_install_flags} ${pkgs}
+		yum-config-manager --disable epel >/dev/null 2>&1
+	fi
+elif command -v pacman >/dev/null 2>&1; then
+	pkgs=""
+	if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
+		if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ] && ! command -v sshfs >/dev/null 2>&1; then
+			pkgs="${pkgs} sshfs"
+		fi
+	fi
+	if ! command -v rsync >/dev/null 2>&1; then
+		pkgs="${pkgs} rsync"
+	fi
+	# other dependencies are preinstalled on Arch Linux
+	if [ -n "${pkgs}" ]; then
+		# shellcheck disable=SC2086
+		pacman -Sy --noconfirm ${pkgs}
+	fi
+elif command -v zypper >/dev/null 2>&1; then
+	pkgs=""
+	if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
+		if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ] && ! command -v sshfs >/dev/null 2>&1; then
+			pkgs="${pkgs} sshfs"
+		fi
+	fi
+	if [ "${INSTALL_IPTABLES}" = 1 ] && [ ! -e /usr/sbin/iptables ]; then
+		pkgs="${pkgs} iptables"
+	fi
+	if [ "${LIMA_CIDATA_CONTAINERD_USER}" = 1 ] && ! command -v mount.fuse3 >/dev/null 2>&1; then
+		pkgs="${pkgs} fuse3"
+	fi
+	if ! command -v rsync >/dev/null 2>&1; then
+		pkgs="${pkgs} rsync"
+	fi
+	if [ -n "${pkgs}" ]; then
+		# shellcheck disable=SC2086
+		zypper --non-interactive install -y --no-recommends ${pkgs}
+	fi
+elif command -v apk >/dev/null 2>&1; then
+	pkgs=""
+	if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
+		if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ] && ! command -v sshfs >/dev/null 2>&1; then
+			pkgs="${pkgs} sshfs"
+		fi
+	fi
+	if [ "${INSTALL_IPTABLES}" = 1 ] && ! command -v iptables >/dev/null 2>&1; then
+		pkgs="${pkgs} iptables"
+	fi
+	if ! command -v rsync >/dev/null 2>&1; then
+		pkgs="${pkgs} rsync"
+	fi
+	if [ -n "${pkgs}" ]; then
+		apk update
+		# shellcheck disable=SC2086
+		apk add ${pkgs}
+	fi
+fi
+
+if [ "${REMOUNT_VIRTIOFS}" = 1 ]; then
+	mount -t virtiofs -a
+fi

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/35-setup-packages.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/35-setup-packages.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux
+
+update_fuse_conf() {
+	# Modify /etc/fuse.conf (/etc/fuse3.conf) to allow "-o allow_root"
+	if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ]; then
+		fuse_conf="/etc/fuse.conf"
+		if [ -e /etc/fuse3.conf ]; then
+			fuse_conf="/etc/fuse3.conf"
+		fi
+		if ! grep -q "^user_allow_other" "${fuse_conf}"; then
+			echo "user_allow_other" >>"${fuse_conf}"
+		fi
+	fi
+}
+
+# update_fuse_conf has to be called after installing all the packages,
+# otherwise apt-get fails with conflict
+if [ "${LIMA_CIDATA_MOUNTTYPE}" = "reverse-sshfs" ]; then
+	update_fuse_conf
+fi
+
+SETUP_DNS=0
+if [ -n "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" ] && [ "${LIMA_CIDATA_UDP_DNS_LOCAL_PORT}" -ne 0 ]; then
+	SETUP_DNS=1
+fi
+if [ -n "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" ] && [ "${LIMA_CIDATA_TCP_DNS_LOCAL_PORT}" -ne 0 ]; then
+	SETUP_DNS=1
+fi
+if [ "${SETUP_DNS}" = 1 ]; then
+	# Try to setup iptables rule again, in case we just installed iptables
+	"${LIMA_CIDATA_MNT}/boot.Linux/09-host-dns-setup.sh"
+fi

--- a/share/lima/cidata.TEMPLATE.d/boot.Linux/40-install-containerd.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.Linux/40-install-containerd.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux
+: "${CONTAINERD_NAMESPACE:=default}"
+# Overridable in .bashrc
+: "${CONTAINERD_SNAPSHOTTER:=overlayfs}"
+
+if [ "${LIMA_CIDATA_CONTAINERD_SYSTEM}" != 1 ] && [ "${LIMA_CIDATA_CONTAINERD_USER}" != 1 ]; then
+	exit 0
+fi
+
+# This script does not work unless systemd is available
+command -v systemctl >/dev/null 2>&1 || exit 0
+
+# Extract bin/nerdctl and compare whether it is newer than the current /usr/local/bin/nerdctl (if already exists).
+# Takes 4-5 seconds. (FIXME: optimize)
+tmp_extract_nerdctl="$(mktemp -d)"
+tar Cxaf "${tmp_extract_nerdctl}" "${LIMA_CIDATA_MNT}"/"${LIMA_CIDATA_CONTAINERD_ARCHIVE}" bin/nerdctl
+
+if [ ! -f "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl ] || [[ "${tmp_extract_nerdctl}"/bin/nerdctl -nt "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl ]]; then
+	if [ -f "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl ]; then
+		(
+			set +e
+			echo "Upgrading existing nerdctl"
+			echo "- Old: $("${LIMA_CIDATA_GUEST_INSTALL_PREFIX}"/bin/nerdctl --version)"
+			echo "- New: $("${tmp_extract_nerdctl}"/bin/nerdctl --version)"
+			systemctl disable --now containerd default-buildkit stargz-snapshotter
+			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" "CONTAINERD_NAMESPACE=${CONTAINERD_NAMESPACE}" containerd-rootless-setuptool.sh uninstall-buildkit-containerd
+			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" containerd-rootless-setuptool.sh uninstall
+		)
+	fi
+	tar Cxaf "${LIMA_CIDATA_GUEST_INSTALL_PREFIX}" "${LIMA_CIDATA_MNT}"/"${LIMA_CIDATA_CONTAINERD_ARCHIVE}"
+
+	mkdir -p /etc/bash_completion.d
+	nerdctl completion bash >/etc/bash_completion.d/nerdctl
+	# TODO: enable zsh completion too
+fi
+
+rm -rf "${tmp_extract_nerdctl}"
+
+if [ "${LIMA_CIDATA_CONTAINERD_SYSTEM}" = 1 ]; then
+	if [ ! -e /etc/containerd/config.toml ]; then
+		mkdir -p /etc/containerd
+		cat >"/etc/containerd/config.toml" <<EOF
+  version = 2
+  # TODO: remove imports after upgrading containerd to v2.2, as
+  # conf.d is set by default since v2.2.
+  imports = ['/etc/containerd/conf.d/*.toml']
+  [plugins."io.containerd.grpc.v1.cri"]
+    enable_cdi = true
+  [proxy_plugins]
+    [proxy_plugins."stargz"]
+      type = "snapshot"
+      address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"
+EOF
+	fi
+	if [ ! -e /etc/buildkit/buildkitd.toml ]; then
+		mkdir -p /etc/buildkit
+		cat >"/etc/buildkit/buildkitd.toml" <<EOF
+[worker.oci]
+  enabled = false
+
+[worker.containerd]
+  enabled = true
+  namespace = "${CONTAINERD_NAMESPACE}"
+  snapshotter = "${CONTAINERD_SNAPSHOTTER}"
+EOF
+	fi
+	systemctl enable --now containerd buildkit stargz-snapshotter
+fi
+
+if [ "${LIMA_CIDATA_CONTAINERD_USER}" = 1 ]; then
+	if [ ! -e "${LIMA_CIDATA_HOME}/.config/containerd/config.toml" ]; then
+		mkdir -p "${LIMA_CIDATA_HOME}/.config/containerd"
+		cat >"${LIMA_CIDATA_HOME}/.config/containerd/config.toml" <<EOF
+  version = 2
+  [plugins."io.containerd.grpc.v1.cri"]
+    enable_cdi = true
+  [proxy_plugins]
+    [proxy_plugins."fuse-overlayfs"]
+      type = "snapshot"
+      address = "/run/user/${LIMA_CIDATA_UID}/containerd-fuse-overlayfs.sock"
+    [proxy_plugins."stargz"]
+      type = "snapshot"
+      address = "/run/user/${LIMA_CIDATA_UID}/containerd-stargz-grpc/containerd-stargz-grpc.sock"
+EOF
+		chown -R "${LIMA_CIDATA_USER}" "${LIMA_CIDATA_HOME}/.config"
+	fi
+	selinux=
+	if command -v selinuxenabled >/dev/null 2>&1 && selinuxenabled; then
+		selinux=1
+	fi
+	if [ ! -e "/etc/apparmor.d/usr.local.bin.rootlesskit" ] && [ -e "/etc/apparmor.d/abi/4.0" ] && [ -e "/proc/sys/kernel/apparmor_restrict_unprivileged_userns" ]; then
+		cat >"/etc/apparmor.d/usr.local.bin.rootlesskit" <<EOF
+# Ubuntu 23.10 introduced kernel.apparmor_restrict_unprivileged_userns
+# to restrict unsharing user namespaces:
+# https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
+#
+# kernel.apparmor_restrict_unprivileged_userns is still opt-in in Ubuntu 23.10,
+# but it is expected to be enabled in future releases of Ubuntu.
+abi <abi/4.0>,
+include <tunables/global>
+
+/usr/local/bin/rootlesskit flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/usr.local.bin.rootlesskit>
+}
+EOF
+		systemctl restart apparmor.service
+	fi
+	if [ ! -e "${LIMA_CIDATA_HOME}/.config/systemd/user/containerd.service" ]; then
+		until [ -e "/run/user/${LIMA_CIDATA_UID}/systemd/private" ]; do sleep 3; done
+		if [ -n "$selinux" ]; then
+			echo "Temporarily disabling SELinux, during installing containerd units"
+			setenforce 0
+		fi
+		if [ "$(sudo -iu "${LIMA_CIDATA_USER}" sh -ec 'systemctl --user show --property=RefuseManualStart --value dbus')" != "yes" ]; then
+			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" systemctl --user enable --now dbus.socket
+		fi
+		sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" "TERM=${TERM}" containerd-rootless-setuptool.sh install
+		sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" "TERM=${TERM}" \
+			"CONTAINERD_NAMESPACE=${CONTAINERD_NAMESPACE}" "CONTAINERD_SNAPSHOTTER=${CONTAINERD_SNAPSHOTTER}" \
+			containerd-rootless-setuptool.sh install-buildkit-containerd
+
+		# $CONTAINERD_SNAPSHOTTER is configured in 20-rootless-base.sh, when the guest kernel is < 5.13, or the instance was created with Lima < 0.9.0.
+		if [ "$(sudo -iu "${LIMA_CIDATA_USER}" sh -ec 'echo $CONTAINERD_SNAPSHOTTER')" = "fuse-overlayfs" ]; then
+			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" "TERM=${TERM}" containerd-rootless-setuptool.sh install-fuse-overlayfs
+		fi
+
+		if compare_version.sh "$(uname -r)" -ge "5.13"; then
+			sudo -iu "${LIMA_CIDATA_USER}" "XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}" "PATH=${PATH}" "TERM=${TERM}" containerd-rootless-setuptool.sh install-stargz
+		else
+			echo >&2 "WARNING: the guest kernel seems older than 5.13. Skipping installing rootless stargz."
+		fi
+		if [ -n "$selinux" ]; then
+			echo "Restoring SELinux"
+			setenforce 1
+		fi
+	fi
+fi

--- a/share/lima/cidata.TEMPLATE.d/boot.essential.FreeBSD/00-freebsd-user-group.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.essential.FreeBSD/00-freebsd-user-group.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# This script ensures that the user is created with the expected UID.
+# This script is needed because nuageinit does not create the user with the expected UID.
+
+set -eu
+
+[ "$(stat -f %u "${LIMA_CIDATA_HOME}")" = "${LIMA_CIDATA_UID}" ] && exit 0
+
+pw usermod -n "${LIMA_CIDATA_USER}" -u "${LIMA_CIDATA_UID}"
+gid="$(id -g "${LIMA_CIDATA_USER}")"
+chown -R "${LIMA_CIDATA_UID}:${gid}" "${LIMA_CIDATA_HOME}"

--- a/share/lima/cidata.TEMPLATE.d/boot.sh
+++ b/share/lima/cidata.TEMPLATE.d/boot.sh
@@ -1,0 +1,211 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+INFO() {
+	echo "LIMA $(date -Iseconds)| $*"
+}
+
+WARNING() {
+	echo "LIMA $(date -Iseconds)| WARNING: $*"
+}
+
+UNAME="$(uname -s)"
+
+RUN="/run"
+if [ "${UNAME}" != "Linux" ]; then
+	RUN="/var/run"
+fi
+rm -f "${RUN}/lima-boot-done"
+
+# shellcheck disable=SC2163
+while read -r line; do [ -n "$line" ] && export "$line"; done <"${LIMA_CIDATA_MNT}"/lima.env
+# shellcheck disable=SC2163
+while read -r line; do [ -n "$line" ] && export "$line"; done <"${LIMA_CIDATA_MNT}"/param.env
+
+# shellcheck disable=SC2163
+while read -r line; do
+	# pam_env implementation:
+	# - '#' is treated the same as newline; terminates value
+	# - skip leading tabs and spaces
+	# - skip leading "export " prefix (only single space)
+	# - skip leading quote ('\'' or '"') on the value side
+	# - skip trailing quote only if leading quote has been skipped;
+	#   quotes don't need to match; trailing quote may be omitted
+	line="$(echo "$line" | sed -E "s/^[ \\t]*(export )?//; s/#.*//; s/(^[^=]+=)[\"'](.*[^\"'])?[\"']?$/\1\2/")"
+	[ -n "$line" ] && export "$line"
+done <"${LIMA_CIDATA_MNT}"/etc_environment
+
+PATH="${LIMA_CIDATA_MNT}"/util:"${PATH}"
+export PATH
+
+CODE=0
+
+# Don't make any changes to /etc or /var/lib until boot.Linux/04-persistent-data-volume.sh
+# has run because it might move the directories to /mnt/data on first boot. In that
+# case changes made on restart would be lost.
+
+run_boot_scripts() {
+	boot="$1"
+	if [ -e "${boot}" ]; then
+		for f in "${boot}"/*.sh; do
+			INFO "Executing $f"
+			if ! "$f"; then
+				WARNING "Failed to execute $f"
+				CODE=1
+			fi
+		done
+	fi
+}
+
+# The boot.essential.${UNAME} scripts are executed in plain mode too.
+run_boot_scripts "${LIMA_CIDATA_MNT}/boot.essential.${UNAME}"
+
+if [ "$LIMA_CIDATA_PLAIN" = "1" ]; then
+	INFO "Plain mode. Skipping to run non-essential boot scripts. Provisioning scripts will be still executed. Guest agent will not be running."
+else
+	run_boot_scripts "${LIMA_CIDATA_MNT}/boot.${UNAME}"
+fi
+
+# indirect variable lookup, like ${!var} in bash
+deref() {
+	eval echo \$"$1"
+}
+
+if [ -d "${LIMA_CIDATA_MNT}"/provision.data ]; then
+	for f in "${LIMA_CIDATA_MNT}"/provision.data/*; do
+		filename=$(basename "$f")
+		overwrite=$(deref "LIMA_CIDATA_DATAFILE_${filename}_OVERWRITE")
+		owner=$(deref "LIMA_CIDATA_DATAFILE_${filename}_OWNER")
+		path=$(deref "LIMA_CIDATA_DATAFILE_${filename}_PATH")
+		permissions=$(deref "LIMA_CIDATA_DATAFILE_${filename}_PERMISSIONS")
+		user="${owner%%:*}"
+		if [ -e "$path" ] && [ "$overwrite" = "false" ]; then
+			INFO "Not overwriting $path"
+		else
+			INFO "Copying $f to $path"
+			if ! sudo -iu "${user}" mkdir -p "$(dirname "$path")"; then
+				WARNING "Failed to create directory for ${path} (as user ${user})"
+				WARNING "Falling back to creating directory as root to maintain compatibility"
+				mkdir -p "$(dirname "$path")"
+			fi
+			cp "$f" "$path"
+			chown "$owner" "$path"
+			chmod "$permissions" "$path"
+		fi
+	done
+fi
+
+if [ -d "${LIMA_CIDATA_MNT}"/provision.yq ]; then
+	yq="${LIMA_CIDATA_MNT}/lima-guestagent yq"
+	for f in "${LIMA_CIDATA_MNT}"/provision.yq/*; do
+		filename=$(basename "${f}")
+		format=$(deref "LIMA_CIDATA_YQ_PROVISION_${filename}_FORMAT")
+		owner=$(deref "LIMA_CIDATA_YQ_PROVISION_${filename}_OWNER")
+		path=$(deref "LIMA_CIDATA_YQ_PROVISION_${filename}_PATH")
+		permissions=$(deref "LIMA_CIDATA_YQ_PROVISION_${filename}_PERMISSIONS")
+		user="${owner%%:*}"
+		# Creating intermediate directories may fail if the user does not have permission.
+		# TODO: Create intermediate directories with the specified group ownership.
+		if ! sudo -iu "${user}" mkdir -p "$(dirname "${path}")"; then
+			WARNING "Failed to create directory for ${path} (as user ${user})"
+			CODE=1
+			continue
+		fi
+		# Since CIDATA is mounted with dmode=700,fmode=700,
+		# `lima-guestagent yq` cannot be executed by non-root users,
+		# and provision.yq/* files cannot be read by non-root users.
+		if [ -f "${path}" ]; then
+			INFO "Updating ${path}"
+			# If the user does not have write permission, it should fail.
+			# This avoids changes being made by the wrong user.
+			if ! sudo -iu "${user}" test -w "${path}"; then
+				WARNING "File ${path} is not writable by user ${user}"
+				CODE=1
+				continue
+			fi
+			# Relies on the fact that yq does not change the owner of the existing file.
+			if ! ${yq} --inplace --from-file "${f}" --input-format "${format}" --output-format "${format}" "${path}"; then
+				WARNING "Failed to update ${path} (as user ${user})"
+				CODE=1
+				continue
+			fi
+		else
+			if [ "${format}" = "auto" ]; then
+				# yq can't determine the output format from non-existing files
+				case "${path}" in
+				*.csv) format=csv ;;
+				*.ini) format=ini ;;
+				*.json) format=json ;;
+				*.properties) format=properties ;;
+				*.toml) format=toml ;;
+				*.tsv) format=tsv ;;
+				*.xml) format=xml ;;
+				*.yaml | *.yml) format=yaml ;;
+				*)
+					format=yaml
+					WARNING "Cannot determine file type for ${path}, using yaml format"
+					;;
+				esac
+			fi
+			INFO "Creating ${path}"
+			if ! ${yq} --null-input --from-file "${f}" --output-format "${format}" | sudo -iu "${user}" tee "${path}"; then
+				WARNING "Failed to create ${path} (as user ${user})"
+				CODE=1
+				continue
+			fi
+		fi
+		if ! sudo -iu "${user}" chown "${owner}" "${path}"; then
+			WARNING "Failed to set owner for ${path} (as user ${user})"
+			CODE=1
+		fi
+		if ! sudo -iu "${user}" chmod "${permissions}" "${path}"; then
+			WARNING "Failed to set permissions for ${path} (as user ${user})"
+			CODE=1
+		fi
+	done
+fi
+
+if [ -d "${LIMA_CIDATA_MNT}"/provision.system ]; then
+	for f in "${LIMA_CIDATA_MNT}"/provision.system/*; do
+		INFO "Executing $f"
+		if ! "$f"; then
+			WARNING "Failed to execute $f"
+			CODE=1
+		fi
+	done
+fi
+
+USER_SCRIPT="${LIMA_CIDATA_HOME}/.lima-user-script"
+if [ -d "${LIMA_CIDATA_MNT}"/provision.user ]; then
+	if [ "$UNAME" = "Linux" ] && [ ! -f /sbin/openrc-run ]; then
+		until [ -e "/run/user/${LIMA_CIDATA_UID}/systemd/private" ]; do sleep 3; done
+	fi
+	params=$(grep -o '^PARAM_[^=]*' "${LIMA_CIDATA_MNT}"/param.env | paste -sd , -)
+	for f in "${LIMA_CIDATA_MNT}"/provision.user/*; do
+		INFO "Executing $f (as user ${LIMA_CIDATA_USER})"
+		cp "$f" "${USER_SCRIPT}"
+		chown "${LIMA_CIDATA_USER}" "${USER_SCRIPT}"
+		chmod 755 "${USER_SCRIPT}"
+		XDG_RUNTIME_DIR_ENV=
+		if [ "${UNAME}" = "Linux" ]; then
+			XDG_RUNTIME_DIR_ENV="XDG_RUNTIME_DIR=/run/user/${LIMA_CIDATA_UID}"
+		fi
+		# shellcheck disable=SC2086
+		if ! sudo -iu "${LIMA_CIDATA_USER}" "--preserve-env=${params}" $XDG_RUNTIME_DIR_ENV "${USER_SCRIPT}"; then
+			WARNING "Failed to execute $f (as user ${LIMA_CIDATA_USER})"
+			CODE=1
+		fi
+		rm "${USER_SCRIPT}"
+	done
+fi
+
+# Signal that provisioning is done. The instance ID changes on every boot,
+# so any value from a previous boot cycle will be different.
+echo "${LIMA_CIDATA_IID}" >"${RUN}/lima-boot-done"
+
+INFO "Exiting with code $CODE"
+exit "$CODE"

--- a/share/lima/cidata.TEMPLATE.d/etc_environment
+++ b/share/lima/cidata.TEMPLATE.d/etc_environment
@@ -1,0 +1,5 @@
+#LIMA-START
+{{- range $key, $val := .Env}}
+{{$key}}={{$val}}
+{{- end}}
+#LIMA-END

--- a/share/lima/cidata.TEMPLATE.d/lima.env
+++ b/share/lima/cidata.TEMPLATE.d/lima.env
@@ -1,0 +1,78 @@
+LIMA_CIDATA_DEBUG={{ .Debug }}
+LIMA_CIDATA_IID={{ .IID }}
+LIMA_CIDATA_NAME={{ .Name }}
+LIMA_CIDATA_USER={{ .User }}
+LIMA_CIDATA_UID={{ .UID }}
+LIMA_CIDATA_COMMENT={{ .Comment }}
+LIMA_CIDATA_HOME={{ .Home}}
+LIMA_CIDATA_SHELL={{ .Shell }}
+LIMA_CIDATA_HOSTHOME_MOUNTPOINT={{ .HostHomeMountPoint }}
+LIMA_CIDATA_MOUNTS={{ len .Mounts }}
+{{- range $i, $val := .Mounts}}
+LIMA_CIDATA_MOUNTS_{{$i}}_MOUNTPOINT={{$val.MountPoint}}
+{{- end}}
+LIMA_CIDATA_MOUNTTYPE={{ .MountType }}
+LIMA_CIDATA_DISKS={{ len .Disks }}
+{{- range $i, $disk := .Disks}}
+LIMA_CIDATA_DISK_{{$i}}_NAME={{$disk.Name}}
+LIMA_CIDATA_DISK_{{$i}}_DEVICE={{$disk.Device}}
+LIMA_CIDATA_DISK_{{$i}}_FORMAT={{$disk.Format}}
+LIMA_CIDATA_DISK_{{$i}}_FSTYPE={{$disk.FSType}}
+LIMA_CIDATA_DISK_{{$i}}_FSARGS={{range $j, $arg := $disk.FSArgs}}{{if $j}} {{end}}{{$arg}}{{end}}
+{{- end}}
+{{- range $dataFile := .DataFiles}}
+LIMA_CIDATA_DATAFILE_{{$dataFile.FileName}}_OVERWRITE={{$dataFile.Overwrite}}
+LIMA_CIDATA_DATAFILE_{{$dataFile.FileName}}_OWNER={{$dataFile.Owner}}
+LIMA_CIDATA_DATAFILE_{{$dataFile.FileName}}_PATH={{$dataFile.Path}}
+LIMA_CIDATA_DATAFILE_{{$dataFile.FileName}}_PERMISSIONS={{$dataFile.Permissions}}
+{{- end}}
+{{- range $yqProvision := .YQProvisions}}
+LIMA_CIDATA_YQ_PROVISION_{{$yqProvision.FileName}}_FORMAT={{$yqProvision.Format}}
+LIMA_CIDATA_YQ_PROVISION_{{$yqProvision.FileName}}_OWNER={{$yqProvision.Owner}}
+LIMA_CIDATA_YQ_PROVISION_{{$yqProvision.FileName}}_PATH={{$yqProvision.Path}}
+LIMA_CIDATA_YQ_PROVISION_{{$yqProvision.FileName}}_PERMISSIONS={{$yqProvision.Permissions}}
+{{- end}}
+LIMA_CIDATA_GUEST_INSTALL_PREFIX={{ .GuestInstallPrefix }}
+{{- if .UpgradePackages}}
+LIMA_CIDATA_UPGRADE_PACKAGES=1
+{{- else}}
+LIMA_CIDATA_UPGRADE_PACKAGES=
+{{- end}}
+{{- if .Containerd.User}}
+LIMA_CIDATA_CONTAINERD_USER=1
+{{- else}}
+LIMA_CIDATA_CONTAINERD_USER=
+{{- end}}
+{{- if .Containerd.System}}
+LIMA_CIDATA_CONTAINERD_SYSTEM=1
+{{- else}}
+LIMA_CIDATA_CONTAINERD_SYSTEM=
+{{- end}}
+{{- if or .Containerd.User .Containerd.System}}
+LIMA_CIDATA_CONTAINERD_ARCHIVE={{.Containerd.Archive}}
+{{- end}}
+LIMA_CIDATA_SLIRP_DNS={{.SlirpDNS}}
+LIMA_CIDATA_SLIRP_GATEWAY={{.SlirpGateway}}
+LIMA_CIDATA_SLIRP_IP_ADDRESS={{.SlirpIPAddress}}
+LIMA_CIDATA_UDP_DNS_LOCAL_PORT={{.UDPDNSLocalPort}}
+LIMA_CIDATA_TCP_DNS_LOCAL_PORT={{.TCPDNSLocalPort}}
+LIMA_CIDATA_ROSETTA_ENABLED={{.RosettaEnabled}}
+LIMA_CIDATA_ROSETTA_BINFMT={{.RosettaBinFmt}}
+{{- if .SkipDefaultDependencyResolution}}
+LIMA_CIDATA_SKIP_DEFAULT_DEPENDENCY_RESOLUTION=1
+{{- else}}
+LIMA_CIDATA_SKIP_DEFAULT_DEPENDENCY_RESOLUTION=
+{{- end}}
+LIMA_CIDATA_VMTYPE={{ .VMType }}
+LIMA_CIDATA_VSOCK_PORT={{ .VSockPort }}
+LIMA_CIDATA_VIRTIO_PORT={{ .VirtioPort}}
+{{- if .Plain}}
+LIMA_CIDATA_PLAIN=1
+{{- else}}
+LIMA_CIDATA_PLAIN=
+{{- end}}
+{{- if .NoCloudInit}}
+LIMA_CIDATA_NO_CLOUD_INIT=1
+{{- else}}
+LIMA_CIDATA_NO_CLOUD_INIT=
+{{- end}}

--- a/share/lima/cidata.TEMPLATE.d/meta-data
+++ b/share/lima/cidata.TEMPLATE.d/meta-data
@@ -1,0 +1,2 @@
+instance-id: {{.IID}}
+local-hostname: {{.Hostname}}

--- a/share/lima/cidata.TEMPLATE.d/network-config
+++ b/share/lima/cidata.TEMPLATE.d/network-config
@@ -1,0 +1,19 @@
+version: 2
+ethernets:
+  {{- range $nw := .Networks}}
+  {{$nw.Interface}}:
+    match:
+      macaddress: '{{$nw.MACAddress}}'
+    dhcp4: true
+    set-name: {{$nw.Interface}}
+    dhcp4-overrides:
+      route-metric: {{$nw.Metric}}
+    dhcp-identifier: mac
+    {{- if and (eq $nw.Interface $.SlirpNICName) (gt (len $.DNSAddresses) 0) }}
+    nameservers:
+      addresses:
+      {{- range $ns := $.DNSAddresses }}
+      - {{$ns}}
+      {{- end }}
+    {{- end }}
+  {{- end }}

--- a/share/lima/cidata.TEMPLATE.d/param.env
+++ b/share/lima/cidata.TEMPLATE.d/param.env
@@ -1,0 +1,3 @@
+{{range $key, $val := .Param -}}
+PARAM_{{ $key }}={{ $val }}
+{{end -}}

--- a/share/lima/cidata.TEMPLATE.d/user-data
+++ b/share/lima/cidata.TEMPLATE.d/user-data
@@ -1,0 +1,189 @@
+#cloud-config
+# vim:syntax=yaml
+
+growpart:
+  mode: auto
+  devices: ['/']
+
+{{- if eq .OS "FreeBSD" }}
+packages:
+  # boot.sh depends on sudo.
+  # TODO: consider replacing sudo with doas.
+  # FIXME: The hostagent script depends on sudo too.
+  # https://github.com/lima-vm/lima/issues/4594
+  - sudo
+{{- end }}
+
+{{- if .UpgradePackages }}
+package_update: true
+package_upgrade: true
+package_reboot_if_required: true
+{{- end }}
+
+{{- if or .RosettaEnabled (and .Mounts (or (eq .MountType "9p") (eq .MountType "virtiofs"))) }}
+mounts:
+  {{- if .RosettaEnabled }}{{/* Mount the rosetta volume before systemd-binfmt.service(8) starts */}}
+- [vz-rosetta, /mnt/lima-rosetta, virtiofs, defaults, "0", "0"]
+  {{- end }}
+  {{- if and .Mounts (or (eq .MountType "9p") (eq .MountType "virtiofs")) }}
+    {{- range $m := $.Mounts}}
+- [{{$m.Tag}}, {{$m.MountPoint}}, {{$m.Type}}, "{{$m.Options}}", "0", "0"]
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- if .TimeZone }}
+timezone: {{.TimeZone}}
+{{- end }}
+
+users:
+  - name: "{{.User}}"
+{{- if ne .OS "FreeBSD" }}
+    # nuageinit does not support specifying the UID.
+    # The UID is fixed up in boot.essential.FreeBSD/00-freebsd-user-group.sh
+    uid: "{{.UID}}"
+{{- end }}
+{{- if .Comment }}
+    gecos: {{ printf "%q" .Comment }}
+{{- end }}
+    homedir: "{{.Home}}"
+    shell: {{.Shell}}
+{{- if eq .OS "Darwin" }}
+    {{/* On macOS, the password is not locked so as to allow GUI login. */}}
+    {{/* Since the user can run sudo with their own password, basically we don't need to set up passwordless sudo. */}}
+    {{/* However, it is still configured to allow `/sbin/shutdown -h now` without password, as it is invoked by `limactl stop` for graceful shutdown. */}}
+    {{/* (Why doesn't macOS VM support graceful shutdown?) */}}
+    sudo: ALL=(ALL) NOPASSWD:/sbin/shutdown -h now
+{{- else }}
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    {{- if eq .OS "FreeBSD" }}
+    groups:
+    - wheel
+    doas: permit nopass :wheel
+    {{- end}}
+    lock_passwd: true
+{{- end }}
+{{- if eq .OS "FreeBSD" }}
+    ssh_authorized_keys:
+{{- else }}
+    ssh-authorized-keys:
+{{- end }}
+    {{- range $val := .SSHPubKeys }}
+      - {{ printf "%q" $val }}
+    {{- end }}
+
+{{- if .BootScripts }}
+write_files:
+ - content: |
+      #!/bin/sh
+      set -eux
+      LIMA_CIDATA_MNT="/mnt/lima-cidata"
+      UNAME="$(uname -s)"
+      if [ "${UNAME}" = "Darwin" ]; then
+        LIMA_CIDATA_MNT="/Volumes/cidata"
+        # Should have been mounted automatically
+      elif [ "${UNAME}" = "FreeBSD" ]; then
+        LIMA_CIDATA_DEV="/dev/iso9660/cidata"
+        if [ ! -e "${LIMA_CIDATA_DEV}" ]; then
+          # When the iso is created with `hdiutil` on macOS,
+          # apparently the volume name becomes "CIDATA" not "cidata"
+          LIMA_CIDATA_DEV="/dev/iso9660/CIDATA"
+        fi
+        mkdir -p -m 700 "${LIMA_CIDATA_MNT}"
+        mount_cd9660 -G wheel -U root -m 0700 -o ro,exec "${LIMA_CIDATA_DEV}" "${LIMA_CIDATA_MNT}"
+      elif [ "${UNAME}" = "Linux" ]; then
+        LIMA_CIDATA_DEV="/dev/disk/by-label/cidata"
+        mkdir -p -m 700 "${LIMA_CIDATA_MNT}"
+        mount -o ro,mode=0700,dmode=0700,overriderockperm,exec,uid=0 "${LIMA_CIDATA_DEV}" "${LIMA_CIDATA_MNT}"
+      else
+        echo "Unsupported OS: ${UNAME}" >&2
+        exit 1
+      fi
+      export LIMA_CIDATA_MNT
+      exec "${LIMA_CIDATA_MNT}"/boot.sh
+{{- if or (eq .OS "Darwin") (eq .OS "FreeBSD") }}
+   owner: root:wheel
+{{- else }}
+   owner: root:root
+{{- end }}
+{{- if eq .OS "FreeBSD" }}
+   # nuageinit requires the path to be under an existing directory
+   path: /usr/sbin/lima-freebsd-init.sh
+{{- else }}
+   path: /var/lib/cloud/scripts/per-boot/00-lima.boot.sh
+{{- end }}
+   permissions: '0755'
+{{- if eq .OS "FreeBSD" }}
+  # nuageinit does not run /var/lib/cloud/scripts/per-boot/* scripts
+ - content: |
+      #!/bin/sh
+
+      # PROVIDE: lima_freebsd_init
+      # REQUIRE: DAEMON
+      # BEFORE: LOGIN
+
+      . /etc/rc.subr
+
+      name="lima_freebsd_init"
+      rcvar="lima_freebsd_init_enable"
+      command="/usr/sbin/lima-freebsd-init.sh"
+
+      load_rc_config "$name"
+      run_rc_command "$1"
+   owner: root:wheel
+   path: /etc/rc.d/lima_freebsd_init
+   permissions: '0755'
+ - content: |
+      lima_freebsd_init_enable="YES"
+   owner: root:wheel
+   path: /etc/rc.conf.d/lima_freebsd_init
+   permissions: '0644'
+{{- end }}
+{{- end }}
+
+{{- if .DNSAddresses }}
+# This has no effect on systems using systemd-resolved, but is used
+# on e.g. Alpine to set up /etc/resolv.conf on first boot.
+
+manage_resolv_conf: true
+
+resolv_conf:
+  nameservers:
+  {{- range $ns := $.DNSAddresses }}
+  - {{$ns}}
+  {{- end }}
+{{- end }}
+
+{{- if or .CACerts.RemoveDefaults .CACerts.Trusted }}
+{{ with .CACerts }}
+ca_certs:
+  {{- if .RemoveDefaults }}
+  remove_defaults: {{ .RemoveDefaults }}
+  {{- end }}
+  {{- if .Trusted}}
+  trusted:
+  {{- range $cert := .Trusted }}
+  - |
+    {{- range $line := $cert.Lines }}
+    {{ $line }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- if .BootCmds }}
+bootcmd:
+  {{- range $cmd := $.BootCmds }}
+- |
+  # We need to embed the params.env as a here-doc because /mnt/lima-cidata is not yet mounted
+  while read -r line; do [ -n "$line" ] && export "$line"; done <<'EOF'
+    {{- range $key, $val := $.Param }}
+  PARAM_{{ $key }}={{ $val }}
+    {{- end }}
+  EOF
+    {{- range $line := $cmd.Lines }}
+  {{ $line }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/share/lima/cidata.TEMPLATE.d/util.FreeBSD/print_cidata_fstab.lua
+++ b/share/lima/cidata.TEMPLATE.d/util.FreeBSD/print_cidata_fstab.lua
@@ -1,0 +1,16 @@
+#!/usr/libexec/flua
+local yaml = require("lyaml")
+local fpath = "/mnt/lima-cidata/user-data"
+local f = io.open(fpath, "r")
+if not f then
+	error("Could not open " .. fpath)
+end
+local content = f:read("*a")
+f:close()
+local config = yaml.load(content)
+for i, row in ipairs(config.mounts) do
+	for j, value in ipairs(row) do
+		io.write(value, "\t")
+	end
+	io.write("\n")
+end

--- a/share/lima/cidata.TEMPLATE.d/util/compare_version.sh
+++ b/share/lima/cidata.TEMPLATE.d/util/compare_version.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+: "${SELFTEST:=}"
+if [ -n "$SELFTEST" ]; then
+	unset SELFTEST
+	echo >&2 "=== Running positive tests ==="
+	(
+		set -x
+		"$0" 0.1.2 -eq 0.1.2
+		"$0" 0.1.2 -ne 0.1.3
+		"$0" 0.1.2 -ge 0.1.1
+		"$0" 0.1.2 -ge 0.1.2
+		"$0" 0.1.10 -ge 0.1.9
+		"$0" 0.1.2 -gt 0.1.1
+		"$0" 0.1.10 -gt 0.1.9
+		"$0" 0.1.2 -le 0.1.2
+		"$0" 0.1.2 -le 0.1.3
+		"$0" 0.1.2 -le 0.1.10
+		"$0" 0.1.2 -lt 0.1.3
+		"$0" 0.1.2 -lt 0.1.10
+	)
+	echo >&2 "=== Running negative tests ==="
+	(
+		set -x
+		"$0" 0.1.2 -eq 0.1.1 && false
+		"$0" 0.1.2 -ne 0.1.2 && false
+		"$0" 0.1.2 -ge 0.1.3 && false
+		"$0" 0.1.2 -gt 0.1.2 && false
+		"$0" 0.1.2 -le 0.1.1 && false
+		"$0" 0.1.2 -lt 0.1.2 && false
+		true
+	)
+	exit 0
+fi
+
+if [ "$#" -ne 3 ]; then
+	echo >&2 "Usage: $0 VERSION-A OP VERSION-B"
+	echo >&2 "Implemented operators: -eq, -ne, -ge, -gt, -le, -lt"
+	echo >&2 ""
+	echo >&2 "Example: $0 1.2.10 -ge 1.2.9"
+	exit 1
+fi
+
+version_a="$1"
+op="$2"
+version_b="$3"
+
+sorted="$(echo -ne "${version_a}\n${version_b}\n" | sort -V -r | head -n1)"
+case "${op}" in
+-eq)
+	[ "${version_a}" = "${version_b}" ]
+	;;
+-ne)
+	[ "${version_a}" != "${version_b}" ]
+	;;
+-ge)
+	[ "${version_a}" = "${sorted}" ]
+	;;
+-gt)
+	[ "${version_a}" = "${sorted}" ] && [ "${version_a}" != "${version_b}" ]
+	;;
+-le)
+	[ "${version_b}" = "${sorted}" ]
+	;;
+-lt)
+	[ "${version_b}" = "${sorted}" ] && [ "${version_a}" != "${version_b}" ]
+	;;
+*)
+	echo "Unknown operator \"$op\""
+	exit 1
+	;;
+esac

--- a/share/lima/defaults/containerd.yaml
+++ b/share/lima/defaults/containerd.yaml
@@ -1,0 +1,11 @@
+# nerdctl version must be >= 2.1.6 since Lima v2.0.0.
+# Port forwarding in rootful mode no longer works with older versions of nerdctl.
+archives:
+- location: https://github.com/containerd/nerdctl/releases/download/v2.2.2/nerdctl-full-2.2.2-linux-amd64.tar.gz
+  arch: x86_64
+  digest: sha256:8a477f35533c6cc1120c19558d8142967c74f25a4b952b481f48104e030de914
+- location: https://github.com/containerd/nerdctl/releases/download/v2.2.2/nerdctl-full-2.2.2-linux-arm64.tar.gz
+  arch: aarch64
+  digest: sha256:55d68d2613b5f065021146bac21f620cde9e7fdd4bd3eff74cd324f5462e107a
+# No arm-v7
+# No riscv64

--- a/share/lima/defaults/networks.TEMPLATE.yaml
+++ b/share/lima/defaults/networks.TEMPLATE.yaml
@@ -1,0 +1,38 @@
+# Path to socket_vmnet executable. Because socket_vmnet is invoked via sudo it should be
+# installed where only root can modify/replace it. This means also none of the
+# parent directories can be writable by the user.
+#
+# The varRun directory also must not be writable by the user because it will
+# include the socket_vmnet pid file. Those will be terminated via sudo, so replacing
+# the pid file would allow killing of arbitrary privileged processes. varRun
+# however MUST be writable by the daemon user.
+#
+# None of the paths segments may be symlinks, why it has to be /private/var
+# instead of /var etc.
+paths:
+# socketVMNet requires Lima >= 0.12 .
+  socketVMNet: "{{.SocketVMNet}}"
+  varRun: /private/var/run/lima
+  sudoers: /private/etc/sudoers.d/lima
+
+group: everyone
+
+networks:
+  user-v2:
+    mode: user-v2
+    gateway: 192.168.104.1
+    netmask: 255.255.255.0
+  shared:
+    mode: shared
+    gateway: 192.168.105.1
+    dhcpEnd: 192.168.105.254
+    netmask: 255.255.255.0
+  bridged:
+    mode: bridged
+    interface: en0
+    # bridged mode doesn't have a gateway; dhcp is managed by outside network
+  host:
+    mode: host
+    gateway: 192.168.106.1
+    dhcpEnd: 192.168.106.254
+    netmask: 255.255.255.0


### PR DESCRIPTION
## What This PR Changes

This PR externalizes Lima's default configurations and templates (`containerd.yaml`, `networks.TEMPLATE.yaml`, `cidata.TEMPLATE.d/`, `launchd` plist, and `systemd` service) to the system share directory (`<PREFIX>/share/lima/`).

Key changes:
- Adds `usrlocal.ReadFile` and `usrlocal.DirFS` to query installed `share/lima/` directories.
- Implements disk-first loading for templates across `pkg/limayaml`, `pkg/networks`, `pkg/cidata`, `pkg/autostart/launchd`, and `pkg/autostart/systemd`.
- Preserves compile-time `//go:embed` as a fallback when disk resources are absent (preventing runtime panics for standalone binaries built with `go install`).
- Updates `Makefile` targets to bundle `defaults`, `autostart`, and `cidata.TEMPLATE.d` into release artifacts (`_output/share/lima/`).

## Linked Issue (Required in most cases)

Closes #5295

## How I Tested This

- `go test ./pkg/...` (All unit tests passed cleanly)
- `go test -v ./pkg/usrlocal/...`
- `make share-lima` (Verified output structure under `_output/share/lima/`)


Note for reviewers:

The actual Go logic changes in this PR are minimal (~100 lines across `usrlocal`, `limayaml`, `networks`, `cidata`, and `autostart`). 

The majority of the 47 files listed in the diff come from copying the existing `cidata.TEMPLATE.d/` guest boot scripts into `share/lima/cidata.TEMPLATE.d/` so they are tracked as externalized disk resources.
