### PR TITLE
wsl2: validate the guest-reported ssh address

### DIFF
--- a/pkg/driver/wsl2/vm_windows.go
+++ b/pkg/driver/wsl2/vm_windows.go
@@ -269,23 +269,40 @@ func getSSHAddress(ctx context.Context, instName string) (string, error) {
 	cmd := exec.CommandContext(ctx, "wsl.exe", "-d", distroName, "bash", "-c", `hostname -I | cut -d ' ' -f1`)
 	out, err := cmd.CombinedOutput()
 	if err == nil {
-		return strings.TrimSpace(string(out)), nil
+		if addr, ok := guestReportedIP(out); ok {
+			return addr, nil
+		}
 	}
 	// Alpine
 	cmd = exec.CommandContext(ctx, "wsl.exe", "-d", distroName, "sh", "-c", `ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}'`)
 	out, err = cmd.CombinedOutput()
 	if err == nil {
-		return strings.TrimSpace(string(out)), nil
+		if addr, ok := guestReportedIP(out); ok {
+			return addr, nil
+		}
 	}
 	// fallback
 	cmd = exec.CommandContext(ctx, "wsl.exe", "-d", distroName, "hostname", "-i")
 	out, err = cmd.CombinedOutput()
 	if err == nil {
-		ip := net.ParseIP(strings.TrimSpace(string(out)))
-		// some distributions use "127.0.1.1" as the host IP, but we want something that we can route to here
-		if ip != nil && !ip.IsLoopback() {
-			return strings.TrimSpace(string(out)), nil
+		if addr, ok := guestReportedIP(out); ok {
+			return addr, nil
 		}
 	}
-	return "", fmt.Errorf("failed to get hostname for instance %#q, err: %w (out=%#q)", instName, err, string(out))
+	return "", fmt.Errorf("failed to get a routable IP for instance %#q, err: %w (out=%#q)", instName, err, string(out))
+}
+
+// guestReportedIP validates the address a distro reports for itself before the
+// host uses it as the SSH/dial target. The address is produced by a command run
+// inside the guest, so a compromised guest could otherwise return an arbitrary
+// string and point the host at a host of its choosing. Empty, malformed, and
+// loopback values (e.g. the "127.0.1.1" some distros use for their own hostname)
+// are rejected; only a routable IP is accepted.
+func guestReportedIP(out []byte) (string, bool) {
+	addr := strings.TrimSpace(string(out))
+	ip := net.ParseIP(addr)
+	if ip == nil || ip.IsLoopback() {
+		return "", false
+	}
+	return addr, true
 }

--- a/pkg/driver/wsl2/wsl_driver_windows_test.go
+++ b/pkg/driver/wsl2/wsl_driver_windows_test.go
@@ -203,3 +203,27 @@ func TestValidateConfigImages(t *testing.T) {
 		})
 	}
 }
+
+func TestGuestReportedIP(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want string
+		ok   bool
+	}{
+		{name: "routable IPv4", out: "192.168.1.10\n", want: "192.168.1.10", ok: true},
+		{name: "trims surrounding space", out: "  10.0.0.5  ", want: "10.0.0.5", ok: true},
+		{name: "routable IPv6", out: "fd00::1\n", want: "fd00::1", ok: true},
+		{name: "empty", out: "\n", ok: false},
+		{name: "loopback", out: "127.0.1.1\n", ok: false},
+		{name: "not an ip", out: "example.com\n", ok: false},
+		{name: "attacker string", out: "$(reboot)\n", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, ok := guestReportedIP([]byte(tt.out))
+			assert.Equal(t, ok, tt.ok)
+			assert.Equal(t, addr, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
## What This PR Changes

On WSL2 the host learns a distro's address by running `hostname`/`ip` inside it and then uses the result as the SSH and reverse-sshfs/port-forward dial target. Two of the three probes in `getSSHAddress` (`hostname -I`, `ip route get 1`) returned the command output verbatim; only the `hostname -i` fallback ran it through `net.ParseIP` and rejected loopback. A distro can print anything on stdout, so a compromised guest could hand the host an arbitrary or unroutable value and steer its SSH operations at a host of its choosing. This moves that check into `guestReportedIP` and applies it to all three probes, so an unparseable or loopback result falls through to the next probe instead of being trusted.

## Linked Issue (Required in most cases)

Small self-contained fix; no separate issue.

## How I Tested This

`GOOS=windows go build ./...` and `golangci-lint` stay clean. Added `TestGuestReportedIP` covering routable v4/v6 and whitespace trimming plus the rejected cases (empty, loopback `127.0.1.1`, non-IP, arbitrary string); it runs on the windows unit-test job.

## AI Usage
