### PR TITLE
portfwdserver: relay TCP half-close from the host

### DIFF
--- a/pkg/portfwdserver/server.go
+++ b/pkg/portfwdserver/server.go
@@ -57,7 +57,8 @@ func (s *TunnelServer) Start(stream api.GuestService_TunnelServer) error {
 	go proxy.HandleConn(rw)
 
 	// The stream will be closed when this function returns.
-	// Wait here until rw.Close(), rw.CloseRead(), or rw.CloseWrite() is called.
+	// Wait here until rw.Close() or rw.CloseWrite() is called. A half-close
+	// from the host does not end the tunnel; see CloseRead below.
 	<-rw.closeCh
 	logrus.Debugf("closed GRPCServerRW for id: %s", in.Id)
 
@@ -68,12 +69,11 @@ type GRPCServerRW struct {
 	id      string
 	stream  api.GuestService_TunnelServer
 	closeCh chan any
-	// closeOnce guards closeCh. Close, CloseRead, and CloseWrite may be
-	// called in any order and multiple times (e.g., tcpproxy calls
-	// CloseRead/CloseWrite from each copy direction and then Close), so
-	// they must be idempotent and must never block; otherwise the proxy
-	// goroutine gets stuck and never closes the dialed guest connection,
-	// leaking one FD per forwarded connection.
+	// closeOnce guards closeCh. Close and CloseWrite may be called in any
+	// order and multiple times (e.g., tcpproxy calls CloseWrite from a copy
+	// direction and then Close), so they must be idempotent and must never
+	// block; otherwise the proxy goroutine gets stuck and never closes the
+	// dialed guest connection, leaking one FD per forwarded connection.
 	closeOnce sync.Once
 
 	// rxBuf holds bytes received from the stream that did not fit in the
@@ -110,12 +110,23 @@ func (g *GRPCServerRW) Close() error {
 // By adding CloseRead and CloseWrite methods, GRPCServerRW can work with
 // other than containers/gvisor-tap-vsock/pkg/tcpproxy, e.g., inetaf/tcpproxy, bicopy.Bicopy.
 
+// CloseRead is called once the host stops sending, which happens both when it
+// shuts down its write side and when it closes the connection outright. Both
+// reach us as io.EOF from stream.Recv, and only the latter also cancels the
+// stream context. Ending the tunnel here would therefore turn every half-close
+// into a full close and discard the response the host is still waiting for.
+// The proxy shuts down the write side of the guest connection by itself, so
+// there is nothing left to do: the tunnel lives on until the guest service
+// closes (CloseWrite) or the host cancels the stream (Close).
 func (g *GRPCServerRW) CloseRead() error {
 	logrus.Debugf("closing read GRPCServerRW for id: %s", g.id)
-	g.closeOnce.Do(func() { close(g.closeCh) })
 	return nil
 }
 
+// CloseWrite is called once the guest service closes its side. The tunnel
+// protocol cannot signal a half-close towards the host, so this ends the whole
+// tunnel; the host then sees the stream end and shuts down the write side of
+// its own connection.
 func (g *GRPCServerRW) CloseWrite() error {
 	logrus.Debugf("closing write GRPCServerRW for id: %s", g.id)
 	g.closeOnce.Do(func() { close(g.closeCh) })

--- a/pkg/portfwdserver/server_test.go
+++ b/pkg/portfwdserver/server_test.go
@@ -76,11 +76,13 @@ func TestGRPCServerRWCloseNeverBlocks(t *testing.T) {
 }
 
 // fakeTunnelStream is a minimal bidi stream: Recv returns queued messages
-// and io.EOF once recvCh is closed; Send discards data.
+// and io.EOF once recvCh is closed; Send forwards the payload to sendCh, or
+// discards it when sendCh is nil.
 type fakeTunnelStream struct {
 	api.GuestService_TunnelServer
 	ctx    context.Context
 	recvCh chan *api.TunnelMessage
+	sendCh chan []byte
 }
 
 func (s *fakeTunnelStream) Context() context.Context { return s.ctx }
@@ -93,7 +95,91 @@ func (s *fakeTunnelStream) Recv() (*api.TunnelMessage, error) {
 	return msg, nil
 }
 
-func (s *fakeTunnelStream) Send(*api.TunnelMessage) error { return nil }
+func (s *fakeTunnelStream) Send(msg *api.TunnelMessage) error {
+	if s.sendCh != nil {
+		s.sendCh <- msg.Data
+	}
+	return nil
+}
+
+// TestTunnelServerRelaysHalfClose verifies that a half-close from the host is
+// relayed to the guest service as a FIN without tearing the tunnel down, so a
+// response written after the half-close still reaches the host
+// (https://github.com/lima-vm/lima/issues/5264).
+//
+// A host-side half-close arrives as Recv returning io.EOF while the stream
+// context stays live; only a full close cancels the context as well.
+func TestTunnelServerRelaysHalfClose(t *testing.T) {
+	var lc net.ListenConfig
+	ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	assert.NilError(t, err)
+	defer ln.Close()
+
+	// The guest service reads the whole request, which completes only once the
+	// half-close reaches it, and replies after the test releases replyCh. The
+	// handshake stands in for a server that takes time to produce a response.
+	reqCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+	replyCh := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer conn.Close()
+		req, err := io.ReadAll(conn)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		reqCh <- req
+		<-replyCh
+		_, err = conn.Write([]byte("response"))
+		errCh <- err
+	}()
+
+	recvCh := make(chan *api.TunnelMessage, 2)
+	recvCh <- &api.TunnelMessage{Id: "test", Protocol: "tcp", GuestAddr: ln.Addr().String()}
+	recvCh <- &api.TunnelMessage{Id: "test", Data: []byte("request")}
+	sendCh := make(chan []byte, 1)
+	stream := &fakeTunnelStream{ctx: t.Context(), recvCh: recvCh, sendCh: sendCh}
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- NewTunnelServer().Start(stream)
+	}()
+
+	// Half-close: the host has nothing more to send, but is still waiting for
+	// the response.
+	close(recvCh)
+
+	select {
+	case req := <-reqCh:
+		assert.DeepEqual(t, req, []byte("request"))
+	case err := <-errCh:
+		assert.NilError(t, err)
+	case <-time.After(5 * time.Second):
+		assert.Assert(t, false, "guest service never saw the half-close")
+	}
+
+	close(replyCh)
+	assert.NilError(t, <-errCh)
+
+	select {
+	case data := <-sendCh:
+		assert.DeepEqual(t, data, []byte("response"))
+	case <-time.After(5 * time.Second):
+		assert.Assert(t, false, "response was lost; the half-close tore the tunnel down")
+	}
+
+	select {
+	case err := <-startDone:
+		assert.NilError(t, err)
+	case <-time.After(5 * time.Second):
+		assert.Assert(t, false, "Start did not return after the guest service closed")
+	}
+}
 
 // TestTunnelServerClosesGuestConn verifies that the connection dialed to the
 // guest service is fully closed (not just shut down for writing) when the
@@ -112,9 +198,12 @@ func TestTunnelServerClosesGuestConn(t *testing.T) {
 		}
 	}()
 
-	recvCh := make(chan *api.TunnelMessage, 1)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	recvCh := make(chan *api.TunnelMessage, 2)
 	recvCh <- &api.TunnelMessage{Id: "test", Protocol: "tcp", GuestAddr: ln.Addr().String()}
-	stream := &fakeTunnelStream{ctx: t.Context(), recvCh: recvCh}
+	recvCh <- &api.TunnelMessage{Id: "test", Data: []byte("x")}
+	stream := &fakeTunnelStream{ctx: ctx, recvCh: recvCh}
 
 	startDone := make(chan error, 1)
 	go func() {
@@ -129,8 +218,21 @@ func TestTunnelServerClosesGuestConn(t *testing.T) {
 	}
 	defer guestConn.Close()
 
-	// Simulate the host closing the tunnel.
+	// Wait for the tunnel to relay a byte before cancelling. Accept returns as
+	// soon as the kernel completes the handshake, which can happen before
+	// DialContext returns inside Start, and cancelling in that window makes the
+	// dial itself fail instead of exercising the teardown.
+	assert.NilError(t, guestConn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	buf := make([]byte, 1)
+	_, err = io.ReadFull(guestConn, buf)
+	assert.NilError(t, err)
+	assert.NilError(t, guestConn.SetReadDeadline(time.Time{}))
+
+	// Simulate the host closing the tunnel: GrpcClientRW.Close both stops
+	// sending and cancels the stream context. Closing recvCh alone would only
+	// be a half-close, which must keep the tunnel up.
 	close(recvCh)
+	cancel()
 
 	select {
 	case err := <-startDone:


### PR DESCRIPTION
Fix #5264

A client that sends its request, calls `shutdown(SHUT_WR)`, and waits for the response
gets a premature EOF through the gRPC forwarder. The FIN does reach the guest service,
but the forwarder tears the tunnel down before the response can be relayed.

Reproducer, analysis and the linked history are @elprans's, from #5329.

## Cause

`tcpproxy` ends each copy direction with `closeRead(src)` / `closeWrite(dst)`. On the
guest side the stream adapter is `src`, so when the host half-closes:

1. the host calls `stream.CloseSend()`, so the guest's `Recv` returns `io.EOF`;
2. the stream to guest copy finishes. `closeWrite` shuts down the write side of the
   dialed connection, which is right, the guest service does see the FIN. `closeRead`
   calls `GRPCServerRW.CloseRead`;
3. `CloseRead` closed `closeCh`, which returns from `TunnelServer.Start`, whose
   deferred `conn.Close()` then tears down the guest connection;
4. the response the guest service writes a moment later has nowhere to go.

## Fix

A half-close and a full close are already distinguishable on the wire:
`GrpcClientRW.CloseWrite` only calls `stream.CloseSend()`, while `GrpcClientRW.Close`
also cancels the stream context. So `io.EOF` from `Recv` with a live context is a
half-close.

`CloseRead` no longer ends the tunnel. The proxy shuts down the write side of the guest
connection by itself, so there is nothing left for it to do, and the tunnel now lives
until the guest service closes (`CloseWrite`) or the host cancels the stream (`Close`).
`Close` and `CloseWrite` keep the `sync.Once` from #5216, so the FD leak fixed there
stays fixed and none of the three can block.

Only the guest side changes. The host side already gets this right: its `CloseRead`
cancels the stream, but it is reached only after `stream.Recv` has failed, so the stream
is over anyway.

## Tradeoff worth a look

Relaying a half-close means the tunnel outlives the host's FIN. A peer that fully closes
is indistinguishable from one that half-closes, so if the guest service ignores EOF and
never closes, that tunnel now stays up where before it was torn down promptly. This is
inherent to half-close support and is why nginx gates the same behaviour behind
`proxy_half_close`. `inetaf/tcpproxy`, `docker-proxy` and `socat` all relay it by
default. Happy to add an idle timeout instead if you would rather bound it.

## Not fixed here

The reverse direction, a half-close from the guest service towards the host, is still
not relayed. `TunnelMessage` cannot express EOF and a gRPC server ends a stream only by
returning from its handler, so that needs a protocol change plus guest agent version
negotiation. I left it out and noted the gap in a comment; glad to follow up separately.

## Tests

`TestTunnelServerRelaysHalfClose` is new and fails on master with
`response was lost; the half-close tore the tunnel down`.

`TestTunnelServerClosesGuestConn` now cancels the stream context to end the tunnel.
Closing the send side alone is a half-close, which must keep the tunnel up, so on its
own it no longer ends `Start`. Its subject, that the dialed connection is fully closed
and not leaked, is unchanged.

`go test ./...` passes; `-race -count=5` on the two portfwd packages passes;
golangci-lint reports 0 issues.

## Verified end to end

With the reproducer from #5264, on Linux/QEMU (Zorin OS, x86_64, Ubuntu 26.04 guest,
`vmType: qemu`), same tree, only the patch differing. containerd is disabled in the
template because this host cannot reach GitHub releases; it plays no part in the test.

master, `2.2.0-110-gb8b365a0`:

```
== running host-side client through the grpc forwarder
FAIL: premature EOF after half-close; connection was fully closed by the forwarder (got b'', expected b'OK 5\n')

real	0m0,207s
```

with this patch, `2.2.0-110-gb8b365a0.m`:

```
== running host-side client through the grpc forwarder
PASS: server saw the half-close and the response came back: b'OK 5\n'

real	0m1,026s
== guest server log:
listening on 127.0.0.1:12345
accepted ('127.0.0.1', 36454)
request complete (5 bytes), responding
```

The 1.0 s is the reproducer's deliberate 0.5 s server-side processing delay plus
overhead, matching the SSH forwarder's timing in #5264. The FIN propagates immediately.

Assisted-by: Claude Code (Opus 5)