### PR TITLE
vz: add audio.microphone to attach a capture stream

### DIFF
--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -128,6 +128,7 @@ func RegisterCreate(cmd *cobra.Command, commentPrefix string) {
 
 	flags.String("audio-device", "", commentPrefix+"Audio device backend (e.g., 'pa', 'coreaudio', 'none')")
 	flags.String("audio-interface", "", commentPrefix+"Audio virtual hardware interface ('hda' or 'virtio')")
+	flags.Bool("audio-microphone", false, commentPrefix+"Attach an audio input stream as well as playback (vz only)")
 }
 
 func defaultExprFunc(expr string) func(v *flag.Flag) ([]string, error) {
@@ -387,6 +388,7 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool, params map[string]stri
 		},
 		{"audio-device", d(".audio.device = %q"), false, true},
 		{"audio-interface", d(".audio.interface = %q"), false, true},
+		{"audio-microphone", d(".audio.microphone = %s"), false, true},
 		{"ssh-port", d(".ssh.localPort = %s"), false, false},
 		{
 			"image-variant",

--- a/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
+++ b/pkg/driver/krunkit/krunkit_driver_darwin_arm64.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/networks/usernet"
 	"github.com/lima-vm/lima/v2/pkg/osutil"
+	"github.com/lima-vm/lima/v2/pkg/reflectutil"
 	"github.com/lima-vm/lima/v2/pkg/store"
 )
 
@@ -247,6 +248,20 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 
 	if cfg.OS != nil && *cfg.OS == limatype.WINDOWS {
 		return errors.New("currently Windows guest OS is only supported on QEMU")
+	}
+
+	audio := cfg.Audio
+	if audio.Device != nil && *audio.Device == "" {
+		audio.Device = nil
+	}
+	if audio.Interface != nil && *audio.Interface == "" {
+		audio.Interface = nil
+	}
+	if audio.Microphone != nil && !*audio.Microphone {
+		audio.Microphone = nil
+	}
+	if unknown := reflectutil.UnknownNonEmptyFields(audio); len(unknown) > 0 {
+		logrus.Warnf("vmType %s: ignoring audio: %+v", *cfg.VMType, unknown)
 	}
 
 	return nil

--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -115,6 +115,17 @@ func validateConfig(cfg *limatype.LimaYAML) error {
 		}
 	}
 
