### PR TITLE
cidata: detect existing additionalDisks by filesystem, not label

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/05-lima-disks.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot.Linux/05-lima-disks.sh
@@ -22,8 +22,12 @@ for i in $(seq 0 $((LIMA_CIDATA_DISKS - 1))); do
 	test -n "$FORMAT_DISK" || FORMAT_DISK=true
 	test -n "$FORMAT_FSTYPE" || FORMAT_FSTYPE=ext4
 
-	# first time setup
-	if [[ ! -b "/dev/disk/by-label/lima-${DISK_NAME}" ]]; then
+	# first time setup: a partition that already carries a filesystem was set up by an
+	# earlier boot (possibly by an older Lima version). This does not rely on the
+	# "lima-${DISK_NAME}" filesystem label, which mkfs silently truncates for long disk
+	# names, causing the label lookup to never match and the disk to be reformatted (and
+	# its data destroyed) on every boot.
+	if ! blkid -s TYPE -o value "/dev/${DEVICE_NAME}1" >/dev/null 2>&1; then
 		if $FORMAT_DISK; then
 			if [ "$FORMAT_FSTYPE" == "swap" ]; then
 				echo 'type=swap' | sfdisk --label gpt "/dev/${DEVICE_NAME}"
@@ -46,11 +50,11 @@ for i in $(seq 0 $((LIMA_CIDATA_DISKS - 1))); do
 	if command -v growpart >/dev/null 2>&1 && command -v resize2fs >/dev/null 2>&1; then
 		growpart "/dev/${DEVICE_NAME}" 1 || true
 		# Only resize when filesystem is in a healthy state
-		if command -v "fsck.$FORMAT_FSTYPE" -f -p "/dev/disk/by-label/lima-${DISK_NAME}"; then
+		if command -v "fsck.$FORMAT_FSTYPE" -f -p "/dev/${DEVICE_NAME}1"; then
 			if [[ $FORMAT_FSTYPE == "ext2" || $FORMAT_FSTYPE == "ext3" || $FORMAT_FSTYPE == "ext4" ]]; then
-				resize2fs "/dev/disk/by-label/lima-${DISK_NAME}" || true
+				resize2fs "/dev/${DEVICE_NAME}1" || true
 			elif [ "$FORMAT_FSTYPE" == "xfs" ]; then
-				xfs_growfs "/dev/disk/by-label/lima-${DISK_NAME}" || true
+				xfs_growfs "/dev/${DEVICE_NAME}1" || true
 			else
 				echo >&2 "WARNING: unknown fs '$FORMAT_FSTYPE'. FS will not be grew up automatically"
 			fi


### PR DESCRIPTION
Motivation:
An additionalDisks entry whose name is longer than 11 characters was
reformatted on every boot, silently destroying whatever was stored on it.
05-lima-disks.sh decided whether a disk needed first-time formatting by
testing for "/dev/disk/by-label/lima-${DISK_NAME}". mkfs truncates
filesystem labels (16 bytes for ext4, 12 for xfs, minus 5 for the "lima-"
prefix), so for any name over that limit the label written to disk never
equals the one being tested for, the "already set up" check is always
false, and the disk is wiped and reformatted every boot. The disk still
mounted normally afterward (mount uses the device path, not the label),
so nothing looked wrong to the user.

Approach:
Detect first-time setup by asking whether the partition already carries a
filesystem ("blkid -s TYPE -o value") instead of checking for the
truncated label. This removes the name-length limit entirely and also
means a disk formatted by an older Lima version is still recognized as
already set up, so upgrading cannot trigger the same data loss. Two
downstream resize/fsck-check lines had the identical truncated-label
problem (they silently skipped growpart/resize2fs/xfs_growfs for
long-named disks instead of losing data); they're switched to the same
direct device path that mount already uses.

Validation:
- go build ./... and go test ./pkg/cidata/... pass.
- shellcheck and shfmt -s -d pass on the changed file.
- I used an AI coding assistant to help draft this change, and checked
  its reasoning myself: commands in an "if ! ...; then" condition are
  exempt from errexit under `set -eux -o pipefail`, so blkid failing on
  a not-yet-partitioned device won't abort the script. I also had it
  write a standalone bash simulation (not part of this commit) of the
  old by-label condition versus the new blkid-based one across two
  simulated boots of a 16-character disk name: the old condition
  reformats on boot 2, reproducing the reported data loss; the new one
  doesn't.
- I have not booted a real Lima VM with this change, so it hasn't been
  exercised through an actual guest boot or this repo's
  BATS/hack/test-templates.sh integration tests. I don't have a working
  VM environment available to me. If there's a lightweight way to get
  that coverage, or someone is willing to test it on a real VM, I'd
  appreciate the help.

Assisted-by: Claude

Report: https://github.com/lima-vm/lima/issues/5407
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #5407
