### PR TITLE
CI: lint-quick: ignore cloud-native.slack.com 403

### DIFF
--- a/.github/workflows/lint-quick.yml
+++ b/.github/workflows/lint-quick.yml
@@ -40,5 +40,6 @@ jobs:
           --exclude https://github.com/lima-vm/lima/releases/download
           --exclude https://xbarapp.com
           --exclude https://api.github.com
+          --exclude https://cloud-native.slack.com
           README.md
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Please read our contribution rules before submitting:

- Pull requests guide: https://lima-vm.io/docs/community/contributing/#sending-pull-requests
- AI usage policy: https://lima-vm.io/docs/community/contributing/#ai-contribution-rules

-->

## What This PR Changes

<!-- Explain the single problem this PR fixes, in your own words. -->
Fix:

`lint-quick` keeps failing due to:

>> ### Errors in README.md
>>   * [403] <https://cloud-native.slack.com/> (at 82:13) | Rejected status code: 403 Forbidden
>>   Notice: Summary report available at: https://github.com/lima-vm/lima/actions/runs/32248488968#summary-96130939801
>
>_Originally posted by @unsuman in https://github.com/lima-vm/lima/issues/5427#issuecomment-5344557837_
            

## Linked Issue (Required in most cases)

<!-- Link the issue here. If your issue is not approved by a maintainer, don't expect your PR to be merged. -->

None

## How I Tested This

CI will test this

## AI Usage

<!-- If you used AI tools, say which tool and how you used it. For example, `Assisted-by: AI_AGENT_NAME:VERSION [TOOL]` or `Co-Authored-By`-->