### PR TITLE
fix(wsl): fix ssh address for mirrored networking

### DIFF
--- a/pkg/driver/wsl2/vm_windows.go
+++ b/pkg/driver/wsl2/vm_windows.go
@@ -257,6 +257,8 @@ func getWslStatus(ctx context.Context, instName string) (string, error) {
 }
 
 // GetSSHAddress runs a hostname command to get the IP from inside of a wsl2 VM.
+// In WSL2 mirrrored mode, this should return 127.0.0.1 per Microsoft docs
+// https://learn.microsoft.com/en-us/windows/wsl/networking
 //
 // Expected output (whitespace preserved, [] for optional):
 // PS > wsl -d <distroName> bash -c hostname -I | cut -d' ' -f1
@@ -265,9 +267,20 @@ func getWslStatus(ctx context.Context, instName string) (string, error) {
 // hostname: unrecognized option: I
 func getSSHAddress(ctx context.Context, instName string) (string, error) {
 	distroName := "lima-" + instName
-	// Ubuntu
-	cmd := exec.CommandContext(ctx, "wsl.exe", "-d", distroName, "bash", "-c", `hostname -I | cut -d ' ' -f1`)
+
+	// Mirrored networking
+	cmd := exec.CommandContext(ctx, "wsl.exe", "-d", distroName, "wslinfo", "--networking-mode")
 	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to check networking mode for instance %s: %w", distroName, err)
+	}
+	if strings.TrimSpace(string(out)) == "mirrored" {
+		return "127.0.0.1", nil
+	}
+
+	// Ubuntu
+	cmd = exec.CommandContext(ctx, "wsl.exe", "-d", distroName, "bash", "-c", `hostname -I | cut -d ' ' -f1`)
+	out, err = cmd.CombinedOutput()
 	if err == nil {
 		return strings.TrimSpace(string(out)), nil
 	}


### PR DESCRIPTION
<!-- Please read our contribution rules before submitting:

- Pull requests guide: https://lima-vm.io/docs/community/contributing/#sending-pull-requests
- AI usage policy: https://lima-vm.io/docs/community/contributing/#ai-contribution-rules

-->

## What This PR Changes

<!-- Explain the single problem this PR fixes, in your own words. -->

This PR returns localhost for mirrored networking mode in WSL2. The existing behavior of checking the hostname from within the VM doesn't work for mirrored networking per the Microsoft [docs](https://learn.microsoft.com/en-us/windows/wsl/networking), and the docs recommend this approach instead

## Linked Issue (Required in most cases)

<!-- Link the issue here. If your issue is not approved by a maintainer, don't expect your PR to be merged. -->

Closes #5392 

## How I Tested This

I tested this with the workflow in runfinch/finch, where running a container would previously time out. With this change, the container runs as expected.

## AI Usage

<!-- If you used AI tools, say which tool and how you used it. For example, `Assisted-by: AI_AGENT_NAME:VERSION [TOOL]` or `Co-Authored-By`-->