### PR TITLE
hostagent: don't fsync every log record

### DIFF
--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -83,6 +83,8 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 
 	stdout := &syncWriter{w: cmd.OutOrStdout()}
 	stderr := &syncWriter{w: cmd.ErrOrStderr()}
+	defer stdout.flush()
+	defer stderr.flush()
 
 	initLogrus(stderr)
 	var opts []hostagent.Opt
@@ -142,7 +144,7 @@ type syncer interface {
 	Sync() error
 }
 
-// syncInterval bounds how long the log can go unflushed.
+// syncInterval is how long syncWriter batches writes before flushing them.
 //
 // Flushing on every write serialised the whole hostagent behind one fsync per
 // record: logrus holds its output mutex across Out.Write, and the port
@@ -156,30 +158,41 @@ const syncInterval = 100 * time.Millisecond
 type syncWriter struct {
 	w io.Writer
 
-	mu       sync.Mutex
-	lastSync time.Time
+	mu    sync.Mutex
+	dirty bool
+	timer *time.Timer
 }
 
 func (w *syncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	written, err := w.w.Write(p)
-	if err == nil && w.syncDue() {
-		if s, ok := w.w.(syncer); ok {
-			_ = s.Sync()
+	if err == nil {
+		w.dirty = true
+		if w.timer == nil {
+			w.timer = time.AfterFunc(syncInterval, w.flush)
 		}
 	}
 	return written, err
 }
 
-// syncDue reports whether syncInterval has passed since the last flush, and
-// records the new flush time when it has.
-func (w *syncWriter) syncDue() bool {
+// flush stops the pending timer and syncs any writes in the current batch.
+func (w *syncWriter) flush() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if time.Since(w.lastSync) < syncInterval {
-		return false
+
+	if w.timer != nil {
+		w.timer.Stop()
+		w.timer = nil
 	}
-	w.lastSync = time.Now()
-	return true
+	if !w.dirty {
+		return
+	}
+	if s, ok := w.w.(syncer); ok {
+		_ = s.Sync()
+	}
+	w.dirty = false
 }
 
 func initLogrus(stderr io.Writer) {

--- a/cmd/limactl/hostagent.go
+++ b/cmd/limactl/hostagent.go
@@ -12,7 +12,9 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"sync"
 	"syscall"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -140,18 +142,44 @@ type syncer interface {
 	Sync() error
 }
 
+// syncInterval bounds how long the log can go unflushed.
+//
+// Flushing on every write serialised the whole hostagent behind one fsync per
+// record: logrus holds its output mutex across Out.Write, and the port
+// forwarder logs once per tunnel teardown, so a burst of closing connections
+// throttled all logging in the process.
+//
+// The flush cannot be dropped entirely. limactl start follows these files with
+// fsnotify, and on Windows the tailer stops seeing new lines without it.
+const syncInterval = 100 * time.Millisecond
+
 type syncWriter struct {
 	w io.Writer
+
+	mu       sync.Mutex
+	lastSync time.Time
 }
 
 func (w *syncWriter) Write(p []byte) (int, error) {
 	written, err := w.w.Write(p)
-	if err == nil {
+	if err == nil && w.syncDue() {
 		if s, ok := w.w.(syncer); ok {
 			_ = s.Sync()
 		}
 	}
 	return written, err
+}
+
+// syncDue reports whether syncInterval has passed since the last flush, and
+// records the new flush time when it has.
+func (w *syncWriter) syncDue() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if time.Since(w.lastSync) < syncInterval {
+		return false
+	}
+	w.lastSync = time.Now()
+	return true
 }
 
 func initLogrus(stderr io.Writer) {

--- a/cmd/limactl/hostagent_test.go
+++ b/cmd/limactl/hostagent_test.go
@@ -5,36 +5,59 @@ package main
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"gotest.tools/v3/assert"
 )
 
 type countingSyncer struct {
-	writes, syncs int
+	writes, syncedWrites, syncs int
 }
 
 func (c *countingSyncer) Write(p []byte) (int, error) { c.writes++; return len(p), nil }
-func (c *countingSyncer) Sync() error                 { c.syncs++; return nil }
+func (c *countingSyncer) Sync() error {
+	c.syncedWrites = c.writes
+	c.syncs++
+	return nil
+}
 
-// TestSyncWriterCoalescesFlushes checks that every record still reaches the
-// underlying writer, and that only the flushes are coalesced.
-func TestSyncWriterCoalescesFlushes(t *testing.T) {
-	c := &countingSyncer{}
-	w := &syncWriter{w: c}
+func TestSyncWriter(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		c := &countingSyncer{}
+		w := &syncWriter{w: c}
 
-	const records = 1000
-	for range records {
-		_, err := w.Write([]byte("record\n"))
+		const records = 1000
+		for range records {
+			_, err := w.Write([]byte("record\n"))
+			assert.NilError(t, err)
+		}
+		time.Sleep(syncInterval)
+		synctest.Wait()
+
+		assert.Equal(t, c.writes, records)
+		assert.Equal(t, c.syncedWrites, records)
+		assert.Equal(t, c.syncs, 1)
+
+		// A coalesced write must be synced even if the stream then goes idle.
+		_, err := w.Write([]byte("first\n"))
 		assert.NilError(t, err)
-	}
-	assert.Equal(t, c.writes, records)
-	assert.Assert(t, c.syncs <= 2, "expected coalesced flushes, got %d for %d records", c.syncs, records)
+		_, err = w.Write([]byte("second\n"))
+		assert.NilError(t, err)
+		time.Sleep(syncInterval)
+		synctest.Wait()
 
-	// The log must not be able to go unflushed indefinitely.
-	before := c.syncs
-	time.Sleep(syncInterval + 20*time.Millisecond)
-	_, err := w.Write([]byte("record\n"))
-	assert.NilError(t, err)
-	assert.Equal(t, c.syncs, before+1)
+		assert.Equal(t, c.syncedWrites, records+2)
+		assert.Equal(t, c.syncs, 2)
+
+		// Shutdown must flush immediately and stop the pending timer.
+		_, err = w.Write([]byte("record\n"))
+		assert.NilError(t, err)
+		w.flush()
+		time.Sleep(syncInterval)
+		synctest.Wait()
+
+		assert.Equal(t, c.syncedWrites, records+3)
+		assert.Equal(t, c.syncs, 3)
+	})
 }

--- a/cmd/limactl/hostagent_test.go
+++ b/cmd/limactl/hostagent_test.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+type countingSyncer struct {
+	writes, syncs int
+}
+
+func (c *countingSyncer) Write(p []byte) (int, error) { c.writes++; return len(p), nil }
+func (c *countingSyncer) Sync() error                 { c.syncs++; return nil }
+
+// TestSyncWriterCoalescesFlushes checks that every record still reaches the
+// underlying writer, and that only the flushes are coalesced.
+func TestSyncWriterCoalescesFlushes(t *testing.T) {
+	c := &countingSyncer{}
+	w := &syncWriter{w: c}
+
+	const records = 1000
+	for range records {
+		_, err := w.Write([]byte("record\n"))
+		assert.NilError(t, err)
+	}
+	assert.Equal(t, c.writes, records)
+	assert.Assert(t, c.syncs <= 2, "expected coalesced flushes, got %d for %d records", c.syncs, records)
+
+	// The log must not be able to go unflushed indefinitely.
+	before := c.syncs
+	time.Sleep(syncInterval + 20*time.Millisecond)
+	_, err := w.Write([]byte("record\n"))
+	assert.NilError(t, err)
+	assert.Equal(t, c.syncs, before+1)
+}


### PR DESCRIPTION
Fixes #5410.

## What this changes

`syncWriter` previously called `Sync()` after every hostagent log write. This change batches successful writes for 100 ms. The first write starts a one-shot timer, and all writes in that window share one sync.

The timer still syncs when the stream goes idle. During shutdown, any pending timer is stopped and the final batch is synced synchronously. Every record is still written in full and at the same log level.

## Why the flush was expensive

logrus holds its output mutex across `Out.Write`, so every record held that lock for the duration of an fsync. This limited all logging in the hostagent process to about 200 records per second.

The gRPC port forwarder writes several debug records for each tunnel that closes. A burst of closed connections can therefore queue thousands of records. Other goroutines that log wait behind that queue, including the guest-agent
event callback. Because that callback runs inline on the event-receive loop, a logging backlog also delays publication of subsequent forwarded ports.

## Why the flush is retained

An earlier version of this PR removed `syncWriter` and wrote directly to the files. Both Windows jobs then failed with `did not receive an event with the running status`, while the hostagent remained healthy and `ha.stdout.log` contained the events. `limactl start` follows these files through `nxadm/tail` and fsnotify, so the sync is retained for Windows visibility.

## Measurements

I reran a clean microbenchmark. It compares the old per-write sync with the trailing timer in this PR. Both methods ran in the same test program.

| Method | Median time per write | Approx. benchmark rate |
| --- | ---: | ---: |
| Sync every record (before) | 3.862 ms | 259 writes/s |
| Trailing timer (this PR) | 1.642 µs | 609,000 writes/s |
| File write only (reference) | 1.480 µs | 676,000 writes/s |

We ran each method 10 times. These were not just 10 writes. Across the runs, Go measured 3,641 writes with the old method and about 7.9 million writes with the new method.

`benchstat` reports a **99.96% reduction in write time** (`p<0.001`). This shows that `Sync` no longer blocks every log write. All methods used zero allocations per write.

The benchmark writes 31-byte records to a real file. The old method calls `Sync` after every successful write. The new method uses the current `syncWriter`, including timer-based syncs and the final flush. The file-write reference calls `Write` directly. It does not call `Sync` or use the timer and lock.

Environment: macOS 14.8.5, Apple M1 Max, APFS with 141 GiB free, Go 1.26.7 (`darwin/arm64`). The machine was about 90% idle before the benchmark.

## Durability and visibility

At runtime, a batch may remain unsynced for up to the 100 ms scheduling window. Graceful shutdown synchronously flushes the final batch. An abrupt power loss may lose the final unsynced batch.

## Testing

`TestSyncWriter`, using the standard library's deterministic `testing/synctest`, checks that:

- all writes reach the underlying writer while a burst produces one sync;
- a coalesced write is synced even when no later write arrives; and
- shutdown immediately syncs the final batch and stops the pending timer.

The focused test passed 100 consecutive runs under the race detector. The full `cmd/limactl` package tests and `go vet ./cmd/limactl` pass, and the package cross-compiles for Windows amd64.

Assisted-by: OpenAI Codex
