### PR TITLE
reject guest agent events that report an invalid IP

### DIFF
--- a/pkg/guestagent/api/client/client.go
+++ b/pkg/guestagent/api/client/client.go
@@ -63,7 +63,7 @@ func (c *GuestAgentClient) Info(ctx context.Context) (*api.Info, error) {
 	return c.cli.GetInfo(ctx, &emptypb.Empty{})
 }
 
-func (c *GuestAgentClient) Events(ctx context.Context, eventCb func(response *api.Event)) error {
+func (c *GuestAgentClient) Events(ctx context.Context, eventCb func(response *api.Event) error) error {
 	events, err := c.cli.GetEvents(ctx, &emptypb.Empty{})
 	if err != nil {
 		return err
@@ -74,7 +74,9 @@ func (c *GuestAgentClient) Events(ctx context.Context, eventCb func(response *ap
 		if err != nil {
 			return err
 		}
-		eventCb(recv)
+		if err := eventCb(recv); err != nil {
+			return err
+		}
 	}
 }
 

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -953,10 +953,17 @@ func (a *HostAgent) processGuestAgentEvents(ctx context.Context, client *guestag
 
 	logrus.Debugf("guest agent info: %+v", info)
 
-	onEvent := func(ev *guestagentapi.Event) {
+	onEvent := func(ev *guestagentapi.Event) error {
 		logrus.Debugf("guest agent event: %+v", ev)
 		for _, f := range ev.Errors {
 			logrus.Warnf("received error from the guest: %#q", f)
+		}
+		// IPPort.Ip is under the guest's control and ends up in PortForwardEvent.GuestAddr,
+		// which limactl start/watch print to the terminal, so reject anything that is not an IP.
+		for _, f := range slices.Concat(ev.AddedLocalPorts, ev.RemovedLocalPorts) {
+			if net.ParseIP(f.Ip) == nil {
+				return fmt.Errorf("guest agent reported invalid IP %#q", f.Ip)
+			}
 		}
 		// History of the default value of useSSHFwd:
 		// - v0.1.0:        true  (effectively)
@@ -978,6 +985,7 @@ func (a *HostAgent) processGuestAgentEvents(ctx context.Context, client *guestag
 			dialContext := portfwd.DialContextToGRPCTunnel(client)
 			a.grpcPortForwarder.OnEvent(ctx, dialContext, ev)
 		}
+		return nil
 	}
 
 	if err := client.Events(ctx, onEvent); err != nil {

--- a/pkg/hostagent/portforward_test.go
+++ b/pkg/hostagent/portforward_test.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hostagent
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"gotest.tools/v3/assert"
+
+	"github.com/lima-vm/lima/v2/pkg/guestagent/api"
+	guestagentclient "github.com/lima-vm/lima/v2/pkg/guestagent/api/client"
+)
+
+// invalidIPGuestService streams one port event whose IP is not an IP address.
+// A compromised guest can report an arbitrary string there; this one carries
+// ANSI escapes that would rewrite the operator's terminal if it reached
+// PortForwardEvent.GuestAddr.
+type invalidIPGuestService struct {
+	api.UnimplementedGuestServiceServer
+}
+
+func (*invalidIPGuestService) GetInfo(context.Context, *emptypb.Empty) (*api.Info, error) {
+	return &api.Info{}, nil
+}
+
+func (*invalidIPGuestService) GetEvents(_ *emptypb.Empty, stream api.GuestService_GetEventsServer) error {
+	return stream.Send(&api.Event{
+		AddedLocalPorts: []*api.IPPort{{Ip: "1.2.3.4\x1b[2Kspoofed\x07", Port: 8080, Protocol: "tcp"}},
+	})
+}
+
+func TestProcessGuestAgentEventsRejectsInvalidIP(t *testing.T) {
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer(grpc.Creds(guestagentclient.NewCredentials()))
+	api.RegisterGuestServiceServer(server, &invalidIPGuestService{})
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+	})
+
+	client, err := guestagentclient.NewGuestAgentClient(listener.DialContext)
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	a := &HostAgent{guestAgentAliveCh: make(chan struct{})}
+	err = a.processGuestAgentEvents(t.Context(), client)
+	assert.ErrorContains(t, err, "invalid IP")
+}


### PR DESCRIPTION
1. GuestAddr on the port-forward event comes from the guest-reported IPPort.Ip (guest.HostString()), an unvalidated protobuf string an untrusted guest fully controls.
2. It flows into the event stream that limactl start and limactl watch print with a bare %s, so a guest can inject ANSI/OSC escapes to spoof the operator terminal; a single AddedLocalPorts entry whose Ip is not a parseable IP takes the not-forwarding branch and emits the raw bytes.

Per review, the guest-reported addresses are validated when the event is received: processGuestAgentEvents fails the event with an error if any AddedLocalPorts or RemovedLocalPorts entry does not parse with net.ParseIP, before either forwarder derives GuestAddr or log lines from it. The Events callback in the guest agent client now returns an error so that failure propagates to the reconnect loop. The regression test streams an event with a malformed IP through an in-process GuestService and asserts the error.
