### PR TITLE
only remove a stale socket at the hostSocket path

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -1079,7 +1079,7 @@ var forwardSSH = func(ctx context.Context, sshConfig *ssh.SSHConfig, sshAddress 
 				}
 			} else {
 				logrus.Infof("Forwarding %#q (guest) to %#q (host)", remote, local)
-				if err := os.RemoveAll(local); err != nil {
+				if err := osutil.RemoveStaleSocket(local); err != nil {
 					logrus.WithError(err).Warnf("Failed to clean up %#q (host) before setting up forwarding", local)
 				}
 			}
@@ -1095,7 +1095,7 @@ var forwardSSH = func(ctx context.Context, sshConfig *ssh.SSHConfig, sshAddress 
 			} else {
 				logrus.Infof("Stopping forwarding %#q (guest) to %#q (host)", remote, local)
 				defer func() {
-					if err := os.RemoveAll(local); err != nil {
+					if err := osutil.RemoveStaleSocket(local); err != nil {
 						logrus.WithError(err).Warnf("Failed to clean up %#q (host) after stopping forwarding", local)
 					}
 				}()
@@ -1115,7 +1115,7 @@ var forwardSSH = func(ctx context.Context, sshConfig *ssh.SSHConfig, sshAddress 
 				}
 			} else {
 				logrus.WithError(err).Warnf("Failed to set up forward from %#q (guest) to %#q (host)", remote, local)
-				if removeErr := os.RemoveAll(local); removeErr != nil {
+				if removeErr := osutil.RemoveStaleSocket(local); removeErr != nil {
 					logrus.WithError(removeErr).Warnf("Failed to clean up %#q (host) after forwarding failed", local)
 				}
 			}

--- a/pkg/osutil/file.go
+++ b/pkg/osutil/file.go
@@ -5,6 +5,7 @@ package osutil
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -23,6 +24,27 @@ func Touch(path string) error {
 		return err
 	}
 	return f.Close()
+}
+
+// RemoveStaleSocket removes path so a fresh listener can bind to it, but only
+// when path is a Unix domain socket. A hostSocket comes from the instance
+// config (which may originate from an untrusted template) and is validated only
+// as an absolute path, so it can point at an existing directory or regular
+// file. os.RemoveAll on such a path would delete it recursively; here anything
+// that is not a socket is left in place and an error is returned instead. A
+// non-existent path is not an error.
+func RemoveStaleSocket(path string) error {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if fi.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("refusing to remove %#q: not a socket (%s)", path, fi.Mode().Type())
+	}
+	return os.Remove(path)
 }
 
 // WriteFileBeneathDir writes data to name without following a symlink at the

--- a/pkg/osutil/file_test.go
+++ b/pkg/osutil/file_test.go
@@ -4,6 +4,7 @@
 package osutil
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,4 +36,33 @@ func TestWriteFileBeneathDir(t *testing.T) {
 	got, err = os.ReadFile(secret)
 	assert.NilError(t, err)
 	assert.Equal(t, string(got), "ORIGINAL\n")
+}
+
+func TestRemoveStaleSocket(t *testing.T) {
+	base := t.TempDir()
+
+	// A non-existent path is not an error.
+	assert.NilError(t, RemoveStaleSocket(filepath.Join(base, "absent")))
+
+	// A regular file at the socket path is left in place, not deleted.
+	file := filepath.Join(base, "file")
+	assert.NilError(t, os.WriteFile(file, []byte("keep\n"), 0o600))
+	assert.Assert(t, RemoveStaleSocket(file) != nil, "expected a regular file to be refused")
+	assert.Assert(t, FileExists(file), "regular file must not be removed")
+
+	// A directory at the socket path is left in place, not deleted recursively.
+	dir := filepath.Join(base, "dir")
+	assert.NilError(t, os.MkdirAll(dir, 0o700))
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "child"), []byte("keep\n"), 0o600))
+	assert.Assert(t, RemoveStaleSocket(dir) != nil, "expected a directory to be refused")
+	assert.Assert(t, FileExists(filepath.Join(dir, "child")), "directory contents must not be removed")
+
+	// An actual stale socket is removed so a new listener can bind.
+	sock := filepath.Join(base, "sock")
+	var lc net.ListenConfig
+	l, err := lc.Listen(t.Context(), "unix", sock)
+	assert.NilError(t, err)
+	defer l.Close()
+	assert.NilError(t, RemoveStaleSocket(sock))
+	assert.Assert(t, !FileExists(sock), "stale socket must be removed")
 }

--- a/pkg/portfwd/listener.go
+++ b/pkg/portfwd/listener.go
@@ -156,7 +156,7 @@ func key(protocol, hostAddress, guestAddress string) string {
 }
 
 func prepareUnixSocket(hostSocket string) error {
-	if err := os.RemoveAll(hostSocket); err != nil {
+	if err := osutil.RemoveStaleSocket(hostSocket); err != nil {
 		return fmt.Errorf("can't clean up %#q: %w", hostSocket, err)
 	}
 	if err := os.MkdirAll(filepath.Dir(hostSocket), 0o755); err != nil {


### PR DESCRIPTION
The unix-socket port forwarders call os.RemoveAll on a rule's hostSocket before binding, but hostSocket is validated only as an absolute path and may come from a remote template, so a value that points at an existing directory or regular file gets deleted recursively when the instance starts. Add osutil.RemoveStaleSocket, which removes the path only when it is a socket and otherwise leaves it in place and returns an error, and call it from both prepareUnixSocket and forwardSSH.