### PR TITLE
fix: Disable LLMNR to prevent Debian SSH login delay

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/06-enable-mdns-on-systemd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/06-enable-mdns-on-systemd.sh
@@ -18,6 +18,9 @@ command -v resolvectl >/dev/null 2>&1 || exit 0
 enable_mdns_conf_path=/etc/systemd/resolved.conf.d/00-lima-enable-mdns.conf
 enable_mdns_conf_content="[Resolve]
 MulticastDNS=yes
+{{if .Param.internal_disableLLMNR -}}
+LLMNR=no
+{{end -}}
 "
 # Create /etc/systemd/resolved.conf.d/00-lima-enable-mdns.conf if its content is different
 if [ "$(echo "${enable_mdns_conf_content}" | sha256sum)" != "$(sha256sum <"${enable_mdns_conf_path}" 2>/dev/null)" ]; then

--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/06-enable-mdns-on-systemd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/06-enable-mdns-on-systemd.sh
@@ -16,12 +16,12 @@ command -v resolvectl >/dev/null 2>&1 || exit 0
 
 # Configure systemd-resolved to enable mDNS resolution globally
 enable_mdns_conf_path=/etc/systemd/resolved.conf.d/00-lima-enable-mdns.conf
-enable_mdns_conf_content="[Resolve]
+enable_mdns_conf_content='[Resolve]
 MulticastDNS=yes
-{{if .Param.internal_disableLLMNR -}}
+{{if eq .Param.internal_disableLLMNR "true" -}}
 LLMNR=no
 {{end -}}
-"
+'
 # Create /etc/systemd/resolved.conf.d/00-lima-enable-mdns.conf if its content is different
 if [ "$(echo "${enable_mdns_conf_content}" | sha256sum)" != "$(sha256sum <"${enable_mdns_conf_path}" 2>/dev/null)" ]; then
 	mkdir -p "$(dirname "${enable_mdns_conf_path}")"

--- a/pkg/cidata/template_test.go
+++ b/pkg/cidata/template_test.go
@@ -125,16 +125,33 @@ func TestTemplate(t *testing.T) {
 	}
 	layout, err := ExecuteTemplateCIDataISO(args)
 	assert.NilError(t, err)
+	var resolverBootScript string
 	for _, f := range layout {
 		t.Logf("=== %#q ===", f.Path)
 		b, err := io.ReadAll(f.Reader)
 		assert.NilError(t, err)
 		t.Log(string(b))
+		if f.Path == "boot.Linux/06-enable-mdns-on-systemd.sh" {
+			resolverBootScript = string(b)
+		}
 		if f.Path == "user-data" {
 			// mounted later
 			assert.Assert(t, !strings.Contains(string(b), "mounts:"))
 			// ca_certs:
 			assert.Assert(t, !strings.Contains(string(b), "trusted:"))
+		}
+	}
+	assert.Assert(t, strings.Contains(resolverBootScript, "MulticastDNS=yes"))
+	assert.Assert(t, !strings.Contains(resolverBootScript, "LLMNR=no"))
+
+	args.Param = map[string]string{"internal_disableLLMNR": "true"}
+	layout, err = ExecuteTemplateCIDataISO(args)
+	assert.NilError(t, err)
+	for _, f := range layout {
+		if f.Path == "boot.Linux/06-enable-mdns-on-systemd.sh" {
+			b, err := io.ReadAll(f.Reader)
+			assert.NilError(t, err)
+			assert.Assert(t, strings.Contains(string(b), "LLMNR=no"))
 		}
 	}
 }

--- a/pkg/cidata/template_test.go
+++ b/pkg/cidata/template_test.go
@@ -144,15 +144,22 @@ func TestTemplate(t *testing.T) {
 	assert.Assert(t, strings.Contains(resolverBootScript, "MulticastDNS=yes"))
 	assert.Assert(t, !strings.Contains(resolverBootScript, "LLMNR=no"))
 
-	args.Param = map[string]string{"internal_disableLLMNR": "true"}
-	layout, err = ExecuteTemplateCIDataISO(args)
-	assert.NilError(t, err)
-	for _, f := range layout {
-		if f.Path == "boot.Linux/06-enable-mdns-on-systemd.sh" {
-			b, err := io.ReadAll(f.Reader)
+	for _, disableLLMNR := range []string{"", "false", "true"} {
+		t.Run("disableLLMNR="+disableLLMNR, func(t *testing.T) {
+			args.Param = map[string]string{"internal_disableLLMNR": disableLLMNR}
+			layout, err := ExecuteTemplateCIDataISO(args)
 			assert.NilError(t, err)
-			assert.Assert(t, strings.Contains(string(b), "LLMNR=no"))
-		}
+			var script string
+			for _, f := range layout {
+				if f.Path == "boot.Linux/06-enable-mdns-on-systemd.sh" {
+					b, err := io.ReadAll(f.Reader)
+					assert.NilError(t, err)
+					script = string(b)
+				}
+			}
+			assert.Equal(t, strings.Contains(script, "LLMNR=no\n"), disableLLMNR == "true")
+			assert.Equal(t, strings.Replace(script, "LLMNR=no\n", "", 1), resolverBootScript)
+		})
 	}
 }
 

--- a/templates/_images/debian-13.yaml
+++ b/templates/_images/debian-13.yaml
@@ -64,3 +64,6 @@ images:
   variant: "nocloud"
 
 mountTypesUnsupported: [9p]
+
+param:
+  internal_disableLLMNR: "true"

--- a/templates/_images/debian-13.yaml
+++ b/templates/_images/debian-13.yaml
@@ -65,5 +65,10 @@ images:
 
 mountTypesUnsupported: [9p]
 
+# Debian 13's sshd passes an UNKNOWN peer address for vsock connections to Linux
+# audit, which tries to resolve it via LLMNR and delays interactive SSH logins.
+# Remove this workaround when the images include the OpenSSH fix:
+# https://github.com/openssh/openssh-portable/commit/e5055ef26abc
+# See https://github.com/lima-vm/lima/issues/5389
 param:
   internal_disableLLMNR: "true"


### PR DESCRIPTION
## What This PR Changes

Extend the existing `[Resolve]` content in `pkg/cidata/cidata.TEMPLATE.d/boot.Linux/06-enable-mdns-on-systemd.sh` with `LLMNR=no`, while preserving `MulticastDNS=yes` and the current per-link mDNS setup. Keep the existing content-hash comparison and resolver restart behavior so an existing guest receives the corrected drop-in once and subsequent boots remain idempotent. Add a focused assertion to the existing cidata template test that inspects the emitted `boot.Linux/06-enable-mdns-on-systemd.sh` artifact and verifies that both resolver directives are present.

Closes #5389

## Linked Issue (Required in most cases)

Closes #

## How I Tested This

Not applicable to this change.

## AI Usage

Not applicable to this change.

AI was used for assistance.
