### PR TITLE
fix(krunkit): add `spirv` library to build `llama.cpp` successfully

### DIFF
--- a/website/content/en/docs/config/vmtype/krunkit.md
+++ b/website/content/en/docs/config/vmtype/krunkit.md
@@ -160,19 +160,31 @@ dnf versionlock add "mesa-vulkan-drivers-${MESA_VERSION}"
 dnf clean all
 
 echo "Installing llama.cpp with Vulkan support..."
-# Build and install llama.cpp with Vulkan support
-dnf install -y git cmake clang curl-devel glslc vulkan-devel virglrenderer
-(
-  cd ~
-  git clone https://github.com/ggml-org/llama.cpp
-  (
-    cd llama.cpp
-    cmake -B build -DGGML_VULKAN=ON -DGGML_CCACHE=OFF -DGGML_NATIVE=OFF -DCMAKE_INSTALL_PREFIX=/usr
-    cmake --build build --config Release -j8
-    cmake --install build
-  )
-  rm -fr llama.cpp
-)
+# Build and install llama.cpp with Vulkan support.
+dnf install -y \
+  git \
+  cmake \
+  clang \
+  curl-devel \
+  spirv-headers-devel \
+  spirv-tools-devel \
+  vulkan-devel \
+  virglrenderer
+
+# Build out of tree so a failed or interrupted run never leaves a stale
+# checkout behind that would break the next attempt.
+SRC_DIR=$(mktemp -d)
+trap 'rm -rf "$SRC_DIR"' EXIT
+
+git clone --depth 1 https://github.com/ggml-org/llama.cpp "$SRC_DIR"
+cmake -S "$SRC_DIR" -B "$SRC_DIR/build" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DGGML_VULKAN=ON \
+  -DGGML_CCACHE=OFF \
+  -DGGML_NATIVE=OFF
+cmake --build "$SRC_DIR/build" --config Release -j"$(nproc)"
+cmake --install "$SRC_DIR/build"
 
 echo "Successfully installed llama.cpp with Vulkan support. Use 'llama-cli' app with .gguf models."
 ```


### PR DESCRIPTION
## What This PR Changes

Adds `spirv-headers-devel` and `spirv-tools-devel` to the list of dependencies to ensure all required Vulkan components are available. These changes also ensures that a failed or interrupted build of `llama.cpp` do not leave stale files or directories that could cause future build failures.

## Linked Issue

<!-- Link the issue here. If your issue is not approved by a maintainer, don't expect your PR to be merged. -->

Fixes:
```
CMake Error at ggml/src/ggml-vulkan/CMakeLists.txt:14 (find_package):
  Could not find a package configuration file provided by "SPIRV-Headers"
  with any of the following names:

    SPIRV-HeadersConfig.cmake
    spirv-headers-config.cmake

  Add the installation prefix of "SPIRV-Headers" to CMAKE_PREFIX_PATH or set
  "SPIRV-Headers_DIR" to a directory containing one of the above files.  If
  "SPIRV-Headers" provides a separate development package or SDK, be sure it
  has been installed.


-- Configuring incomplete, errors occurred!
```

## How I Tested This

By following the doc for `Run models without containers (hard way)`:
https://deploy-preview-5388--lima-vm.netlify.app/docs/config/vmtype/krunkit/#2-run-models-without-containers-hard-way