### PR TITLE
validate 9p securityModel, protocolVersion, and cache

### DIFF
--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -104,6 +104,10 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 		return err
 	}
 
+	if err := validate9pMountOptions(cfg); err != nil {
+		return err
+	}
+
 	for i, nw := range cfg.Networks {
 		if unknown := reflectutil.UnknownNonEmptyFields(nw,
 			"Lima",
@@ -138,6 +142,35 @@ func validateArch(ctx context.Context, cfg *limatype.LimaYAML) error {
 		}
 		if err := checkBinarySignature(ctx, vmArch); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// The 9p option values below are interpolated verbatim into the QEMU `-virtfs`
+// argument (securityModel) and the guest mount options (protocolVersion, cache),
+// so a value outside these sets, e.g. one containing a comma, would inject extra
+// options. Keep them in sync with the documented values in docs/config/mount.md.
+var (
+	supported9pSecurityModels   = []string{"passthrough", "mapped-xattr", "mapped-file", "none"}
+	supported9pProtocolVersions = []string{"9p2000", "9p2000.u", "9p2000.L"}
+	supported9pCaches           = []string{"none", "loose", "fscache", "mmap"}
+)
+
+// validate9pMountOptions rejects 9p mount options that are not among the
+// documented values, since they are interpolated verbatim into the QEMU
+// `-virtfs` argument and the guest mount options string.
+func validate9pMountOptions(cfg *limatype.LimaYAML) error {
+	for i := range cfg.Mounts {
+		nineP := cfg.Mounts[i].NineP
+		if sm := nineP.SecurityModel; sm != nil && !slices.Contains(supported9pSecurityModels, *sm) {
+			return fmt.Errorf("field `mounts[%d].9p.securityModel` must be one of %v, got %#q", i, supported9pSecurityModels, *sm)
+		}
+		if pv := nineP.ProtocolVersion; pv != nil && !slices.Contains(supported9pProtocolVersions, *pv) {
+			return fmt.Errorf("field `mounts[%d].9p.protocolVersion` must be one of %v, got %#q", i, supported9pProtocolVersions, *pv)
+		}
+		if c := nineP.Cache; c != nil && !slices.Contains(supported9pCaches, *c) {
+			return fmt.Errorf("field `mounts[%d].9p.cache` must be one of %v, got %#q", i, supported9pCaches, *c)
 		}
 	}
 	return nil

--- a/pkg/driver/qemu/qemu_test.go
+++ b/pkg/driver/qemu/qemu_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"github.com/lima-vm/lima/v2/pkg/ptr"
 )
 
 func TestArgValue(t *testing.T) {
@@ -150,4 +151,50 @@ func TestSwtpmCmdline(t *testing.T) {
 	assert.NilError(t, err)
 	_, err = os.Stat(swtpmSock)
 	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestValidate9pMountOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		nineP   limatype.NineP
+		wantErr string
+	}{
+		{
+			name: "valid non-default values",
+			nineP: limatype.NineP{
+				SecurityModel:   ptr.Of("mapped-xattr"),
+				ProtocolVersion: ptr.Of("9p2000.u"),
+				Cache:           ptr.Of("loose"),
+			},
+		},
+		{
+			// A comma in securityModel would inject extra options into the QEMU -virtfs argument.
+			name:    "securityModel with injected option",
+			nineP:   limatype.NineP{SecurityModel: ptr.Of("none,readonly=off")},
+			wantErr: "mounts[0].9p.securityModel",
+		},
+		{
+			name:    "unknown protocolVersion",
+			nineP:   limatype.NineP{ProtocolVersion: ptr.Of("9p2000.L,foo=bar")},
+			wantErr: "mounts[0].9p.protocolVersion",
+		},
+		{
+			name:    "unknown cache",
+			nineP:   limatype.NineP{Cache: ptr.Of("fscache,foo")},
+			wantErr: "mounts[0].9p.cache",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &limatype.LimaYAML{
+				Mounts: []limatype.Mount{{Location: "/", NineP: tt.nineP}},
+			}
+			err := validate9pMountOptions(cfg)
+			if tt.wantErr == "" {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## What This PR Changes

`Validate` checked only `msize` among the 9p mount options and left `securityModel`, `protocolVersion`, and `cache` unvalidated. `securityModel` is written verbatim into the host-side QEMU `-virtfs local,...,security_model=%s` argument, and `protocolVersion`/`cache` go into the guest mount options string, so a value containing a comma in a template that `limactl create`/`start` fetches from a URL injects extra options into those strings (for example `securityModel: "none,readonly=off"`). This rejects values outside the sets already documented in `docs/config/mount.md`, next to the existing `mountType` check.

## Linked Issue (Required in most cases)

N/A, small validation hardening; the accepted values are already documented for these fields.

## How I Tested This

`go test ./pkg/limayaml/...`, plus a new table test in `validate_test.go` that fails before this change and passes after: the documented non-default values are accepted, and a `securityModel`/`protocolVersion`/`cache` value carrying an injected `,option` is rejected.

## AI Usage
