### PR TITLE
Allow installing k8s on minimal image variant

### DIFF
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -53,11 +53,7 @@ provision:
     # Installing kubeadm, kubelet and kubectl
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
-    {{- if .Param.proxy }}
-    apt-get install -y --no-upgrade ca-certificates curl
-    {{- else}}
-    apt-get install -y apt-transport-https ca-certificates curl
-    {{- end}}
+    apt-get install -y --no-upgrade ca-certificates curl gnupg
     STABILITY="{{.Param.stability}}"
     {{if eq .Param.release "stable" }}
     RELEASE=$(curl -L -s https://dl.k8s.io/release/stable.txt | cut -d'.' -f1-2)


### PR DESCRIPTION

## What This PR Changes

The kubernetes template was failing, when running on the "minimal" ubuntu images...

The "gnupg" package was not installed by default, causing the package installation to fail.

`407M	ubuntu-26.04-minimal-cloudimg-amd64.img`

`821M	ubuntu-26.04-server-cloudimg-amd64.img`

## Linked Issue (Required in most cases)

<!-- Link the issue here. If your issue is not approved by a maintainer, don't expect your PR to be merged. -->

Closes #

## How I Tested This

`limactl start --yes template:k8s --image-variant minimal`

## AI Usage

No