### PR TITLE
go.mod: golang.org/x/crypto v0.56.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 // gomodjail:confined
 module github.com/lima-vm/lima/v2
 
-go 1.26
+go 1.26.0
 
 // Our own packages and golang.org/x packages are trusted
 //gosocialcheck:trusted
@@ -64,7 +64,7 @@ require (
 
 //gosocialcheck:trusted
 require (
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/term v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -332,8 +332,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
 golang.org/x/crypto v0.15.0/go.mod h1:4ChreQoLWfG3xLDer1WdlH5NdlQ3+mwnQq1YTKY+72g=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=


### PR DESCRIPTION
<!-- Please read our contribution rules before submitting:

- Pull requests guide: https://lima-vm.io/docs/community/contributing/#sending-pull-requests
- AI usage policy: https://lima-vm.io/docs/community/contributing/#ai-contribution-rules

-->

## What This PR Changes

<!-- Explain the single problem this PR fixes, in your own words. -->

Silence govulncheck

```
Vulnerability #1: GO-2026-6355
    Prevent DoS on deadlocked established channel in golang.org/x/crypto/ssh
  More info: https://pkg.go.dev/vuln/GO-2026-6355
  Module: golang.org/x/crypto
    Found in: golang.org/x/crypto@v0.55.0
    Fixed in: golang.org/x/crypto@v0.56.0
    Example traces found:
      #1: pkg/portfwdserver/server.go:57:2: portfwdserver.TunnelServer.Start calls tcpproxy.DialProxy.HandleConn, which eventually calls ssh.NewClientConn

Vulnerability #2: GO-2026-6354
    Prevent DoS on deadlocked undecided channel in golang.org/x/crypto/ssh
  More info: https://pkg.go.dev/vuln/GO-2026-6354
  Module: golang.org/x/crypto
    Found in: golang.org/x/crypto@v0.55.0
    Fixed in: golang.org/x/crypto@v0.56.0
    Example traces found:
      #1: pkg/portfwdserver/server.go:57:2: portfwdserver.TunnelServer.Start calls tcpproxy.DialProxy.HandleConn, which eventually calls ssh.NewClientConn
```

## Linked Issue (Required in most cases)

<!-- Link the issue here. If your issue is not approved by a maintainer, don't expect your PR to be merged. -->

None

## How I Tested This

None

## AI Usage

<!-- If you used AI tools, say which tool and how you used it. For example, `Assisted-by: AI_AGENT_NAME:VERSION [TOOL]` or `Co-Authored-By`-->

None