### PR TITLE
match static hosts case-insensitively in lookupCnameToHost

### DIFF
--- a/pkg/hostagent/dns/dns.go
+++ b/pkg/hostagent/dns/dns.go
@@ -212,7 +212,7 @@ func (h *Handler) handleQuery(ctx context.Context, w dns.ResponseWriter, req *dn
 					continue
 				}
 			}
-			if cname != "" && cname != q.Name {
+			if cname != "" && cname != dns.CanonicalName(q.Name) {
 				hdr.Rrtype = dns.TypeCNAME
 				a := &dns.CNAME{
 					Hdr:    hdr,

--- a/pkg/hostagent/dns/dns.go
+++ b/pkg/hostagent/dns/dns.go
@@ -73,6 +73,10 @@ func newStaticClientConfig(ips []string) (*dns.ClientConfig, error) {
 }
 
 func (h *Handler) lookupCnameToHost(cname string) string {
+	// Domain names are case-insensitive (RFC 4343), and the static host maps are
+	// keyed by dns.CanonicalName, so the query name has to be folded the same way
+	// before it is matched against them.
+	cname = dns.CanonicalName(cname)
 	seen := make(map[string]bool)
 	for !seen[cname] { // break cyclic definition
 		if _, ok := h.cnameToHost[cname]; ok {

--- a/pkg/hostagent/dns/dns_test.go
+++ b/pkg/hostagent/dns/dns_test.go
@@ -232,6 +232,25 @@ func TestDNSRecords(t *testing.T) {
 		}
 	})
 
+	t.Run("test static hosts are matched case-insensitively", func(t *testing.T) {
+		tests := []struct {
+			testDomain     string
+			expectedRecord string
+			qtype          uint16
+		}{
+			{testDomain: "My.Domain.Com", expectedRecord: `My.Domain.Com.\s+5\s+IN\s+A\s+192.168.0.23`, qtype: dns.TypeA},
+			{testDomain: "HOST.LIMA.INTERNAL", expectedRecord: `HOST.LIMA.INTERNAL.\s+5\s+IN\s+A\s+10.10.0.34`, qtype: dns.TypeA},
+			{testDomain: "MY.HOST", expectedRecord: `MY.HOST.\s+5\s+IN\s+CNAME\s+host.lima.internal.`, qtype: dns.TypeCNAME},
+		}
+
+		for _, tc := range tests {
+			req := new(dns.Msg)
+			req.SetQuestion(dns.Fqdn(tc.testDomain), tc.qtype)
+			h.ServeDNS(w, req)
+			assert.Assert(t, regexMatch(dnsResult.String(), tc.expectedRecord))
+		}
+	})
+
 	t.Run("test cyclic CNAME records", func(t *testing.T) {
 		tests := []struct {
 			testDomain    string


### PR DESCRIPTION
1. `NewHandler` keys `hostToIP` and `cnameToHost` by `dns.CanonicalName`, so both maps are lowercased and fully qualified.
2. `handleQuery` matches against them with the raw `q.Name`, which is never folded. Domain names are case-insensitive (RFC 4343) and stub resolvers vary query-name case deliberately (DNS 0x20), so a guest asking for `HOST.LIMA.INTERNAL` misses the map, falls through to `handleDefault`, and gets whatever the system resolver or upstream returns instead of the configured address. Same for anything an operator pins through `hostResolver.hosts`.
3. Folded the name in `lookupCnameToHost`, the one entry point the A/AAAA and CNAME paths share. The answer still echoes the owner name as it was queried.

`go test ./pkg/hostagent/dns/` covers it. The new subtest fails before the change, with the mixed-case query answered by the upstream resolver rather than the static entry.