### PR TITLE
Bump k8s flannel version from 0.28.5 to 0.28.9

### DIFF
--- a/templates/k8s.yaml
+++ b/templates/k8s.yaml
@@ -260,7 +260,7 @@ param:
   # The k8s version can be either "stable" or "v1.xx.y"
   version: "stable"
   # The flannel version is either "latest" or "v0.xx.y"
-  flannelVersion: "v0.28.5"
+  flannelVersion: "v0.28.9"
   url: ""
   token: ""
   discoveryTokenCaCertHash: ""


### PR DESCRIPTION
<!-- Please read our contribution rules before submitting:

- Pull requests guide: https://lima-vm.io/docs/community/contributing/#sending-pull-requests
- AI usage policy: https://lima-vm.io/docs/community/contributing/#ai-contribution-rules

-->

## What This PR Changes

This is the change in `kube-flannel.yml`

```diff
@@ -147,3 +147,3 @@
           value: "false"
-        image: ghcr.io/flannel-io/flannel:v0.28.4
+        image: ghcr.io/flannel-io/flannel:v0.28.9
         name: kube-flannel
@@ -174,3 +174,3 @@
         - cp
-        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.9.1-flannel1
+        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.9.1-flannel3
         name: install-cni-plugin
@@ -185,3 +185,3 @@
         - cp
-        image: ghcr.io/flannel-io/flannel:v0.28.4
+        image: ghcr.io/flannel-io/flannel:v0.28.9
         name: install-cni
```

## Linked Issue (Required in most cases)

<!-- Link the issue here. If your issue is not approved by a maintainer, don't expect your PR to be merged. -->

Closes #

## How I Tested This

## AI Usage

<!-- If you used AI tools, say which tool and how you used it. For example, `Assisted-by: AI_AGENT_NAME:VERSION [TOOL]` or `Co-Authored-By`-->