### PR TITLE
Add parameter for Kubernetes registry (k3s)

### DIFF
--- a/templates/k3s.yaml
+++ b/templates/k3s.yaml
@@ -41,6 +41,15 @@ provision:
             INSTALL_K3S_ARTIFACT_URL={{.Param.proxy}}/HTTPS///github.com/k3s-io/k3s/releases/download
             export INSTALL_K3S_ARTIFACT_URL
     {{- end}}
+    {{if .Param.mirror }}
+            mkdir -p /etc/rancher/k3s
+            cat <<EOF >/etc/rancher/k3s/registries.yaml
+    mirrors:
+      "*":
+        endpoint:
+          - "{{.Param.mirror}}"
+    EOF
+    {{end}}
     {{if not ( and .Param.url .Param.token )}}
             curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --write-kubeconfig-mode 644" sh -
     {{else}}
@@ -78,5 +87,8 @@ param:
   # The proxy to use when downloading artifacts from k3s.io
   # For a local proxy use for instance "http://host.lima.internal:3142"
   proxy: ""
+  # The mirror to use when pulling images from registry
+  # For a local mirror use for instance "http://host.lima.internal:8080"
+  mirror: ""
   url: ""
   token: ""


### PR DESCRIPTION
Now supports a parameter "mirror" for pulling the images from:

`mirror: "http://host.lima.internal:8080"`

A pull-through cache for docker.io and other registries is at:

https://aceeric.github.io/ociregistry/

## What This PR Changes

Adds the same "mirror" support as was in k8s (v2.2.0), also to k3s template:

* https://github.com/lima-vm/lima/pull/5200

Good to have the same parameter support, for both Kubernetes templates?

Previously it was using a tarball archive for k3s, but a registry mirror for k8s.

## Linked Issue (Required in most cases)

Issue #4875

## How I Tested This

```
limactl start ./templates/k3s.yaml --param mirror="http://host.lima.internal:8080"
```

## AI Usage

No

----

https://docs.k3s.io/installation/private-registry

Main feature is that it will also cache the apps.