### PR TITLE
gomodjail: update to v2.0.1, enforce `gomodjail analyze` in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,8 @@ jobs:
       run: go install github.com/google/go-licenses@v1.6.0
     - name: Check licenses
       run: make go-licenses
+    - name: Check the gomodjail confinement of Go dependencies
+      run: NO_COLOR=true make gomodjail
     - name: Check social reputation of Go dependencies
       run: make gosocialcheck
     - name: Check license boilerplates
@@ -593,10 +595,14 @@ jobs:
   # gomodjail is a library sandbox for Go
   # https://github.com/AkihiroSuda/gomodjail
   #
+  # The static analysis mode (`gomodjail analyze`) is enforced by the "Lints" job above.
+  # This job exercises the legacy dynamic mode (`gomodjail run`), which enforces a similar
+  # (but not identical) policy at runtime, via syscall interception.
+  #
   # This is an early experiment.
   # CI failures that only occurs with gomodjail shall not block merging PRs.
   gomodjail:
-    name: "gomodjail (experimental; failures shall not block merging PRs)"
+    name: "gomodjail, dynamic mode (experimental; failures shall not block merging PRs)"
     runs-on: macos-15-large  # Intel
     timeout-minutes: 30
     steps:
@@ -608,9 +614,11 @@ jobs:
         go-version: stable
         cache: false
     - name: Install gomodjail
+      env:
+        GOMODJAIL_VERSION: v2.0.1
       run: |
         set -eux -o pipefail
-        git clone https://github.com/AkihiroSuda/gomodjail
+        git clone --depth=1 --branch="${GOMODJAIL_VERSION}" https://github.com/AkihiroSuda/gomodjail
         cd gomodjail
         make binaries install
     - name: Install Lima

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,4 +45,8 @@ Pointers to the authoritative sources - read these rather than a duplicated copy
 
 - New Go, shell, Dockerfile, and Makefile files need an SPDX header (`ltag` enforces this in CI;
   other file types, including markdown, are exempt).
-- Keep the `gomodjail` / `gosocialcheck` annotations in `go.mod`.
+- Keep the `gomodjail` / `gosocialcheck` annotations in `go.mod`. `make gomodjail` statically
+  verifies that the modules annotated `gomodjail:confined` cannot reach a denied capability
+  (filesystem, network, process execution, raw syscalls, ...); when a dependency bump makes one
+  of them reach a capability, `make gomodjail-fix` downgrades that annotation to
+  `gomodjail:unconfined` instead of confining it by hand.

--- a/Makefile
+++ b/Makefile
@@ -651,6 +651,44 @@ go-licenses:
 	# see also https://github.com/google/licenseclassifier/issues/75
 	go-licenses check --include_tests --ignore github.com/hashicorp/hcl/v2 --ignore github.com/segmentio/asm ./... --allowed_licenses=$$(cat ./hack/allowed-licenses.txt)
 
+# gomodjail statically verifies that the Go modules annotated `gomodjail:confined` in go.mod
+# cannot reach a denied capability (filesystem, network, process execution, raw syscalls,
+# OS state modification, or cgo).
+# https://github.com/AkihiroSuda/gomodjail
+#
+# The verdicts are platform-dependent, so the gate is pinned to linux/amd64 and linux/arm64.
+# These are the only platforms that can be analyzed from any host: analyzing darwin needs a
+# macOS host, as the "vz" driver requires cgo. The linux verdicts are a superset of the
+# darwin ones anyway.
+#
+# When a dependency bump makes a confined module reach a denied capability, run
+# `make gomodjail-fix` to downgrade its annotation to `gomodjail:unconfined`,
+# so that the decision stays visible and reviewable in go.mod.
+GOMODJAIL = $(GO) run -modfile=./hack/tools/go.mod github.com/AkihiroSuda/gomodjail/v2/cmd/gomodjail
+
+# gomodjail itself does not build on Windows hosts, as its legacy dynamic mode is compiled in
+# unconditionally.
+.PHONY: gomodjail
+gomodjail:
+ifeq ($(GOHOSTOS),windows)
+	@echo "Skipped: gomodjail does not support Windows hosts"
+else
+	$(GOMODJAIL) analyze --goos=linux --goarch=amd64 ./...
+	$(GOMODJAIL) analyze --goos=linux --goarch=arm64 ./...
+endif
+
+# Downgrades the `gomodjail:confined` annotation of the modules that fail `make gomodjail`
+# to `gomodjail:unconfined`. Unconfining is the only safe automated fix: a violation means
+# that the module's own dependency cone reaches the capability.
+.PHONY: gomodjail-fix
+gomodjail-fix:
+ifeq ($(GOHOSTOS),windows)
+	@echo "Skipped: gomodjail does not support Windows hosts"
+else
+	$(GOMODJAIL) fix --goos=linux --goarch=amd64 ./...
+	$(GOMODJAIL) fix --goos=linux --goarch=arm64 ./...
+endif
+
 .PHONY: gosocialcheck
 gosocialcheck:
 	-$(GO) run -modfile=./hack/tools/go.mod github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck run --gha=$(GITHUB_ACTIONS) ./...
