### PR TITLE
MAINTAINERS: move alexandear to emeritus section

### DIFF
--- a/website/content/en/docs/community/governance.md
+++ b/website/content/en/docs/community/governance.md
@@ -45,11 +45,13 @@ See also the [Contributing](../contributing) page.
 | Balaji Vijayakumar | Thoughtworks | Committer | [@balajiv113](https://github.com/balajiv113)     | [80E1 01FE 5C89 FCF6 6171  72C8 377C 6A63 934B 8E6E](https://github.com/balajiv113.gpg)   |
 | Norio Nomura       | Individual   | Committer | [@norio-nomura](https://github.com/norio-nomura) | [0010 36FA 2504 DBFF 37BA  2EF8 D4A7 318E B7F7 138D](https://github.com/norio-nomura.gpg) |
 | Ansuman Sahoo      | Individual   | Committer | [@unsuman](https://github.com/unsuman)           | [0AA6 D4D0 E084 D8B9 36B7  68D8 FF58 56B9 C216 D800](https://github.com/unsuman.gpg)      |
-| Oleksandr Redko    | Individual   | Reviewer  | [@alexandear](https://github.com/alexandear)     | [50F8 9811 D8D8 3E79 3E7E  0680 A947 E3F1 1A61 2A57](https://github.com/alexandear.gpg)   |
 | Nir Soffer         | IBM          | Reviewer  | [@nirs](https://github.com/nirs)                 | [6F81 B717 51A1 4171 4C09  AF19 4C67 29D7 B2DD 8AFF](https://github.com/nirs.gpg)         |
 
 ### Emeritus maintainers
-(No emeritus maintainers yet)
+
+| Name               | Affiliation  | Role      | GitHub ID (not X ID)                             |
+|--------------------|--------------|-----------|--------------------------------------------------|
+| Oleksandr Redko    | Individual   | Reviewer  | [@alexandear](https://github.com/alexandear)     |
 
 ### Addition and promotion of Maintainers
 An active contributor to the project can be invited as a Reviewer,


### PR DESCRIPTION
I propose removing @alexandear from the reviewers list, as I'm not actively involved in the project.

---

https://lima-vm.io/docs/community/governance/

> A proposal to demote or remove a Maintainer must be approved by 2/3 of the Committers (excluding the person in question) who vote within 14 days.
Voting needs 2 approvals at least. The proposer can vote too.

- [x] @afbjorklund 
- [x] @AkihiroSuda 
- [ ] @balajiv113 
- [x] @jandubois
- [ ] @norio-nomura
- [ ] @nirs

Needs an approval from the candidate too
- [x] @alexandear 
