### PR TITLE
Implement screenshot for the QEMU driver too

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ go 1.26
 require (
 	github.com/lima-vm/go-qcow2reader v0.7.1
 	github.com/lima-vm/sshocker v0.3.11 // gomodjail:unconfined
+	golang.org/x/image v0.45.0
 	golang.org/x/net v0.58.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0 // gomodjail:unconfined
@@ -54,6 +55,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	github.com/sethvargo/go-password v0.4.0
 	github.com/sirupsen/logrus v1.10.2
+	github.com/spakin/netpbm v1.3.2
 	github.com/spf13/cobra v1.10.2 // gomodjail:unconfined
 	github.com/spf13/pflag v1.0.10
 	google.golang.org/grpc v1.83.1

--- a/go.sum
+++ b/go.sum
@@ -277,6 +277,8 @@ github.com/sethvargo/go-password v0.4.0 h1:eSidVKQw5C7CmTDAtH3RipBTSjdU1ZRxQaynD
 github.com/sethvargo/go-password v0.4.0/go.mod h1:PO3nYHwUpcHPR0F9woy7a4abZPvzRuqJr0GaeIYTm3k=
 github.com/sirupsen/logrus v1.10.2 h1:G2SED73/qrAu6YwbdxOD6peLkCBI3z7L+ykJFTXJBBo=
 github.com/sirupsen/logrus v1.10.2/go.mod h1:SLEg8TqYulVKKfIGHldVp2K2aYz2DKSVBq4g/H5bR7Q=
+github.com/spakin/netpbm v1.3.2 h1:ZAb16Sw/+b4QeO9NokEvejVvbrYdF6DdcYJe0dKONL0=
+github.com/spakin/netpbm v1.3.2/go.mod h1:cVep9uXARFgAu2UU+0c+OE1J+eKmDN2hW0EN+tazkTA=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -335,6 +337,8 @@ golang.org/x/crypto v0.15.0/go.mod h1:4ChreQoLWfG3xLDer1WdlH5NdlQ3+mwnQq1YTKY+72
 golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
 golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/image v0.45.0 h1:FMb1nTbH5H9vF55SriQHgFw5GnNL9Jg6L25BwXKzhB0=
+golang.org/x/image v0.45.0/go.mod h1:n62x/7RqlwXDvGsSU4u6IUTUf6KghUZ9Bt7cG/T9Fx4=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"image/png"
 	"io"
 	"io/fs"
 	"net"
@@ -31,6 +32,8 @@ import (
 	"github.com/lima-vm/go-qcow2reader/image/vhdx"
 	"github.com/lima-vm/go-qcow2reader/image/vmdk"
 	"github.com/sirupsen/logrus"
+	"github.com/spakin/netpbm"
+	"golang.org/x/image/bmp"
 
 	"github.com/lima-vm/lima/v2/pkg/driver"
 	"github.com/lima-vm/lima/v2/pkg/driver/qemu/entitlementutil"
@@ -914,4 +917,69 @@ func (l *LimaQemuDriver) ForwardGuestAgent(_ context.Context) bool {
 
 func (l *LimaQemuDriver) AdditionalSetupForSSH(_ context.Context) error {
 	return nil
+}
+
+func (l *LimaQemuDriver) CaptureScreenshot(format string) ([]byte, error) {
+	if format == "" {
+		format = "png"
+	}
+	if format != "png" && format != "bmp" {
+		return nil, fmt.Errorf("unsupported format %q: must be png or bmp", format)
+	}
+
+	if l.Instance.Config.Video.Display != nil && *l.Instance.Config.Video.Display == "none" {
+		return nil, fmt.Errorf("%w (set video.display to \"default\" or a VNC display to enable screenshots)", driver.ErrNoDisplay)
+	}
+
+	qmpSockPath := filepath.Join(l.Instance.Dir, filenames.QMPSock)
+	err := waitFileExists(qmpSockPath, 30*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	qmpClient, err := qmp.NewSocketMonitor("unix", qmpSockPath, 5*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	if err := qmpClient.Connect(); err != nil {
+		return nil, err
+	}
+	defer func() { _ = qmpClient.Disconnect() }()
+
+	rawClient := raw.NewMonitor(qmpClient)
+
+	tmpFile, err := os.CreateTemp("", "screendump-*.ppm")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+	tmpFile.Close()
+
+	if err := rawClient.Screendump(tmpPath); err != nil {
+		return nil, fmt.Errorf("screendump failed: %w", err)
+	}
+
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read screendump: %w", err)
+	}
+
+	img, err := netpbm.Decode(bytes.NewReader(data), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode PPM screendump: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if format == "bmp" {
+		if err := bmp.Encode(&buf, img); err != nil {
+			return nil, fmt.Errorf("failed to encode BMP: %w", err)
+		}
+	} else {
+		if err := png.Encode(&buf, img); err != nil {
+			return nil, fmt.Errorf("failed to encode PNG: %w", err)
+		}
+	}
+
+	return buf.Bytes(), nil
 }


### PR DESCRIPTION
Previously it was only implemented for VZ.

Convert PPM into the expected output formats.

Assisted-by: LLM

## What This PR Changes

Implements the `screenshot` functionality, for the QEMU driver.

## Linked Issue (Required in most cases)

Issue #5094

## How I Tested This

Tested locally, using the `template:experimental/vnc` template.

## AI Usage

Qwen