@@ -666,7 +704,7 @@ protolint:
 
 # Main lint target - runs all linting stages
 .PHONY: lint
-lint: check-generated nobin editorconfig-checker golangci-lint yamllint ls-lint shellcheck shfmt go-licenses gosocialcheck ltag protolint
+lint: check-generated nobin editorconfig-checker golangci-lint yamllint ls-lint shellcheck shfmt go-licenses gomodjail gosocialcheck ltag protolint
 
 .PHONY: clean
 clean:

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ go 1.26.0
 // Our own packages and golang.org/x packages are trusted
 //gosocialcheck:trusted
 require (
-	github.com/lima-vm/go-qcow2reader v0.7.1
+	github.com/lima-vm/go-qcow2reader v0.7.1 // gomodjail:unconfined
 	github.com/lima-vm/sshocker v0.3.11 // gomodjail:unconfined
 	golang.org/x/image v0.45.0
-	golang.org/x/net v0.58.0
+	golang.org/x/net v0.58.0 // gomodjail:unconfined
 	golang.org/x/sync v0.23.0
 	golang.org/x/sys v0.48.0 // gomodjail:unconfined
 	golang.org/x/text v0.41.0
@@ -17,58 +17,61 @@ require (
 
 require (
 	al.essio.dev/pkg/shellescape v1.6.1
-	github.com/AlecAivazis/survey/v2 v2.3.7
+	github.com/AlecAivazis/survey/v2 v2.3.7 // gomodjail:unconfined
 	github.com/Code-Hex/vz/v3 v3.7.1 // gomodjail:unconfined
 	github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29 // gomodjail:unconfined
 	github.com/Microsoft/hcsshim v0.14.1
 	github.com/apparentlymart/go-cidr v1.1.1
-	github.com/balajiv113/fd v0.0.0-20230330094840-143eec500f3e
+	github.com/balajiv113/fd v0.0.0-20230330094840-143eec500f3e // gomodjail:unconfined
 	github.com/cheggaaa/pb/v3 v3.2.1 // gomodjail:unconfined
 	github.com/cilium/ebpf v0.22.0 // gomodjail:unconfined
-	github.com/containerd/continuity v0.5.0
+	github.com/containerd/continuity v0.5.0 // gomodjail:unconfined
 	github.com/containers/gvisor-tap-vsock v0.8.9 // gomodjail:unconfined
 	github.com/coreos/go-semver v0.3.1
-	github.com/coreos/go-systemd/v22 v22.7.0
+	github.com/coreos/go-systemd/v22 v22.7.0 // gomodjail:unconfined
 	github.com/cpuguy83/go-md2man/v2 v2.0.7
-	github.com/digitalocean/go-qemu v0.0.0-20221209210016-f035778c97f7
+	github.com/digitalocean/go-qemu v0.0.0-20221209210016-f035778c97f7 // gomodjail:unconfined
 	github.com/diskfs/go-diskfs v1.9.4 // gomodjail:unconfined
 	github.com/docker/go-units v0.5.0
 	github.com/foxcpp/go-mockdns v1.2.0
-	github.com/goccy/go-yaml v1.19.2
+	github.com/goccy/go-yaml v1.19.2 // gomodjail:unconfined
 	github.com/google/go-cmp v0.7.0
-	github.com/google/yamlfmt v0.21.0
-	github.com/inetaf/tcpproxy v0.0.0-20250222171855-c4b9df066048
-	github.com/invopop/jsonschema v0.14.0
-	github.com/mattn/go-isatty v0.0.24
-	github.com/mattn/go-shellwords v1.0.14
-	github.com/mdlayher/netlink v1.11.2
+	github.com/google/yamlfmt v0.21.0 // gomodjail:unconfined
+	github.com/inetaf/tcpproxy v0.0.0-20250222171855-c4b9df066048 // gomodjail:unconfined
+	github.com/invopop/jsonschema v0.14.0 // gomodjail:unconfined
+	github.com/mattn/go-isatty v0.0.24 // gomodjail:unconfined
+	github.com/mattn/go-shellwords v1.0.14 // gomodjail:unconfined
+	github.com/mdlayher/netlink v1.11.2 // gomodjail:unconfined
 	github.com/mdlayher/vsock v1.3.0 // gomodjail:unconfined
 	github.com/miekg/dns v1.1.73 // gomodjail:unconfined
-	github.com/mikefarah/yq/v4 v4.53.6
-	github.com/modelcontextprotocol/go-sdk v1.7.0
+	github.com/mikefarah/yq/v4 v4.53.6 // gomodjail:unconfined
+	github.com/modelcontextprotocol/go-sdk v1.7.0 // gomodjail:unconfined
 	github.com/nxadm/tail v1.4.11 // gomodjail:unconfined
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/pb33f/ordered-map/v2 v2.3.1
-	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
-	github.com/pkg/sftp v1.13.11
-	github.com/rjeczalik/notify v0.9.3
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // gomodjail:unconfined
+	github.com/pkg/sftp v1.13.11 // gomodjail:unconfined
+	github.com/rjeczalik/notify v0.9.3 // gomodjail:unconfined
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 // gomodjail:unconfined
 	github.com/sethvargo/go-password v0.4.0
-	github.com/sirupsen/logrus v1.10.2
+	github.com/sirupsen/logrus v1.10.2 // gomodjail:unconfined
 	github.com/spakin/netpbm v1.3.2
 	github.com/spf13/cobra v1.10.2 // gomodjail:unconfined
 	github.com/spf13/pflag v1.0.10
-	google.golang.org/grpc v1.83.2
+	google.golang.org/grpc v1.83.2 // gomodjail:unconfined
 	google.golang.org/protobuf v1.36.12 // gomodjail:unconfined
-	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
+	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473 // gomodjail:unconfined
 	gotest.tools/v3 v3.5.2
 )
 
 //gosocialcheck:trusted
 require (
+	// gomodjail:unconfined
 	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/mod v0.40.0 // indirect
+	// gomodjail:unconfined
 	golang.org/x/oauth2 v0.36.0 // indirect
+	// gomodjail:unconfined
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.49.0 // indirect
@@ -82,6 +85,7 @@ require (
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	// gomodjail:unconfined
 	github.com/bmatcuk/doublestar/v4 v4.7.1 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/containerd/cgroups/v3 v3.1.3 // indirect
@@ -89,13 +93,17 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/typeurl/v2 v2.3.0 // indirect
+	// gomodjail:unconfined
 	github.com/digitalocean/go-libvirt v0.0.0-20220804181439-8648fbde413e // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
+	// gomodjail:unconfined
 	github.com/djherbis/times v1.6.0 // indirect
 	github.com/elliotchance/orderedmap v1.8.0 // indirect
+	// gomodjail:unconfined
 	github.com/fatih/color v1.19.0 // indirect
 	// gomodjail:unconfined
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	// gomodjail:unconfined
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
@@ -108,11 +116,14 @@ require (
 	github.com/insomniacslk/dhcp v0.0.0-20240710054256-ddd8a41251c9 // indirect
 	github.com/jinzhu/copier v0.4.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	// gomodjail:unconfined
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/linuxkit/virtsock v0.0.0-20220523201153-1a23e78aa7a2 // indirect
+	// gomodjail:unconfined
 	github.com/magiconair/properties v1.18.11 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-runewidth v0.0.27 // indirect
+	// gomodjail:unconfined
 	github.com/mdlayher/socket v0.6.0 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
@@ -121,12 +132,14 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	// gomodjail:unconfined
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	// gomodjail:unconfined
 	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	// gomodjail:unconfined
 	github.com/yuin/gopher-lua v1.1.2 // indirect
 	github.com/zclconf/go-cty v1.19.0 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 // Should be in sync with pinversion.go
 tool (
+	github.com/AkihiroSuda/gomodjail/v2/cmd/gomodjail
 	github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck
 	github.com/containerd/ltag
 	github.com/editorconfig-checker/editorconfig-checker/v3/cmd/editorconfig-checker
@@ -16,6 +17,7 @@ tool (
 )
 
 require (
+	github.com/AkihiroSuda/gomodjail/v2 v2.0.1
 	github.com/AkihiroSuda/gosocialcheck v0.1.3
 	github.com/containerd/ltag v0.3.0
 	github.com/golangci/golangci-lint/v2 v2.13.2
@@ -89,6 +91,7 @@ require (
 	github.com/dlclark/regexp2/v2 v2.2.1 // indirect
 	github.com/editorconfig-checker/editorconfig-checker/v3 v3.6.1 // indirect
 	github.com/editorconfig/editorconfig-core-go/v2 v2.6.4 // indirect
+	github.com/elastic/go-seccomp-bpf v1.6.0 // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
@@ -124,6 +127,7 @@ require (
 	github.com/golangci/rowserrcheck v0.0.0-20260419091836-c5f79b8a11ba // indirect
 	github.com/golangci/swaggoswag v0.0.0-20250504205917-77f2aca3143e // indirect
 	github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e // indirect
+	github.com/google/capslock v0.3.3 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/renameio/v2 v2.0.2 // indirect
 	github.com/gordonklaus/ineffassign v0.2.0 // indirect
@@ -240,7 +244,7 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260811152304-ee035b5b010f // indirect
-	golang.org/x/mod v0.40.0 // indirect
+	golang.org/x/mod v0.41.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sync v0.23.0 // indirect
 	golang.org/x/sys v0.48.0 // indirect

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -55,6 +55,8 @@ github.com/AdminBenni/iota-mixing v1.0.0 h1:Os6lpjG2dp/AE5fYBPAA1zfa2qMdCAWwPMCg
 github.com/AdminBenni/iota-mixing v1.0.0/go.mod h1:i4+tpAaB+qMVIV9OK3m4/DAynOd5bQFaOu+2AhtBCNY=
 github.com/AkihiroSuda/gomoddirectivecomments v0.1.0 h1:5sKxYIkq9GGs0DTnuPNVm2Z/LmhKdTN+8QblThzTKqg=
 github.com/AkihiroSuda/gomoddirectivecomments v0.1.0/go.mod h1:flXOhVLWfsi4FuFhFoc9F3m7wAH2RT4aM3fVyQROKt4=
+github.com/AkihiroSuda/gomodjail/v2 v2.0.1 h1:SqgyFDrlLM7h3OAyCvxRC1pJFU1lj6iR7lzx3FUPSs0=
+github.com/AkihiroSuda/gomodjail/v2 v2.0.1/go.mod h1:It5FphTQzZYRLzIHqHhkchbTqEOUAu/BbNZ3oG+nOzE=
 github.com/AkihiroSuda/gosocialcheck v0.1.3 h1:WnVyuhQSrYUd/sGsPIGlpDgEHXCAZmHqQH21eY/EytY=
 github.com/AkihiroSuda/gosocialcheck v0.1.3/go.mod h1:DcwCgmA5NmgQWE90IoosrUlyKQic3P2GmibNQ1s1F9w=
 github.com/AlwxSin/noinlineerr v1.0.6 h1:KAvuxunTe9QxvqrFB7nZTdb/7Wzas4AvifslTnG0Ld8=
@@ -191,6 +193,8 @@ github.com/editorconfig-checker/editorconfig-checker/v3 v3.6.1 h1:jdfYul8o1YpAb0
 github.com/editorconfig-checker/editorconfig-checker/v3 v3.6.1/go.mod h1:3M/pJVyyr63yWjRWOFpPqKNAzj6JaE/I/+dNDfgN+3I=
 github.com/editorconfig/editorconfig-core-go/v2 v2.6.4 h1:CHwUbBVVyKWRX9kt5A/OtwhYUJB32DrFp9xzmjR6cac=
 github.com/editorconfig/editorconfig-core-go/v2 v2.6.4/go.mod h1:JWRVKHdVW+dkv6F8p+xGCa6a+TyMrqsFbFkSs/aQkrQ=
+github.com/elastic/go-seccomp-bpf v1.6.0 h1:NYduiYxRJ0ZkIyQVwlSskcqPPSg6ynu5pK0/d7SQATs=
+github.com/elastic/go-seccomp-bpf v1.6.0/go.mod h1:5tFsTvH4NtWGfpjsOQD53H8HdVQ+zSZFRUDSGevC0Kc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -329,6 +333,8 @@ github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e h1:gD6P7NEo7Eqt
 github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e/go.mod h1:h+wZwLjUTJnm/P2rwlbJdRPZXOzaT36/FwnPnY2inzc=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/capslock v0.3.3 h1:YwfaVEI0RRx02JHjtxLq4bbQ/LyVrQNaNj6CjXAiTyw=
+github.com/google/capslock v0.3.3/go.mod h1:d52IIMdI8UlRPF8PFNt/dxKpARTksvWNdxh7fm8u2Fo=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -774,8 +780,8 @@ golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
-golang.org/x/mod v0.40.0 h1:hUv+3cXcdRHz08UmSiOob7sadHig73uo5bkXxQ/tvUs=
-golang.org/x/mod v0.40.0/go.mod h1:0/weTWkPWGBikyTWAX3dkjVztMmBA5hM0DH6BElSupE=
+golang.org/x/mod v0.41.0 h1:qJmnOUb4YB+FsEuM3HcWucdZASCPGhsX6uljO6pog0c=
+golang.org/x/mod v0.41.0/go.mod h1:Ek9pY8RKWXwsWvd3rQiHYtMqkjSUV+s1Rj7j4H5Ur6o=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/hack/tools/pinversion.go
+++ b/hack/tools/pinversion.go
@@ -8,6 +8,7 @@
 package tools
 
 import (
+	_ "github.com/AkihiroSuda/gomodjail/v2/pkg/static/analyzer"
 	_ "github.com/AkihiroSuda/gosocialcheck/pkg/source/cncf"
 	_ "github.com/containerd/ltag"
 	_ "github.com/golangci/golangci-lint/v2/pkg/exitcodes"


### PR DESCRIPTION

<!-- Please read our contribution rules before submitting:

- Pull requests guide: https://lima-vm.io/docs/community/contributing/#sending-pull-requests
- AI usage policy: https://lima-vm.io/docs/community/contributing/#ai-contribution-rules

-->

## What This PR Changes

<!-- Explain the single problem this PR fixes, in your own words. -->

Updated to gomodjail to v2 ([v2.0.0](https://github.com/AkihiroSuda/gomodjail/releases/tag/v2.0.0), [v2.0.1](https://github.com/AkihiroSuda/gomodjail/releases/tag/v2.0.1)), which moves the focus to static analysis: `gomodjail analyze` verifies that the modules annotated `gomodjail:confined` in go.mod cannot reach a denied capability (filesystem, network, process execution, raw syscalls, OS state modification, or cgo).

## Linked Issue (Required in most cases)

<!-- Link the issue here. If your issue is not approved by a maintainer, don't expect your PR to be merged. -->

None

## How I Tested This

```console
$ gomodjail analyze ./...
[...]
gomodjail: 65 confined module(s): 37 ok, 28 warning(s), 0 violation(s)
```

This static analysis is enforced in the CI for every PR.
If it fails, that indicates that the new version of the dependency has more "privileges" than before and should be reviewed carefully.
The error can be silenced by adding `gomodjail:confined` annotation in `go.mod`.

## AI Usage

<!-- If you used AI tools, say which tool and how you used it. For example, `Assisted-by: AI_AGENT_NAME:VERSION [TOOL]` or `Co-Authored-By`-->

Assisted-by: Claude Code (Opus 5)
