### PR TITLE
qemuimgutil: reject qcow2 external data file references

### DIFF
--- a/pkg/qemuimgutil/qemuimgutil.go
+++ b/pkg/qemuimgutil/qemuimgutil.go
@@ -84,6 +84,7 @@ func (sp *InfoFormatSpecific) Vmdk() *InfoFormatSpecificDataVmdk {
 
 type InfoFormatSpecificDataQcow2 struct {
 	Compat          string `json:"compat,omitempty"`           // since QEMU 1.7
+	DataFile        string `json:"data-file,omitempty"`        // since QEMU 3.0
 	LazyRefcounts   bool   `json:"lazy-refcounts,omitempty"`   // since QEMU 1.7
 	Corrupt         bool   `json:"corrupt,omitempty"`          // since QEMU 2.2
 	RefcountBits    int    `json:"refcount-bits,omitempty"`    // since QEMU 2.3
@@ -212,8 +213,8 @@ func (q *QemuImageUtil) Convert(ctx context.Context, imageType image.Type, sourc
 		if err != nil {
 			return fmt.Errorf("failed to get info for source disk %#q: %w", source, err)
 		}
-		if info.BackingFilename != "" || info.FullBackingFilename != "" {
-			return fmt.Errorf("qcow2 image %#q has an unexpected backing file: %#q", source, info.BackingFilename)
+		if err := rejectExternalFileReferences(info); err != nil {
+			return err
 		}
 	}
 
@@ -235,6 +236,35 @@ func (q *QemuImageUtil) Convert(ctx context.Context, imageType image.Type, sourc
 	return nil
 }
 
+// rejectExternalFileReferences returns an error if info references any file
+// other than itself: a backing file, a qcow2 external data-file, or a VMDK
+// extent. qemu-img reads those files from the host when it opens the image, so
+// an untrusted image that points them at an arbitrary host path (e.g.
+// /etc/passwd) would have that path's contents copied into the guest disk. The
+// native converter already refuses such images via go-qcow2reader's Readable();
+// this keeps the qemu path and the base-disk gate consistent with it.
+func rejectExternalFileReferences(info *Info) error {
+	if info.BackingFilename != "" {
+		return fmt.Errorf("image (%#q) must not have a backing file (%#q)", info.Filename, info.BackingFilename)
+	}
+	if info.FullBackingFilename != "" {
+		return fmt.Errorf("image (%#q) must not have a backing file (%#q)", info.Filename, info.FullBackingFilename)
+	}
+	if info.FormatSpecific != nil {
+		if qcow2 := info.FormatSpecific.Qcow2(); qcow2 != nil && qcow2.DataFile != "" {
+			return fmt.Errorf("image (%#q) must not have an external data file (%#q)", info.Filename, qcow2.DataFile)
+		}
+		if vmdk := info.FormatSpecific.Vmdk(); vmdk != nil {
+			for _, e := range vmdk.Extents {
+				if e.Filename != info.Filename {
+					return fmt.Errorf("image (%#q) must not have an extent file (%#q)", info.Filename, e.Filename)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // AcceptableAsBaseDisk checks if a disk image is acceptable as a base disk.
 func AcceptableAsBaseDisk(info *Info) error {
 	switch info.Format {
@@ -244,20 +274,8 @@ func AcceptableAsBaseDisk(info *Info) error {
 		logrus.WithField("filename", info.Filename).
 			Warnf("Unsupported image format %#q. The image may not boot, or may have an extra privilege to access the host filesystem. Use with caution.", info.Format)
 	}
-	if info.BackingFilename != "" {
-		return fmt.Errorf("base disk (%#q) must not have a backing file (%#q)", info.Filename, info.BackingFilename)
-	}
-	if info.FullBackingFilename != "" {
-		return fmt.Errorf("base disk (%#q) must not have a backing file (%#q)", info.Filename, info.FullBackingFilename)
-	}
-	if info.FormatSpecific != nil {
-		if vmdk := info.FormatSpecific.Vmdk(); vmdk != nil {
-			for _, e := range vmdk.Extents {
-				if e.Filename != info.Filename {
-					return fmt.Errorf("base disk (%#q) must not have an extent file (%#q)", info.Filename, e.Filename)
-				}
-			}
-		}
+	if err := rejectExternalFileReferences(info); err != nil {
+		return err
 	}
 	// info.Children is set since QEMU 8.0
 	switch len(info.Children) {

--- a/pkg/qemuimgutil/qemuimgutil_test.go
+++ b/pkg/qemuimgutil/qemuimgutil_test.go
@@ -4,6 +4,7 @@
 package qemuimgutil
 
 import (
+	"encoding/json"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -115,6 +116,46 @@ func TestParseInfo(t *testing.T) {
 			assert.Equal(t, qcow2.Compat, "1.1")
 		})
 	})
+	t.Run("qcow2 external data file", func(t *testing.T) {
+		// qemu-img create -f qcow2 -o data_file=secret.bin,data_file_raw=on evil.qcow2 4096
+		// (QEMU 11.0)
+		const s = `{
+    "children": [
+        {
+            "name": "file",
+            "info": {
+                "children": [],
+                "virtual-size": 327680,
+                "filename": "evil.qcow2",
+                "format": "file",
+                "dirty-flag": false
+            }
+        }
+    ],
+    "virtual-size": 4096,
+    "filename": "evil.qcow2",
+    "cluster-size": 65536,
+    "format": "qcow2",
+    "format-specific": {
+        "type": "qcow2",
+        "data": {
+            "compat": "1.1",
+            "compression-type": "zlib",
+            "data-file": "secret.bin",
+            "data-file-raw": true,
+            "refcount-bits": 16
+        }
+    },
+    "dirty-flag": false
+}`
+		info, err := parseInfo([]byte(s))
+		assert.NilError(t, err)
+		assert.Equal(t, "", info.BackingFilename)
+		assert.Check(t, info.FormatSpecific != nil)
+		qcow2 := info.FormatSpecific.Qcow2()
+		assert.Check(t, qcow2 != nil)
+		assert.Equal(t, "secret.bin", qcow2.DataFile)
+	})
 	t.Run("vmdk", func(t *testing.T) {
 		t.Run("twoGbMaxExtentSparse", func(t *testing.T) {
 			// qemu-img create -f vmdk foo.vmdk 4G -o subformat=twoGbMaxExtentSparse
@@ -211,5 +252,49 @@ func TestParseInfo(t *testing.T) {
 			assert.Check(t, vmdk != nil)
 			assert.Equal(t, vmdk.CreateType, "twoGbMaxExtentSparse")
 		})
+	})
+}
+
+func TestRejectExternalFileReferences(t *testing.T) {
+	t.Run("plain qcow2", func(t *testing.T) {
+		info := &Info{
+			Filename: "foo.qcow2",
+			Format:   "qcow2",
+			FormatSpecific: &InfoFormatSpecific{
+				Type: "qcow2",
+				Data: json.RawMessage(`{"compat":"1.1"}`),
+			},
+		}
+		assert.NilError(t, rejectExternalFileReferences(info))
+		assert.NilError(t, AcceptableAsBaseDisk(info))
+	})
+	t.Run("backing file", func(t *testing.T) {
+		info := &Info{Filename: "bar.qcow2", Format: "qcow2", BackingFilename: "foo.qcow2"}
+		assert.ErrorContains(t, rejectExternalFileReferences(info), "backing file")
+		assert.ErrorContains(t, AcceptableAsBaseDisk(info), "backing file")
+	})
+	t.Run("qcow2 external data file", func(t *testing.T) {
+		info := &Info{
+			Filename: "evil.qcow2",
+			Format:   "qcow2",
+			FormatSpecific: &InfoFormatSpecific{
+				Type: "qcow2",
+				Data: json.RawMessage(`{"data-file":"/etc/passwd","data-file-raw":true}`),
+			},
+		}
+		assert.ErrorContains(t, rejectExternalFileReferences(info), "external data file")
+		assert.ErrorContains(t, AcceptableAsBaseDisk(info), "external data file")
+	})
+	t.Run("vmdk extent", func(t *testing.T) {
+		info := &Info{
+			Filename: "foo.vmdk",
+			Format:   "vmdk",
+			FormatSpecific: &InfoFormatSpecific{
+				Type: "vmdk",
+				Data: json.RawMessage(`{"extents":[{"filename":"/etc/passwd"}]}`),
+			},
+		}
+		assert.ErrorContains(t, rejectExternalFileReferences(info), "extent file")
+		assert.ErrorContains(t, AcceptableAsBaseDisk(info), "extent file")
 	})
 }


### PR DESCRIPTION
## What This PR Changes

`QemuImageUtil.Convert` only rejected a source image that had a backing file, and `AcceptableAsBaseDisk` rejected backing files and VMDK extents but not a qcow2 external data file (`format-specific.data.data-file`). `qemu-img` reads that file from the host when it opens the image, so a crafted qcow2 whose data file points at a host path such as `/etc/passwd` gets that path's contents copied into the guest disk during conversion, or read directly when the image is booted as a base disk. An image URL can come from a remote template, so those bytes are attacker-influenced. The native converter already refuses such images through go-qcow2reader's `Readable()`, and `proxyimgutil` prefers the qemu implementation when `qemu-img` is installed, so the weaker check was the one that ran. This adds the missing `data-file` field to the parsed info and routes both callees through one `rejectExternalFileReferences` helper covering backing files, the qcow2 data file, and VMDK extents.

## Linked Issue (Required in most cases)

No pre-filed issue; this is a self-contained fix for a host-file disclosure on the image path. Glad to open one first if you prefer.

## How I Tested This

`go test ./pkg/qemuimgutil/...`, with new cases asserting the `Convert` validation and `AcceptableAsBaseDisk` reject a qcow2 data file and a VMDK extent while a plain qcow2 still passes. Manual check with qemu-img 11.0:

```
qemu-img create -f qcow2 -o data_file=secret.bin,data_file_raw=on evil.qcow2 4096
# place a host file at ./secret.bin, then:
qemu-img convert -O raw evil.qcow2 out.raw   # out.raw now holds secret.bin's bytes
qemu-img info --output=json evil.qcow2       # backing-filename is empty; data-file is set
```

Before the fix the empty backing filename let the image through; after it, the data file is rejected.

## AI Usage