+	audio := cfg.Audio
+	if audio.Microphone != nil && !*audio.Microphone {
+		audio.Microphone = nil
+	}
+	if unknown := reflectutil.UnknownNonEmptyFields(audio,
+		"Device",
+		"Interface",
+	); len(unknown) > 0 {
+		logrus.Warnf("vmType %s: ignoring audio: %+v", *cfg.VMType, unknown)
+	}
+
 	var qemuOpts limatype.QEMUOpts
 	if err := limayaml.Convert(cfg.VMOpts[limatype.QEMU], &qemuOpts, "vmOpts.qemu"); err != nil {
 		return err

--- a/pkg/driver/vz/vm_darwin.go
+++ b/pkg/driver/vz/vm_darwin.go
@@ -785,17 +785,31 @@ func attachAudio(inst *limatype.Instance, config *vz.VirtualMachineConfiguration
 		if err != nil {
 			return fmt.Errorf("failed to create host audio output stream: %w", err)
 		}
+		streams := []vz.VirtioSoundDeviceStreamConfiguration{outputStream}
+
+		// Opt-in: an input stream makes macOS ask for microphone permission
+		// on behalf of the process running the VM.
+		if y.Audio.Microphone != nil && *y.Audio.Microphone {
+			inputStream, err := vz.NewVirtioSoundDeviceHostInputStreamConfiguration()
+			if err != nil {
+				return fmt.Errorf("failed to create host audio input stream: %w", err)
+			}
+			streams = append(streams, inputStream)
+		}
 
 		soundDeviceConfiguration, err := vz.NewVirtioSoundDeviceConfiguration()
 		if err != nil {
 			return fmt.Errorf("failed to create virtio sound device configuration: %w", err)
 		}
-		soundDeviceConfiguration.SetStreams(outputStream)
+		soundDeviceConfiguration.SetStreams(streams...)
 		config.SetAudioDevicesVirtualMachineConfiguration([]vz.AudioDeviceConfiguration{
 			soundDeviceConfiguration,
 		})
 		return nil
 	case "", "none":
+		if y.Audio.Microphone != nil && *y.Audio.Microphone {
+			logrus.Warn("`audio.microphone` requires `audio.device` to be set. Ignoring it.")
+		}
 		return nil
 	default:
 		return fmt.Errorf("unexpected audio device %#q", *inst.Config.Audio.Device)

--- a/pkg/driver/wsl2/wsl_driver_windows.go
+++ b/pkg/driver/wsl2/wsl_driver_windows.go
@@ -24,6 +24,7 @@ import (
 
 var knownYamlProperties = []string{
 	"Arch",
+	"Audio",
 	"Containerd",
 	"CopyToHost",
 	"CPUType",
@@ -161,11 +162,18 @@ func validateConfig(_ context.Context, cfg *limatype.LimaYAML) error {
 			}
 		}
 
-		if cfg.Audio.Device != nil {
-			audioDevice := *cfg.Audio.Device
-			if audioDevice != "" {
-				logrus.Warnf("Ignoring: vmType %s: `audio.device`: %+v", *cfg.VMType, audioDevice)
-			}
+		audio := cfg.Audio
+		if audio.Device != nil && *audio.Device == "" {
+			audio.Device = nil
+		}
+		if audio.Interface != nil && *audio.Interface == "" {
+			audio.Interface = nil
+		}
+		if audio.Microphone != nil && !*audio.Microphone {
+			audio.Microphone = nil
+		}
+		if unknown := reflectutil.UnknownNonEmptyFields(audio); len(unknown) > 0 {
+			logrus.Warnf("Ignoring: vmType %s: audio: %+v", *cfg.VMType, unknown)
 		}
 	}
 
@@ -242,9 +250,6 @@ func (l *LimaWslDriver) Start(ctx context.Context) (chan error, error) {
 	if l.Instance.Config.SSH.OverVsock != nil && *l.Instance.Config.SSH.OverVsock {
 		// Probably never supportable for WSL2
 		logrus.Warn(".ssh.overVsock is not supported for WSL2 driver")
-	}
-	if l.Instance.Config.Audio.Interface != nil {
-		logrus.Warn("`audio.interface` is ignored when using the WSL2 driver")
 	}
 	logrus.Infof("Starting WSL VM")
 	status, err := getWslStatus(ctx, l.Instance.Name)

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -225,6 +225,10 @@ type Audio struct {
 	Device *string `yaml:"device,omitempty" json:"device,omitempty" jsonschema:"nullable"`
 	// Interface is the virtual hardware presentation
 	Interface *string `yaml:"interface,omitempty" json:"interface,omitempty" jsonschema:"nullable"`
+	// Microphone attaches an audio *input* stream in addition to playback.
+	// Opt-in, because it makes the host ask for microphone permission.
+	// VZ driver only for now; the QEMU driver warns and ignores it.
+	Microphone *bool `yaml:"microphone,omitempty" json:"microphone,omitempty" jsonschema:"nullable"` // default: false
 }
 
 type VNCOptions struct {

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -322,6 +322,16 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 		y.Audio.Interface = new("")
 	}
 
+	if y.Audio.Microphone == nil {
+		y.Audio.Microphone = d.Audio.Microphone
+	}
+	if o.Audio.Microphone != nil {
+		y.Audio.Microphone = o.Audio.Microphone
+	}
+	if y.Audio.Microphone == nil {
+		y.Audio.Microphone = new(false)
+	}
+
 	if y.Video.Display == nil {
 		y.Video.Display = d.Video.Display
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -133,8 +133,9 @@ func TestFillDefault(t *testing.T) {
 			LegacyBIOS: new(false),
 		},
 		Audio: limatype.Audio{
-			Device:    new(""),
-			Interface: new(""),
+			Device:     new(""),
+			Interface:  new(""),
+			Microphone: new(false),
 		},
 		Video: limatype.Video{
 			Display: new("none"),
@@ -380,8 +381,9 @@ func TestFillDefault(t *testing.T) {
 			// Remove driver-specific firmware images from defaults
 		},
 		Audio: limatype.Audio{
-			Device:    new("coreaudio"),
-			Interface: new("virtio"),
+			Device:     new("coreaudio"),
+			Interface:  new("virtio"),
+			Microphone: new(true),
 		},
 		Video: limatype.Video{
 			Display: new("cocoa"),
@@ -594,8 +596,9 @@ func TestFillDefault(t *testing.T) {
 			LegacyBIOS: new(true),
 		},
 		Audio: limatype.Audio{
-			Device:    new("coreaudio"),
-			Interface: new("hda"),
+			Device:     new("coreaudio"),
+			Interface:  new("hda"),
+			Microphone: new(true),
 		},
 		Video: limatype.Video{
 			Display: new("cocoa"),

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -682,6 +682,9 @@ func warnExperimental(y *limatype.LimaYAML) {
 			logrus.Warn("`audio.interface` is experimental")
 		}
 	}
+	if y.Audio.Microphone != nil && *y.Audio.Microphone {
+		logrus.Warn("`audio.microphone` is experimental")
+	}
 	if y.MountInotify != nil && *y.MountInotify {
 		logrus.Warn("`mountInotify` is experimental")
 	}

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -466,6 +466,14 @@ audio:
   # VZ driver always uses virtio-sound regardless of this setting.
   # 🟢 Builtin default: "" (resolves to "hda" when audio.device is set)
   interface: null
+  # EXPERIMENTAL
+  # Attach a microphone as well as speakers, so the guest gets a capture device
+  # (ALSA "pcmC0D1c") and not only playback. Needs audio.device to be set.
+  # Off by default: an input stream makes macOS ask for microphone permission on
+  # behalf of Lima.
+  # VZ driver only. The QEMU driver warns and ignores it.
+  # 🟢 Builtin default: false
+  microphone: null
 
 video:
   # QEMU display, e.g., "none", "cocoa", "sdl", "gtk", "vnc", "default".

--- a/website/content/en/docs/releases/experimental.md
+++ b/website/content/en/docs/releases/experimental.md
@@ -10,7 +10,7 @@ The following features are experimental and subject to change:
 - `vmType: wsl2` and relevant configurations (`mountType: wsl2`)
 - `arch`: `riscv64`, `armv7l`, `s390x`, and `ppc64le`
 - `video.display: vnc` and relevant configuration (`video.vnc.display`)
-- `audio.device` and `audio.interface`
+- `audio.device`, `audio.interface`, and `audio.microphone`
 - `mountInotify: true`
 - `tpm: true`
 - `user.passwordlessSudo` (See [Sudo](../config/sudo))


### PR DESCRIPTION
## What This PR Changes

A vz guest gets a speaker but no microphone: the driver only creates a host output
stream. This adds an opt-in `audio.microphone` boolean, default `false`. When it is
true, the driver also creates a host input stream and the guest gets a capture device.
Opt-in because an input stream makes macOS ask for microphone permission; enabling
sound alone shouldn't trigger that prompt.

The key warns as experimental. Setting it without `audio.device` warns and is ignored.
The QEMU driver warns that it ignores the field; QEMU support belongs in its own change.

## Linked Issue

Closes #5457 (PR creation approved there, including manual testing for now)

## How I Tested This

Manually, on an Apple silicon Mac running macOS 26.6.2:

- Both warnings fire on `limactl start`.
- With the knob on, the guest gains `pcmC0D1c` in `/dev/snd`. With it off, there is
  only `pcmC0D0p`.
- macOS asks for microphone permission at first capture, not at VM start, and
  attributes the request to the terminal running `limactl`. No entitlement or signing
  change is needed.
- `arecord -D plughw:0,1 -f S16_LE -r 16000 -c 1 -d 3` in the guest records real
  audio: maximum amplitude 0.36 in a spoken test, measured with `sox stat`.

`TestFillDefault` covers the config side: the default, and that user-provided defaults
and overrides propagate. The driver code is cgo against Virtualization.framework, so it
has no unit test.

## AI Usage

Assisted-by: Claude Opus 5 and Claude Fable 5 [Claude Code]

Both models drafted the patch and this description with my review; the commit carries
their `Co-Authored-By` trailers. I tested on hardware and review everything myself, I had claude explain the all the code changes in terms of nodejs cli terms, which I have experience with, and explanation made sense. I also made claude make sure my code and comments don't stick out and fit in with the rest of the code.