### PR TITLE
Add any go comments to the jsonschema

### DIFF
--- a/cmd/limactl/genschema.go
+++ b/cmd/limactl/genschema.go
@@ -52,7 +52,12 @@ func genschemaAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	schema := jsonschema.Reflect(&limatype.LimaYAML{})
+	reflector := new(jsonschema.Reflector)
+	err = reflector.AddGoComments("github.com/lima-vm/lima/v2", "./")
+	if err != nil {
+		return err
+	}
+	schema := reflector.Reflect(&limatype.LimaYAML{})
 	// allow Disk to be either string (name) or object (struct)
 	schema.Definitions["Disk"].Type = "" // was: "object"
 	schema.Definitions["Disk"].OneOf = []*jsonschema.Schema{


### PR DESCRIPTION

## What This PR Changes

Found a setting in the schema generator, that would also include the Go comments from the struct.

https://github.com/invopop/jsonschema#using-go-comments

## Linked Issue (Required in most cases)

Broken out from:

PR #5339

## How I Tested This

## AI Usage
