### PR TITLE
quote guest error string in time sync log

### DIFF
--- a/pkg/hostagent/timesync.go
+++ b/pkg/hostagent/timesync.go
@@ -60,7 +60,7 @@ func (a *HostAgent) syncTimeOnce(ctx context.Context) {
 	}
 
 	if resp.Error != "" {
-		logrus.Warnf("Time sync: guest failed to set time: %s (drift was %dms)", resp.Error, resp.DriftMs)
+		logrus.Warnf("Time sync: guest failed to set time: %#q (drift was %dms)", resp.Error, resp.DriftMs)
 		return
 	}
 


### PR DESCRIPTION
syncTimeOnce logs the guest agent's TimeSyncResponse.Error with %s, but that field is a proto string the guest sets, so a compromised guest can return CR/LF and ANSI escape bytes that forge log lines or inject terminal escapes into the host agent's log stream. This runs automatically every 10s. Log it with %#q, matching how the rest of hostagent already renders guest-supplied strings (e.g. the "received error from the guest" line).