### PR TITLE
Support stopping multiple instances in limactl stop

### DIFF
--- a/cmd/limactl/stop.go
+++ b/cmd/limactl/stop.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/lima-vm/lima/v2/pkg/instance"
@@ -13,9 +15,9 @@ import (
 
 func newStopCommand() *cobra.Command {
 	stopCmd := &cobra.Command{
-		Use:               "stop INSTANCE",
+		Use:               "stop INSTANCE [INSTANCE, ...]",
 		Short:             "Stop an instance",
-		Args:              WrapArgsError(cobra.MaximumNArgs(1)),
+		Args:              WrapArgsError(cobra.ArbitraryArgs),
 		RunE:              stopAction,
 		ValidArgsFunction: stopBashComplete,
 		GroupID:           basicCommand,
@@ -27,30 +29,37 @@ func newStopCommand() *cobra.Command {
 
 func stopAction(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	instName := DefaultInstanceName
-	if len(args) > 0 {
-		instName = args[0]
-	}
 
-	inst, err := store.Inspect(ctx, instName)
-	if err != nil {
-		return err
+	instNames := args
+	if len(instNames) == 0 {
+		instNames = []string{DefaultInstanceName}
 	}
 
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
 		return err
 	}
-	if force {
-		instance.StopForcibly(inst)
-	} else {
-		err = instance.StopGracefully(ctx, inst, false)
+
+	var errs []error
+	for _, instName := range instNames {
+		inst, err := store.Inspect(ctx, instName)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		if force {
+			instance.StopForcibly(inst)
+		} else if err := instance.StopGracefully(ctx, inst, false); err != nil {
+			errs = append(errs, err)
+		}
 	}
+
 	// TODO: should we also reconcile networks if graceful stop returned an error?
-	if err == nil {
-		err = reconcile.Reconcile(ctx, "")
+	if err := reconcile.Reconcile(ctx, ""); err != nil {
+		errs = append(errs, err)
 	}
-	return err
+	return errors.Join(errs...)
 }
 
 func stopBashComplete(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
## What this does
Updates `limactl stop` to accept multiple instance names in a single command,
following the same pattern already used by `limactl delete`.

Before:
    limactl stop instance1
    limactl stop instance2

After:
    limactl stop instance1 instance2

## Changes
- Changed `Args` from `cobra.MaximumNArgs(1)` to `cobra.ArbitraryArgs`
- Updated `Use` string to `stop INSTANCE [INSTANCE, ...]`
- Rewrote `stopAction` to loop over all provided instance names, collecting
  errors with `errors.Join` instead of returning on the first failure —
  matching the existing pattern in `deleteAction`
- `reconcile.Reconcile` is now called once after all instances are processed,
  rather than per-instance

## Testing
- `go build` succeeds
- Verified `--help` shows updated usage
- Verified multiple nonexistent instance names both surface in the error
  output (confirms the loop processes all args, not just the first)

Closes #5367