### PR TITLE
sshutil: only prioritize ciphers ssh actually supports

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -373,6 +373,12 @@ type openSSHInfo struct {
 
 	// Some distributions omit this feature by default, for example, Alpine, NixOS.
 	GSSAPISupported bool
+
+	// SupportedCiphers is the set of cipher names reported by `ssh -Q cipher`.
+	// It is empty when the query could not be run or produced no output
+	// (e.g. very old ssh clients that do not support "-Q"), in which case
+	// callers should not filter ciphers based on it.
+	SupportedCiphers map[string]bool
 }
 
 var sshInfo struct {
@@ -380,9 +386,6 @@ var sshInfo struct {
 	// aesAccelerated is set to true when AES acceleration is available.
 	// Available on almost all modern Intel/AMD processors.
 	aesAccelerated bool
-
-	// OpenSSH executable information for the version and supported options.
-	openSSH openSSHInfo
 }
 
 // CommonOpts returns ssh option key-value pairs like {"IdentityFile=/path/to/id_foo"}.
@@ -456,36 +459,65 @@ func CommonOpts(ctx context.Context, sshExe SSHExe, useDotSSH bool) ([]string, e
 
 	sshInfo.Do(func() {
 		sshInfo.aesAccelerated = detectAESAcceleration()
-		sshInfo.openSSH = detectOpenSSHInfo(ctx, sshExe)
 	})
+	// detectOpenSSHInfo has its own cache keyed by the resolved executable, so
+	// calling it per sshExe (rather than caching openSSHInfo process-wide)
+	// keeps callers from picking up a different ssh binary's capabilities.
+	openSSH := detectOpenSSHInfo(ctx, sshExe)
 
-	if sshInfo.openSSH.GSSAPISupported {
+	if openSSH.GSSAPISupported {
 		opts = append(opts, "GSSAPIAuthentication=no")
 	}
 
 	// Only OpenSSH version 8.1 and later support adding ciphers to the front of the default set
-	if !sshInfo.openSSH.Version.LessThan(*semver.New("8.1.0")) {
+	if !openSSH.Version.LessThan(*semver.New("8.1.0")) {
 		// By default, `ssh` choose chacha20-poly1305@openssh.com, even when AES accelerator is available.
 		// (OpenSSH_8.1p1, macOS 11.6, MacBookPro 2020, Core i7-1068NG7)
 		//
 		// We prioritize AES algorithms when AES accelerator is available.
+		var preferred []string
 		if sshInfo.aesAccelerated {
-			logrus.Debugf("AES accelerator seems available, prioritizing aes128-gcm@openssh.com and aes256-gcm@openssh.com")
-			if runtime.GOOS == "windows" {
-				opts = append(opts, "Ciphers=^aes128-gcm@openssh.com,aes256-gcm@openssh.com")
-			} else {
-				opts = append(opts, "Ciphers=\"^aes128-gcm@openssh.com,aes256-gcm@openssh.com\"")
-			}
+			preferred = []string{"aes128-gcm@openssh.com", "aes256-gcm@openssh.com"}
 		} else {
-			logrus.Debugf("AES accelerator does not seem available, prioritizing chacha20-poly1305@openssh.com")
+			preferred = []string{"chacha20-poly1305@openssh.com"}
+		}
+		// Some ssh builds (e.g. compiled `--without-openssl`) do not support
+		// every preferred cipher, so only prioritize ciphers that `ssh -Q
+		// cipher` actually reports as supported. A nil SupportedCiphers means
+		// the query could not be run, so fall back to the historical
+		// unconditional behavior instead of dropping the option.
+		supported := filterSupportedCiphers(preferred, openSSH.SupportedCiphers)
+		if len(supported) == 0 {
+			logrus.Debugf("none of %v are supported by %#q, leaving the default cipher order unchanged", preferred, sshExe.Exe)
+		} else {
+			logrus.Debugf("prioritizing %v", supported)
+			ciphers := "^" + strings.Join(supported, ",")
 			if runtime.GOOS == "windows" {
-				opts = append(opts, "Ciphers=^chacha20-poly1305@openssh.com")
+				opts = append(opts, "Ciphers="+ciphers)
 			} else {
-				opts = append(opts, "Ciphers=\"^chacha20-poly1305@openssh.com\"")
+				opts = append(opts, fmt.Sprintf("Ciphers=%q", ciphers))
 			}
 		}
 	}
 	return opts, nil
+}
+
+// filterSupportedCiphers returns the entries of preferred that are present
+// in supported, preserving preferred's order. A nil supported means the
+// caller could not determine which ciphers are available (e.g. an old ssh
+// client that does not support `-Q cipher`), so every preferred cipher is
+// kept rather than assuming none are supported.
+func filterSupportedCiphers(preferred []string, supported map[string]bool) []string {
+	if supported == nil {
+		return preferred
+	}
+	var result []string
+	for _, cipher := range preferred {
+		if supported[cipher] {
+			result = append(result, cipher)
+		}
+	}
+	return result
 }
 
 func identityFileEntry(ctx context.Context, sshExe SSHExe, privateKeyPath string) (string, error) {
@@ -689,15 +721,45 @@ func detectOpenSSHInfo(ctx context.Context, sshExe SSHExe) openSSHInfo {
 		logrus.Warnf("failed to run %v: stderr=%#q", cmd.Args, stderr.String())
 	} else {
 		info = openSSHInfo{
-			Version:         *ParseOpenSSHVersion(stderr.Bytes()),
-			GSSAPISupported: parseOpenSSHGSSAPISupported(stderr.String()),
+			Version:          *ParseOpenSSHVersion(stderr.Bytes()),
+			GSSAPISupported:  parseOpenSSHGSSAPISupported(stderr.String()),
+			SupportedCiphers: detectSupportedCiphers(ctx, sshExe),
 		}
-		logrus.Debugf("OpenSSH version %s detected, is GSSAPI supported: %t", info.Version, info.GSSAPISupported)
+		logrus.Debugf("OpenSSH version %s detected, is GSSAPI supported: %t, supported ciphers: %v", info.Version, info.GSSAPISupported, info.SupportedCiphers)
 		openSSHInfosRW.Lock()
 		openSSHInfos[exe] = &info
 		openSSHInfosRW.Unlock()
 	}
 	return info
+}
+
+// detectSupportedCiphers returns the set of cipher names reported by
+// `ssh -Q cipher`, or nil if the query could not be run (e.g. an ssh client
+// too old to support "-Q"). Some builds (e.g. compiled `--without-openssl`)
+// omit ciphers that a default build would support, such as the GCM variants.
+func detectSupportedCiphers(ctx context.Context, sshExe SSHExe) map[string]bool {
+	sshArgs := append([]string{}, sshExe.Args...)
+	sshArgs = append(sshArgs, "-Q", "cipher")
+	out, err := exec.CommandContext(ctx, sshExe.Exe, sshArgs...).Output()
+	if err != nil {
+		logrus.WithError(err).Debugf("failed to query %#q -Q cipher", sshExe.Exe)
+		return nil
+	}
+	return parseSupportedCiphers(string(out))
+}
+
+func parseSupportedCiphers(output string) map[string]bool {
+	ciphers := make(map[string]bool)
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			ciphers[line] = true
+		}
+	}
+	if len(ciphers) == 0 {
+		return nil
+	}
+	return ciphers
 }
 
 func DetectOpenSSHVersion(ctx context.Context, sshExe SSHExe) semver.Version {

--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -68,6 +68,47 @@ func TestParseOpenSSHGSSAPISupported(t *testing.T) {
 OpenSSH_10.0p2, OpenSSL 3.4.1 11 Feb 2025`))
 }
 
+func TestParseSupportedCiphers(t *testing.T) {
+	// Typical `ssh -Q cipher` output from an OpenSSL-linked build.
+	ciphers := parseSupportedCiphers("aes128-ctr\naes192-ctr\naes256-ctr\naes128-gcm@openssh.com\naes256-gcm@openssh.com\nchacha20-poly1305@openssh.com\n")
+	assert.Check(t, ciphers["aes128-gcm@openssh.com"])
+	assert.Check(t, ciphers["chacha20-poly1305@openssh.com"])
+	assert.Check(t, !ciphers["not-a-cipher"])
+
+	// A build without OpenSSL support (see https://github.com/lima-vm/lima/issues/2913)
+	// omits the GCM ciphers, but still supports chacha20-poly1305.
+	ciphers = parseSupportedCiphers("aes128-ctr\naes192-ctr\naes256-ctr\nchacha20-poly1305@openssh.com\n")
+	assert.Check(t, !ciphers["aes128-gcm@openssh.com"])
+	assert.Check(t, ciphers["chacha20-poly1305@openssh.com"])
+	assert.Check(t, ciphers["aes256-ctr"])
+
+	// Empty output (e.g. an ssh too old to support "-Q") yields a nil map, so
+	// callers treat it as "unknown" rather than "nothing supported".
+	assert.Check(t, parseSupportedCiphers("") == nil)
+	assert.Check(t, parseSupportedCiphers("\n\n") == nil)
+}
+
+func TestFilterSupportedCiphers(t *testing.T) {
+	preferred := []string{"aes128-gcm@openssh.com", "aes256-gcm@openssh.com"}
+
+	// https://github.com/lima-vm/lima/issues/2913: an ssh built --without-openssl
+	// reports ctr and chacha20-poly1305 ciphers but not GCM, so none of the
+	// preferred GCM ciphers survive.
+	openSSLLess := map[string]bool{"aes128-ctr": true, "aes192-ctr": true, "aes256-ctr": true, "chacha20-poly1305@openssh.com": true}
+	assert.Check(t, len(filterSupportedCiphers(preferred, openSSLLess)) == 0)
+
+	// A normal OpenSSL-linked build supports both preferred ciphers, and order is preserved.
+	openSSLLinked := map[string]bool{"aes128-gcm@openssh.com": true, "aes256-gcm@openssh.com": true, "aes128-ctr": true}
+	assert.DeepEqual(t, filterSupportedCiphers(preferred, openSSLLinked), preferred)
+
+	// A build supporting only one of the two preferred ciphers keeps just that one.
+	partial := map[string]bool{"aes128-gcm@openssh.com": true}
+	assert.DeepEqual(t, filterSupportedCiphers(preferred, partial), []string{"aes128-gcm@openssh.com"})
+
+	// nil (query could not be run) means "unknown", so nothing is filtered out.
+	assert.DeepEqual(t, filterSupportedCiphers(preferred, nil), preferred)
+}
+
 func Test_detectValidPublicKey(t *testing.T) {
 	assert.Check(t, detectValidPublicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAACQDf2IooTVPDBw== 64bit"))
 	assert.Check(t, detectValidPublicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAACQDf2IooTVPDBw=="))


### PR DESCRIPTION
Motivation:
CommonOpts unconditionally emits a `Ciphers=^...` ssh option that
prioritizes aes128-gcm/aes256-gcm@openssh.com (or
chacha20-poly1305@openssh.com without AES acceleration). ssh clients
built `--without-openssl` (e.g. some minimal/embedded distributions)
do not implement any of those AEAD ciphers at all, only ctr/cbc
variants, so ssh rejects the forced cipher spec outright:

  command-line line 0: Bad SSH2 cipher spec
  '^aes128-gcm@openssh.com,aes256-gcm@openssh.com'.

This makes `limactl shell` fail unconditionally for anyone using such
an ssh build. A maintainer confirmed on the report that Lima should
query `ssh -Q cipher` to validate available algorithms before forcing
a cipher preference.

Approach:
- Add detectSupportedCiphers/parseSupportedCiphers, which run
  `ssh -Q cipher` once per resolved ssh executable (cached alongside
  the existing version/GSSAPI detection) and parse the supported
  cipher names into a set. A nil result (query failed, or the client
  is too old to support "-Q") means "unknown", not "unsupported".
- Add filterSupportedCiphers, a small pure helper used by CommonOpts
  to keep only the preferred ciphers that are actually supported,
  preserving order. When SupportedCiphers is nil it returns the
  preferred list unchanged, preserving the historical behavior for
  ssh clients this query cannot inspect.
- When none of the preferred ciphers are supported, CommonOpts now
  omits the Ciphers= option entirely instead of emitting one ssh will
  reject, letting ssh fall back to its own default cipher negotiation
  (which includes aes-ctr etc. on openssl-less builds).
- When ssh does support the preferred ciphers, the emitted Ciphers=
  string is unchanged from before (verified by inspection: the new
  windows/non-windows formatting produces byte-identical output to
  the old hardcoded literals).

Validation:
- go build ./...
- go test ./pkg/sshutil/...  (includes new TestParseSupportedCiphers
  and TestFilterSupportedCiphers, which directly cover the
  --without-openssl scenario: a ctr-only supported-cipher set filters
  out every preferred GCM cipher, matching the reported failure mode)
- gofmt -l and go vet ./pkg/sshutil/... clean
I did not build or run against an actual ssh binary compiled
--without-openssl, and did not run the BATS/VM integration suite;
this change is validated at the unit level against the exact cipher
sets described in the report, not via a live end-to-end reproduction.

Report: https://github.com/lima-vm/lima/issues/2913
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #2913