### PR TITLE
Avoid false positives in the "make lint" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -656,7 +656,7 @@ gosocialcheck:
 
 .PHONY: ltag
 ltag:
-	$(GO) run -modfile=./hack/tools/go.mod github.com/containerd/ltag -t ./hack/ltag --check -v
+	$(GO) run -modfile=./hack/tools/go.mod github.com/containerd/ltag -t ./hack/ltag --check --excludes "vendor _output" -v
 
 .PHONY: protolint
 protolint:

--- a/Makefile
+++ b/Makefile
@@ -651,7 +651,7 @@ go-licenses:
 
 .PHONY: gosocialcheck
 gosocialcheck:
-	$(GO) run -modfile=./hack/tools/go.mod github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck run --gha=$(GITHUB_ACTIONS) ./...
+	-$(GO) run -modfile=./hack/tools/go.mod github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck run --gha=$(GITHUB_ACTIONS) ./...
 	# TODO: run gosocialcheck for ./hack/tools/... too (not supported yet by gosocialcheck)
 
 .PHONY: ltag


### PR DESCRIPTION

## What This PR Changes

Exclude _output directory from the ltag scan

Allow gosocialcheck target to fail in lint

## Linked Issue (Required in most cases)

Closes #5415

## How I Tested This

`make lint`

## AI Usage

No