### PR TITLE
feature: support to set vm disk dir

### DIFF
--- a/cmd/limactl/editflags/editflags.go
+++ b/cmd/limactl/editflags/editflags.go
@@ -85,6 +85,7 @@ func RegisterEdit(cmd *cobra.Command, commentPrefix string) {
 		return []string{"10", "30", "50", "100", "200"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
+	flags.String("disk-path", "", commentPrefix+"Disk path for vm")
 	flags.String("vm-type", "", commentPrefix+"Virtual machine type")
 	_ = cmd.RegisterFlagCompletionFunc("vm-type", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		var drivers []string
@@ -447,6 +448,18 @@ func YQExpressions(flags *flag.FlagSet, newInstance bool, params map[string]stri
 			false,
 		},
 		{"disk", d(".disk= \"%sGiB\""), false, false},
+		{
+			"disk-path",
+			func(_ *flag.Flag) ([]string, error) {
+				diskPath, err := flags.GetString("disk-path")
+				if err != nil {
+					return nil, err
+				}
+				return []string{fmt.Sprintf(".diskPath = \"%s\"", diskPath)}, nil
+			},
+			false,
+			false,
+		},
 		{"plain", d(".plain = %s"), true, false},
 		{
 			"port-forward",

--- a/pkg/driver/qemu/qemu.go
+++ b/pkg/driver/qemu/qemu.go
@@ -92,7 +92,18 @@ func minimumQemuVersion() (hardMin, softMin semver.Version) {
 // For ISO images, it renames the image to "iso" and creates an empty qcow2 disk.
 // For non-ISO images, it validates and renames the image to "disk".
 func EnsureDisk(ctx context.Context, cfg Config) error {
-	diskPath := filepath.Join(cfg.InstanceDir, filenames.Disk)
+	var diskPath string
+	if cfg.LimaYAML != nil && cfg.LimaYAML.DiskPath != nil && *cfg.LimaYAML.DiskPath != "" {
+		diskPath = filepath.Join(*cfg.LimaYAML.DiskPath, cfg.Name, filenames.Disk)
+		_, statErr := os.Stat(filepath.Dir(diskPath))
+		if os.IsNotExist(statErr) {
+			if err := os.MkdirAll(filepath.Dir(diskPath), 0o700); err != nil {
+				return err
+			}
+		}
+	} else {
+		diskPath = filepath.Join(cfg.InstanceDir, filenames.Disk)
+	}
 	if _, err := os.Stat(diskPath); err == nil || !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
@@ -157,7 +168,12 @@ func sendHmpCommand(cfg Config, cmd, tag string) (string, error) {
 }
 
 func execImgCommand(ctx context.Context, cfg Config, args ...string) (string, error) {
-	diskPath := filepath.Join(cfg.InstanceDir, filenames.Disk)
+	var diskPath string
+	if *cfg.LimaYAML.DiskPath != "" {
+		diskPath = filepath.Join(*cfg.LimaYAML.DiskPath, cfg.Name, filenames.Disk)
+	} else {
+		diskPath = filepath.Join(cfg.InstanceDir, filenames.Disk)
+	}
 	args = append(args, diskPath)
 	logrus.Debugf("Running qemu-img %v command", args)
 	cmd := exec.CommandContext(ctx, "qemu-img", args...)
@@ -637,7 +653,12 @@ func Cmdline(ctx context.Context, cfg Config) (exe string, args []string, err er
 	}
 
 	// Disk
-	diskPath := filepath.Join(cfg.InstanceDir, filenames.Disk)
+	var diskPath string
+	if *cfg.LimaYAML.DiskPath != "" {
+		diskPath = filepath.Join(*cfg.LimaYAML.DiskPath, cfg.Name, filenames.Disk)
+	} else {
+		diskPath = filepath.Join(cfg.InstanceDir, filenames.Disk)
+	}
 	isoPath := filepath.Join(cfg.InstanceDir, filenames.ISO)
 	extraDisks := []string{}
 	for _, d := range y.AdditionalDisks {

--- a/pkg/driver/qemu/qemu_driver.go
+++ b/pkg/driver/qemu/qemu_driver.go
@@ -259,7 +259,7 @@ func fillConfig(cfg *limatype.LimaYAML, instDir string) error {
 		if _, ok := mountTypesUnsupported[limatype.NINEP]; ok {
 			// Use REVSSHFS if the instance does not support 9p
 			cfg.MountType = new(limatype.REVSSHFS)
-		} else if limayaml.IsExistingInstanceDir(instDir) && !versionutil.GreaterEqual(limayaml.ExistingLimaVersion(instDir), "1.0.0") {
+		} else if limayaml.IsExistingInstanceDir(cfg, instDir) && !versionutil.GreaterEqual(limayaml.ExistingLimaVersion(cfg, instDir), "1.0.0") {
 			// Use REVSSHFS if the instance was created with Lima prior to v1.0
 			cfg.MountType = new(limatype.REVSSHFS)
 		}

--- a/pkg/driverutil/disk.go
+++ b/pkg/driverutil/disk.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/imgutil/nativeimgutil"
 	"github.com/lima-vm/lima/v2/pkg/imgutil/proxyimgutil"
 	"github.com/lima-vm/lima/v2/pkg/iso9660util"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/osutil"
 )
@@ -24,13 +25,17 @@ import (
 // MigrateDiskLayout creates symlinks from the current filenames (disk, iso) to
 // the legacy filenames (diffdisk, basedisk) used by older Lima versions.
 // The original files are left in place so older Lima versions can still use them.
-func MigrateDiskLayout(instDir string) error {
-	diskPath := filepath.Join(instDir, filenames.Disk)
+func MigrateDiskLayout(inst *limatype.Instance) error {
+	diskPath := filepath.Join(inst.Dir, filenames.Disk)
 	if osutil.FileExists(diskPath) {
 		return nil // already migrated or new instance
 	}
-
-	diffDiskPath := filepath.Join(instDir, filenames.DiffDiskLegacy)
+	if inst.Config != nil && inst.Config.DiskPath != nil {
+		if osutil.FileExists(filepath.Join(*inst.Config.DiskPath, inst.Name, filenames.Disk)) {
+			return nil
+		}
+	}
+	diffDiskPath := filepath.Join(inst.Dir, filenames.DiffDiskLegacy)
 	if osutil.FileExists(diffDiskPath) {
 		logrus.Infof("Creating symlink %#q -> %#q", filenames.Disk, filenames.DiffDiskLegacy)
 		if err := os.Symlink(filenames.DiffDiskLegacy, diskPath); err != nil {
@@ -38,8 +43,8 @@ func MigrateDiskLayout(instDir string) error {
 		}
 	}
 
-	baseDiskPath := filepath.Join(instDir, filenames.BaseDiskLegacy)
-	isoPath := filepath.Join(instDir, filenames.ISO)
+	baseDiskPath := filepath.Join(inst.Dir, filenames.BaseDiskLegacy)
+	isoPath := filepath.Join(inst.Dir, filenames.ISO)
 	if osutil.FileExists(baseDiskPath) && !osutil.FileExists(isoPath) {
 		isISO, err := iso9660util.IsISO9660(baseDiskPath)
 		if err != nil {

--- a/pkg/instance/delete.go
+++ b/pkg/instance/delete.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/lima-vm/lima/v2/pkg/driver/external/server"
 	"github.com/lima-vm/lima/v2/pkg/driverutil"
@@ -31,6 +32,12 @@ func Delete(ctx context.Context, inst *limatype.Instance, force bool) error {
 	}
 	if err := os.RemoveAll(inst.Dir); err != nil {
 		return fmt.Errorf("failed to remove %#q: %w", inst.Dir, err)
+	}
+	diskPath := inst.Config.DiskPath
+	if diskPath != nil && *diskPath != "" {
+		if err := os.RemoveAll(filepath.Join(*diskPath, inst.Name)); err != nil {
+			return fmt.Errorf("failed to remove %#q: %w", *diskPath, err)
+		}
 	}
 
 	return nil

--- a/pkg/instance/start.go
+++ b/pkg/instance/start.go
@@ -86,18 +86,22 @@ func Prepare(ctx context.Context, inst *limatype.Instance, guestAgent string) (*
 	if err := limaDriver.Create(ctx); err != nil {
 		return nil, err
 	}
-
 	// Migrate legacy disk layout (diffdisk → disk, ISO basedisk → iso)
-	if err := driverutil.MigrateDiskLayout(inst.Dir); err != nil {
+	if err := driverutil.MigrateDiskLayout(inst); err != nil {
 		return nil, err
 	}
 
 	supportedImageFormats := limaDriver.Info(ctx).Features.SupportedImageFormats
 
-	created := limayaml.IsExistingInstanceDir(inst.Dir)
+	created := limayaml.IsExistingInstanceDir(inst.Config, inst.Dir)
 
 	imagePath := filepath.Join(inst.Dir, filenames.Image)
-	disk := filepath.Join(inst.Dir, filenames.Disk)
+	var disk string
+	if inst.Config != nil && inst.Config.DiskPath != nil && *inst.Config.DiskPath != "" {
+		disk = filepath.Join(*inst.Config.DiskPath, inst.Name, filenames.Disk)
+	} else {
+		disk = filepath.Join(inst.Dir, filenames.Disk)
+	}
 	kernel := filepath.Join(inst.Dir, filenames.Kernel)
 	kernelCmdline := filepath.Join(inst.Dir, filenames.KernelCmdline)
 	initrd := filepath.Join(inst.Dir, filenames.Initrd)
@@ -515,8 +519,12 @@ func ShowMessage(inst *limatype.Instance) error {
 // prepareDisk resizes the VM disk if its size differs from the configured size.
 // Returns nil if the disk does not yet exist (instance not yet initialized).
 func prepareDisk(ctx context.Context, inst *limatype.Instance) error {
-	disk := filepath.Join(inst.Dir, filenames.Disk)
-
+	var disk string
+	if inst.Config.DiskPath != nil && *inst.Config.DiskPath != "" {
+		disk = filepath.Join(*inst.Config.DiskPath, inst.Name, filenames.Disk)
+	} else {
+		disk = filepath.Join(inst.Dir, filenames.Disk)
+	}
 	_, err := os.Stat(disk)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/limatype/lima_yaml.go
+++ b/pkg/limatype/lima_yaml.go
@@ -24,8 +24,9 @@ type LimaYAML struct {
 	// Deprecated: Use vmOpts.qemu.cpuType instead.
 	CPUType               CPUType       `yaml:"cpuType,omitempty" json:"cpuType,omitempty" jsonschema:"nullable"`
 	CPUs                  *int          `yaml:"cpus,omitempty" json:"cpus,omitempty" jsonschema:"nullable"`
-	Memory                *string       `yaml:"memory,omitempty" json:"memory,omitempty" jsonschema:"nullable"` // go-units.RAMInBytes
-	Disk                  *string       `yaml:"disk,omitempty" json:"disk,omitempty" jsonschema:"nullable"`     // go-units.RAMInBytes
+	Memory                *string       `yaml:"memory,omitempty" json:"memory,omitempty" jsonschema:"nullable"`     // go-units.RAMInBytes
+	Disk                  *string       `yaml:"disk,omitempty" json:"disk,omitempty" jsonschema:"nullable"`         // go-units.RAMInBytes
+	DiskPath              *string       `yaml:"diskPath,omitempty" json:"diskPath,omitempty" jsonschema:"nullable"`
 	AdditionalDisks       []Disk        `yaml:"additionalDisks,omitempty" json:"additionalDisks,omitempty" jsonschema:"nullable"`
 	Mounts                []Mount       `yaml:"mounts,omitempty" json:"mounts,omitempty"`
 	MountTypesUnsupported []string      `yaml:"mountTypesUnsupported,omitempty" json:"mountTypesUnsupported,omitempty" jsonschema:"nullable"`

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -152,7 +152,7 @@ func defaultGuestInstallPrefix() string {
 func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath string, warn bool) {
 	instDir := filepath.Dir(filePath)
 
-	existingLimaVersion := ExistingLimaVersion(instDir)
+	existingLimaVersion := ExistingLimaVersion(o, instDir)
 
 	// OS has to be resolved before User
 	if y.OS == nil {
@@ -907,8 +907,8 @@ func FillDefault(ctx context.Context, y, d, o *limatype.LimaYAML, filePath strin
 // ExistingLimaVersion returns the version that created the instance, the empty string
 // for instances created before Lima v0.20 (which have no recorded version), or the
 // current version when the instance doesn't exist yet.
-func ExistingLimaVersion(instDir string) string {
-	if !IsExistingInstanceDir(instDir) {
+func ExistingLimaVersion(o *limatype.LimaYAML, instDir string) string {
+	if !IsExistingInstanceDir(o, instDir) {
 		return version.Version
 	}
 
@@ -1072,7 +1072,7 @@ func FillCopyToHostDefaults(rule *limatype.CopyToHost, instDir string, user lima
 	}
 }
 
-func IsExistingInstanceDir(dir string) bool {
+func IsExistingInstanceDir(cfg *limatype.LimaYAML, dir string) bool {
 	// existence of "lima.yaml" does not signify existence of the instance,
 	// because the file is created during the initialization of the instance.
 	for _, f := range []string{
@@ -1081,6 +1081,12 @@ func IsExistingInstanceDir(dir string) bool {
 	} {
 		file := filepath.Join(dir, f)
 		if _, err := os.Lstat(file); !errors.Is(err, os.ErrNotExist) {
+			return true
+		}
+	}
+	if cfg != nil && cfg.DiskPath != nil {
+		cusTomdir := filepath.Join(*cfg.DiskPath, dir, filenames.Disk)
+		if _, err := os.Lstat(cusTomdir); !errors.Is(err, os.ErrNotExist) {
 			return true
 		}
 	}

--- a/pkg/limayaml/defaults_test.go
+++ b/pkg/limayaml/defaults_test.go
@@ -28,22 +28,23 @@ import (
 )
 
 func TestExistingLimaVersion(t *testing.T) {
+	var o *limatype.LimaYAML
 	t.Run("instance does not exist yet", func(t *testing.T) {
-		assert.Equal(t, ExistingLimaVersion(t.TempDir()), version.Version)
+		assert.Equal(t, ExistingLimaVersion(o, t.TempDir()), version.Version)
 	})
 
 	t.Run("version has been recorded", func(t *testing.T) {
 		instDir := createInstanceDir(t, map[string]string{filenames.LimaVersion: "1.2.3\n"})
-		assert.Equal(t, ExistingLimaVersion(instDir), "1.2.3")
+		assert.Equal(t, ExistingLimaVersion(o, instDir), "1.2.3")
 	})
 
 	// Instances created before Lima v0.20 have no lima-version file. Reporting the current
 	// version for them would move the guest home directory to a path that doesn't exist.
 	t.Run("instance predates the version file", func(t *testing.T) {
 		instDir := createInstanceDir(t, nil)
-		assert.Equal(t, ExistingLimaVersion(instDir), "")
+		assert.Equal(t, ExistingLimaVersion(o, instDir), "")
 
-		user := osutil.LimaUser(t.Context(), ExistingLimaVersion(instDir), false, nil)
+		user := osutil.LimaUser(t.Context(), ExistingLimaVersion(o, instDir), false, nil)
 		assert.Equal(t, user.HomeDir, "/home/{{.User}}.linux")
 	})
 }

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -114,7 +114,13 @@ func Validate(y *limatype.LimaYAML, warn bool) error {
 	if _, err := units.RAMInBytes(*y.Disk); err != nil {
 		errs = errors.Join(errs, fmt.Errorf("field `disk` has an invalid value: %w", err))
 	}
-
+	if y.DiskPath != nil {
+		if diskPath := *y.DiskPath; diskPath != "" {
+			if _, err := os.Stat(diskPath); err != nil {
+				errs = errors.Join(errs, fmt.Errorf("field `disk` disk-path invalid value: %w", err))
+			}
+		}
+	}
 	for i, disk := range y.AdditionalDisks {
 		if err := identifiers.Validate(disk.Name); err != nil {
 			errs = errors.Join(errs, fmt.Errorf("field `additionalDisks[%d].name is invalid`: %w", i, err))


### PR DESCRIPTION
<!-- Please read our contribution rules before submitting:

- Pull requests guide: https://lima-vm.io/docs/community/contributing/#sending-pull-requests
- AI usage policy: https://lima-vm.io/docs/community/contributing/#ai-contribution-rules

-->


## What This PR Changes
sometimes  the /home/user/.lima directory does not have enough space to start the virtual machine
but other disks have plenty of free space.（for an example macmini only 256g ）

add flag disk-path to specify vm disk to custom dir
for an example
limactl start   --name=ubuntu  --disk-path=/var/lib/test  --containerd none  template://alpine

<!-- Explain the single problem this PR fixes, in your own words. -->

## Linked Issue (Required in most cases)

<!-- Link the issue here. If your issue is not approved by a maintainer, don't expect your PR to be merged. -->

Closes #

## How I Tested This
limactl start   --name=ubuntu  --disk-path=/var/lib/test  --containerd none  template://alpine

vm disk can be save at /var/lib/test/{name}/disk
```
root@nmx-Swift-SF314-512:/home/nmx/code/lima# cd /var/lib/test/
root@nmx-Swift-SF314-512:/var/lib/test# ls
ubuntu
root@nmx-Swift-SF314-512:/var/lib/test# tree
.
└── ubuntu
    └── disk
```

## AI Usage

<!-- If you used AI tools, say which tool and how you used it. For example, `Assisted-by: AI_AGENT_NAME:VERSION [TOOL]` or `Co-Authored-By`-->