### PR TITLE
portfwd: don't close the live udp listener on a duplicate forward

### DIFF
--- a/pkg/portfwd/listener.go
+++ b/pkg/portfwd/listener.go
@@ -130,7 +130,6 @@ func (p *ClosableListeners) forwardTCP(ctx context.Context, dialContext func(ctx
 
 func (p *ClosableListeners) forwardUDP(ctx context.Context, dialContext func(ctx context.Context, network string, addr string) (net.Conn, error), hostAddress, guestAddress string) {
 	key := key("udp", hostAddress, guestAddress)
-	defer p.Remove(ctx, "udp", hostAddress, guestAddress)
 
 	p.udpListenersRW.Lock()
 	_, ok := p.udpListeners[key]
@@ -145,6 +144,7 @@ func (p *ClosableListeners) forwardUDP(ctx context.Context, dialContext func(ctx
 		p.udpListenersRW.Unlock()
 		return
 	}
+	defer p.Remove(ctx, "udp", hostAddress, guestAddress)
 	p.udpListeners[key] = udpConn
 	p.udpListenersRW.Unlock()
 

--- a/pkg/portfwd/listener_test.go
+++ b/pkg/portfwd/listener_test.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package portfwd
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/freeport"
+)
+
+func hasUDPListener(p *ClosableListeners, k string) bool {
+	p.udpListenersRW.Lock()
+	defer p.udpListenersRW.Unlock()
+	_, ok := p.udpListeners[k]
+	return ok
+}
+
+func waitUDPListener(p *ClosableListeners, k string) bool {
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if hasUDPListener(p, k) {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// A guest can report a port it has already reported, e.g. after the guest agent
+// reconnects. The duplicate has to be a no-op, not a teardown of the live listener.
+func TestForwardUDPDuplicateKeepsListener(t *testing.T) {
+	port, err := freeport.UDP()
+	assert.NilError(t, err)
+	hostAddress := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	guestAddress := "127.0.0.1:60000"
+	k := key("udp", hostAddress, guestAddress)
+
+	p := NewClosableListener()
+	defer p.Close()
+
+	dialContext := func(_ context.Context, _, _ string) (net.Conn, error) {
+		return nil, errors.New("dial is not expected in this test")
+	}
+
+	served := make(chan struct{})
+	go func() {
+		defer close(served)
+		p.forwardUDP(t.Context(), dialContext, hostAddress, guestAddress)
+	}()
+	assert.Assert(t, waitUDPListener(p, k), "timed out waiting for the UDP listener to be registered")
+
+	p.forwardUDP(t.Context(), dialContext, hostAddress, guestAddress)
+
+	assert.Assert(t, hasUDPListener(p, k), "duplicate forward closed the existing listener")
+	select {
+	case <-served:
+		assert.Assert(t, false, "duplicate forward stopped the running listener")
+	case <-time.After(100 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
forwardUDP registers its cleanup with `defer p.Remove(...)` as its first statement, before the check for a listener already registered under the same key, so the deduplication path carries that cleanup out with it. The host reaches that path whenever the guest agent reports a UDP port it has already reported, which happens on every guest agent reconnect since the agent re-sends its whole local port list, and which the guest can also trigger on demand by repeating an entry inside one event. Remove closes the PacketConn the first goroutine is still serving through HandleUDPConnection and drops the map entry, so the forward is gone while the rule is still in effect and neither side notices. That first goroutine then unwinds out of proxy.Run and runs its own deferred Remove, which can take out a listener a later re-add has since installed under the same key. I found it while comparing the two forwarders side by side: forwardTCP registers the identical defer only after the duplicate check and a successful bind, and the UDP one is the odd one out. Moving the defer to the same position gives forwardUDP the same ownership rule, and the listen-failure path that no longer calls Remove never held the key anyway. The regression test fails on master and passes with the change.