### PR TITLE
DO NOT MERGE: hostagent: add a timeout to requirement check attempts

### DIFF
--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -25,6 +25,10 @@ func (a *HostAgent) waitForRequirements(label string, requirements []requirement
 	const (
 		retries       = 200
 		sleepDuration = 3 * time.Second
+		// attemptTimeout limits a single probe attempt; the connection is
+		// local, so a probe that outlives the retry interval is wedged
+		// (e.g. security software interfering with the socket), not slow.
+		attemptTimeout = 3 * time.Second
 	)
 	var errs []error
 
@@ -37,7 +41,9 @@ func (a *HostAgent) waitForRequirements(label string, requirements []requirement
 		logrus.Infof("Waiting for the %s requirement %d of %d: %#q", label, i+1, len(requirements), req.description)
 	retryLoop:
 		for j := range retries {
-			err := fn(req)
+			ctx, cancel := context.WithTimeout(context.Background(), attemptTimeout)
+			err := fn(ctx, req)
+			cancel()
 			if err == nil {
 				logrus.Infof("The %s requirement %d of %d is satisfied", label, i+1, len(requirements))
 				break retryLoop
@@ -118,7 +124,7 @@ func (a *HostAgent) bashAvailable() bool {
 	return *a.instConfig.OS != limatype.FREEBSD && *a.instConfig.OS != limatype.WINDOWS
 }
 
-func (a *HostAgent) waitForRequirement(r requirement) error {
+func (a *HostAgent) waitForRequirement(ctx context.Context, r requirement) error {
 	logrus.Debugf("executing script %#q", r.description)
 	script := r.script
 	if a.bashAvailable() {
@@ -148,7 +154,7 @@ func (a *HostAgent) waitForRequirement(r requirement) error {
 			AdditionalArgs: sshutil.DisableControlMasterOptsFromSSHArgs(sshConfig.AdditionalArgs),
 		}
 	}
-	stdout, stderr, err := ssh.ExecuteScript(a.instSSHAddress, a.sshLocalPort, sshConfig, script, r.description)
+	stdout, stderr, err := executeScript(ctx, a.instSSHAddress, a.sshLocalPort, sshConfig, script, r.description)
 	logrus.Debugf("stdout=%#q, stderr=%#q, err=%v", stdout, stderr, err)
 	if err != nil {
 		return fmt.Errorf("stdout=%#q, stderr=%#q: %w", stdout, stderr, err)
@@ -156,10 +162,42 @@ func (a *HostAgent) waitForRequirement(r requirement) error {
 	return nil
 }
 
+// executeScript is sshocker's ssh.ExecuteScript with a context added, so a
+// wedged ssh process is killed when the attempt times out.
+// TODO: Support contexts on sshocker, and replace this function.
+func executeScript(ctx context.Context, host string, port int, c *ssh.SSHConfig, script, scriptName string) (stdout, stderr string, err error) {
+	if c == nil {
+		return "", "", errors.New("got nil SSHConfig")
+	}
+	interpreter, err := ssh.ParseScriptInterpreter(script)
+	if err != nil {
+		return "", "", err
+	}
+	sshBinary := c.Binary()
+	sshArgs := c.Args()
+	if port != 0 {
+		sshArgs = append(sshArgs, "-p", strconv.Itoa(port))
+	}
+	sshArgs = append(sshArgs, host, "--", interpreter)
+	sshCmd := exec.CommandContext(ctx, sshBinary, sshArgs...)
+	sshCmd.Stdin = strings.NewReader(script)
+	var stderrBuf bytes.Buffer
+	sshCmd.Stderr = &stderrBuf
+	logrus.Debugf("executing ssh for script %q: %s %v", scriptName, sshCmd.Path, sshCmd.Args)
+	out, err := sshCmd.Output()
+	if err != nil {
+		if ctxErr := context.Cause(ctx); ctxErr != nil {
+			err = fmt.Errorf("%w: %w", ctxErr, err)
+		}
+		return string(out), stderrBuf.String(), fmt.Errorf("failed to execute script %q: stdout=%q, stderr=%q: %w", scriptName, string(out), stderrBuf.String(), err)
+	}
+	return string(out), stderrBuf.String(), nil
+}
+
 // This function is copied from sshocker's ExecuteScript, because
 // the function doesn't support Windows commands.
 // TODO: Support Windows on sshocker, and replace this function.
-func (a *HostAgent) waitForWinRequirement(r requirement) error {
+func (a *HostAgent) waitForWinRequirement(ctx context.Context, r requirement) error {
 	logrus.Debugf("executing script for windows %q", r.description)
 	script := r.script
 	sshConfig := a.sshConfig
@@ -190,13 +228,16 @@ func (a *HostAgent) waitForWinRequirement(r requirement) error {
 		sshArgs = append(sshArgs, "-p", strconv.Itoa(a.sshLocalPort))
 	}
 	sshArgs = append(sshArgs, a.instSSHAddress, "--", script)
-	sshCmd := exec.CommandContext(context.Background(), sshBinary, sshArgs...)
+	sshCmd := exec.CommandContext(ctx, sshBinary, sshArgs...)
 	sshCmd.Stdin = strings.NewReader(script)
 	var stderr bytes.Buffer
 	sshCmd.Stderr = &stderr
 	logrus.Debugf("executing ssh for script :%s %v", sshCmd.Path, sshCmd.Args)
 	out, err := sshCmd.Output()
 	if err != nil {
+		if ctxErr := context.Cause(ctx); ctxErr != nil {
+			err = fmt.Errorf("%w: %w", ctxErr, err)
+		}
 		return fmt.Errorf("failed to execute script: stdout=%q, stderr=%q: %w", string(out), stderr.String(), err)
 	}
 	return nil

--- a/pkg/hostagent/requirements_test.go
+++ b/pkg/hostagent/requirements_test.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hostagent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/lima-vm/sshocker/pkg/ssh"
+	"gotest.tools/v3/assert"
+)
+
+const testScript = "#!/bin/sh\ntrue\n"
+
+// fakeSSH prepends a fake ssh binary to PATH so executeScript runs it instead
+// of the real ssh client.
+func fakeSSH(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" + body + "\n"
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "ssh"), []byte(script), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestExecuteScript(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell to fake the ssh binary")
+	}
+	fakeSSH(t, "exit 0")
+	_, _, err := executeScript(t.Context(), "127.0.0.1", 0, &ssh.SSHConfig{}, testScript, "test")
+	assert.NilError(t, err)
+}
+
+func TestExecuteScriptTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell to fake the ssh binary")
+	}
+	fakeSSH(t, "exec sleep 30")
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, _, err := executeScript(ctx, "127.0.0.1", 0, &ssh.SSHConfig{}, testScript, "test")
+	assert.Assert(t, err != nil)
+	assert.Assert(t, errors.Is(err, context.DeadlineExceeded), "unexpected error: %v", err)
+	assert.Assert(t, time.Since(start) < 10*time.Second, "the ssh process was not killed by the context")
+}


### PR DESCRIPTION
A requirement check gets 200 retries, but each attempt waits on its ssh probe forever, so one connection that never returns blocks startup until limactl's watchdog expires. This happened on a macOS host where security software withheld data from the first ssh connection while a second connection succeeded instantly (rancher-sandbox/rancher-desktop#10761).

Kill the probe after 3 seconds and let the loop retry; the connection is local, so a slow probe is a wedged probe.

Assisted-by: Fable 5

---

This should not be merged as-is; part of the change should go into sshocker instead.